### PR TITLE
delete remove-orphans option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The easiest way to start running your Appwrite server is by running our docker c
 mkdir appwrite-ce && \
 cd appwrite-ce && \
 curl -o docker-compose.yml https://appwrite.io/docker-compose.yml?version=0.2.0 && \
-docker-compose up -d --remove-orphans
+docker-compose up -d
 ```
 
 


### PR DESCRIPTION
`--remove-orphans` is only needed when you have old containers e.g. when you renaming a service while its container is running then the container considered as an orphan that should be removed which might not the case as you start a new deployment