### PR TITLE
fix(account): add anon session id

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -714,9 +714,15 @@ App::post('/v1/account/sessions/anonymous')
             $detector->getDevice()
         ));
 
-        $user->setAttribute('sessions', $session, Document::SET_TYPE_APPEND);
-
         Authorization::setRole('user:'.$user->getId());
+
+        $session = $projectDB->createDocument($session->getArrayCopy());
+
+        if (false === $session) {
+            throw new Exception('Failed saving session to DB', 500);
+        }
+
+        $user->setAttribute('sessions', $session, Document::SET_TYPE_APPEND);
 
         $user = $projectDB->updateDocument($user->getArrayCopy());
 

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -240,6 +240,10 @@ class AccountCustomClientTest extends Scope
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertIsArray($response['body']);
+        $this->assertNotEmpty($response['body']);
+        $this->assertNotEmpty($response['body']['$id']);
+        $this->assertNotEmpty($response['body']['userId']);
 
         $session = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_'.$this->getProject()['$id']];
 


### PR DESCRIPTION
## What does this PR do?

- Adds missing session `$id` to anon account

## Test Plan

- Adds test to check for the `$id` and `userId` after creating anon session

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 