### PR TITLE
Feat - Parellel builds to reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ notifications:
   email:
   - team@appwrite.io
 
+env:
+  - COMPOSE_INTERACTIVE_NO_CLI=1
+  - DOCKER_BUILDKIT=1
+  - COMPOSE_DOCKER_CLI_BUILD=1
+  - BUILDKIT_PROGRESS=plain
+
 before_install:
 - curl -fsSL https://get.docker.com | sh
 - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
@@ -25,13 +31,12 @@ before_install:
 - docker --version
 - docker buildx create --use
 - chmod -R u+x ./.travis-ci
-- export COMPOSE_INTERACTIVE_NO_CLI=1
 # Only pass a single runtime for CI stability
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
 
 install:
 - docker-compose pull
-- DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 BUILDKIT_PROGRESS=plain docker-compose build
+- docker-compose build
 - docker-compose up -d
 - sleep 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,12 @@ before_install:
 - docker buildx create --use
 - chmod -R u+x ./.travis-ci
 - export COMPOSE_INTERACTIVE_NO_CLI=1
-- export DOCKER_BUILDKIT=1
-- export COMPOSE_DOCKER_CLI_BUILD=1
 # Only pass a single runtime for CI stability
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
 
 install:
 - docker-compose pull
-- docker-compose build
+- DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 BUILDKIT_PROGRESS=plain docker-compose build
 - docker-compose up -d
 - sleep 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,6 @@ notifications:
   email:
   - team@appwrite.io
 
-env:
-  - DOCKER_COMPOSE_VERSION=1.29.2
-  - COMPOSE_INTERACTIVE_NO_CLI=1
-  - DOCKER_BUILDKIT=1
-  - COMPOSE_DOCKER_CLI_BUILD=1
-  - BUILDKIT_PROGRESS=plain
-
 before_install:
 - curl -fsSL https://get.docker.com | sh
 - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
@@ -31,12 +24,16 @@ before_install:
   fi
 - docker --version
 - sudo rm /usr/local/bin/docker-compose
-- curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+- curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` > docker-compose
 - chmod +x docker-compose
 - sudo mv docker-compose /usr/local/bin
 - docker-compose --version
 - docker buildx create --use
 - chmod -R u+x ./.travis-ci
+- export COMPOSE_INTERACTIVE_NO_CLI
+- export DOCKER_BUILDKIT=1
+- export COMPOSE_DOCKER_CLI_BUILD=1
+- export BUILDKIT_PROGRESS=plain
 # Only pass a single runtime for CI stability
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,35 @@ notifications:
   - team@appwrite.io
 
 before_install:
+# Install latest Docker
 - curl -fsSL https://get.docker.com | sh
+# Enable Buildkit in Docker config
 - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
 - mkdir -p $HOME/.docker
 - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
 - sudo service docker start
+# Login to increase Docker Hub ratelimit
 - >
   if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
     echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
   fi
 - docker --version
+# Install latest Compose
 - sudo rm /usr/local/bin/docker-compose
 - curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` > docker-compose
 - chmod +x docker-compose
 - sudo mv docker-compose /usr/local/bin
 - docker-compose --version
+# Enable Buildkit
 - docker buildx create --use
-- chmod -R u+x ./.travis-ci
 - export COMPOSE_INTERACTIVE_NO_CLI
 - export DOCKER_BUILDKIT=1
 - export COMPOSE_DOCKER_CLI_BUILD=1
 - export BUILDKIT_PROGRESS=plain
 # Only pass a single runtime for CI stability
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
+# Ensure Travis scripts are executable
+- chmod -R u+x ./.travis-ci
 
 install:
 - docker-compose pull

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ before_install:
 
 install:
 - docker-compose pull
+# Upstream bug causes buildkit pulls to fail so prefetch base images
+# https://github.com/moby/moby/issues/41864
+- docker pull composer:2.0
+- docker pull php:8.0-cli-alpine
 - docker-compose build
 - docker-compose up -d
 - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,15 @@ before_install:
 - docker buildx create --use
 - chmod -R u+x ./.travis-ci
 - export COMPOSE_INTERACTIVE_NO_CLI=1
+- export DOCKER_BUILDKIT=1
+- export COMPOSE_DOCKER_CLI_BUILD=1
 # Only pass a single runtime for CI stability
 - echo "_APP_FUNCTIONS_RUNTIMES=php-8.0" >> .env
 
 install:
-- docker-compose up -d --build
+- docker-compose pull
+- docker-compose build
+- docker-compose up -d
 - sleep 10
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ arch:
 
 os: linux
 
+vm:
+  size: large
+
 language: shell
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
   - team@appwrite.io
 
 env:
+  - DOCKER_COMPOSE_VERSION=1.29.2
   - COMPOSE_INTERACTIVE_NO_CLI=1
   - DOCKER_BUILDKIT=1
   - COMPOSE_DOCKER_CLI_BUILD=1
@@ -29,6 +30,11 @@ before_install:
     echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
   fi
 - docker --version
+- sudo rm /usr/local/bin/docker-compose
+- curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+- chmod +x docker-compose
+- sudo mv docker-compose /usr/local/bin
+- docker-compose --version
 - docker buildx create --use
 - chmod -R u+x ./.travis-ci
 # Only pass a single runtime for CI stability

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 - sudo mv docker-compose /usr/local/bin
 - docker-compose --version
 # Enable Buildkit
-- docker buildx create --use
+- docker buildx create --name travis_builder --use
 - export COMPOSE_INTERACTIVE_NO_CLI
 - export DOCKER_BUILDKIT=1
 - export COMPOSE_DOCKER_CLI_BUILD=1
@@ -56,6 +56,10 @@ script:
 - docker-compose exec appwrite doctor
 - docker-compose exec appwrite vars
 - docker-compose exec appwrite test --debug
+
+after_script:
+# travis re-uses their build nodes so clean them up
+- docker buildx rm travis_builder
 
 after_failure:
 - docker-compose logs appwrite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.0 as step0
+FROM composer:2.0 as composer
 
 ARG TESTING=false
 ENV TESTING=$TESTING
@@ -12,7 +12,7 @@ RUN composer update --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM php:8.0-cli-alpine as step1
+FROM php:8.0-cli-alpine as compile
 
 ARG DEBUG=false
 ENV DEBUG=$DEBUG
@@ -40,43 +40,24 @@ RUN \
 
 RUN docker-php-ext-install sockets
 
+FROM compile AS redis
 RUN \
   # Redis Extension
   git clone --depth 1 --branch $PHP_REDIS_VERSION https://github.com/phpredis/phpredis.git && \
   cd phpredis && \
   phpize && \
   ./configure && \
-  make && make install && \
-  cd .. && \
-  ## Swoole Extension
+  make && make install
+
+## Swoole Extension
+FROM compile AS swoole
+RUN \
   git clone --depth 1 --branch $PHP_SWOOLE_VERSION https://github.com/swoole/swoole-src.git && \
   cd swoole-src && \
   phpize && \
   ./configure --enable-http2 && \
   make && make install && \
-  cd .. && \
-  ## Imagick Extension
-  git clone --depth 1 --branch $PHP_IMAGICK_VERSION https://github.com/imagick/imagick && \
-  cd imagick && \
-  phpize && \
-  ./configure && \
-  make && make install && \
-  cd .. && \
-  ## YAML Extension
-  git clone --depth 1 --branch $PHP_YAML_VERSION https://github.com/php/pecl-file_formats-yaml && \
-  cd pecl-file_formats-yaml && \
-  phpize && \
-  ./configure && \
-  make && make install && \
-  cd .. && \
-  ## Maxminddb extension
-  git clone --depth 1 --branch $PHP_MAXMINDDB_VERSION https://github.com/maxmind/MaxMind-DB-Reader-php.git && \
-  cd MaxMind-DB-Reader-php && \
-  cd ext && \
-  phpize && \
-  ./configure && \
-  make && make install && \
-  cd ../..
+  cd ..
 
 ## Swoole Debugger setup
 RUN if [ "$DEBUG" == "true" ]; then \
@@ -89,6 +70,34 @@ RUN if [ "$DEBUG" == "true" ]; then \
     make && make install && \
     cd ..;\
   fi
+
+## Imagick Extension
+FROM compile AS imagick
+RUN \
+  git clone --depth 1 --branch $PHP_IMAGICK_VERSION https://github.com/imagick/imagick && \
+  cd imagick && \
+  phpize && \
+  ./configure && \
+  make && make install
+
+## YAML Extension
+FROM compile AS yaml
+RUN \
+  git clone --depth 1 --branch $PHP_YAML_VERSION https://github.com/php/pecl-file_formats-yaml && \
+  cd pecl-file_formats-yaml && \
+  phpize && \
+  ./configure && \
+  make && make install
+
+## Maxminddb extension
+FROM compile AS maxmind
+RUN \
+  git clone --depth 1 --branch $PHP_MAXMINDDB_VERSION https://github.com/maxmind/MaxMind-DB-Reader-php.git && \
+  cd MaxMind-DB-Reader-php && \
+  cd ext && \
+  phpize && \
+  ./configure && \
+  make && make install
 
 FROM php:8.0-cli-alpine as final
 
@@ -184,12 +193,12 @@ RUN \
 
 WORKDIR /usr/src/code
 
-COPY --from=step0 /usr/local/src/vendor /usr/src/code/vendor
-COPY --from=step1 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
-COPY --from=step1 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/redis.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
-COPY --from=step1 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
-COPY --from=step1 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yaml.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
-COPY --from=step1 /usr/local/lib/php/extensions/no-debug-non-zts-20200930/maxminddb.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/ 
+COPY --from=composer /usr/local/src/vendor /usr/src/code/vendor
+COPY --from=swoole /usr/local/lib/php/extensions/no-debug-non-zts-20200930/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yasd.so* /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
+COPY --from=redis /usr/local/lib/php/extensions/no-debug-non-zts-20200930/redis.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
+COPY --from=imagick /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
+COPY --from=yaml /usr/local/lib/php/extensions/no-debug-non-zts-20200930/yaml.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
+COPY --from=maxmind /usr/local/lib/php/extensions/no-debug-non-zts-20200930/maxminddb.so /usr/local/lib/php/extensions/no-debug-non-zts-20200930/
 
 # Add Source Code
 COPY ./app /usr/src/code/app


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR makes a few changes to the structure of the Dockerfile and Travis config to allow for much faster builds:

- Uses `buildkit` as the build engine, which is much better at running builds in parallel
- Breaks the `compile` step into multiple stages, since we can use [a previous stage as a new stage](https://docs.docker.com/develop/develop-images/multistage-build/#use-a-previous-stage-as-a-new-stage)
- Renames stages to be descriptive, instead of serial.
- Calls `docker-compose pull` before bringing the stack up, which pulls images in parallel

## Test Plan

Test suite will demonstrate the build change is successful.

## TODO
- [x] investigate why `composer:2.0` fails to pull correctly on `arm64`:
https://app.travis-ci.com/github/appwrite/appwrite/jobs/535129292

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/714

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
