### PR TITLE
updated phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,10 +7,22 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         syntaxCheck="false"
         >
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/e2e/</directory>
         </testsuite>
     </testsuites>
+         
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+         
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+         
 </phpunit>


### PR DESCRIPTION
added extra code in it. The <filter> element and its children can be used to configure the whitelist for the code coverage reporting. The <php> element and its children can be used to configure PHP settings, constants, and global variables. It can also be used to prepend the include_path.