### PR TITLE
fix(functions): properly cast cpu counts variable

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -410,9 +410,9 @@ class FunctionsV1 extends Worker
             $executionStart = \microtime(true);
             $executionTime = \time();
 
-            $orchestration->setCpus(App::getEnv('_APP_FUNCTIONS_CPUS', '1'));
-            $orchestration->setMemory(App::getEnv('_APP_FUNCTIONS_MEMORY', '256'));
-            $orchestration->setSwap(App::getEnv('_APP_FUNCTIONS_MEMORY_SWAP', '256'));
+            $orchestration->setCpus((int) App::getEnv('_APP_FUNCTIONS_CPUS', 0));
+            $orchestration->setMemory((int) App::getEnv('_APP_FUNCTIONS_MEMORY', 256));
+            $orchestration->setSwap((int) App::getEnv('_APP_FUNCTIONS_MEMORY_SWAP', 256));
 
             foreach ($vars as &$value) {
                 $value = strval($value);


### PR DESCRIPTION
## What does this PR do?

- fixes casting an env variable to integer
- set count to `0` by default (unlimited)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 