### PR TITLE
Added " to wrap environment name in a log

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -337,7 +337,7 @@ class FunctionsV1 extends Worker
             : null;
 
         if(\is_null($runtime)) {
-            throw new Exception('Runtime "'.$function->getAttribute('runtime', '').' is not supported');
+            throw new Exception('Runtime "'.$function->getAttribute('runtime', '').'" is not supported');
         }
 
         $vars = \array_merge($function->getAttribute('vars', []), [


### PR DESCRIPTION
## What does this PR do?

Fixes a tiny mistake, adding an `"` to wrap the environment name properly in the log.

## Test Plan

Did not test, should not cause any bugs.

I noticed a bug when someone reported their error on Discord and the environment name was missing.
![image](https://user-images.githubusercontent.com/19310830/125172554-a991bf80-e1ba-11eb-9be4-7d2e10720e15.png)

