### PR TITLE
Feat - Add Function Name Tags

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -1590,6 +1590,15 @@ $collections = [
             ],
             [
                 '$collection' => Database::SYSTEM_COLLECTION_RULES,
+                'label' => 'Name',
+                'key' => 'name',
+                'type' => Database::SYSTEM_VAR_TYPE_TEXT,
+                'default' => '',
+                'required' => false,
+                'array' => false,
+            ],
+            [
+                '$collection' => Database::SYSTEM_COLLECTION_RULES,
                 'label' => 'Code Path',
                 'key' => 'path',
                 'type' => Database::SYSTEM_VAR_TYPE_TEXT,

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -445,11 +445,12 @@ App::post('/v1/functions/:functionId/tags')
     ->param('functionId', '', new UID(), 'Function unique ID.')
     ->param('command', '', new Text('1028'), 'Code execution command.')
     ->param('code', [], new File(), 'Gzip file with your code package. When used with the Appwrite CLI, pass the path to your code directory, and the CLI will automatically package your code. Use a path that is within the current directory.', false)
+    ->param('name', '', new Text(512), 'Function Name', true)
     ->inject('request')
     ->inject('response')
     ->inject('projectDB')
     ->inject('usage')
-    ->action(function ($functionId, $command, $file, $request, $response, $projectDB, $usage) {
+    ->action(function ($functionId, $command, $file, $name, $request, $response, $projectDB, $usage) {
         /** @var Utopia\Swoole\Request $request */
         /** @var Appwrite\Utopia\Response $response */
         /** @var Appwrite\Database\Database $projectDB */
@@ -505,6 +506,7 @@ App::post('/v1/functions/:functionId/tags')
             'functionId' => $function->getId(),
             'dateCreated' => time(),
             'command' => $command,
+            'name' => $name,
             'path' => $path,
             'size' => $size,
         ]);

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -442,15 +442,15 @@ App::post('/v1/functions/:functionId/tags')
     ->label('sdk.response.code', Response::STATUS_CODE_CREATED)
     ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
     ->label('sdk.response.model', Response::MODEL_TAG)
+    ->param('name', '', new Text(512), 'Function Name', true)
     ->param('functionId', '', new UID(), 'Function unique ID.')
     ->param('command', '', new Text('1028'), 'Code execution command.')
     ->param('code', [], new File(), 'Gzip file with your code package. When used with the Appwrite CLI, pass the path to your code directory, and the CLI will automatically package your code. Use a path that is within the current directory.', false)
-    ->param('name', '', new Text(512), 'Function Name', true)
     ->inject('request')
     ->inject('response')
     ->inject('projectDB')
     ->inject('usage')
-    ->action(function ($functionId, $command, $file, $name, $request, $response, $projectDB, $usage) {
+    ->action(function ($name, $functionId, $command, $file, $request, $response, $projectDB, $usage) {
         /** @var Utopia\Swoole\Request $request */
         /** @var Appwrite\Utopia\Response $response */
         /** @var Appwrite\Database\Database $projectDB */

--- a/src/Appwrite/Utopia/Response/Model/Tag.php
+++ b/src/Appwrite/Utopia/Response/Model/Tag.php
@@ -34,6 +34,12 @@ class Tag extends Model
                 'default' => '',
                 'example' => 'enabled',
             ])
+            ->addRule('name', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Function Name.',
+                'default' => '',
+                'example' => 'Hello World Script',
+            ])
             ->addRule('size', [
                 'type' => self::TYPE_STRING,
                 'description' => 'The code size in bytes.',

--- a/src/Appwrite/Utopia/Response/Model/Tag.php
+++ b/src/Appwrite/Utopia/Response/Model/Tag.php
@@ -28,17 +28,17 @@ class Tag extends Model
                 'default' => 0,
                 'example' => 1592981250,
             ])
+            ->addRule('name', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Function Name.',
+                'default' => '',
+                'example' => 'Hello World Tag',
+            ])
             ->addRule('command', [
                 'type' => self::TYPE_STRING,
                 'description' => 'The entrypoint command in use to execute the tag code.',
                 'default' => '',
                 'example' => 'enabled',
-            ])
-            ->addRule('name', [
-                'type' => self::TYPE_STRING,
-                'description' => 'Function Name.',
-                'default' => '',
-                'example' => 'Hello World Script',
             ])
             ->addRule('size', [
                 'type' => self::TYPE_STRING,

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -184,6 +184,7 @@ class FunctionsCustomServerTest extends Scope
         ], $this->getHeaders()), [
             'command' => 'php index.php',
             'code' => new CURLFile(realpath(__DIR__ . '/../../../resources/functions/php.tar.gz'), 'application/x-gzip', 'php-fx.tar.gz'),
+            'name' => 'Hello World!'
         ]);
 
         $tagId = $tag['body']['$id'] ?? '';
@@ -192,6 +193,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertNotEmpty($tag['body']['$id']);
         $this->assertIsInt($tag['body']['dateCreated']);
         $this->assertEquals('php index.php', $tag['body']['command']);
+        $this->assertEquals('Hello World!', $tag['body']['name']);
         $this->assertGreaterThan(10000, $tag['body']['size']);
        
         /**


### PR DESCRIPTION
## What does this PR do?
This PR Introduces the ability to name function tags to be more easily identifiable.

## Test Plan

I have added a new name field to tags, I have also implemented the relevant tests to ensure this is working as expected.

`POST v1/functions/:functionID/tags` has been updated to optionally accept a `name` field. If no name is given a blank string is used instead.

## Related PRs and Issues
https://github.com/appwrite/appwrite/issues/1222

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes
