### PR TITLE
fix(database): default value for empty rules

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -437,7 +437,7 @@ App::get('/v1/database/collections/:collectionId/documents')
         }
 
         $types = [];
-        foreach ($collection->getAttribute('rules') as $rule) {
+        foreach ($collection->getAttribute('rules', []) as $rule) {
             /** @var Document $rule */
             $types[$rule->getAttribute('key')] = $rule->getAttribute('type');
         }


### PR DESCRIPTION
## What does this PR do?

- sets a default value for getting rules on `listDocuments`

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 