### PR TITLE
Minor fixes for composer warnings about autoloading

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -16,8 +16,7 @@ use Appwrite\Database\Validator\Authorization;
 use Appwrite\Network\Validator\Origin;
 use Appwrite\Storage\Device\Local;
 use Appwrite\Storage\Storage;
-use Appwrite\Utopia\Response\Filter;
-use Appwrite\Utopia\Response\Filter\V06;
+use Appwrite\Utopia\Response\Filters\V06;
 use Utopia\CLI\Console;
 
 Config::setParam('domainVerification', false);

--- a/src/Appwrite/Utopia/Response.php
+++ b/src/Appwrite/Utopia/Response.php
@@ -7,7 +7,6 @@ use Utopia\Swoole\Response as SwooleResponse;
 use Swoole\Http\Response as SwooleHTTPResponse;
 use Appwrite\Database\Document;
 use Appwrite\Utopia\Response\Filter;
-use Appwrite\Utopia\Response\Filter\V06;
 use Appwrite\Utopia\Response\Model;
 use Appwrite\Utopia\Response\Model\None;
 use Appwrite\Utopia\Response\Model\Any;

--- a/src/Appwrite/Utopia/Response/Filters/V06.php
+++ b/src/Appwrite/Utopia/Response/Filters/V06.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appwrite\Utopia\Response\Filter;
+namespace Appwrite\Utopia\Response\Filters;
 
 use Appwrite\Auth\Auth;
 use Appwrite\Database\Database;

--- a/tests/unit/Utopia/Filters/V06Test.php
+++ b/tests/unit/Utopia/Filters/V06Test.php
@@ -7,7 +7,7 @@ use Appwrite\Database\Database;
 use Appwrite\Database\Validator\Authorization;
 use Appwrite\OpenSSL\OpenSSL;
 use Appwrite\Utopia\Response;
-use Appwrite\Utopia\Response\Filter\V06;
+use Appwrite\Utopia\Response\Filters\V06;
 use PHPUnit\Framework\TestCase;
 use Utopia\Config\Config;
 

--- a/tests/unit/Utopia/ResponseTest.php
+++ b/tests/unit/Utopia/ResponseTest.php
@@ -3,7 +3,7 @@
 namespace Appwrite\Tests;
 
 use Appwrite\Utopia\Response;
-use Appwrite\Utopia\Response\Filter\V06;
+use Appwrite\Utopia\Response\Filters\V06;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Response as SwooleResponse;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix for autoloading warning thrown by composer:
```
Class Appwrite\Utopia\Response\Filter\V06 located in ./vendor/appwrite/server-ce/src/Appwrite/Utopia/Response/Filters/V06.php does not comply with psr-4 autoloading standard. Skipping.
```

## Test Plan

N/A

## Related PRs and Issues

#772 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
