### PR TITLE
Fixed the unknown SVG icon

### DIFF
--- a/public/images/unknown.svg
+++ b/public/images/unknown.svg
@@ -1,3 +1,3 @@
-<svg height="100" width="100">
+<svg xmlns="http://www.w3.org/2000/svg" height="100" width="100">
   <circle cx="50" cy="50" r="40" fill="#c9c9c9" />
 </svg>


### PR DESCRIPTION
## What does this PR do?

This PR fixes a small but annoying glitch present in the page `http://<your-appwrite-host>/console/account/activity`.
As you can see in the image below, the code of the country is not detected properly (I don't know exactly the reason) and a placeholder (`unknown.svg`) is used instead. The problem is that the images fails to load.
<img width="1080" alt="Schermata 2021-10-19 alle 23 15 07" src="https://user-images.githubusercontent.com/8852116/137995191-f513a9e4-5891-44a1-a383-55a1a9139881.png">

The issue is actually that the file `unknown.svg` is not a valid SVG file since it's missing the declaration of the _XML NameSpace_ (`xmlns` attribute) or the DOCTYPE specification.
I have fixed the file so that now is recognized as a proper SVG file and rendered correctly as it was ment.
<img width="1080" alt="Schermata 2021-10-19 alle 23 33 12" src="https://user-images.githubusercontent.com/8852116/137996064-79c159a5-e171-4ddc-9923-98cd32c1cb68.png">

## Test Plan

I tested the modification by applying it and than checking the outcome visiting the same page that was showing the bug.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes!

Thanks for such an amazing project! :smile: 