### PR TITLE
Feat stateless webhooks worker

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -768,6 +768,7 @@ App::post('/v1/functions/:functionId/executions')
 
         Resque::enqueue('v1-functions', 'FunctionsV1', [
             'projectId' => $project->getId(),
+            'webhooks' => $project->getAttribute('webhooks', []),
             'functionId' => $function->getId(),
             'executionId' => $execution->getId(),
             'trigger' => 'http',

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -321,6 +321,7 @@ App::put('/v1/functions/:functionId')
         if ($next && $schedule !== $original) {
             ResqueScheduler::enqueueAt($next, 'v1-functions', 'FunctionsV1', [
                 'projectId' => $project->getId(),
+                'webhooks' => $project->getAttribute('webhooks', []),
                 'functionId' => $function->getId(),
                 'executionId' => null,
                 'trigger' => 'schedule',
@@ -375,6 +376,7 @@ App::patch('/v1/functions/:functionId/tag')
         if ($next) { // Init first schedule
             ResqueScheduler::enqueueAt($next, 'v1-functions', 'FunctionsV1', [
                 'projectId' => $project->getId(),
+                'webhooks' => $project->getAttribute('webhooks', []),
                 'functionId' => $function->getId(),
                 'executionId' => null,
                 'trigger' => 'schedule',

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -76,6 +76,7 @@ App::init(function ($utopia, $request, $response, $project, $user, $register, $e
      */
     $events
         ->setParam('projectId', $project->getId())
+        ->setParam('webhooks', $project->getAttribute('webhooks', []))
         ->setParam('userId', $user->getId())
         ->setParam('event', $route->getLabel('event', ''))
         ->setParam('eventData', [])
@@ -188,7 +189,6 @@ App::shutdown(function ($utopia, $request, $response, $project, $events, $audits
         $webhooks
             ->setQueue('v1-webhooks')
             ->setClass('WebhooksV1')
-            ->setParam('webhooks', $project->getAttribute('webhooks', []))
             ->trigger();
 
         $functions

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -188,6 +188,7 @@ App::shutdown(function ($utopia, $request, $response, $project, $events, $audits
         $webhooks
             ->setQueue('v1-webhooks')
             ->setClass('WebhooksV1')
+            ->setParam('webhooks', $project->getAttribute('webhooks', []))
             ->trigger();
 
         $functions

--- a/app/tasks/sdks.php
+++ b/app/tasks/sdks.php
@@ -21,20 +21,6 @@ use Appwrite\SDK\Language\Swift;
 $cli
     ->task('sdks')
     ->action(function () {
-        function getSSLPage($url)
-        {
-            $ch = \curl_init();
-            \curl_setopt($ch, CURLOPT_HEADER, false);
-            \curl_setopt($ch, CURLOPT_URL, $url);
-            \curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-            \curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-            \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            $result = \curl_exec($ch);
-            \curl_close($ch);
-
-            return $result;
-        }
-
         $platforms = Config::getParam('platforms');
         $selected = \strtolower(Console::confirm('Choose SDK ("*" for all):'));
         $version = Console::confirm('Choose an Appwrite version');

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -141,6 +141,7 @@ class FunctionsV1
 
         $projectId = $this->args['projectId'] ?? '';
         $functionId = $this->args['functionId'] ?? '';
+        $webhooks = $this->args['webhooks'] ?? [];
         $executionId = $this->args['executionId'] ?? '';
         $trigger = $this->args['trigger'] ?? '';
         $event = $this->args['event'] ?? '';
@@ -196,7 +197,7 @@ class FunctionsV1
 
                         Console::success('Triggered function: '.$event);
 
-                        $this->execute('event', $projectId, '', $database, $function, $event, $eventData, $data, $userId, $jwt);
+                        $this->execute('event', $projectId, '', $database, $function, $event, $eventData, $data, $webhooks, $userId, $jwt);
                     }
                 }
                 break;
@@ -252,7 +253,7 @@ class FunctionsV1
                     'scheduleOriginal' => $function->getAttribute('schedule', ''),
                 ]);  // Async task rescheduale
 
-                $this->execute($trigger, $projectId, $executionId, $database, $function, /*$event*/'', /*$eventData*/'', $data, $userId, $jwt);
+                $this->execute($trigger, $projectId, $executionId, $database, $function, /*$event*/'', /*$eventData*/'', $data, $webhooks, $userId, $jwt);
                 break;
 
             case 'http':
@@ -264,7 +265,7 @@ class FunctionsV1
                     throw new Exception('Function not found ('.$functionId.')');
                 }
 
-                $this->execute($trigger, $projectId, $executionId, $database, $function, /*$event*/'', /*$eventData*/'', $data, $userId, $jwt);
+                $this->execute($trigger, $projectId, $executionId, $database, $function, /*$event*/'', /*$eventData*/'', $data, $webhooks, $userId, $jwt);
                 break;
             
             default:
@@ -287,7 +288,7 @@ class FunctionsV1
      * 
      * @return void
      */
-    public function execute(string $trigger, string $projectId, string $executionId, Database $database, Document $function, string $event = '', string $eventData = '', string $data = '', string $userId = '', string $jwt = ''): void
+    public function execute(string $trigger, string $projectId, string $executionId, Database $database, Document $function, string $event = '', string $eventData = '', string $data = '', array $webhooks = [], string $userId = '', string $jwt = ''): void
     {
         global $list;
 
@@ -479,6 +480,7 @@ class FunctionsV1
         $executionUpdate
             ->setParam('projectId', $projectId)
             ->setParam('userId', $userId)
+            ->setParam('webhooks', $webhooks)
             ->setParam('event', 'functions.executions.update')
             ->setParam('eventData', [
                 '$id' => $execution['$id'],

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -247,6 +247,7 @@ class FunctionsV1
 
                 ResqueScheduler::enqueueAt($next, 'v1-functions', 'FunctionsV1', [
                     'projectId' => $projectId,
+                    'webhooks' => $webhooks,
                     'functionId' => $function->getId(),
                     'executionId' => null,
                     'trigger' => 'schedule',
@@ -285,6 +286,9 @@ class FunctionsV1
      * @param string $event
      * @param string $eventData
      * @param string $data
+     * @param array $webhooks
+     * @param string $userId
+     * @param string $jwt
      * 
      * @return void
      */

--- a/app/workers/mails.php
+++ b/app/workers/mails.php
@@ -29,7 +29,6 @@ class MailsV1
             return;
         }
 
-        $event = $this->args['event'];
         $from = $this->args['from'];
         $recipient = $this->args['recipient'];
         $name = $this->args['name'];

--- a/app/workers/webhooks.php
+++ b/app/workers/webhooks.php
@@ -2,11 +2,6 @@
 
 use Utopia\App;
 use Utopia\CLI\Console;
-use Utopia\Config\Config;
-use Appwrite\Database\Database;
-use Appwrite\Database\Adapter\MySQL as MySQLAdapter;
-use Appwrite\Database\Adapter\Redis as RedisAdapter;
-use Appwrite\Database\Validator\Authorization;
 
 require_once __DIR__.'/../init.php';
 
@@ -24,34 +19,16 @@ class WebhooksV1
 
     public function perform()
     {
-        global $register;
-
-        $consoleDB = new Database();
-        $consoleDB->setAdapter(new RedisAdapter(new MySQLAdapter($register), $register));
-        $consoleDB->setNamespace('app_console'); // Main DB
-        $consoleDB->setMocks(Config::getParam('collections', []));
-    
         $errors = [];
 
         // Event
         $projectId = $this->args['projectId'] ?? '';
+        $webhooks = $this->args['webhooks'] ?? [];
         $userId = $this->args['userId'] ?? '';
         $event = $this->args['event'] ?? '';
         $eventData = \json_encode($this->args['eventData']);
 
-        // Webhook
-
-        Authorization::disable();
-
-        $project = $consoleDB->getDocument($projectId);
-
-        Authorization::reset();
-
-        if (\is_null($project->getId()) || Database::SYSTEM_COLLECTION_PROJECTS !== $project->getCollection()) {
-            throw new Exception('Project Not Found');
-        }
-
-        foreach ($project->getAttribute('webhooks', []) as $webhook) {
+        foreach ($webhooks as $webhook) {
             if (!(isset($webhook['events']) && \is_array($webhook['events']) && \in_array($event, $webhook['events']))) {
                 continue;
             }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Drops all DB related stuff from the webhooks worker and just pass the relevant data from the API point where we trigger the task for the worker?

The worker is only accessing  the db to fetch the project's webhooks list which is already available to us in the relevant API scope. This change will increase the size of the task payload but will reduce database queries, improve speed, and make the webhooks worker completely independent.

## Test Plan

Leverage e2e tests

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
