### PR TITLE
fix: mobile storage image preview

### DIFF
--- a/public/styles/forms.less
+++ b/public/styles/forms.less
@@ -25,7 +25,7 @@ input, textarea {
 
 input[type=file],
 input[type=file]::-webkit-file-upload-button {
-    cursor: pointer; 
+    cursor: pointer;
 }
 
 button,
@@ -412,6 +412,7 @@ fieldset {
   width: ~"calc(100% - 2px)";
   max-height: 180px;
   visibility: visible !important;
+  object-fit: contain;
 }
 
 .video-preview {
@@ -591,7 +592,7 @@ input[type=checkbox], input[type=radio] {
     color: var(--config-color-background-fade);
     background: var(--config-color-focus);
   }
-  
+
   &[type=radio] {
     &:checked:after {
       //content: '●';
@@ -650,7 +651,7 @@ input[type=checkbox], input[type=radio] {
   color: var(--config-color-fade);
   padding: 5px 15px;
   font-size: 12px;
-  
+
   form {
     display: inline-block;
   }
@@ -817,7 +818,7 @@ label.switch {
     &:focus,
     &:hover {
       background: var(--config-color-success);
-    }  
+    }
   }
 
   &:focus,
@@ -929,7 +930,7 @@ hr {
   height: 1px;
   background: var(--config-border-color)!important;
   border: none;
-  
+
   &.fade {
     opacity: .7;
   }
@@ -1299,7 +1300,7 @@ ol {
   height: 26px;
   width: 44px;
   margin: 9px 0;
-  
+
   button {
     padding: 3px;
     display: block;
@@ -1322,7 +1323,7 @@ ol {
     &.force-light {
       .pull-end;
     }
-    
+
     &.force-dark {
       .pull-start;
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes the mobile image preview size of images in `Storage`

The **current image preview** looks like this:
![](https://user-images.githubusercontent.com/4334997/136633815-4640d1a9-8856-4f3b-85fa-50906d50e9dc.png)

**After this PR** it will look like this:
![](https://user-images.githubusercontent.com/4334997/136633819-01d71407-66d9-454c-8779-543b86a4c993.png)

<b>The change is only in [line 415](https://github.com/appwrite/appwrite/compare/master...m1ga:imageFix?expand=1#diff-6bbe38673cd43269c0b2b737d892f61507b15646a5bed5efcf26285884475089R415) but my linter removed some trailing spaces </b> :wink: 

## Test Plan

tested it in local Appwrite build with Firefox and Chrome

* Go to `Storage`
* Upload an image
* Change Browser size to a mobile layout (or just a small browser window)
* open the preview of the image

## Related PRs and Issues

Relates https://github.com/appwrite/appwrite/issues/2164

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

:heavy_check_mark:  yes
