### PR TITLE
Avoid errors when response-format header is not available

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -93,7 +93,7 @@ App::init(function ($utopia, $request, $response, $console, $project, $user, $lo
                 Response::setFilter(new V06());
                 break;
             default:
-                throw new Exception('No filter available for response format : '.$responseFormat, 400);
+                Response::setFilter(null);
         }
     } else {
         Response::setFilter(null);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When there is no response filter header in the request, set default filter instead of throwing exception

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
