### PR TITLE
Return oneOf models for getAttribute

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -1040,7 +1040,14 @@ App::get('/v1/database/collections/:collectionId/attributes/:attributeId')
     ->label('sdk.description', '/docs/references/database/get-attribute.md')
     ->label('sdk.response.code', Response::STATUS_CODE_OK)
     ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
-    ->label('sdk.response.model', Response::MODEL_ATTRIBUTE)
+    ->label('sdk.response.model', [
+        Response::MODEL_ATTRIBUTE_BOOLEAN,
+        Response::MODEL_ATTRIBUTE_INTEGER,
+        Response::MODEL_ATTRIBUTE_FLOAT,
+        Response::MODEL_ATTRIBUTE_EMAIL,
+        Response::MODEL_ATTRIBUTE_URL,
+        Response::MODEL_ATTRIBUTE_IP,
+        Response::MODEL_ATTRIBUTE_STRING,])// needs to be last, since its condition would dominate any other string attribute
     ->param('collectionId', '', new UID(), 'Collection unique ID. You can create a new collection using the Database service [server integration](/docs/server/database#createCollection).')
     ->param('attributeId', '', new Key(), 'Attribute ID.')
     ->inject('response')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR changes the response model of `getAttribute` to be oneOf the list of typed attributes.

## Test Plan

API spec check tests cover this change.

## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/1484

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
