### PR TITLE
Support negative numbers in file preview

### DIFF
--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -247,7 +247,7 @@ App::get('/v1/storage/files/:fileId/preview')
     ->param('borderColor', '', new HexColor(), 'Preview image border color. Use a valid HEX color, no # is needed for prefix.', true)
     ->param('borderRadius', 0, new Range(0, 4000), 'Preview image border radius in pixels. Pass an integer between 0 to 4000.', true)
     ->param('opacity', 1, new Range(0,1, Range::TYPE_FLOAT), 'Preview image opacity. Only works with images having an alpha channel (like png). Pass a number between 0 to 1.', true)
-    ->param('rotation', 0, new Range(0,360), 'Preview image rotation in degrees. Pass an integer between 0 and 360.', true)
+    ->param('rotation', 0, new Range(-360,360), 'Preview image rotation in degrees. Pass an integer between -360 and 360.', true)
     ->param('background', '', new HexColor(), 'Preview image background color. Only works with transparent images (png). Use a valid HEX color, no # is needed for prefix.', true)
     ->param('output', '', new WhiteList(\array_keys(Config::getParam('storage-outputs')), true), 'Output format type (jpeg, jpg, png, gif and webp).', true)
     ->inject('request')
@@ -362,7 +362,7 @@ App::get('/v1/storage/files/:fileId/preview')
         }
 
         if (!empty($rotation)) {
-            $image->setRotation($rotation);
+            $image->setRotation(($rotation + 360) % 360);
         }
 
         $output = (empty($output)) ? $type : $output;

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -144,6 +144,31 @@ trait StorageBase
         $this->assertEquals('image/png', $file6['headers']['content-type']);
         $this->assertNotEmpty($file6['body']);
 
+        // Test for negative angle values in fileGetPreview
+        $file7 = $this->client->call(Client::METHOD_GET, '/storage/files/' . $data['fileId'] . '/preview', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'width' => 300,
+            'height' => 100,
+            'borderRadius' => '50',
+            'opacity' => '0.5',
+            'output' => 'png',
+            'rotation' => '-315',
+        ]);
+        
+        $this->assertEquals(200, $file7['headers']['status-code']);
+        $this->assertEquals('image/png', $file7['headers']['content-type']);
+        $this->assertNotEmpty($file7['body']);
+
+        $image = new \Imagick();
+        $image->readImageBlob($file7['body']);
+        $original = new \Imagick(__DIR__ . '/../../../resources/logo-after.png');
+
+        $this->assertEquals($image->getImageWidth(), $original->getImageWidth());
+        $this->assertEquals($image->getImageHeight(), $original->getImageHeight());
+        $this->assertEquals('PNG', $image->getImageFormat());
+
         /**
          * Test for FAILURE
          */


### PR DESCRIPTION
## What does this PR do?
Allows dev to rotate image by providing negative number as input.

## Test Plan
The test for -315 degrees image rotation is exactly the same as the test for 45 degrees rotation. So, creating a new file with the former rotation angle and keeping other parameters same as the latter angle's test verifies that the code works properly.

## Related PRs and Issues
Fixes #2387

### Have you read the [Contributing Guidelines on issues]
Yes