### PR TITLE
fix(refactor-db): catch duplicate exception when creating and updating documents

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1307,6 +1307,9 @@ App::patch('/v1/database/collections/:collectionId/documents/:documentId')
         catch (AuthorizationException $exception) {
             throw new Exception('Unauthorized permissions', 401);
         }
+        catch (DuplicateException $exception) {
+            throw new Exception($exception->getMessage(), 400);
+        }
         catch (StructureException $exception) {
             throw new Exception('Bad structure. '.$exception->getMessage(), 400);
         }
@@ -1369,4 +1372,3 @@ App::delete('/v1/database/collections/:collectionId/documents/:documentId')
         ;
 
         $response->noContent();
-    });

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1308,10 +1308,10 @@ App::patch('/v1/database/collections/:collectionId/documents/:documentId')
             throw new Exception('Unauthorized permissions', 401);
         }
         catch (DuplicateException $exception) {
-            throw new Exception($exception->getMessage(), 409);
+            throw new Exception('Document already exists', 409);
         }
         catch (StructureException $exception) {
-            throw new Exception('Bad structure. '.$exception->getMessage(), 400);
+            throw new Exception($exception->getMessage(), 400);
         }
 
         $audits

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1372,3 +1372,4 @@ App::delete('/v1/database/collections/:collectionId/documents/:documentId')
         ;
 
         $response->noContent();
+    });

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1308,7 +1308,7 @@ App::patch('/v1/database/collections/:collectionId/documents/:documentId')
             throw new Exception('Unauthorized permissions', 401);
         }
         catch (DuplicateException $exception) {
-            throw new Exception($exception->getMessage(), 400);
+            throw new Exception($exception->getMessage(), 409);
         }
         catch (StructureException $exception) {
             throw new Exception('Bad structure. '.$exception->getMessage(), 400);

--- a/composer.lock
+++ b/composer.lock
@@ -6287,5 +6287,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/e2e/Services/Database/DatabaseBase.php
+++ b/tests/e2e/Services/Database/DatabaseBase.php
@@ -1127,6 +1127,8 @@ trait DatabaseBase
             'write' => ['user:'.$this->getUser()['$id']],
         ]);
 
+        $this->assertEquals(409, $duplicate['headers']['status-code']);
+
         // Test for exception when updating document to conflict
         $document = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['moviesId'] . '/documents', array_merge([
             'content-type' => 'application/json',
@@ -1165,7 +1167,7 @@ trait DatabaseBase
             'write' => ['user:'.$this->getUser()['$id']],
         ]);
 
-        $this->assertEquals(400, $duplicate['headers']['status-code']);
+        $this->assertEquals(409, $duplicate['headers']['status-code']);
 
         return $data;
     }

--- a/tests/e2e/Services/Database/DatabaseBase.php
+++ b/tests/e2e/Services/Database/DatabaseBase.php
@@ -1089,4 +1089,84 @@ trait DatabaseBase
 
         return $data;
     }
+
+    /**
+     * @depends testDefaultPermissions
+     */
+    public function testUniqueIndexDuplicate(array $data): array
+    {
+        $uniqueIndex = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['moviesId'] . '/indexes', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'indexId' => 'unique_title',
+            'type' => 'unique',
+            'attributes' => ['title'],
+        ]);
+
+        $this->assertEquals($uniqueIndex['headers']['status-code'], 201);
+
+        sleep(2);
+
+        // test for failure
+        $duplicate = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['moviesId'] . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'title' => 'Captain America',
+                'releaseYear' => 1944,
+                'actors' => [
+                    'Chris Evans',
+                    'Samuel Jackson',
+                ]
+            ],
+            'read' => ['user:'.$this->getUser()['$id']],
+            'write' => ['user:'.$this->getUser()['$id']],
+        ]);
+
+        // Test for exception when updating document to conflict
+        $document = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['moviesId'] . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'title' => 'Captain America 5',
+                'releaseYear' => 1944,
+                'actors' => [
+                    'Chris Evans',
+                    'Samuel Jackson',
+                ]
+            ],
+            'read' => ['user:'.$this->getUser()['$id']],
+            'write' => ['user:'.$this->getUser()['$id']],
+        ]);
+
+        $this->assertEquals(201, $document['headers']['status-code']);
+
+        // Test for exception when updating document to conflict
+        $duplicate = $this->client->call(Client::METHOD_PATCH, '/database/collections/' . $data['moviesId'] . '/documents/' . $document['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'title' => 'Captain America',
+                'releaseYear' => 1944,
+                'actors' => [
+                    'Chris Evans',
+                    'Samuel Jackson',
+                ]
+            ],
+            'read' => ['user:'.$this->getUser()['$id']],
+            'write' => ['user:'.$this->getUser()['$id']],
+        ]);
+
+        $this->assertEquals(400, $duplicate['headers']['status-code']);
+
+        return $data;
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR catches `\Utopia\Database\Exception\Duplicate` when creating or updating documents. This catches the enforcement of unique indexes.

## Test Plan

Tests included in the PR.

## Related PRs and Issues

https://github.com/utopia-php/database/pull/63 must be released for these tests to pass.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
