### PR TITLE
fix(migration): prevent throwing error when document is missing ID

### DIFF
--- a/src/Appwrite/Migration/Migration.php
+++ b/src/Appwrite/Migration/Migration.php
@@ -87,7 +87,8 @@ abstract class Migration
                         $new = call_user_func($callback, $document);
 
                         if (empty($new->getId())) {
-                            throw new Exception('Missing ID');
+                            Console::warning('Skipped Document due to missing ID.');
+                            return;
                         }
 
                         if (!$this->check_diff_multi($new->getArrayCopy(), $old)) {


### PR DESCRIPTION
## What does this PR do?

- prevents throwing error when document is missing id
- shows warning when document with a missing ID is found

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 