### PR TITLE
Force security email and better SSL errors

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -105,10 +105,10 @@ return [
             ],
             [
                 'name' => '_APP_SYSTEM_SECURITY_EMAIL_ADDRESS',
-                'description' => 'This is the email address used to issue SSL certificates for custom domains or the user agent in webhooks. The default value is \'security@localhost.test\'.',
+                'description' => 'This is the email address used to issue SSL certificates for custom domains or the user agent in your webhooks payload.',
                 'introduction' => '0.7.0',
-                'default' => 'security@localhost.test',
-                'required' => false,
+                'default' => '',
+                'required' => true,
                 'question' => '',
             ],
             [

--- a/app/init.php
+++ b/app/init.php
@@ -34,7 +34,7 @@ use PDO as PDONative;
 const APP_NAME = 'Appwrite';
 const APP_DOMAIN = 'appwrite.io';
 const APP_EMAIL_TEAM = 'team@localhost.test'; // Default email address
-const APP_EMAIL_SECURITY = 'security@localhost.test'; // Default security email address
+const APP_EMAIL_SECURITY = ''; // Default security email address
 const APP_USERAGENT = APP_NAME.'-Server v%s. Please report abuse at %s';
 const APP_MODE_DEFAULT = 'default';
 const APP_MODE_ADMIN = 'admin';

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -110,14 +110,22 @@ class CertificatesV1
         }
 
         $staging = (App::isProduction()) ? '' : ' --dry-run';
+        $email = App::getEnv('_APP_SYSTEM_SECURITY_EMAIL_ADDRESS');
 
-        $response = \shell_exec("certbot certonly --webroot --noninteractive --agree-tos{$staging}"
-            ." --email ".App::getEnv('_APP_SYSTEM_SECURITY_EMAIL_ADDRESS', 'security@localhost.test')
+        if(empty($email)) {
+            throw new Exception('You must set a valid security email address (_APP_SYSTEM_SECURITY_EMAIL_ADDRESS) to issue an SSL certificate');
+        }
+
+        $stdout = '';
+        $stderr = '';
+
+        $exit = Console::execute("certbot certonly --webroot --noninteractive --agree-tos{$staging}"
+            ." --email ".$email
             ." -w ".APP_STORAGE_CERTIFICATES
-            ." -d {$domain->get()}");
+            ." -d {$domain->get()}", '', $stdout, $stderr);
 
-        if(!$response) {
-            throw new Exception('Failed to issue a certificate');
+        if($stderr || $exit !== 0) {
+            throw new Exception('Failed to issue a certificate with message: '.$stderr);
         }
 
         $path = APP_STORAGE_CERTIFICATES.'/'.$domain->get();
@@ -129,19 +137,19 @@ class CertificatesV1
         }
         
         if(!@\rename('/etc/letsencrypt/live/'.$domain->get().'/cert.pem', APP_STORAGE_CERTIFICATES.'/'.$domain->get().'/cert.pem')) {
-            throw new Exception('Failed to rename certificate cert.pem: '.\json_encode($response));
+            throw new Exception('Failed to rename certificate cert.pem: '.\json_encode($stdout));
         }
 
         if(!@\rename('/etc/letsencrypt/live/'.$domain->get().'/chain.pem', APP_STORAGE_CERTIFICATES.'/'.$domain->get().'/chain.pem')) {
-            throw new Exception('Failed to rename certificate chain.pem: '.\json_encode($response));
+            throw new Exception('Failed to rename certificate chain.pem: '.\json_encode($stdout));
         }
 
         if(!@\rename('/etc/letsencrypt/live/'.$domain->get().'/fullchain.pem', APP_STORAGE_CERTIFICATES.'/'.$domain->get().'/fullchain.pem')) {
-            throw new Exception('Failed to rename certificate fullchain.pem: '.\json_encode($response));
+            throw new Exception('Failed to rename certificate fullchain.pem: '.\json_encode($stdout));
         }
 
         if(!@\rename('/etc/letsencrypt/live/'.$domain->get().'/privkey.pem', APP_STORAGE_CERTIFICATES.'/'.$domain->get().'/privkey.pem')) {
-            throw new Exception('Failed to rename certificate privkey.pem: '.\json_encode($response));
+            throw new Exception('Failed to rename certificate privkey.pem: '.\json_encode($stdout));
         }
 
         $certificate = \array_merge($certificate, [
@@ -154,7 +162,7 @@ class CertificatesV1
             'issueDate' => \time(),
             'renewDate' => $renew,
             'attempts' => 0,
-            'log' => \json_encode($response),
+            'log' => \json_encode($stdout),
         ]);
 
         $certificate = $consoleDB->createDocument($certificate);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- `_APP_SYSTEM_SECURITY_EMAIL_ADDRESS` variable is now required in the setup process
- Change default value for `_APP_SYSTEM_SECURITY_EMAIL_ADDRESS` to an empty string
- Throws an error when `_APP_SYSTEM_SECURITY_EMAIL_ADDRESS` is empty on certs worker
- Print Letsencrypt std error message on the certs worker logs

## Test Plan

Using existing tests.

## Related PRs and Issues

Related to some user issues raised on Discord

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
