### PR TITLE
[FIX] Correctly use runtime defaults with no _APP_FUNCTIONS_RUNTIMES variable

### DIFF
--- a/app/config/runtimes.php
+++ b/app/config/runtimes.php
@@ -8,7 +8,13 @@ use Appwrite\Runtimes\Runtimes;
  */
 $runtimes = new Runtimes();
 
-$allowList = \explode(',', App::getEnv('_APP_FUNCTIONS_RUNTIMES', 'node-16.0,php-8.0,python-3.9,ruby-3.0,java-16.0'));
+$allowString = App::getEnv('_APP_FUNCTIONS_RUNTIMES', 'node-16.0,php-8.0,python-3.9,ruby-3.0,java-16.0');
+
+$allowList = \explode(',', $allowString);;
+
+if (empty($allowString)) {
+    $allowList = \explode(',', 'node-16.0,php-8.0,python-3.9,ruby-3.0,java-16.0');
+}
 
 $runtimes = $runtimes->getAll(true, $allowList);
 

--- a/app/config/runtimes.php
+++ b/app/config/runtimes.php
@@ -8,7 +8,7 @@ use Appwrite\Runtimes\Runtimes;
  */
 $runtimes = new Runtimes();
 
-$allowList = empty(App::getEnv('_APP_FUNCTIONS_RUNTIMES')) ? [] : \explode(',', App::getEnv('_APP_FUNCTIONS_RUNTIMES'));
+$allowList = \explode(',', App::getEnv('_APP_FUNCTIONS_RUNTIMES', 'node-16.0,php-8.0,python-3.9,ruby-3.0,java-16.0'));
 
 $runtimes = $runtimes->getAll(true, $allowList);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR is a small fix so if _APP_FUNCTIONS_RUNTIMES is blank then default runtimes are loaded correctly instead of just showing all possible runtimes

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/1376

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have
