### PR TITLE
ci(travis): improve build speed and arm stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ script:
 - docker-compose exec appwrite vars
 - docker-compose exec appwrite test --debug
 
+after_failure:
+- docker-compose logs appwrite
+
 deploy:
   - provider: script
     edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_install:
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
 
 install:
-- docker-compose build --parallel
-- docker-compose up -d
+- docker-compose up -d --build
 - sleep 10
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-dist: xenial
+dist: focal
 
 arch:
   - amd64
-  - arm64
+  - arm64-graviton2
 
 os: linux
 
@@ -30,6 +30,7 @@ before_install:
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
 
 install:
+- docker-compose build --parallel
 - docker-compose up -d
 - sleep 10
 


### PR DESCRIPTION
## What does this PR do?

- upgrade ci distro to `focal`
- use `arm64-graviton2` instead of `arm64`

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 