### PR TITLE
feat(refactor-db): catch index limit exceptions

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -156,7 +156,7 @@ App::post('/v1/account/sessions')
         $email = \strtolower($email);
         $protocol = $request->getProtocol();
         
-        $profile = $dbForInternal->findFirst('users', [new Query('email', Query::TYPE_EQUAL, [$email])], 1); // Get user by email address
+        $profile = $dbForInternal->findOne('users', [new Query('email', Query::TYPE_EQUAL, [$email])]); // Get user by email address
 
         if (!$profile || !Auth::passwordVerify($password, $profile->getAttribute('password'))) {
             $audits
@@ -442,16 +442,16 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
             }
         }
 
-        $user = ($user->isEmpty()) ? $dbForInternal->findFirst('sessions', [ // Get user by provider id
+        $user = ($user->isEmpty()) ? $dbForInternal->findOne('sessions', [ // Get user by provider id
             new Query('provider', QUERY::TYPE_EQUAL, [$provider]),
             new Query('providerUid', QUERY::TYPE_EQUAL, [$oauth2ID]),
-        ], 1) : $user;
+        ]) : $user;
 
         if ($user === false || $user->isEmpty()) { // No user logged in or with OAuth2 provider ID, create new one or connect with account with same email
             $name = $oauth2->getUserName($accessToken);
             $email = $oauth2->getUserEmail($accessToken);
 
-            $user = $dbForInternal->findFirst('users', [new Query('email', Query::TYPE_EQUAL, [$email])], 1); // Get user by email address
+            $user = $dbForInternal->findOne('users', [new Query('email', Query::TYPE_EQUAL, [$email])]); // Get user by email address
 
             if ($user === false || $user->isEmpty()) { // Last option -> create the user, generate random password
                 $limit = $project->getAttribute('usersAuthLimit', 0);
@@ -1074,7 +1074,7 @@ App::patch('/v1/account/email')
         }
 
         $email = \strtolower($email);
-        $profile = $dbForInternal->findFirst('users', [new Query('email', Query::TYPE_EQUAL, [\strtolower($email)])], 1); // Get user by email address
+        $profile = $dbForInternal->findOne('users', [new Query('email', Query::TYPE_EQUAL, [\strtolower($email)])]); // Get user by email address
 
         if ($profile) {
             throw new Exception('User already registered', 400);
@@ -1379,7 +1379,7 @@ App::post('/v1/account/recovery')
         $isAppUser = Auth::isAppUser(Authorization::$roles);
 
         $email = \strtolower($email);
-        $profile = $dbForInternal->findFirst('users', [new Query('email', Query::TYPE_EQUAL, [$email])], 1); // Get user by email address
+        $profile = $dbForInternal->findOne('users', [new Query('email', Query::TYPE_EQUAL, [$email])]); // Get user by email address
 
         if (!$profile) {
             throw new Exception('User not found', 404);

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -273,7 +273,7 @@ App::post('/v1/teams/:teamId/memberships')
             throw new Exception('Team not found', 404);
         }
 
-        $invitee = $dbForInternal->findFirst('users', [new Query('email', Query::TYPE_EQUAL, [$email])], 1); // Get user by email address
+        $invitee = $dbForInternal->findOne('users', [new Query('email', Query::TYPE_EQUAL, [$email])]); // Get user by email address
 
         if (empty($invitee)) { // Create new user if no user with same email found
 

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -44,9 +44,9 @@ App::init(function ($utopia, $request, $response, $console, $project, $dbForCons
         } else {
             Authorization::disable();
 
-            $certificate = $dbForConsole->findFirst('certificates', [
+            $certificate = $dbForConsole->findOne('certificates', [
                 new Query('domain', QUERY::TYPE_EQUAL, [$domain->get()])
-            ], /*limit*/ 1);
+            ]);
 
             if (empty($certificate)) {
                 $certificate = new Document([

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -78,9 +78,9 @@ class CertificatesV1 extends Worker
             }
         }
 
-        $certificate = $dbForConsole->findFirst('certificates', [
+        $certificate = $dbForConsole->findOne('certificates', [
             new Query('domain', QUERY::TYPE_EQUAL, [$domain->get()])
-        ], /*limit*/ 1);
+        ]);
 
         // $condition = ($certificate
         //     && $certificate instanceof Document

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "utopia-php/cache": "0.4.*",
         "utopia-php/cli": "0.11.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "0.5.*",
+        "utopia-php/database": "dev-main as 0.5.1",
         "utopia-php/locale": "0.3.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",
@@ -70,6 +70,10 @@
         {
             "type": "git",
             "url": "https://github.com/lohanidamodar/audit"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/utopia-php/database"
         }
     ],
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "utopia-php/cache": "0.4.*",
         "utopia-php/cli": "0.11.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "dev-main as 0.5.1",
+        "utopia-php/database": "dev-fix-index-queue-exception as 0.5.1",
         "utopia-php/locale": "0.3.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc019facd9b13d886f91c98c25b1fcf2",
+    "content-hash": "cfbf9d5788ea18f4132811acb464ab28",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1962,11 +1962,11 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "dev-main",
+            "version": "dev-fix-index-queue-exception",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database",
-                "reference": "1d939e8c97c6b815b4ca1c8e53a8a7b1a488b66b"
+                "reference": "c7cb1226dfa39487fc912016e19f510939cb4eeb"
             },
             "require": {
                 "ext-mongodb": "*",
@@ -1983,7 +1983,6 @@
                 "utopia-php/cli": "^0.11.0",
                 "vimeo/psalm": "4.0.1"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -2016,7 +2015,7 @@
                 "upf",
                 "utopia"
             ],
-            "time": "2021-07-29T17:38:56+00:00"
+            "time": "2021-07-30T17:56:50+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -6231,7 +6230,7 @@
     "aliases": [
         {
             "package": "utopia-php/database",
-            "version": "dev-main",
+            "version": "dev-fix-index-queue-exception",
             "alias": "0.5.1",
             "alias_normalized": "0.5.1.0"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17c1c46d283e4745df9915d082c22078",
+    "content-hash": "fc019facd9b13d886f91c98c25b1fcf2",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1583,16 +1583,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -1646,7 +1646,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -1662,7 +1662,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "utopia-php/abuse",
@@ -1962,17 +1962,11 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.5.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://github.com/utopia-php/database.git",
-                "reference": "e050e51060df72eff3af9fc24fc95a41ca9a2096"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/e050e51060df72eff3af9fc24fc95a41ca9a2096",
-                "reference": "e050e51060df72eff3af9fc24fc95a41ca9a2096",
-                "shasum": ""
+                "url": "https://github.com/utopia-php/database",
+                "reference": "1d939e8c97c6b815b4ca1c8e53a8a7b1a488b66b"
             },
             "require": {
                 "ext-mongodb": "*",
@@ -1989,13 +1983,18 @@
                 "utopia-php/cli": "^0.11.0",
                 "vimeo/psalm": "4.0.1"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Utopia\\Database\\": "src/Database"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Utopia\\Tests\\": "tests/Database"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -2017,11 +2016,7 @@
                 "upf",
                 "utopia"
             ],
-            "support": {
-                "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.5.0"
-            },
-            "time": "2021-07-03T16:49:44+00:00"
+            "time": "2021-07-29T17:38:56+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -5298,16 +5293,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.2",
+            "version": "v5.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
+                "reference": "51b71afd6d2dc8f5063199357b9880cea8d8bfe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/51b71afd6d2dc8f5063199357b9880cea8d8bfe2",
+                "reference": "51b71afd6d2dc8f5063199357b9880cea8d8bfe2",
                 "shasum": ""
             },
             "require": {
@@ -5315,11 +5310,12 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2",
                 "symfony/string": "^5.1"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -5327,10 +5323,10 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^4.4|^5.0",
@@ -5376,7 +5372,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.2"
+                "source": "https://github.com/symfony/console/tree/v5.3.6"
             },
             "funding": [
                 {
@@ -5392,7 +5388,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-12T09:42:48+00:00"
+            "time": "2021-07-27T19:10:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5463,16 +5459,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
                 "shasum": ""
             },
             "require": {
@@ -5524,7 +5520,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5540,7 +5536,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:17:38+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -5628,16 +5624,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -5688,7 +5684,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5704,7 +5700,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -5949,16 +5945,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -5987,7 +5983,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -5995,7 +5991,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "twig/twig",
@@ -6232,11 +6228,19 @@
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/database",
+            "version": "dev-main",
+            "alias": "0.5.1",
+            "alias_normalized": "0.5.1.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
         "utopia-php/abuse": 20,
-        "utopia-php/audit": 20
+        "utopia-php/audit": 20,
+        "utopia-php/database": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
@@ -6259,5 +6263,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/e2e/Services/Database/DatabaseCustomServerTest.php
+++ b/tests/e2e/Services/Database/DatabaseCustomServerTest.php
@@ -132,4 +132,77 @@ class DatabaseCustomServerTest extends Scope
 
         $this->assertEquals($response['headers']['status-code'], 404);
     }
+
+    public function testIndexLimitException()
+    {
+        $collection = $this->client->call(Client::METHOD_POST, '/database/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'name' => 'testLimitException',
+            'read' => ['role:all'],
+            'write' => ['role:all'],
+        ]);
+
+        $this->assertEquals($collection['headers']['status-code'], 201);
+        $this->assertEquals($collection['body']['name'], 'testLimitException');
+
+        $collectionId = $collection['body']['$id'];
+
+        // add unique attributes for indexing
+        for ($i=0; $i < 64; $i++) {
+            // $this->assertEquals(true, static::getDatabase()->createAttribute('indexLimit', "test{$i}", Database::VAR_STRING, 16, true));
+            $attribute = $this->client->call(Client::METHOD_POST, '/database/collections/' . $collectionId . '/attributes', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey']
+            ]), [
+                'id' => "attribute{$i}",
+                'type' => 'string',
+                'size' => 64,
+                'required' => true,
+            ]);
+
+            $this->assertEquals($attribute['headers']['status-code'], 201);
+        }
+
+        sleep(2);
+
+        // testing for indexLimit = 64
+        // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
+        // Add up to the limit, then check if the next index throws IndexLimitException
+        for ($i=0; $i < 61; $i++) {
+            // $this->assertEquals(true, static::getDatabase()->createIndex('indexLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
+            $index = $this->client->call(Client::METHOD_POST, '/database/collections/' . $collectionId . '/indexes', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey']
+            ]), [
+                'id' => "key_attribute{$i}",
+                'type' => 'fulltext',
+                'attributes' => ["attribute{$i}"],
+            ]);
+        }
+
+        sleep(2);
+
+        $collection = $this->client->call(Client::METHOD_GET, '/database/collections/' . $collectionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]));
+
+        $tooMany = $this->client->call(Client::METHOD_POST, '/database/collections/' . $collectionId . '/indexes', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'id' => 'titleIndex',
+            'type' => 'fulltext',
+            'attributes' => ['attribute62'],
+        ]);
+
+        $this->assertEquals(400, $tooMany['headers']['status-code']);
+    }
 }

--- a/tests/e2e/Services/Database/DatabaseCustomServerTest.php
+++ b/tests/e2e/Services/Database/DatabaseCustomServerTest.php
@@ -167,7 +167,7 @@ class DatabaseCustomServerTest extends Scope
             $this->assertEquals($attribute['headers']['status-code'], 201);
         }
 
-        sleep(5);
+        sleep(10);
 
         $collection = $this->client->call(Client::METHOD_GET, '/database/collections/' . $collectionId, array_merge([
             'content-type' => 'application/json',
@@ -205,7 +205,7 @@ class DatabaseCustomServerTest extends Scope
             $this->assertEquals("key_attribute{$i}", $index['body']['$id']);
         }
 
-        sleep(5);
+        sleep(10);
 
         $collection = $this->client->call(Client::METHOD_GET, '/database/collections/' . $collectionId, array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Database/DatabaseCustomServerTest.php
+++ b/tests/e2e/Services/Database/DatabaseCustomServerTest.php
@@ -167,7 +167,24 @@ class DatabaseCustomServerTest extends Scope
             $this->assertEquals($attribute['headers']['status-code'], 201);
         }
 
-        sleep(2);
+        sleep(5);
+
+        $collection = $this->client->call(Client::METHOD_GET, '/database/collections/' . $collectionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]));
+
+        $this->assertEquals($collection['headers']['status-code'], 200);
+        $this->assertEquals($collection['body']['name'], 'testLimitException');
+        $this->assertIsArray($collection['body']['attributes']);
+        $this->assertIsArray($collection['body']['indexes']);
+        $this->assertIsArray($collection['body']['attributesInQueue']);
+        $this->assertIsArray($collection['body']['indexesInQueue']);
+        $this->assertCount(64, $collection['body']['attributes']);
+        $this->assertCount(0, $collection['body']['indexes']);
+        $this->assertCount(0, $collection['body']['attributesInQueue']);
+        $this->assertCount(0, $collection['body']['indexesInQueue']);
 
         // testing for indexLimit = 64
         // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
@@ -180,12 +197,15 @@ class DatabaseCustomServerTest extends Scope
                 'x-appwrite-key' => $this->getProject()['apiKey']
             ]), [
                 'id' => "key_attribute{$i}",
-                'type' => 'fulltext',
+                'type' => 'key',
                 'attributes' => ["attribute{$i}"],
             ]);
+
+            $this->assertEquals(201, $index['headers']['status-code']);
+            $this->assertEquals("key_attribute{$i}", $index['body']['$id']);
         }
 
-        sleep(2);
+        sleep(5);
 
         $collection = $this->client->call(Client::METHOD_GET, '/database/collections/' . $collectionId, array_merge([
             'content-type' => 'application/json',
@@ -193,13 +213,24 @@ class DatabaseCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
+        $this->assertEquals($collection['headers']['status-code'], 200);
+        $this->assertEquals($collection['body']['name'], 'testLimitException');
+        $this->assertIsArray($collection['body']['attributes']);
+        $this->assertIsArray($collection['body']['indexes']);
+        $this->assertIsArray($collection['body']['attributesInQueue']);
+        $this->assertIsArray($collection['body']['indexesInQueue']);
+        $this->assertCount(0, $collection['body']['attributesInQueue']);
+        $this->assertCount(0, $collection['body']['indexesInQueue']);
+        $this->assertCount(64, $collection['body']['attributes']);
+        $this->assertCount(61, $collection['body']['indexes']);
+
         $tooMany = $this->client->call(Client::METHOD_POST, '/database/collections/' . $collectionId . '/indexes', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]), [
-            'id' => 'titleIndex',
-            'type' => 'fulltext',
+            'id' => 'tooMany',
+            'type' => 'key',
             'attributes' => ['attribute62'],
         ]);
 

--- a/tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php
+++ b/tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php
@@ -64,7 +64,7 @@ class WebhooksCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]), [
             'id' => 'fullname',
-            'type' => 'text',
+            'type' => 'key',
             'attributes' => ['lastName', 'firstName'],
             'orders' => ['ASC', 'ASC'],
         ]);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR introduces a thrown exception when trying to create an index that would exceed the maximum count per collection. The necessary changes to  the database library were added in: https://github.com/utopia-php/database/pull/44

This PR also incorporates the latest changes from `utopia-php/database` main branch, largely renaming `findFirst` to `findOne`.

## Test Plan

End-to-end tests have been added.

## Related PRs and Issues

https://github.com/utopia-php/database/pull/33
https://github.com/utopia-php/database/pull/39

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
