### PR TITLE
Add Godot Engine SDK to Community SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ Below is a list of currently supported platforms and languages. If you wish to h
 * ✅  &nbsp; [.NET](https://github.com/appwrite/sdk-for-dotnet) - **Experimental** (Maintained by the Appwrite Team)
 
 #### Community
-* ✅  &nbsp; [Appcelerator Titanium](https://github.com/m1ga/ti.appwrite) (Maintained by [Michael Gangolf](https://github.com/m1ga/))    
-    
+* ✅  &nbsp; [Appcelerator Titanium](https://github.com/m1ga/ti.appwrite) (Maintained by [Michael Gangolf](https://github.com/m1ga/))  
+* ✅  &nbsp; [Godot Engine](https://github.com/m1ga/ti.appwrite) (Maintained by [fenix-hub @GodotNuts](https://github.com/GodotNuts/appwrite-sdk/))  
+
 Looking for more SDKs? - Help us by contributing a pull request to our [SDK Generator](https://github.com/appwrite/sdk-generator)!
 
 ## Contributing


### PR DESCRIPTION
## What does this PR do?
This PR will mention [Godot Engine](https://godotengine.org/) community-maintained SDK in the README

## Test Plan
No test plan required.

## Related PRs and Issues
[Implement Godot SDK](https://github.com/appwrite/sdk-generator/issues/276#issuecomment-934114150)
[Mention SDK](https://github.com/appwrite/awesome-appwrite/pull/365#issuecomment-955645247)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes, I did
