### PR TITLE
Feat switch standard ports to 95xx prefix 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,10 @@ Each container in Appwrite is a microservice on its own. Each service is an inde
 
 Currently, all of the Appwrite microservices are intended to communicate using the TCP protocol over a private network. You should be aware to not expose any of the services to the public-facing network, besides the public port 80 and 443, who, by default, are used to expose the Appwrite HTTP API.
 
+## Ports
+
+Appwrite dev version uses ports 80 and 443 as an entry point to the Appwrite API and console. We also expose multiple ports in the range of 9500-9504 for debugging some of the Appwrite containers on dev mode. If you have any conflicts with the ports running on your system, you can easily replace them by editing Appwrite's docker-compose.yml file and executing `docker-compose up -d` command.
+
 ## Technology Stack
 
 To start helping us to improve the Appwrite server by submitting code, prior knowledge of Appwrite's technology stack can help you with getting started.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,7 +311,7 @@ services:
     volumes:
       - appwrite-mariadb:/var/lib/mysql:rw
     ports:
-      - "3306:3306"
+      - "9502:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=password
       - MYSQL_DATABASE=${_APP_DB_SCHEMA}
@@ -371,7 +371,7 @@ services:
     container_name: appwrite-maildev
     restart: unless-stopped
     ports:
-      - '1080:80'
+      - '9503:80'
     networks:
       - appwrite
 
@@ -380,7 +380,7 @@ services:
     container_name: appwrite-request-catcher
     restart: unless-stopped
     ports:
-      - '5000:5000'
+      - '9504:5000'
     networks:
       - appwrite
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Replaces standard ports like 8080, 3306 1080 and other with ports in the range of 9500-9504. This is done to minimize conflict with occasional contributors that might have this standard ports already taken by other apps or containers.

## Test Plan

Using existing tests.

## Related PRs and Issues

None.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
