### PR TITLE
Fix for typos in es translations

### DIFF
--- a/app/config/locale/es.continents.php
+++ b/app/config/locale/es.continents.php
@@ -2,7 +2,7 @@
 
 return [
     'AF' => 'África',
-    'AN' => 'Antártica',
+    'AN' => 'Antártida',
     'AS' => 'Asia',
     'EU' => 'Europa',
     'NA' => 'América del Norte',


### PR DESCRIPTION
Update on es.continents.php. 'AN' with 'Antártida'(Related to  #25). It's the most used form.
The previous translation was 'Antártica' which is used in Chile. Sorry, but when I read it, I thought that it was a wrong translation, here in Argentina it's not used. I checked it, It's valid but it's not very common to use it in Latin America and it's not used in Spain. Only in Chile.

Refer: http://lema.rae.es/dpd/?key=Ant%C3%A1rtida
