### PR TITLE
doc-577-corrected-links-in-"add-oauth2-provider.md"-file

### DIFF
--- a/docs/tutorials/add-oauth2-provider.md
+++ b/docs/tutorials/add-oauth2-provider.md
@@ -1,6 +1,6 @@
 # Adding a New OAuth2 Provider
 
-This document is part of the Appwrite contributors' guide. Before you continue reading this document make sure you have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and the [Contributing Guide](../CONTRIBUTING.md).
+This document is part of the Appwrite contributors' guide. Before you continue reading this document make sure you have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guide](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md).
 
 ## Getting Started
 


### PR DESCRIPTION
I have corrected the links for Code of Conduct and Contribuiting Guide mentioned in "add-oauth2-provider.md". These links are now pointing to the right pages.