### PR TITLE
Fix 938 remove dangling exec containers

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -651,6 +651,12 @@ App::delete('/v1/functions/:functionId/tags/:tagId')
             }
         }
 
+        Resque::enqueue('v1-functions', 'FunctionsV1', [
+            'functionId' => $function->getId(),
+            'tagId' => $tag->getId(),
+            'trigger' => 'delete',
+        ]);
+
         $usage
             ->setParam('storage', $tag->getAttribute('size', 0) * -1)
         ;

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -417,6 +417,21 @@ App::delete('/v1/functions/:functionId')
             ->setParam('document', $function->getArrayCopy())
         ;
 
+        $tags = $projectDB->getCollection([
+            'filters' => [
+                '$collection='.Database::SYSTEM_COLLECTION_TAGS,
+                'functionId='.$function->getId(),
+            ],
+        ]);
+
+        foreach($tags as &$tag) {
+            Resque::enqueue('v1-functions', 'FunctionsV1', [
+                'functionId' => $function->getId(),
+                'tagId' => $tag->getId(),
+                'trigger' => 'delete',
+            ]);
+        }
+
         $response->noContent();
     });
 

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -143,6 +143,7 @@ class FunctionsV1
 
         $projectId = $this->args['projectId'] ?? '';
         $functionId = $this->args['functionId'] ?? '';
+        $tagId = $this->args['tagId'] ?? '';
         $executionId = $this->args['executionId'] ?? '';
         $trigger = $this->args['trigger'] ?? '';
         $event = $this->args['event'] ?? '';
@@ -265,6 +266,16 @@ class FunctionsV1
                 }
 
                 $this->execute($trigger, $projectId, $executionId, $database, $function);
+                break;
+
+            case 'delete':
+
+                $container = 'appwrite-function-'.$tagId;
+
+                $stdout = '';
+                $stderr = '';
+                Console::execute("docker container rm --force {$container}", '', $stdout, $stderr, 30);
+
                 break;
             
             default:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds a `delete` trigger to the functions worker to handle cleanup of dangling containers left from DELETE API endpoints. Currently, the containers remain unless they are bumped due to the 10 container cleanup.

## Test Plan

- Create function
- Deploy, activate, and execute a few tags
- Check for containers with `docker ps`
- Delete tag/function
- Check the container has been deleted

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/938

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.