### PR TITLE
doc: Add info about _APP_STORAGE_LIMIT environment variable to Storage doc

### DIFF
--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -4,4 +4,4 @@ Each file in the service is granted with read and write permissions to manage wh
 
 The preview endpoint allows you to generate preview images for your files. Using the preview endpoint, you can also manipulate the resulting image so that it will fit perfectly inside your app in terms of dimensions, file size, and style. The preview endpoint also allows you to change the resulting image file format for better compression or image quality for better delivery over the network.
 
-The maximum file size allowed for file upload is controlled by the `_APP_STORAGE_LIMIT` environment variable, which defaults to 10 MB. See [Environment Variables](https://appwrite.io/docs/environment-variables#storage) for more information.
+The maximum file size allowed for file upload is controlled by the `_APP_STORAGE_LIMIT` environment variable, which defaults to 10 MB. See [Environment Variables](/docs/environment-variables#storage) for more information.

--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -3,3 +3,5 @@ The Storage service allows you to manage your project files. Using the Storage s
 Each file in the service is granted with read and write permissions to manage who has access to view or edit it. You can also learn more about how to manage your [resources permissions](/docs/permissions).
 
 The preview endpoint allows you to generate preview images for your files. Using the preview endpoint, you can also manipulate the resulting image so that it will fit perfectly inside your app in terms of dimensions, file size, and style. The preview endpoint also allows you to change the resulting image file format for better compression or image quality for better delivery over the network.
+
+The maximum file size allowed for file upload is controlled by the `_APP_STORAGE_LIMIT` environment variable, which defaults to 10 MB. See [Environment Variables](https://appwrite.io/docs/environment-variables#storage) for more information.

--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -4,4 +4,4 @@ Each file in the service is granted with read and write permissions to manage wh
 
 The preview endpoint allows you to generate preview images for your files. Using the preview endpoint, you can also manipulate the resulting image so that it will fit perfectly inside your app in terms of dimensions, file size, and style. The preview endpoint also allows you to change the resulting image file format for better compression or image quality for better delivery over the network.
 
-The maximum file size allowed for file upload is controlled by the `_APP_STORAGE_LIMIT` environment variable, which defaults to 10 MB. See [Environment Variables](/docs/environment-variables#storage) for more information.
+The maximum file size allowed for file upload is controlled by the `_APP_STORAGE_LIMIT` environment variable, which defaults to 30 MB. See [Environment Variables](/docs/environment-variables#storage) for more information.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Discussed in discord, adding this for give the _APP_STORAGE_LIMIT env variable more exposure. Since users might come to this doc page looking for information on max file size.


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)? ✅ 