### PR TITLE
FIX Commands executing before the tar has finished extracting

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -433,9 +433,9 @@ class FunctionsV1 extends Worker
             }
 
             $exitCodeUntar = Console::execute("docker exec ".
-            $container.
-            " sh -c 'mv /tmp/code.tar.gz /usr/local/src/code.tar.gz && tar -zxf /usr/local/src/code.tar.gz --strip 1 && rm /usr/local/src/code.tar.gz'"
-            , '', $stdout, $stderr, 60);
+                $container.
+                " sh -c 'mv /tmp/code.tar.gz /usr/local/src/code.tar.gz && tar -zxf /usr/local/src/code.tar.gz --strip 1 && rm /usr/local/src/code.tar.gz'"
+                , '', $stdout, $stderr, 60);
 
             if($exitCodeUntar !== 0) {
                 throw new Exception('Failed to extract tar: '.$stderr);

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -425,14 +425,23 @@ class FunctionsV1 extends Worker
                 " --workdir /usr/local/src".
                 " ".\implode(" ", $vars).
                 " {$runtime['image']}".
-                " sh -c 'mv /tmp/code.tar.gz /usr/local/src/code.tar.gz && tar -zxf /usr/local/src/code.tar.gz --strip 1 && rm /usr/local/src/code.tar.gz && tail -f /dev/null'"
+                " tail -f /dev/null"
             , '', $stdout, $stderr, 30);
 
-            $executionEnd = \microtime(true);
-    
             if($exitCode !== 0) {
                 throw new Exception('Failed to create function environment: '.$stderr);
             }
+
+            $exitCodeUntar = Console::execute("docker exec ".
+            $container.
+            " sh -c 'mv /tmp/code.tar.gz /usr/local/src/code.tar.gz && tar -zxf /usr/local/src/code.tar.gz --strip 1 && rm /usr/local/src/code.tar.gz'"
+            , '', $stdout, $stderr, 60);
+
+            if($exitCodeUntar !== 0) {
+                throw new Exception('Failed to extract tar: '.$stderr);
+            }
+
+            $executionEnd = \microtime(true);
 
             $list[$container] = [
                 'name' => $container,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR will fix a bug where commands could potentially run before a the code tar file has finished extracting. This PR seperates the untarring process into it's own execute command and makes it a blocking task. 

## Test Plan

I have tested it thoroughly manually and through the automatic phpunit tests.

## Related PRs and Issues

This issue was brought up on the discord server: https://discord.com/channels/564160730845151244/564161373148414012/867413956833968158

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have
