### PR TITLE
feat(refactor-db): restrict assignable permissions

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -26,6 +26,7 @@ use Utopia\Database\Exception\Authorization as AuthorizationException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
 use Utopia\Database\Exception\Structure as StructureException;
+use Appwrite\Auth\Auth;
 use Appwrite\Database\Validator\CustomId;
 use Appwrite\Network\Validator\Email;
 use Appwrite\Network\Validator\IP;
@@ -1575,6 +1576,18 @@ App::post('/v1/database/collections/:collectionId/documents')
         $data['$read'] = (is_null($read) && !$user->isEmpty()) ? ['user:'.$user->getId()] : $read ?? []; //  By default set read permissions for user
         $data['$write'] = (is_null($write) && !$user->isEmpty()) ? ['user:'.$user->getId()] : $write ?? []; //  By default set write permissions for user
 
+        // Users can only add their roles to documents, API keys can add any
+        foreach ($data['$read'] as $read) {
+            if (!Authorization::isRole('role:'.Auth::USER_ROLE_APP) && !Authorization::isRole($read)) {
+                throw new Exception('Read permissions must be one of: ('.\implode(', ', Authorization::getRoles()).')', 400);
+            }
+        }
+        foreach ($data['$write'] as $write) {
+            if (!Authorization::isRole('role:'.Auth::USER_ROLE_APP) && !Authorization::isRole($write)) {
+                throw new Exception('Write permissions must be one of: ('.\implode(', ', Authorization::getRoles()).')', 400);
+            }
+        }
+
         try {
             if ($collection->getAttribute('permission') === 'collection') {
                 /** @var Document $document */
@@ -1812,6 +1825,18 @@ App::patch('/v1/database/collections/:collectionId/documents/:documentId')
         $data['$id'] = $document->getId(); // Make sure user don't switch document unique ID
         $data['$read'] = (is_null($read)) ? ($document->getRead() ?? []) : $read; // By default inherit read permissions
         $data['$write'] = (is_null($write)) ? ($document->getWrite() ?? []) : $write; // By default inherit write permissions
+
+        // Users can only add their roles to documents, API keys can add any
+        foreach ($data['$read'] as $read) {
+            if (!Authorization::isRole('role:'.Auth::USER_ROLE_APP) && !Authorization::isRole($read)) {
+                throw new Exception('Read permissions must be one of: ('.\implode(', ', Authorization::getRoles()).')', 400);
+            }
+        }
+        foreach ($data['$write'] as $write) {
+            if (!Authorization::isRole('role:'.Auth::USER_ROLE_APP) && !Authorization::isRole($write)) {
+                throw new Exception('Write permissions must be one of: ('.\implode(', ', Authorization::getRoles()).')', 400);
+            }
+        }
 
         try {
             if ($collection->getAttribute('permission') === 'collection') {

--- a/tests/e2e/Services/Database/DatabaseBase.php
+++ b/tests/e2e/Services/Database/DatabaseBase.php
@@ -1127,8 +1127,8 @@ trait DatabaseBase
                 'releaseYear' => 2017,
                 'actors' => [],
             ],
-            'read' => ['user:'.$this->getUser()['$id'], 'user:testx'],
-            'write' => ['user:'.$this->getUser()['$id'], 'user:testy'],
+            'read' => ['user:'.$this->getUser()['$id']],
+            'write' => ['user:'.$this->getUser()['$id']],
         ]);
 
         $id = $document['body']['$id'];
@@ -1136,8 +1136,8 @@ trait DatabaseBase
         $this->assertEquals($document['headers']['status-code'], 201);
         $this->assertEquals($document['body']['title'], 'Thor: Ragnaroc');
         $this->assertEquals($document['body']['releaseYear'], 2017);
-        $this->assertEquals($document['body']['$read'][1], 'user:testx');
-        $this->assertEquals($document['body']['$write'][1], 'user:testy');
+        $this->assertEquals('user:'.$this->getUser()['$id'], $document['body']['$read'][0],);
+        $this->assertEquals('user:'.$this->getUser()['$id'], $document['body']['$write'][0],);
 
         $document = $this->client->call(Client::METHOD_PATCH, '/database/collections/' . $data['moviesId'] . '/documents/' . $id, array_merge([
             'content-type' => 'application/json',
@@ -1146,11 +1146,15 @@ trait DatabaseBase
             'data' => [
                 'title' => 'Thor: Ragnarok',
             ],
+            'read' => ['role:member'],
+            'write' => ['role:member'],
         ]);
 
         $this->assertEquals($document['headers']['status-code'], 200);
         $this->assertEquals($document['body']['title'], 'Thor: Ragnarok');
         $this->assertEquals($document['body']['releaseYear'], 2017);
+        $this->assertEquals('role:member', $document['body']['$read'][0]);
+        $this->assertEquals('role:member', $document['body']['$write'][0]);
 
         $document = $this->client->call(Client::METHOD_GET, '/database/collections/' . $data['moviesId'] . '/documents/' . $id, array_merge([
             'content-type' => 'application/json',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds application logic to the `createDocument` and `updateDocument` endpoints such that a user cannot assign permissions for roles they do not possess.

## Test Plan

Tests have been updated to reflect this change.

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
