### PR TITLE
Feat: enable SMTP debugging when not in production

### DIFF
--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -129,6 +129,7 @@ $cli
 
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
+            $mail->SMTPDebug = \PHPMailer\PHPMailer\SMTP::DEBUG_SERVER;
 
             $mail->addAddress('demo@example.com', 'Example.com');
             $mail->Subject = 'Test SMTP Connection';

--- a/app/workers/mails.php
+++ b/app/workers/mails.php
@@ -76,6 +76,11 @@ class MailsV1 extends Worker
         /** @var \PHPMailer\PHPMailer\PHPMailer $mail */
         $mail = $register->get('smtp');
 
+        // https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#enabling-debug-output
+        if (App::getEnv('_APP_ENV') !== App::MODE_TYPE_PRODUCTION) {
+            $mail->SMTPDebug = \PHPMailer\PHPMailer\SMTP::DEBUG_SERVER;
+        }
+
         // Set project mail
         /*$register->get('smtp')
             ->setFrom(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

PHPMailer doesn't have very useful error messages by default, and in fact provides a [URL to their wiki](https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting). This PR increases the debugging level of PHPMailer when not in production.

## Test Plan

Check logs on failed SMTP delivery.

## Unanswered questions

- [ ] This will `echo` the logs by default, but I can overwrite the logging function. Will `echo`ing logs work, or should we use the Utopia CLI lib?

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/1390

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
