### PR TITLE
Update eu.php

### DIFF
--- a/app/config/locale/eu.php
+++ b/app/config/locale/eu.php
@@ -30,8 +30,4 @@ $list = [
     'SE', // Sweden
 ];
 
-if (\time() < \strtotime('2020-01-31')) { // @see https://en.wikipedia.org/wiki/Brexit
-    $list[] = 'GB'; // // United Kingdom
-}
-
 return $list;


### PR DESCRIPTION
since time() cannot be less than 2020-01-31, 'GB' is not required

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

removing unnecessary lines

## Test Plan

compatible with previous tests

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
