### PR TITLE
Feat remove default order field where possible

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -110,9 +110,6 @@ App::get('/v1/database/collections')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'name',
-            'orderType' => $orderType,
-            'orderCast' => 'string',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_COLLECTIONS,
@@ -400,7 +397,7 @@ App::get('/v1/database/collections/:collectionId/documents')
     ->param('filters', [], new ArrayList(new Text(128)), 'Array of filter strings. Each filter is constructed from a key name, comparison operator (=, !=, >, <, <=, >=) and a value. You can also use a dot (.) separator in attribute names to filter by child document attributes. Examples: \'name=John Doe\' or \'category.$id>=5bed2d152c362\'.', true)
     ->param('limit', 25, new Range(0, 100), 'Maximum number of documents to return in response.  Use this value to manage pagination. By default will return maximum 25 results. Maximum of 100 results allowed per request.', true)
     ->param('offset', 0, new Range(0, 900000000), 'Offset value. The default value is 0. Use this param to manage pagination.', true)
-    ->param('orderField', '$id', new Text(128), 'Document field that results will be sorted by.', true)
+    ->param('orderField', '', new Text(128), 'Document field that results will be sorted by.', true)
     ->param('orderType', 'ASC', new WhiteList(['DESC', 'ASC'], true), 'Order direction. Possible values are DESC for descending order, or ASC for ascending order.', true)
     ->param('orderCast', 'string', new WhiteList(['int', 'string', 'date', 'time', 'datetime'], true), 'Order field type casting. Possible values are int, string, date, time or datetime. The database will attempt to cast the order field to the value you pass here. The default value is a string.', true)
     ->param('search', '', new Text(256), 'Search query. Enter any free text search. The database will try to find a match against all document attributes and children. Max length: 256 chars.', true)

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -88,9 +88,6 @@ App::get('/v1/functions')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'dateCreated',
-            'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_FUNCTIONS,
@@ -483,9 +480,6 @@ App::get('/v1/functions/:functionId/tags')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'dateCreated',
-            'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_TAGS,
@@ -681,9 +675,6 @@ App::get('/v1/functions/:functionId/executions')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'dateCreated',
-            'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_EXECUTIONS,

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -115,7 +115,6 @@ App::get('/v1/projects')
             ],
         ]);
 
-        var_dump($consoleDB->getDebug());
         $response->dynamic(new Document([
             'sum' => $consoleDB->getSum(),
             'projects' => $results

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -109,15 +109,13 @@ App::get('/v1/projects')
         $results = $consoleDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'registration',
-            'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_PROJECTS,
             ],
         ]);
 
+        var_dump($consoleDB->getDebug());
         $response->dynamic(new Document([
             'sum' => $consoleDB->getSum(),
             'projects' => $results

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -178,9 +178,7 @@ App::get('/v1/storage/files')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'dateCreated',
             'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_FILES,

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -115,9 +115,7 @@ App::get('/v1/teams')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'dateCreated',
             'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_TEAMS,
@@ -464,9 +462,7 @@ App::get('/v1/teams/:teamId/memberships')
         $memberships = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'joined',
             'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_MEMBERSHIPS,

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -97,9 +97,7 @@ App::get('/v1/users')
         $results = $projectDB->getCollection([
             'limit' => $limit,
             'offset' => $offset,
-            'orderField' => 'registration',
             'orderType' => $orderType,
-            'orderCast' => 'int',
             'search' => $search,
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_USERS,

--- a/app/tasks/migrate.php
+++ b/app/tasks/migrate.php
@@ -30,9 +30,7 @@ $callbacks = [
             $all = $projectDB->getCollection([
                 'limit' => $limit,
                 'offset' => $offset,
-                'orderField' => '$uid',
                 'orderType' => 'DESC',
-                'orderCast' => 'string',
             ]);
 
             $sum = \count($all);
@@ -215,9 +213,6 @@ $cli
             $projects = $consoleDB->getCollection([
                 'limit' => $limit,
                 'offset' => $offset,
-                'orderField' => 'name',
-                'orderType' => 'ASC',
-                'orderCast' => 'string',
                 'filters' => [
                     '$collection='.Database::SYSTEM_COLLECTION_PROJECTS,
                 ],

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -88,9 +88,6 @@ class CertificatesV1
         $certificate = $consoleDB->getCollectionFirst([
             'limit' => 1,
             'offset' => 0,
-            'orderField' => 'id',
-            'orderType' => 'ASC',
-            'orderCast' => 'string',
             'filters' => [
                 '$collection='.Database::SYSTEM_COLLECTION_CERTIFICATES,
                 'domain='.$domain->get(),

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -160,9 +160,6 @@ class DeletesV1
             $results = $database->getCollection([
                 'limit' => $limit,
                 'offset' => 0,
-                'orderField' => '$id',
-                'orderType' => 'ASC',
-                'orderCast' => 'string',
                 'filters' => $filters,
             ]);
 

--- a/src/Appwrite/Database/Adapter/MySQL.php
+++ b/src/Appwrite/Database/Adapter/MySQL.php
@@ -501,7 +501,7 @@ class MySQL extends Adapter
         ];
         $orderTypeMap = ['DESC', 'ASC'];
 
-        $options['orderField'] = (empty($options['orderField'])) ? '$id' : $options['orderField']; // Set default order field
+        $options['orderField'] = (empty($options['orderField'])) ? '' : $options['orderField']; // Set default order field
         $options['orderCast'] = (empty($options['orderCast'])) ? 'string' : $options['orderCast']; // Set default order field
 
         if (!\array_key_exists($options['orderCast'], $orderCastMap)) {
@@ -567,34 +567,39 @@ class MySQL extends Adapter
         }
 
         // Sorting
-        $orderPath = \explode('.', $options['orderField']);
-        $len = \count($orderPath);
-        $orderKey = 'order_b';
-        $part = $this->getPDO()->quote(\implode('', $orderPath), PDO::PARAM_STR);
-        $orderSelect = "CASE WHEN {$orderKey}.key = {$part} THEN CAST({$orderKey}.value AS {$orderCastMap[$options['orderCast']]}) END AS sort_ff";
-
-        if (1 === $len) {
-            //if($path == "''") { // Handle direct attributes queries
-            $sorts[] = 'LEFT JOIN `'.$this->getNamespace().".database.properties` order_b ON a.uid IS NOT NULL AND order_b.documentUid = a.uid AND (order_b.key = {$part})";
-        } else { // Handle direct child attributes queries
-            $prev = 'c';
-            $orderKey = 'order_e';
-
-            foreach ($orderPath as $y => $part) {
-                $part = $this->getPDO()->quote($part, PDO::PARAM_STR);
-                $x = $y - 1;
-
-                if (0 === $y) { // First key
-                    $sorts[] = 'JOIN `'.$this->getNamespace().".database.relationships` order_c{$y} ON a.uid IS NOT NULL AND order_c{$y}.start = a.uid AND order_c{$y}.key = {$part}";
-                } elseif ($y == $len - 1) { // Last key
-                    $sorts[] .= 'JOIN `'.$this->getNamespace().".database.properties` order_e ON order_e.documentUid = order_{$prev}{$x}.end AND order_e.key = {$part}";
-                } else {
-                    $sorts[] .= 'JOIN `'.$this->getNamespace().".database.relationships` order_d{$y} ON order_d{$y}.start = order_{$prev}{$x}.end AND order_d{$y}.key = {$part}";
-                    $prev = 'd';
+        if(!empty($options['orderField'])) {
+            $orderPath = \explode('.', $options['orderField']);
+            $len = \count($orderPath);
+            $orderKey = 'order_b';
+            $part = $this->getPDO()->quote(\implode('', $orderPath), PDO::PARAM_STR);
+            $orderSelect = "CASE WHEN {$orderKey}.key = {$part} THEN CAST({$orderKey}.value AS {$orderCastMap[$options['orderCast']]}) END AS sort_ff";
+    
+            if (1 === $len) {
+                //if($path == "''") { // Handle direct attributes queries
+                $sorts[] = 'LEFT JOIN `'.$this->getNamespace().".database.properties` order_b ON a.uid IS NOT NULL AND order_b.documentUid = a.uid AND (order_b.key = {$part})";
+            } else { // Handle direct child attributes queries
+                $prev = 'c';
+                $orderKey = 'order_e';
+    
+                foreach ($orderPath as $y => $part) {
+                    $part = $this->getPDO()->quote($part, PDO::PARAM_STR);
+                    $x = $y - 1;
+    
+                    if (0 === $y) { // First key
+                        $sorts[] = 'JOIN `'.$this->getNamespace().".database.relationships` order_c{$y} ON a.uid IS NOT NULL AND order_c{$y}.start = a.uid AND order_c{$y}.key = {$part}";
+                    } elseif ($y == $len - 1) { // Last key
+                        $sorts[] .= 'JOIN `'.$this->getNamespace().".database.properties` order_e ON order_e.documentUid = order_{$prev}{$x}.end AND order_e.key = {$part}";
+                    } else {
+                        $sorts[] .= 'JOIN `'.$this->getNamespace().".database.relationships` order_d{$y} ON order_d{$y}.start = order_{$prev}{$x}.end AND order_d{$y}.key = {$part}";
+                        $prev = 'd';
+                    }
                 }
-            }
+            }    
         }
-
+        else {
+            $orderSelect = 'a.uid AS sort_ff';
+        }
+        
         /*
          * Workaround for a MySQL bug as reported here:
          * https://bugs.mysql.com/bug.php?id=78485

--- a/src/Appwrite/Database/Database.php
+++ b/src/Appwrite/Database/Database.php
@@ -149,7 +149,7 @@ class Database
             'limit' => 15,
             'search' => '',
             'relations' => true,
-            'orderField' => '$id',
+            'orderField' => '',
             'orderType' => 'ASC',
             'orderCast' => 'int',
             'filters' => [],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Optimized system queries by using the internal Appwrite numeric ID as sort field instead of using an extra join/s for custom field. This change was only applied to queries where the sort was done by according to creation date which can be replaced by our incremental numeric ID (the internal ID, not the public UID that looks like: "5e63e0a61d9c2").

## Test Plan

Leveraging current test plan.

## Related PRs and Issues

None.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
