### PR TITLE
Fix(refactor-db): swagger validator multi-arch image

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -56,6 +56,9 @@ $http->on('start', function (Server $http) use ($payloadSize, $register) {
     go(function() use ($register, $app) {
         // wait for database to be ready
         $attempts = 0;
+        $max = 10;
+        $sleep = 1;
+
         do {
             try {
                 $attempts++;
@@ -64,13 +67,13 @@ $http->on('start', function (Server $http) use ($payloadSize, $register) {
                 break; // leave the do-while if successful
             } catch(\Exception $e) {
                 Console::warning("Database not ready. Retrying connection ({$attempts})...");
-                if ($attempts >= 10) {
+                if ($attempts >= $max) {
                     throw new \Exception('Failed to connect to database: '. $e->getMessage());
                 }
-                sleep(1);
+                sleep($sleep);
                 continue;
             }
-        } while ($attempts < 10);
+        } while ($attempts < $max);
 
         App::setResource('db', function () use (&$db) {
             return $db;

--- a/app/http.php
+++ b/app/http.php
@@ -72,7 +72,13 @@ $http->on('start', function (Server $http) use ($payloadSize, $register) {
         // wait for database to be ready
         sleep(5);
 
-        $dbForConsole = $app->getResource('dbForConsole'); /** @var Utopia\Database\Database $dbForConsole */
+        try {
+            $dbForConsole = $app->getResource('dbForConsole'); /** @var Utopia\Database\Database $dbForConsole */
+        } catch(\Exception $e) {
+            Console::warning('Database not ready. Retrying connection...');
+            sleep(5);
+            $dbForConsole = $app->getResource('dbForConsole'); /** @var Utopia\Database\Database $dbForConsole */
+        }
 
         if(!$dbForConsole->exists()) {
             Console::success('[Setup] - Server database init started...');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -509,7 +509,7 @@ services:
       - appwrite
 
   swagger-validator:
-    image: 'swaggerapi/swagger-validator-v2:v2.0.5'
+    image: 'kodumbeats/swagger-validator-v2:v2.0.5'
     container_name: appwrite-swagger-validator
     ports:
       - '9506:8080'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The Swagger validator [Docker image](https://hub.docker.com/r/swaggerapi/swagger-validator-v2) is only available for `amd64`, not ARM, causing the test suite to fail on `arm64`. 

I [forked](https://github.com/kodumbeats/validator-badge) the [swagger-validator repo](https://github.com/swagger-api/validator-badge) and built a multi-arch image from their v2.0.5 tag:

https://hub.docker.com/layers/kodumbeats/swagger-validator-v2/v2.0.5/images/sha256-0235f0cab857cf8e7d41b2ead1ebc06b44dcd0623a448bac0238914b1c7e19f5?context=explore 

> Note: this was forked from `fix-retry-init-db-connection` so we can hopefully see everything 🟢 

## Test Plan

If this PR is successful, ARM tests should 🟢 

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
