### PR TITLE
Fixed typo

### DIFF
--- a/docs/services/functions.md
+++ b/docs/services/functions.md
@@ -1,5 +1,5 @@
 The Functions service allows you to create custom behaviour that can be triggered by any supported Appwrite system events or by a predefined schedule.
 
-Appwrite Cloud Functions lets you automatically run backend code in response to events triggered by Appwrite or by setting it to be executed in a predefined schedule. Your code is stored in a secure way on your Appwrite instance and is executed in an isolated enviornment.
+Appwrite Cloud Functions lets you automatically run backend code in response to events triggered by Appwrite or by setting it to be executed in a predefined schedule. Your code is stored in a secure way on your Appwrite instance and is executed in an isolated environment.
 
 You can learn more by following our [Cloud Functions tutorial](https://appwrite.io/docs/functions).


### PR DESCRIPTION
## What does this PR do?

This PR fixes the mistyped 'enviornment' to the correct 'environment' spelling.

Glad I could contribute!


