### PR TITLE
fix(refactor-db): use correct constant when deleting usage stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,12 @@ install:
 
 script:
 - docker ps -a
+# Tests should fail if any container is in exited status
+- ALL_UP=`docker ps -aq --filter "status=exited"`
+- >
+  if [[ "$ALL_UP" != "" ]]; then
+    exit 1
+  fi
 - docker-compose logs appwrite
 - docker-compose logs mariadb
 - docker-compose logs appwrite-worker-functions

--- a/app/tasks/maintenance.php
+++ b/app/tasks/maintenance.php
@@ -42,7 +42,7 @@ $cli
         function notifyDeleteUsageStats(int $interval30m, int $interval1d) 
         {
             Resque::enqueue(Event::DELETE_QUEUE_NAME, Event::DELETE_CLASS_NAME, [
-                'type' => DELETE_TYPE_USAGE_STATS,
+                'type' => DELETE_TYPE_USAGE,
                 'timestamp1d' => time() - $interval1d,
                 'timestamp30m' => time() - $interval30m,
             ]);

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -79,7 +79,7 @@ class DeletesV1 extends Worker
                 $this->deleteCertificates($document);
                 break;
 
-            case DELETE_TYPE_USAGE_STATS:
+            case DELETE_TYPE_USAGE:
                 $this->deleteUsageStats($this->args['timestamp1d'], $this->args['timestamp30m']);
                 break;
             default:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In https://github.com/appwrite/appwrite/pull/1557, code was added to clean up usage stats. The last commit https://github.com/appwrite/appwrite/pull/1557/commits/b38c77255e0d03e4e5206a5da09ede133d7ec508 updates the constant for the delete queue, but the constant was not updated in the task or worker. 

This bug was deceptive because the test suite passed with this change: https://app.travis-ci.com/github/appwrite/appwrite/jobs/536125257. However, if you look at the output of `docker ps`, you'll see `appwrite-maintenance` fails to start.

This PR uses the updated constant in the maintenance task and deletes worker.

## Test Plan

The Travis job has been updated to exit if any container is in exited status.

## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/1557

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
