### PR TITLE
Disabling functions cpus and memory limit when environment is empty

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -339,15 +339,15 @@ return [
             ],
             [
                 'name' => '_APP_FUNCTIONS_CPUS',
-                'description' => 'The maximum number of CPU core a single cloud function is allowed to use. Please note that setting a value higher than available cores will result in a function error, which might result in an error. The default value is 1.',
+                'description' => 'The maximum number of CPU core a single cloud function is allowed to use. Please note that setting a value higher than available cores will result in a function error, which might result in an error. The default value is empty. When it\'s empty, CPU limit will be disabled.',
                 'introduction' => '0.7.0',
-                'default' => '1',
+                'default' => '',
                 'required' => false,
                 'question' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY',
-                'description' => 'The maximum amount of memory a single cloud function is allowed to use in megabytes. The default value is 128.',
+                'description' => 'The maximum amount of memory a single cloud function is allowed to use in megabytes. The default value is  empty. When it\'s empty, memory limit will be disabled.',
                 'introduction' => '0.7.0',
                 'default' => '256',
                 'required' => false,
@@ -355,7 +355,7 @@ return [
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY_SWAP',
-                'description' => 'The maximum amount of swap memory a single cloud function is allowed to use in megabytes. The default value is 128.',
+                'description' => 'The maximum amount of swap memory a single cloud function is allowed to use in megabytes. The default value is  empty. When it\'s empty, swap memory limit will be disabled.',
                 'introduction' => '0.7.0',
                 'default' => '256',
                 'required' => false,

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -397,13 +397,15 @@ class FunctionsV1
     
             $executionStart = \microtime(true);
             $executionTime = \time();
-
+            $cpus = App::getEnv('_APP_FUNCTIONS_CPUS', '');
+            $memory = App::getEnv('_APP_FUNCTIONS_MEMORY', '');
+            $swap = App::getEnv('_APP_FUNCTIONS_MEMORY_SWAP', '');
             $exitCode = Console::execute("docker run ".
                 " -d".
                 " --entrypoint=\"\"".
-                " --cpus=".App::getEnv('_APP_FUNCTIONS_CPUS', '1').
-                " --memory=".App::getEnv('_APP_FUNCTIONS_MEMORY', '256')."m".
-                " --memory-swap=".App::getEnv('_APP_FUNCTIONS_MEMORY_SWAP', '256')."m".
+                (empty($cpus) ? "" : (" --cpus=".$cpus)).
+                (empty($memory) ? "" : (" --memory=".$memory."m")).
+                (empty($swap) ? "" : (" --memory-swap=".$swap."m")).
                 " --name={$container}".
                 " --label appwrite-type=function".
                 " --label appwrite-created={$executionTime}".


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)
Disable the cpus, memory and swap options while running functions environment if corresponding environment variables are empty.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes