### PR TITLE
Fix anchor link to Technology Stack heading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ We love to create issues that are good for beginners and label them as `good fir
 - [PHP FIG](https://www.php-fig.org/) - [PSR-1](https://www.php-fig.org/psr/psr-1/) and [PSR-4](https://www.php-fig.org/psr/psr-4/)
 - [PHP Swoole](https://www.swoole.co.uk/)
 
-Learn more at our [Technology Stack](## Technology Stack) section.
+Learn more at our [Technology Stack](#technology-stack) section.
 
 ##### Network and Protocols
 - [OSI Model](https://en.wikipedia.org/wiki/OSI_model)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the anchor link in [Tools and Libs](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md?plain=1#L102) in [CONTRIBUTING.md](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md) that refers to the **Technology Stack** heading 

## Test Plan

1. Visit [Tools and Libs](https://github.com/appwrite/appwrite/blob/7ca025f1ad84322189ea0e1ec8ee02579ab7e3dd/CONTRIBUTING.md#tools-and-libs) in CONTRIBUTING.md in the branch
2. Click on the **Technology Stack** link

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
