### PR TITLE
fix(install): escape shell args

### DIFF
--- a/app/tasks/install.php
+++ b/app/tasks/install.php
@@ -129,7 +129,7 @@ $cli
             $httpsPort = Console::confirm('Choose your server HTTPS port: (default: '.$defaultHTTPSPort.')');
             $httpsPort = ($httpsPort) ? $httpsPort : $defaultHTTPSPort;
         }
-    
+
         $input = [];
 
         foreach($vars as $key => $var) {
@@ -196,7 +196,7 @@ $cli
 
         foreach ($input as $key => $value) {
             if($value) {
-                $env .= $key.'='.$value.' ';
+                $env .= $key.'='.\escapeshellarg($value).' ';
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

- escapes shell args for running Appwrite the first time installation
- when using a `$` char anywhere in the questions answered during the installation process, bash interprets the dollar sign and messes up the env variables for the first `docker-compose up -d`

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
