### PR TITLE
Updated sort method before containers cleanup

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -535,7 +535,7 @@ class FunctionsV1
         if(\count($list) > $max) {
             Console::info('Starting containers cleanup');
 
-            \usort($list, function ($item1, $item2) {
+            \uasort($list, function ($item1, $item2) {
                 return (int)($item1['appwrite-created'] ?? 0) <=> (int)($item2['appwrite-created'] ?? 0);
             });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixed a problem that caused the creation of already running functions which was causing a docker conflict error. This error was happening when the max container limit has reached and the cleanup method was wrongly removing the containers list array keys.

## Test Plan

Existing tests.

## Related PRs and Issues

#1232 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
