### PR TITLE
Use uppercase countryCode as index for $countries assoc array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-- Better error logs on appwrite cretificates worker
+- Better error logs on appwrite certificates worker
 - Added option for Redis authentication
 - Force adding a security email on setup
 - SMTP is now disabled by default, no dummy SMTP is included in setup
@@ -28,6 +28,7 @@
 
 - Updated missing storage env vars
 - Fixed a bug, that Response format header was not added in the access-control-allow-header list.
+- Fixed a bug where countryName is unknown on sessions (#933)
 
 ## Security
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -236,9 +236,11 @@ App::post('/v1/account/sessions')
             ->setStatusCode(Response::STATUS_CODE_CREATED)
         ;
 
+        $countries = $locale->getText('countries');
+
         $session
             ->setAttribute('current', true)
-            ->setAttribute('countryName', (isset($countries[$session->getAttribute('countryCode')])) ? $countries[$session->getAttribute('countryCode')] : $locale->getText('locale.country.unknown'))
+            ->setAttribute('countryName', (isset($countries[strtoupper($session->getAttribute('countryCode'))])) ? $countries[strtoupper($session->getAttribute('countryCode'))] : $locale->getText('locale.country.unknown'))
         ;
         
         $response->dynamic($session, Response::MODEL_SESSION);
@@ -679,8 +681,8 @@ App::get('/v1/account/sessions')
                 continue;
             }
 
-            $token->setAttribute('countryName', (isset($countries[$token->getAttribute('contryCode')]))
-                ? $countries[$token->getAttribute('contryCode')]
+            $token->setAttribute('countryName', (isset($countries[strtoupper($token->getAttribute('countryCode'))]))
+                ? $countries[strtoupper($token->getAttribute('countryCode'))]
                 : $locale->getText('locale.country.unknown'));
             $token->setAttribute('current', ($current == $token->getId()) ? true : false);
 

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -205,8 +205,8 @@ App::get('/v1/users/:userId/sessions')
                 continue;
             }
 
-            $token->setAttribute('countryName', (isset($countries[$token->getAttribute('contryCode')]))
-                ? $countries[$token->getAttribute('contryCode')]
+            $token->setAttribute('countryName', (isset($countries[strtoupper($token->getAttribute('contryCode'))]))
+                ? $countries[strtoupper($token->getAttribute('contryCode'))]
                 : $locale->getText('locale.country.unknown'));
             $token->setAttribute('current', false);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Correctly assigns `countryName` from `countryCode`, as the associative array `$countries` expects uppercase country codes.

## Test Plan

- Login to public-facing appwrite server
- Navigate to `/console/account/activity`
- Verify countryName is not `Unknown` in the UI or in the network request to `GET /account/sessions`

## Related PRs and Issues

#933 

## Screenshot

![sessioncountry](https://user-images.githubusercontent.com/9708641/110374987-5a2a5f80-801f-11eb-8bd7-37be8a9f39ac.png)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.