### PR TITLE
Update locale/es.php. The order in the sentence is not correct in spanish

### DIFF
--- a/app/config/locale/es.php
+++ b/app/config/locale/es.php
@@ -6,7 +6,7 @@ return [
     'settings.direction' => 'ltr',
 
     // Service - Users
-    'auth.emails.team' => '%s Equipo',
+    'auth.emails.team' => 'Equipo %s',
     'auth.emails.confirm.title' => 'Confirmación de la cuenta',
     'auth.emails.confirm.body' => 'es.email.auth.confirm.tpl',
     'auth.emails.recovery.title' => 'Reestablecer contraseña',


### PR DESCRIPTION
On Spanish make more senses:   "Team" + team_name. Also, it's more consistent with the translations on:

[app/config/locale/templates/es.email.auth.confirm.tpl](https://github.com/appwrite/appwrite/blob/master/app/config/locale/templates/es.email.auth.confirm.tpl#L23)
[app/config/locale/templates/es.email.auth.invitation.tpl](https://github.com/appwrite/appwrite/blob/master/app/config/locale/templates/es.email.auth.invitation.tpl#L26)
[app/config/locale/templates/es.email.auth.recovery.tpl](https://github.com/appwrite/appwrite/blob/master/app/config/locale/templates/es.email.auth.recovery.tpl#L23)
