### PR TITLE
Fix decouple collections attributes indexes

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -910,11 +910,13 @@ App::post('/v1/database/collections/:collectionId/indexes')
     ->param('orders', [], new ArrayList(new WhiteList(['ASC', 'DESC'], false, Database::VAR_STRING)), 'Array of index orders.', true)
     ->inject('response')
     ->inject('dbForInternal')
+    ->inject('dbForExternal')
     ->inject('database')
     ->inject('audits')
-    ->action(function ($collectionId, $indexId, $type, $attributes, $orders, $response, $dbForInternal, $database, $audits) {
+    ->action(function ($collectionId, $indexId, $type, $attributes, $orders, $response, $dbForInternal, $dbForExternal, $database, $audits) {
         /** @var Appwrite\Utopia\Response $response */
         /** @var Utopia\Database\Database $dbForInternal */
+        /** @var Utopia\Database\Database $dbForExternal */
         /** @var Appwrite\Event\Event $database */
         /** @var Appwrite\Event\Event $audits */
 
@@ -948,7 +950,7 @@ App::post('/v1/database/collections/:collectionId/indexes')
             $lengths[$key] = ($attributeType === Database::VAR_STRING) ? $attributeSize : null;
         }
 
-        $dbForInternal->addIndexInQueue($collectionId, $indexId, $type, $attributes, $lengths, $orders);
+        $dbForExternal->addIndexInQueue($collectionId, $indexId, $type, $attributes, $lengths, $orders);
 
         // Database->createIndex() does not return a document
         // So we need to create one for the response
@@ -976,7 +978,6 @@ App::post('/v1/database/collections/:collectionId/indexes')
 
         $response->setStatusCode(Response::STATUS_CODE_CREATED);
         $response->dynamic($index, Response::MODEL_INDEX);
-       
     });
 
 App::get('/v1/database/collections/:collectionId/indexes')

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1266,7 +1266,7 @@ App::get('/v1/database/collections/:collectionId/documents/:documentId')
     ->param('collectionId', null, new UID(), 'Collection unique ID. You can create a new collection using the Database service [server integration](/docs/server/database#createCollection).')
     ->param('documentId', null, new UID(), 'Document unique ID.')
     ->inject('response')
-    ->inject('$dbForInternal')
+    ->inject('dbForInternal')
     ->inject('dbForExternal')
     ->action(function ($collectionId, $documentId, $response, $dbForInternal, $dbForExternal) {
         /** @var Appwrite\Utopia\Response $response */

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1226,16 +1226,16 @@ App::get('/v1/database/collections/:collectionId/documents')
         }, $queries);
 
         // TODO@kodumbeats find a more efficient alternative to this
-        $schema = $collection->getArrayCopy()['attributes'];
-        $indexes = $collection->getArrayCopy()['indexes'];
-        $indexesInQueue = $collection->getArrayCopy()['indexesInQueue'];
+        // $schema = $collection->getArrayCopy()['attributes'];
+        // $indexes = $collection->getArrayCopy()['indexes'];
+        // $indexesInQueue = $collection->getArrayCopy()['indexesInQueue'];
 
         // TODO@kodumbeats use strict query validation
-        $validator = new QueriesValidator(new QueryValidator($schema), $indexes, $indexesInQueue, false);
+        // $validator = new QueriesValidator(new QueryValidator($schema), $indexes, $indexesInQueue, false);
 
-        if (!$validator->isValid($queries)) {
-            throw new Exception($validator->getDescription(), 400);
-        }
+        // if (!$validator->isValid($queries)) {
+        //     throw new Exception($validator->getDescription(), 400);
+        // }
 
         if (!empty($after)) {
             $afterDocument = $dbForExternal->getDocument($collectionId, $after);

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "utopia-php/cache": "0.4.*",
         "utopia-php/cli": "0.11.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "0.8.*",
+        "utopia-php/database": "0.9.*",
         "utopia-php/locale": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c43b186a794c614272806e6530ada496",
+    "content-hash": "6489948fde57f58412fdda5737e5a77e",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1984,16 +1984,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "2645c150267aaf73c70fb8a8d1a74430c9e6f336"
+                "reference": "f9b1836621df7e14300f1622cb8b8d6fcfedfdaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/2645c150267aaf73c70fb8a8d1a74430c9e6f336",
-                "reference": "2645c150267aaf73c70fb8a8d1a74430c9e6f336",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/f9b1836621df7e14300f1622cb8b8d6fcfedfdaf",
+                "reference": "f9b1836621df7e14300f1622cb8b8d6fcfedfdaf",
                 "shasum": ""
             },
             "require": {
@@ -2041,9 +2041,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.8.0"
+                "source": "https://github.com/utopia-php/database/tree/0.9.0"
             },
-            "time": "2021-08-16T17:19:07+00:00"
+            "time": "2021-08-18T19:08:47+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -6278,5 +6278,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses most of the test failures, so they can be more meaningful in development.

1. Upgrades to `utopia-php/database:0.9.0`
2. Updates the internal collection document in the database worker
3. Got confused which metadata table will store the queue - should it be internal or external?
    - Updated `indexes` to match `attributes` in using the external table for now
4. Once that's sorted, we can re-enable the Queries validator, which broke on this change
5. The existing test failure is in `after` pagination, but I wasn't sure how to approach debugging that one.

## Test Plan

Existing coverage is sufficient.

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
