### PR TITLE
add container_name to all of the compose containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   traefik:
     image: traefik:v2.1.4
+    container_name: appwrite_traefik
     command:
       - --log.level=DEBUG
       - --api.insecure=true
@@ -86,6 +87,7 @@ services:
 
   mariadb:
     image: appwrite/mariadb:1.0.3 # fix issues when upgrading using: mysql_upgrade -u root -p
+    container_name: appwrite_mariadb
     restart: unless-stopped
     networks:
       - appwrite
@@ -102,6 +104,7 @@ services:
 
   maildev:
     image: djfarrelly/maildev
+    container_name: appwrite_maildev
     restart: unless-stopped
     ports:
       - '1080:80'
@@ -110,6 +113,7 @@ services:
 
   # smtp:
   #   image: appwrite/smtp:1.0.1
+  #   container_name: appwrite_smtp
   #   restart: unless-stopped
   #   networks:
   #     - appwrite
@@ -119,6 +123,7 @@ services:
 
   redis:
     image: redis:5.0
+    container_name: appwrite_redis
     restart: unless-stopped
     networks:
       - appwrite
@@ -127,6 +132,7 @@ services:
 
   clamav:
     image: appwrite/clamav:1.0.9
+    container_name: appwrite_clamav
     restart: unless-stopped
     networks:
       - appwrite
@@ -135,6 +141,7 @@ services:
 
   influxdb:
     image: influxdb:1.6
+    container_name: appwrite_influxdb
     restart: unless-stopped
     networks:
       - appwrite
@@ -143,6 +150,7 @@ services:
 
   telegraf:
     image: appwrite/telegraf:1.0.0
+    container_name: appwrite_telegraf
     restart: unless-stopped
     networks:
       - appwrite
@@ -172,6 +180,7 @@ services:
 
   chronograf:
     image: chronograf:1.5
+    container_name: appwrite_chronograf
     restart: unless-stopped
     networks:
     - appwrite


### PR DESCRIPTION
All of the containers the compose file creates should be named the same regardless of where the docker-compose file is ran from. 

i.e running this currently from a folder called appwrite defines the container name for redis as;
```
appwrite_redis_1 
```
This change will now make the redis container name;


I can see the main appwrite container already has this but the rest do not. 
```
appwrite_redis
```