### PR TITLE
Fix hyperlink in documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -26,7 +26,7 @@ body:
   - type: checkboxes
     id: read-code-of-conduct
     attributes:
-      label: "🏢 Have you read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)?"
+      label: "🏢 Have you read the Code of Conduct?"
       options:
-        - label: "I read the Code of Conduct"
+        - label: "I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)"
           required: true


### PR DESCRIPTION
## What does this PR do?

This PR fixes the `documentation.yaml` markdown hyperlink not being translated in the "Have you read the Code of Conduct" title, also sneaked in a quick little grammar fix.

## Test Plan

I looked at the file on GitHub, here are screenshots of the before and after.

#### Before fix

![Screen Shot 2021-10-01 at 1 07 24 AM](https://user-images.githubusercontent.com/2221746/135541843-42fce764-7b62-4cd2-ab5e-aa0f201d5200.png)

#### After fix

![Screen Shot 2021-10-01 at 1 08 57 AM](https://user-images.githubusercontent.com/2221746/135541855-df457c09-1b1e-4fdc-a713-a70aac587777.png)

## Related PRs and Issues

No related PR or issue.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

![](https://media.giphy.com/media/xUNd9Xbh0kbq4ox2Fi/giphy.gif)