### PR TITLE
Fix migration comparison bug

### DIFF
--- a/src/Appwrite/Migration/Migration.php
+++ b/src/Appwrite/Migration/Migration.php
@@ -90,7 +90,8 @@ abstract class Migration
                         if (empty($new->getId())) {
                             throw new Exception('Missing ID');
                         }
-                        if (!array_diff($new->getArrayCopy(), $old)) {
+                        
+                        if (!array_diff_assoc($new->getArrayCopy(), $old)) {
                             return;
                         }
 

--- a/src/Appwrite/Migration/Version/V06.php
+++ b/src/Appwrite/Migration/Version/V06.php
@@ -26,7 +26,7 @@ class V06 extends Migration
     {
         switch ($document->getAttribute('$collection')) {
             case Database::SYSTEM_COLLECTION_USERS:
-                if ($document->getAttribute('password-update', null)) {
+                if ($document->isSet('password-update')) {
                     $document
                         ->setAttribute('passwordUpdate', $document->getAttribute('password-update', $document->getAttribute('passwordUpdate', '')))
                         ->removeAttribute('password-update');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix for comparison bug not detecting changes in object keys thinking both are the same. This was specifically detected on the `passwordUpdate` migration. The value stayed the same and only its key was changed. The final object structure was correct, but the save never happened because the comparison was only looking for changes in values, while ignoring keys. 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
