### PR TITLE
Fix platforms zone not aligning with statistics

### DIFF
--- a/app/views/console/home/index.phtml
+++ b/app/views/console/home/index.phtml
@@ -139,7 +139,7 @@ $usageStatsEnabled = $this->getParam('usageStatsEnabled',true);
     </div>
 </div>
 
-<div class="zone xl margin-top-xl clear" data-ls-if="({{console-project}})">
+<div class="zone xxl margin-top-xl clear" data-ls-if="({{console-project}})">
     <h2 class="margin-bottom">Platforms</h2>
 
     <div class="box margin-bottom" data-ls-if="0 < {{console-project.platforms.length}} && undefined !== {{console-project.platforms}}">


### PR DESCRIPTION
## What does this PR do?
Adjusts the zone for platform to align with the zone above it.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes