### PR TITLE
Replaced $(...) instead of legacy backticked `...`

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,7 +20,7 @@ function setEnvironmentVariable() {
 }
 
 # Grep for variables that look like MySQL (APP_)
-for _curVar in `env | grep _APP_ | awk -F = '{print $1}'`;do
+for _curVar in $(env | grep _APP_ | awk -F = '{print $1}');do
     # awk has split them by the equals sign
     # Pass the name and value to our function
     setEnvironmentVariable ${_curVar} ${!_curVar}


### PR DESCRIPTION
Backtick command substitution `...` is legacy syntax with several
issues.

1. It has a series of undefined behaviors related to quoting in POSIX.
2. It imposes a custom escaping mode with surprising results.
3. It's exceptionally hard to nest.

$(...) command substitution has none of these problems, and is therefore
strongly encouraged.