### PR TITLE
Feat execution permission

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # Version 0.8.0 (Not Released Yet)
 
+## Features
+
 - Anonymous login
+
+## Breaking Changes
+
+- Only logged in users can execute functions (for guests, use anonymous login)
+- Only the user who has triggered the execution get access to the relevant execution logs
 
 # Version 0.7.1
 

--- a/app/config/roles.php
+++ b/app/config/roles.php
@@ -60,8 +60,6 @@ return [
             'files.read',
             'locale.read',
             'avatars.read',
-            'execution.read',
-            'execution.write',
         ],
     ],
     Auth::USER_ROLE_MEMBER => [

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -676,10 +676,12 @@ App::post('/v1/functions/:functionId/executions')
     ->inject('response')
     ->inject('project')
     ->inject('projectDB')
-    ->action(function ($functionId, /*$async,*/ $response, $project, $projectDB) {
+    ->inject('user')
+    ->action(function ($functionId, /*$async,*/ $response, $project, $projectDB, $user) {
         /** @var Appwrite\Utopia\Response $response */
         /** @var Appwrite\Database\Document $project */
         /** @var Appwrite\Database\Database $projectDB */
+        /** @var Appwrite\Database\Document $user */
 
         Authorization::disable();
 
@@ -712,7 +714,7 @@ App::post('/v1/functions/:functionId/executions')
         $execution = $projectDB->createDocument([
             '$collection' => Database::SYSTEM_COLLECTION_EXECUTIONS,
             '$permissions' => [
-                'read' => $function->getPermissions()['execute'] ?? [],
+                'read' => (!empty($user->getId())) ? ['user:' . $user->getId()] : [],
                 'write' => [],
             ],
             'dateCreated' => time(),

--- a/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
@@ -113,6 +113,15 @@ class FunctionsCustomClientTest extends Scope
 
         $this->assertEquals(201, $execution['headers']['status-code']);
        
+        $execution = $this->client->call(Client::METHOD_POST, '/functions/'.$function['body']['$id'].'/executions', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'async' => 1,
+        ]);
+
+        $this->assertEquals(401, $execution['headers']['status-code']);
+       
         return [];
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Only logged in users can execute functions (for guests, use anonymous login)
- Only the user who has triggered the execution get access to the relevant execution logs

API Keys, console users, schedules, and event functions still have access to all executions.

## Test Plan

Added a new test.

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
