### PR TITLE
(docs): Remove unnecessary Getting Started tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Getting started with Appwrite is as easy as creating a new project, choosing you
 * [Getting Started for Android](https://appwrite.io/docs/getting-started-for-android)
 * [Getting Started for Server](https://appwrite.io/docs/getting-started-for-server)
 * [Getting Started for CLI](https://appwrite.io/docs/command-line)
-* Getting Started for iOS (Coming soon...)
 
 ### Services
 


### PR DESCRIPTION
## What does this PR do?

Removes unnecessary **Getting Started for iOS (Coming soon...)** list item from the [Getting Started](https://github.com/appwrite/appwrite/tree/docs-remove-unnecessary-getting-started-tutorial-link#getting-started) section of the Readme since the **Getting Started for Apple** tutorial has already been added. 

## Test Plan

No tests since this is just an update in the Readme

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes