### PR TITLE
Fixed errors in reference documentation

### DIFF
--- a/docs/references/auth/confirm-resend.md
+++ b/docs/references/auth/confirm-resend.md
@@ -1,3 +1,3 @@
-This endpoint allows the user to request your app to resend him his email confirmation message. The redirect arguments acts the same way as in /auth/register endpoint.
+This endpoint allows the user to request your app to resend him his email confirmation message. The redirect arguments act the same way as in /auth/register endpoint.
 
-Please notice that in order to avoid a [Redirect Attacks](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URL's are the once from domains you have set when added your platforms in the console interface.
+Please notice that in order to avoid a [Redirect Attack](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.

--- a/docs/references/auth/login.md
+++ b/docs/references/auth/login.md
@@ -1,5 +1,5 @@
 Allow the user to login into his account by providing a valid email and password combination. Use the success and failure arguments to provide a redirect URL\'s back to your app when login is completed. 
 
-Please notice that in order to avoid a [Redirect Attacks](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.
+Please notice that in order to avoid a [Redirect Attack](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.
 
 When accessing this route using Javascript from the browser, success and failure parameter URLs are required. Appwrite server will respond with a 301 redirect status code and will set the user session cookie. This behavior is enforced because modern browsers are limiting 3rd party cookies in XHR of fetch requests to protect user privacy.

--- a/docs/references/auth/login.md
+++ b/docs/references/auth/login.md
@@ -1,5 +1,5 @@
 Allow the user to login into his account by providing a valid email and password combination. Use the success and failure arguments to provide a redirect URL\'s back to your app when login is completed. 
 
-Please notice that in order to avoid a [Redirect Attacks](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URL's are the once from domains you have set when added your platforms in the console interface.
+Please notice that in order to avoid a [Redirect Attacks](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.
 
 When accessing this route using Javascript from the browser, success and failure parameter URLs are required. Appwrite server will respond with a 301 redirect status code and will set the user session cookie. This behavior is enforced because modern browsers are limiting 3rd party cookies in XHR of fetch requests to protect user privacy.

--- a/docs/references/auth/logout.md
+++ b/docs/references/auth/logout.md
@@ -1,1 +1,1 @@
-Use this endpoint to log out the currently logged in user from his account. When succeed this endpoint will delete the user session and remove the session secret cookie from the user client.
+Use this endpoint to log out the currently logged in user from his account. When successful this endpoint will delete the user session and remove the session secret cookie from the user client.

--- a/docs/references/auth/recovery-reset.md
+++ b/docs/references/auth/recovery-reset.md
@@ -1,3 +1,3 @@
 Use this endpoint to complete the user account password reset. Both the **userId** and **token** arguments will be passed as query parameters to the redirect URL you have provided when sending your request to the /auth/recovery endpoint.
 
-Please notice that in order to avoid a [Redirect Attacks](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URL's are the once from domains you have set when added your platforms in the console interface.
+Please notice that in order to avoid a [Redirect Attack](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.

--- a/docs/references/auth/register.md
+++ b/docs/references/auth/register.md
@@ -1,7 +1,7 @@
-Use this endpoint to allow a new user to register an account in your project. Use the success and failure URL's to redirect users back to your application after signup completes.
+Use this endpoint to allow a new user to register an account in your project. Use the success and failure URLs to redirect users back to your application after signup completes.
 
 If registration completes successfully user will be sent with a confirmation email in order to confirm he is the owner of the account email address. Use the confirmation parameter to redirect the user from the confirmation email back to your app. When the user is redirected, use the /auth/confirm endpoint to complete the account confirmation.
 
-Please notice that in order to avoid a [Redirect Attacks](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URL's are the once from domains you have set when added your platforms in the console interface.
+Please notice that in order to avoid a [Redirect Attack](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.
 
 When accessing this route using Javascript from the browser, success and failure parameter URLs are required. Appwrite server will respond with a 301 redirect status code and will set the user session cookie. This behavior is enforced because modern browsers are limiting 3rd party cookies in XHR of fetch requests to protect user privacy.

--- a/docs/references/avatars/get-browser.md
+++ b/docs/references/avatars/get-browser.md
@@ -1,1 +1,1 @@
-You can use this endpoint to show different browser icons to your users, The code argument receives the browser code as appear in your user /account/sessions endpoint. Use width, height and quality arguments to change the output settings.
+You can use this endpoint to show different browser icons to your users. The code argument receives the browser code as it appears in your user /account/sessions endpoint. Use width, height and quality arguments to change the output settings.

--- a/docs/references/avatars/get-credit-card.md
+++ b/docs/references/avatars/get-credit-card.md
@@ -1,1 +1,1 @@
-Need to display your users with your billing method or there payment methods? The credit card endpoint will return you the icon of the credit card provider you need. Use width, height and quality arguments to change the output settings.
+Need to display your users with your billing method or their payment methods? The credit card endpoint will return you the icon of the credit card provider you need. Use width, height and quality arguments to change the output settings.

--- a/docs/references/avatars/get-flag.md
+++ b/docs/references/avatars/get-flag.md
@@ -1,1 +1,1 @@
-You can use this endpoint to show different country flags icons to your users, The code argument receives the a 2 letter country code. Use width, height and quality arguments to change the output settings.
+You can use this endpoint to show different country flags icons to your users. The code argument receives the 2 letter country code. Use width, height and quality arguments to change the output settings.

--- a/docs/references/avatars/get-image.md
+++ b/docs/references/avatars/get-image.md
@@ -1,1 +1,1 @@
-Use this endpoint to fetch a remote image URL and crop it to any image size you want. This endpoint is very useful if you need to crop and display remote images in your app or in cases, you want to make sure a 3rd party image is properly served using a TLS protocol.
+Use this endpoint to fetch a remote image URL and crop it to any image size you want. This endpoint is very useful if you need to crop and display remote images in your app or in case you want to make sure a 3rd party image is properly served using a TLS protocol.


### PR DESCRIPTION
Fixed multiple errors on reference documentation:

1. `references/auth`: Fixed typos on documentation on following:
- `once` -> `ones`
- Changed `Redirect Attacks` to `Redirect Attack`
- `URL's` -> `URLs` to be consistent with rest of documentation
- `added` -> `adding`. May need to be changed depending on context (i.e. `added` -> `you added`)

2. `references/auth/confirm-resend.md`: 
- Changed `acts` to `act` (might need to change `arguments` to `argument` instead)

3. `references/avatar`: Typo and grammar errors on:
- `appear` -> `it appears`
- `there` -> `their`
- `cases` -> `case`
- Replaced some inappropriate commas with periods
- Removed `a` in front of `2 letter country code`