### PR TITLE
Fix - remove local swagger validator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -508,17 +508,6 @@ services:
     networks:
       - appwrite
 
-  swagger-validator:
-    image: 'swaggerapi/swagger-validator-v2:v2.0.5'
-    container_name: appwrite-swagger-validator
-    ports:
-      - '9506:8080'
-    environment:
-      - REJECT_LOCAL=false
-      - REJECT_REDIRECT=false
-    networks:
-      - appwrite
-
   # redis-commander:
   #   image: rediscommander/redis-commander:latest
   #   restart: unless-stopped

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -133,7 +133,7 @@ class HTTPTest extends Scope
         }
 
         $client = new Client();
-        $client->setEndpoint('http://appwrite-swagger-validator:8080');
+        $client->setEndpoint('https://validator.swagger.io');
 
         /**
          * Test for SUCCESS


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The Swagger validator [Docker image](https://hub.docker.com/r/swaggerapi/swagger-validator-v2) is only available for `amd64`, not ARM, causing the test suite to fail on `arm64`. 

This PR reverts back to checking the spec against https://validator.swagger.io in tests.

## Test Plan

If this PR is successful, ARM tests should 🟢 

## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/1415

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
