### PR TITLE
Backfill usage stats with empty records when required

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -323,10 +323,13 @@ App::get('/v1/database/usage')
 
             Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
+                    $limit = $period[$range]['limit'];
+                    $period = $period[$range]['period'];
+
                     $requestDocs = $dbForInternal->find('stats', [
-                        new Query('period', Query::TYPE_EQUAL, [$period[$range]['period']]),
+                        new Query('period', Query::TYPE_EQUAL, [$period]),
                         new Query('metric', Query::TYPE_EQUAL, [$metric]),
-                    ], $period[$range]['limit'], 0, ['time'], [Database::ORDER_DESC]);
+                    ], $limit, 0, ['time'], [Database::ORDER_DESC]);
 
                     $stats[$metric] = [];
                     foreach ($requestDocs as $requestDoc) {
@@ -334,6 +337,21 @@ App::get('/v1/database/usage')
                             'value' => $requestDoc->getAttribute('value'),
                             'date' => $requestDoc->getAttribute('time'),
                         ];
+                    }
+
+                    // backfill metrics with empty values for graphs
+                    $backfill = $limit - \count($requestDocs);
+                    while ($backfill > 0) {
+                        $last = $limit - $backfill - 1; // array index of last added metric
+                        $diff = match($period) { // convert period to seconds for unix timestamp math
+                            '30m' => 1800,
+                            '1d' => 86400,
+                        };
+                        $stats[$metric][] = [
+                            'value' => 0,
+                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                        ];
+                        $backfill--;
                     }
                     $stats[$metric] = array_reverse($stats[$metric]);
                 }
@@ -417,10 +435,13 @@ App::get('/v1/database/:collectionId/usage')
 
             Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
+                    $limit = $period[$range]['limit'];
+                    $period = $period[$range]['period'];
+
                     $requestDocs = $dbForInternal->find('stats', [
-                        new Query('period', Query::TYPE_EQUAL, [$period[$range]['period']]),
+                        new Query('period', Query::TYPE_EQUAL, [$period]),
                         new Query('metric', Query::TYPE_EQUAL, [$metric]),
-                    ], $period[$range]['limit'], 0, ['time'], [Database::ORDER_DESC]);
+                    ], $limit, 0, ['time'], [Database::ORDER_DESC]);
 
                     $stats[$metric] = [];
                     foreach ($requestDocs as $requestDoc) {
@@ -428,6 +449,21 @@ App::get('/v1/database/:collectionId/usage')
                             'value' => $requestDoc->getAttribute('value'),
                             'date' => $requestDoc->getAttribute('time'),
                         ];
+                    }
+
+                    // backfill metrics with empty values for graphs
+                    $backfill = $limit - \count($requestDocs);
+                    while ($backfill > 0) {
+                        $last = $limit - $backfill - 1; // array index of last added metric
+                        $diff = match($period) { // convert period to seconds for unix timestamp math
+                            '30m' => 1800,
+                            '1d' => 86400,
+                        };
+                        $stats[$metric][] = [
+                            'value' => 0,
+                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                        ];
+                        $backfill--;
                     }
                     $stats[$metric] = array_reverse($stats[$metric]);
                 }    

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -287,7 +287,7 @@ App::get('/v1/database/usage')
 
         $usage = [];
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -321,10 +321,10 @@ App::get('/v1/database/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),
@@ -404,7 +404,7 @@ App::get('/v1/database/:collectionId/usage')
         
         $usage = [];
         if(App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -433,10 +433,10 @@ App::get('/v1/database/:collectionId/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -349,7 +349,7 @@ App::get('/v1/database/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }
@@ -461,7 +461,7 @@ App::get('/v1/database/:collectionId/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -353,6 +353,7 @@ App::get('/v1/database/usage')
                         ];
                         $backfill--;
                     }
+                    // TODO@kodumbeats explore performance if query is ordered by time ASC
                     $stats[$metric] = array_reverse($stats[$metric]);
                 }
             });

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -176,7 +176,7 @@ App::get('/v1/functions/:functionId/usage')
         
         $usage = [];
         if(App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -203,10 +203,10 @@ App::get('/v1/functions/:functionId/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -231,7 +231,7 @@ App::get('/v1/functions/:functionId/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -205,10 +205,13 @@ App::get('/v1/functions/:functionId/usage')
 
             Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
+                    $limit = $period[$range]['limit'];
+                    $period = $period[$range]['period'];
+
                     $requestDocs = $dbForInternal->find('stats', [
-                        new Query('period', Query::TYPE_EQUAL, [$period[$range]['period']]),
+                        new Query('period', Query::TYPE_EQUAL, [$period]),
                         new Query('metric', Query::TYPE_EQUAL, [$metric]),
-                    ], $period[$range]['limit'], 0, ['time'], [Database::ORDER_DESC]);
+                    ], $limit, 0, ['time'], [Database::ORDER_DESC]);
     
                     $stats[$metric] = [];
                     foreach ($requestDocs as $requestDoc) {
@@ -216,6 +219,21 @@ App::get('/v1/functions/:functionId/usage')
                             'value' => $requestDoc->getAttribute('value'),
                             'date' => $requestDoc->getAttribute('time'),
                         ];
+                    }
+
+                    // backfill metrics with empty values for graphs
+                    $backfill = $limit - \count($requestDocs);
+                    while ($backfill > 0) {
+                        $last = $limit - $backfill - 1; // array index of last added metric
+                        $diff = match($period) { // convert period to seconds for unix timestamp math
+                            '30m' => 1800,
+                            '1d' => 86400,
+                        };
+                        $stats[$metric][] = [
+                            'value' => 0,
+                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                        ];
+                        $backfill--;
                     }
                     $stats[$metric] = array_reverse($stats[$metric]);
                 }    

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -316,7 +316,7 @@ App::get('/v1/projects/:projectId/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -255,7 +255,7 @@ App::get('/v1/projects/:projectId/usage')
 
         $usage = [];
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -288,10 +288,10 @@ App::get('/v1/projects/:projectId/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -290,10 +290,13 @@ App::get('/v1/projects/:projectId/usage')
 
             Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
+                    $limit = $period[$range]['limit'];
+                    $period = $period[$range]['period'];
+
                     $requestDocs = $dbForInternal->find('stats', [
-                        new Query('period', Query::TYPE_EQUAL, [$period[$range]['period']]),
+                        new Query('period', Query::TYPE_EQUAL, [$period]),
                         new Query('metric', Query::TYPE_EQUAL, [$metric]),
-                    ], $period[$range]['limit'], 0, ['time'], [Database::ORDER_DESC]);
+                    ], $limit, 0, ['time'], [Database::ORDER_DESC]);
 
                     $stats[$metric] = [];
                     foreach ($requestDocs as $requestDoc) {
@@ -301,6 +304,21 @@ App::get('/v1/projects/:projectId/usage')
                             'value' => $requestDoc->getAttribute('value'),
                             'date' => $requestDoc->getAttribute('time'),
                         ];
+                    }
+
+                    // backfill metrics with empty values for graphs
+                    $backfill = $limit - \count($requestDocs);
+                    while ($backfill > 0) {
+                        $last = $limit - $backfill - 1; // array index of last added metric
+                        $diff = match($period) { // convert period to seconds for unix timestamp math
+                            '30m' => 1800,
+                            '1d' => 86400,
+                        };
+                        $stats[$metric][] = [
+                            'value' => 0,
+                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                        ];
+                        $backfill--;
                     }
                     $stats[$metric] = array_reverse($stats[$metric]);
                 }

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -670,7 +670,7 @@ App::get('/v1/storage/usage')
 
         $usage = [];
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -696,10 +696,10 @@ App::get('/v1/storage/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),
@@ -764,7 +764,7 @@ App::get('/v1/storage/:bucketId/usage')
         
         $usage = [];
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -793,10 +793,10 @@ App::get('/v1/storage/:bucketId/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -724,7 +724,7 @@ App::get('/v1/storage/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }
@@ -821,7 +821,7 @@ App::get('/v1/storage/:bucketId/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -833,6 +833,7 @@ App::get('/v1/users/usage')
                     // backfill metrics with empty values for graphs
                     $backfill = $limit - \count($requestDocs);
                     while ($backfill > 0) {
+
                         $last = $limit - $backfill - 1; // array index of last added metric
                         $diff = match($period) { // convert period to seconds for unix timestamp math
                             '30m' => 1800,
@@ -840,7 +841,7 @@ App::get('/v1/users/usage')
                         };
                         $stats[$metric][] = [
                             'value' => 0,
-                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                            'date' => ($stats[$metric][$last]['date'] ?? \time()) - $diff, // time of last metric minus period
                         ];
                         $backfill--;
                     }

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -814,10 +814,13 @@ App::get('/v1/users/usage')
 
             Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
+                    $limit = $period[$range]['limit'];
+                    $period = $period[$range]['period'];
+
                     $requestDocs = $dbForInternal->find('stats', [
-                        new Query('period', Query::TYPE_EQUAL, [$period[$range]['period']]),
+                        new Query('period', Query::TYPE_EQUAL, [$period]),
                         new Query('metric', Query::TYPE_EQUAL, [$metric]),
-                    ], $period[$range]['limit'], 0, ['time'], [Database::ORDER_DESC]);
+                    ], $limit, 0, ['time'], [Database::ORDER_DESC]);
     
                     $stats[$metric] = [];
                     foreach ($requestDocs as $requestDoc) {
@@ -825,6 +828,21 @@ App::get('/v1/users/usage')
                             'value' => $requestDoc->getAttribute('value'),
                             'date' => $requestDoc->getAttribute('time'),
                         ];
+                    }
+
+                    // backfill metrics with empty values for graphs
+                    $backfill = $limit - \count($requestDocs);
+                    while ($backfill > 0) {
+                        $last = $limit - $backfill - 1; // array index of last added metric
+                        $diff = match($period) { // convert period to seconds for unix timestamp math
+                            '30m' => 1800,
+                            '1d' => 86400,
+                        };
+                        $stats[$metric][] = [
+                            'value' => 0,
+                            'date' => $stats[$metric][$last]['time'] - $diff, // time of last metric minus period
+                        ];
+                        $backfill--;
                     }
                     $stats[$metric] = array_reverse($stats[$metric]);
                 }    

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -780,7 +780,7 @@ App::get('/v1/users/usage')
 
         $usage = [];
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
-            $period = [
+            $periods = [
                 '24h' => [
                     'period' => '30m',
                     'limit' => 48,
@@ -812,10 +812,10 @@ App::get('/v1/users/usage')
 
             $stats = [];
 
-            Authorization::skip(function() use ($dbForInternal, $period, $range, $metrics, &$stats) {
+            Authorization::skip(function() use ($dbForInternal, $periods, $range, $metrics, &$stats) {
                 foreach ($metrics as $metric) {
-                    $limit = $period[$range]['limit'];
-                    $period = $period[$range]['period'];
+                    $limit = $periods[$range]['limit'];
+                    $period = $periods[$range]['period'];
 
                     $requestDocs = $dbForInternal->find('stats', [
                         new Query('period', Query::TYPE_EQUAL, [$period]),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR updates the `usage` routes to backfill with empty record if the range (e.g. 30d) doesn't have a full history (created 5d ago). The following controllers were affected:
- database
- functions
- projects
- storage
- users

### Backfilled dashboard:
![dbusagestats](https://user-images.githubusercontent.com/9708641/139157982-92497fd4-403e-4eb2-99cd-6c510aad8908.png)

## Test Plan

Can verify visually that stats are backfilled.

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
