### PR TITLE
Feat 516 Add code hot-reload functionality for docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ docker-compose up -d
 
 After finishing the installation process, you can start writing and editing code. To compile new CSS and JS distribution files, use 'less' and 'build' tasks using gulp as a task manager.
 
+Note that code hot-reloading is supported. Therefore instead of `docker-compose up -d`, you may run the following:
+
+```bash
+docker-compose -f docker-compose.yml -f docker-compose-reload.yml up
+``` 
+
 ## Architecture
 
 Appwrite's current structure is a combination of both [Monolithic](https://en.wikipedia.org/wiki/Monolithic_application) and [Microservice](https://en.wikipedia.org/wiki/Microservices) architectures, but our final goal, as we grow, is to be using only microservices.

--- a/docker-compose-reload.yml
+++ b/docker-compose-reload.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+
+  appwrite:
+    container_name: appwrite
+
+  live-reloader:
+    image: apogiatzis/livereloading
+    container_name: livereloader
+    privileged: true
+      environment:
+        - RELOAD_CONTAINER=appwrite
+        - RELOAD_DELAY=20              # seconds
+        - RESTART_TIMEOUT=10         # seconds
+        - RELOAD_DIR=/usr/share/nginx/html/public
+      volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
+


### PR DESCRIPTION
## What does this PR do?

Adds code hot-reload functionality.

Took advantage of [docker-compose-livereloader](https://github.com/apogiatzis/docker-compose-livereloader) project where it allows live reloading of code for efficient development.

In order to make it work the following command should be run:

```bash
docker-compose -f docker-compose.yml -f docker-compose-reload.yml up
```

## Test Plan

I have only added the public directory to be reloaded every time there is a change. I tested it and it works fine. This is a work in progress and you should advice which other directory I should add for hot reloading (i guess `/app` is a good candidate).

The reload delay is currently set to 20 seconds but it is configurable.

## Related PRs and Issues

#516 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
