### PR TITLE
Updated domnikl/statsd to slickdeals/statsd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Upgraded influxdb/influxdb-php lib to version 1.15.2
 - Upgraded phpmailer/phpmailer lib to version 6.3.0
 - Upgraded adhocore/jwt lib to version 1.1.2
+- Upgraded domnikl/statsd to slickdeals/statsd version 3.0
  
 ## Bug Fixes
 

--- a/composer.json
+++ b/composer.json
@@ -53,11 +53,11 @@
         "resque/php-resque": "1.3.6",
         "matomo/device-detector": "4.1.0",
         "dragonmantank/cron-expression": "3.1.0",
-        "domnikl/statsd": "3.0.2",
         "influxdb/influxdb-php": "1.15.2",
         "phpmailer/phpmailer": "6.3.0",
         "chillerlan/php-qrcode": "4.3.0",
-        "adhocore/jwt": "1.1.2"
+        "adhocore/jwt": "1.1.2",
+        "slickdeals/statsd": "~3.0"
     },
     "require-dev": {
         "appwrite/sdk-generator": "0.5.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f58de92fb64af44d915387895472881",
+    "content-hash": "c89bd786aae720e161185007212f6594",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -296,61 +296,6 @@
                 "source": "https://github.com/colinmollenhour/credis/tree/v1.12.1"
             },
             "time": "2020-11-06T16:09:14+00:00"
-        },
-        {
-            "name": "domnikl/statsd",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/domnikl/statsd-php.git",
-                "reference": "393c6565efbfb23c8296ae3099a62fb6366c6ce3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/domnikl/statsd-php/zipball/393c6565efbfb23c8296ae3099a62fb6366c6ce3",
-                "reference": "393c6565efbfb23c8296ae3099a62fb6366c6ce3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 7.2"
-            },
-            "require-dev": {
-                "flyeralarm/php-code-validator": "^2.2",
-                "phpunit/phpunit": "~8.0",
-                "vimeo/psalm": "^3.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Domnikl\\Statsd\\": "src/",
-                    "Domnikl\\Test\\Statsd\\": "tests/unit"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dominik Liebler",
-                    "email": "liebler.dominik@gmail.com"
-                }
-            ],
-            "description": "a PHP client for statsd",
-            "homepage": "https://domnikl.github.com/statsd-php",
-            "keywords": [
-                "Metrics",
-                "monitoring",
-                "statistics",
-                "statsd",
-                "udp"
-            ],
-            "support": {
-                "issues": "https://github.com/domnikl/statsd-php/issues",
-                "source": "https://github.com/domnikl/statsd-php/tree/master"
-            },
-            "abandoned": true,
-            "time": "2020-01-03T14:24:58+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -1191,6 +1136,59 @@
                 "source": "https://github.com/resque/php-resque/tree/v1.3.6"
             },
             "time": "2020-04-16T16:39:50+00:00"
+        },
+        {
+            "name": "slickdeals/statsd",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Slickdeals/statsd-php.git",
+                "reference": "393c6565efbfb23c8296ae3099a62fb6366c6ce3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Slickdeals/statsd-php/zipball/393c6565efbfb23c8296ae3099a62fb6366c6ce3",
+                "reference": "393c6565efbfb23c8296ae3099a62fb6366c6ce3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7.2"
+            },
+            "require-dev": {
+                "flyeralarm/php-code-validator": "^2.2",
+                "phpunit/phpunit": "~8.0",
+                "vimeo/psalm": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Domnikl\\Statsd\\": "src/",
+                    "Domnikl\\Test\\Statsd\\": "tests/unit"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dominik Liebler",
+                    "email": "liebler.dominik@gmail.com"
+                }
+            ],
+            "description": "a PHP client for statsd",
+            "homepage": "https://domnikl.github.com/statsd-php",
+            "keywords": [
+                "Metrics",
+                "monitoring",
+                "statistics",
+                "statsd",
+                "udp"
+            ],
+            "support": {
+                "source": "https://github.com/Slickdeals/statsd-php/tree/3.0.2"
+            },
+            "time": "2020-01-03T14:24:58+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses an abandoned package warning in composer by following its instructions: 
`Package domnikl/statsd is abandoned, you should avoid using it. Use slickdeals/statsd instead.`

Dependencies don't change, according to `composer.lock`.

## Test Plan

- Hit any logged endpoint
- Verify endpoint activity is reflected in graphs in the console.

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
