### PR TITLE
Changed OAuth paths and some route titles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 
 ## Breaking Changes
 
-* OAuth path is now /auth/login/oauth instead of /auth/oauth, this is for better consistency with new login methods we will introduce in the future
+* OAuth path is now /auth/login/oauth instead of /auth/oauth and /auth/oauth/callback is now /auth/login/oauth/callback, this is for better consistency with new login methods we will introduce in the future
 
 # Version 0.3.0
 

--- a/app/controllers/auth.php
+++ b/app/controllers/auth.php
@@ -19,7 +19,7 @@ use Template\Template;
 use OpenSSL\OpenSSL;
 
 $utopia->post('/v1/auth/register')
-    ->desc('Register User')
+    ->desc('Register')
     ->label('webhook', 'auth.register')
     ->label('scope', 'auth')
     ->label('sdk.namespace', 'auth')
@@ -185,7 +185,7 @@ $utopia->post('/v1/auth/register')
     );
 
 $utopia->post('/v1/auth/register/confirm')
-    ->desc('Confirm User')
+    ->desc('Confirmation')
     ->label('webhook', 'auth.confirm')
     ->label('scope', 'public')
     ->label('sdk.namespace', 'auth')
@@ -299,7 +299,7 @@ $utopia->post('/v1/auth/register/confirm/resend')
     );
 
 $utopia->post('/v1/auth/login')
-    ->desc('Login User')
+    ->desc('Login')
     ->label('webhook', 'auth.login')
     ->label('scope', 'auth')
     ->label('sdk.namespace', 'auth')
@@ -590,8 +590,8 @@ $utopia->put('/v1/auth/recovery/reset')
         }
     );
 
-$utopia->get('/v1/auth/oauth/:provider')
-    ->desc('OAuth Login')
+$utopia->get('/v1/auth/login/oauth/:provider')
+    ->desc('Login with OAuth')
     ->label('error', __DIR__.'/../views/general/error.phtml')
     ->label('scope', 'auth')
     ->label('sdk.namespace', 'auth')
@@ -605,7 +605,7 @@ $utopia->get('/v1/auth/oauth/:provider')
     ->param('failure', '', function () use ($clients) { return new Host($clients); }, 'URL to redirect back to your app after a failed login attempt.')
     ->action(
         function ($provider, $success, $failure) use ($response, $request, $project) {
-            $callback = $request->getServer('REQUEST_SCHEME', 'https').'://'.$request->getServer('HTTP_HOST').'/v1/auth/oauth/callback/'.$provider.'/'.$project->getUid();
+            $callback = $request->getServer('REQUEST_SCHEME', 'https').'://'.$request->getServer('HTTP_HOST').'/v1/auth/login/oauth/callback/'.$provider.'/'.$project->getUid();
             $appId = $project->getAttribute('usersOauth'.ucfirst($provider).'Appid', '');
             $appSecret = $project->getAttribute('usersOauth'.ucfirst($provider).'Secret', '{}');
 
@@ -632,7 +632,7 @@ $utopia->get('/v1/auth/oauth/:provider')
         }
     );
 
-$utopia->get('/v1/auth/oauth/callback/:provider/:projectId')
+$utopia->get('/v1/auth/login/oauth/callback/:provider/:projectId')
     ->desc('OAuth Callback')
     ->label('error', __DIR__.'/../views/general/error.phtml')
     ->label('scope', 'auth')
@@ -645,12 +645,12 @@ $utopia->get('/v1/auth/oauth/callback/:provider/:projectId')
     ->param('state', '', function () { return new Text(2048); }, 'Login state params', true)
     ->action(
         function ($projectId, $provider, $code, $state) use ($response, $request, $domain) {
-            $response->redirect($request->getServer('REQUEST_SCHEME', 'https').'://'.$domain.'/v1/auth/oauth/'.$provider.'/redirect?'
+            $response->redirect($request->getServer('REQUEST_SCHEME', 'https').'://'.$domain.'/v1/auth/login/oauth/'.$provider.'/redirect?'
                 .http_build_query(['project' => $projectId, 'code' => $code, 'state' => $state]));
         }
     );
 
-$utopia->get('/v1/auth/oauth/:provider/redirect')
+$utopia->get('/v1/auth/login/oauth/:provider/redirect')
     ->desc('OAuth Redirect')
     ->label('error', __DIR__.'/../views/general/error.phtml')
     ->label('webhook', 'auth.oauth')
@@ -663,7 +663,7 @@ $utopia->get('/v1/auth/oauth/:provider/redirect')
     ->param('state', '', function () { return new Text(2048); }, 'OAuth state params', true)
     ->action(
         function ($provider, $code, $state) use ($response, $request, $user, $projectDB, $project, $audit) {
-            $callback = $request->getServer('REQUEST_SCHEME', 'https').'://'.$request->getServer('HTTP_HOST').'/v1/auth/oauth/callback/'.$provider.'/'.$project->getUid();
+            $callback = $request->getServer('REQUEST_SCHEME', 'https').'://'.$request->getServer('HTTP_HOST').'/v1/auth/login/oauth/callback/'.$provider.'/'.$project->getUid();
             $defaultState = ['success' => $project->getAttribute('url', ''), 'failure' => ''];
             $validateURL = new URL();
 

--- a/app/views/console/users/index.phtml
+++ b/app/views/console/users/index.phtml
@@ -352,7 +352,7 @@ $providers = $this->getParam('providers', []);
                                             <p>To complete set up, add this OAuth redirect URI to your <?php echo ucfirst($provider); ?> app configuration.</p>
 
                                             <div class="input-copy">
-                                                <input data-forms-copy type="text" disabled data-ls-bind="{{env.PROTOCOL}}://{{env.DOMAIN}}/v1/auth/oauth/callback/<?php echo $provider; ?>/{{router.params.project}}" class="margin-bottom-no" />
+                                                <input data-forms-copy type="text" disabled data-ls-bind="{{env.PROTOCOL}}://{{env.DOMAIN}}/v1/auth/login/oauth/callback/<?php echo $provider; ?>/{{router.params.project}}" class="margin-bottom-no" />
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Updated the path of our OAuth login route to allow better API predictability when we introduce new login methods in the future.

New login method mights include:

/auth/login/sms
/auth/login/passwordless || /auth/login/email || /auth/login/otp
/auth/login/qrcode

etc...