### PR TITLE
Added Licence badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Build Status](https://travis-ci.org/appwrite/appwrite.svg?branch=master)](https://travis-ci.org/appwrite/appwrite)
 [![Follow  Appwrite on StackShare](https://img.stackshare.io/misc/follow-on-stackshare-badge.svg)](https://stackshare.io/appwrite)
 [![Follow new releases](https://app.releasly.co/assets/badges/badge-blue.svg)](https://app.releasly.co/sites/appwrite/appwrite?utm_source=github_badge)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
 
 ---
 


### PR DESCRIPTION
It's important for the licence badge to be on README.markdown as it improves the visibility of the documentation. 