### PR TITLE
Update es.email.auth.confirm.tpl: Fixed typo error

### DIFF
--- a/app/config/locale/templates/es.email.auth.confirm.tpl
+++ b/app/config/locale/templates/es.email.auth.confirm.tpl
@@ -10,7 +10,7 @@
     Hola {{name}},
     <br />
     <br />
-    Sigue este enlace para verificar tu dirección de correo:
+    Sigue este enlace para verificar tu dirección de correo.
     <br />
     <a href="{{redirect}}">{{redirect}}</a>
     <br />


### PR DESCRIPTION
The original message on English doesnt use the punctuation on that way.