### PR TITLE
Added new routes to mock errors

### DIFF
--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -280,6 +280,32 @@ App::get('/v1/mock/tests/general/empty')
         $response->noContent();
     });
 
+App::get('/v1/mock/tests/general/400-error')
+    ->desc('Mock a an 400 failed request')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.platform', [APP_PLATFORM_CLIENT, APP_PLATFORM_SERVER])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'error400')
+    ->label('sdk.description', 'Mock an 400 error')
+    ->label('sdk.mock', true)
+    ->action(function () {
+        throw new Exception('Mock 400 error', 400);
+    });
+
+App::get('/v1/mock/tests/general/500-error')
+    ->desc('Mock a an 500 failed request')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.platform', [APP_PLATFORM_CLIENT, APP_PLATFORM_SERVER])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'error500')
+    ->label('sdk.description', 'Mock an 500 error')
+    ->label('sdk.mock', true)
+    ->action(function () {
+        throw new Exception('Mock 500 error', 500);
+    });
+
 App::get('/v1/mock/tests/general/oauth2')
     ->desc('Mock an OAuth2 login route')
     ->groups(['mock'])


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Added 2 new mock routes for simulating HTTP errors:
https://localhost/v1/mock/tests/general/400-error
https://localhost/v1/mock/tests/general/500-error

I will update the swagger spec file in the SDK generator, so we can use new methods to test our custom exceptions using those routes.

## Test Plan

N/A

## Related PRs and Issues

All new custom exceptions PRs on the SDK-Generator

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
