### PR TITLE
Fix Unique Keys not being updated when changing a user's email address

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1117,7 +1117,7 @@ App::patch('/v1/account/email')
             ]
             ));
 
-        $user = $projectDB->updateDocument($document, ['email' => $email]);
+        $user = $projectDB->updateDocument($document);
 
         $projectDB->addUniqueKey(\md5($document['$collection'].':'.'email'.'='.$email));
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1103,14 +1103,23 @@ App::patch('/v1/account/email')
 
         // TODO after this user needs to confirm mail again
 
-        $user = $projectDB->updateDocument(\array_merge(
+        if (!$isAnonymousUser) {
+            // Remove previous unique ID.
+            $projectDB->deleteUniqueKey(\md5($user->getArrayCopy()['$collection'].':'.'email'.'='.$user->getAttribute('email')));
+        }
+
+        $document = (\array_merge(
             $user->getArrayCopy(),
             ($isAnonymousUser ? [ 'password' => Auth::passwordHash($password) ] : []),
             [
                 'email' => $email,
                 'emailVerification' => false,
             ]
-        ));
+            ));
+
+        $user = $projectDB->updateDocument($document, ['email' => $email]);
+
+        $projectDB->addUniqueKey(\md5($document['$collection'].':'.'email'.'='.$email));
 
         if (false === $user) {
             throw new Exception('Failed saving user to DB', 500);

--- a/src/Appwrite/Database/Adapter.php
+++ b/src/Appwrite/Database/Adapter.php
@@ -91,11 +91,20 @@ abstract class Adapter
     /**
      * Delete Unique Key.
      *
-     * @param int $key
+     * @param String $key
      *
      * @return array
      */
     abstract public function deleteUniqueKey($key);
+
+    /**
+     * Add Unique Key.
+     *
+     * @param String $key
+     *
+     * @return array
+     */
+    abstract public function addUniqueKey($key);
 
     /**
      * Create Namespace.

--- a/src/Appwrite/Database/Adapter.php
+++ b/src/Appwrite/Database/Adapter.php
@@ -91,7 +91,7 @@ abstract class Adapter
     /**
      * Delete Unique Key.
      *
-     * @param String $key
+     * @param string $key
      *
      * @return array
      */
@@ -100,7 +100,7 @@ abstract class Adapter
     /**
      * Add Unique Key.
      *
-     * @param String $key
+     * @param string $key
      *
      * @return array
      */

--- a/src/Appwrite/Database/Adapter/MySQL.php
+++ b/src/Appwrite/Database/Adapter/MySQL.php
@@ -360,7 +360,7 @@ class MySQL extends Adapter
     /**
      * Delete Unique Key.
      *
-     * @param int $key
+     * @param String $key
      *
      * @return array
      *
@@ -373,6 +373,31 @@ class MySQL extends Adapter
         $st1->bindValue(':key', $key, PDO::PARAM_STR);
 
         $st1->execute();
+
+        return [];
+    }
+
+    /**
+     * Add Unique Key.
+     *
+     * @param String $key
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+
+    public function addUniqueKey($key)
+    {
+        $st = $this->getPDO()->prepare('INSERT INTO `'.$this->getNamespace().'.database.unique`
+        SET `key` = :key;
+        ');
+    
+        $st->bindValue(':key', $key, PDO::PARAM_STR);
+
+        if (!$st->execute()) {
+            throw new Duplicate('Duplicated Property: '.$key);
+        }
 
         return [];
     }

--- a/src/Appwrite/Database/Adapter/MySQL.php
+++ b/src/Appwrite/Database/Adapter/MySQL.php
@@ -360,7 +360,7 @@ class MySQL extends Adapter
     /**
      * Delete Unique Key.
      *
-     * @param String $key
+     * @param string $key
      *
      * @return array
      *
@@ -380,13 +380,12 @@ class MySQL extends Adapter
     /**
      * Add Unique Key.
      *
-     * @param String $key
+     * @param string $key
      *
      * @return array
      *
      * @throws Exception
      */
-
     public function addUniqueKey($key)
     {
         $st = $this->getPDO()->prepare('INSERT INTO `'.$this->getNamespace().'.database.unique`

--- a/src/Appwrite/Database/Adapter/Redis.php
+++ b/src/Appwrite/Database/Adapter/Redis.php
@@ -170,6 +170,22 @@ class Redis extends Adapter
     }
 
     /**
+     * Add Unique Key.
+     *
+     * @param $key
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function addUniqueKey($key)
+    {
+        $data = $this->adapter->addUniqueKey($key);
+
+        return $data;
+    }
+
+    /**
      * Create Namespace.
      *
      * @param string $namespace

--- a/src/Appwrite/Database/Database.php
+++ b/src/Appwrite/Database/Database.php
@@ -371,6 +371,18 @@ class Database
     }
 
     /**
+     * @param int $key
+     *
+     * @return Document|false
+     *
+     * @throws AuthorizationException
+     */
+    public function addUniqueKey($key)
+    {
+        return new Document($this->adapter->addUniqueKey($key));
+    }
+
+    /**
      * @return array
      */
     public function getDebug()

--- a/tests/e2e/Services/Account/AccountBase.php
+++ b/tests/e2e/Services/Account/AccountBase.php
@@ -591,6 +591,29 @@ trait AccountBase
         
         $this->assertEquals($response['headers']['status-code'], 400);
 
+        // Test if we can create a new account with the old email
+
+        /**
+         * Test for SUCCESS
+         */
+        $response = $this->client->call(Client::METHOD_POST, '/account', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'email' =>  $data['email'],
+            'password' =>  $data['password'],
+            'name' =>  $data['name'],
+        ]);
+
+        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertNotEmpty($response['body']);
+        $this->assertNotEmpty($response['body']['$id']);
+        $this->assertIsNumeric($response['body']['registration']);
+        $this->assertEquals($response['body']['email'], $data['email']);
+        $this->assertEquals($response['body']['name'], $data['name'],);
+        
+
         $data['email'] = $newEmail;
 
         return $data;


### PR DESCRIPTION
## What does this PR do?
This PR Fixes the behavior of not being able to create a new account with a email address if it has been previously used but changed using the change email endpoint. It fixes this by correctly cleaning up the unique key when the email gets updated.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/1104
https://github.com/appwrite/appwrite/issues/1295

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have
