### PR TITLE
Feat update base images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
   - Removed user roles attribute from user object (can be fetched from /v1/teams/memberships) **
   - Removed type attribute from session object response (used only internally)
   - ** - might be changed before merging to master
+- Upgraded Traefik image to version 2.3
+- Upgraded Redis Docker image to version 6.0 (alpine)
+- Upgraded Influxdb Docker image to version 1.8 (alpine)
 
 ## Breaking Changes (Read before upgrading!)
 - **Deprecated** `first` and `last` query params for documents list route in the database API

--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -7,7 +7,7 @@ $version = $this->getParam('version', '');
 
 services:
   traefik:
-    image: traefik:2.2
+    image: traefik:2.3
     container_name: appwrite-traefik
     command:
       - --providers.file.directory=/storage/config

--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -286,7 +286,7 @@ services:
         - RELAY_NETWORKS=:192.168.0.0/24:10.0.0.0/16
 
   redis:
-    image: redis:5.0
+    image: redis:6.0-alpine3.12
     container_name: appwrite-redis
     restart: unless-stopped
     networks:
@@ -304,7 +304,7 @@ services:
       - appwrite-uploads:/storage/uploads
 
   influxdb:
-    image: influxdb:1.6
+    image: influxdb:1.8-alpine
     container_name: appwrite-influxdb
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -320,9 +320,9 @@ services:
   #     - RELAY_FROM_HOSTS=192.168.0.0/16 ; *.yourdomain.com
   #     - SMARTHOST_HOST=smtp
   #     - SMARTHOST_PORT=587
-
+  
   redis:
-    image: redis:5.0
+    image: redis:6.0-alpine3.12
     container_name: appwrite-redis
     restart: unless-stopped
     networks:
@@ -338,9 +338,9 @@ services:
       - appwrite
     volumes:
       - appwrite-uploads:/storage/uploads
-
+      
   influxdb:
-    image: influxdb:1.6
+    image: influxdb:1.8-alpine
     container_name: appwrite-influxdb
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   traefik:
-    image: traefik:2.2
+    image: traefik:2.3
     container_name: appwrite-traefik
     command:
       - --log.level=DEBUG
@@ -322,7 +322,7 @@ services:
   #     - SMARTHOST_PORT=587
   
   redis:
-    image: redis:6.0-alpine3.12
+    image: redis:6.0-alpine
     container_name: appwrite-redis
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Updated all origin images version and now we are using alpine as the base images for all of them (redis, traefik, and influxdb).