### PR TITLE
fix: save false values in database for filtering

### DIFF
--- a/src/Appwrite/Database/Adapter/MySQL.php
+++ b/src/Appwrite/Database/Adapter/MySQL.php
@@ -283,6 +283,9 @@ class MySQL extends Adapter
             if (\is_array($prop['value'])) {
                 throw new Exception('Value can\'t be an array: '.\json_encode($prop['value']));
             }
+            if (\is_bool($prop['value'])) {
+                $prop['value'] = (int) $prop['value'];
+            }
             $st2->bindValue(':documentUid', $data['$id'], PDO::PARAM_STR);
             $st2->bindValue(':documentRevision', $revision, PDO::PARAM_STR);
 


### PR DESCRIPTION
## What does this PR do?

- save `0` as false value in database for filtering

## Related PRs and Issues

I didn't see a smart way to introduce `true`/`false` into the filters - since the querying of the collection rules and the parsing of the filters happen in two completely different classes. Meaning I would need to repeat one of them for introducing true/false.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 