### PR TITLE
Fix Event not being triggered when a new account is created through OAuth

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -529,9 +529,10 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                     ], ['email' => $email]);
 
                     $createUserEvent = clone $audits;
+                    $eventData = $response->output($user, Response::MODEL_USER);
 
                     $createUserEvent
-                        ->setParam('eventData', $response->output($user, Response::MODEL_USER))
+                        ->setParam('eventData', $eventData)
                         ->setParam('event', 'account.create')
                         ->setParam('userId', $user->getId())
                         ->setParam('resource', 'users/'.$user->getId())
@@ -544,7 +545,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                         ->setQueue('v1-functions')
                         ->setClass('FunctionsV1')
                         ->setParam('event', 'account.create')
-                        ->setParam('eventData', $response->output($user, Response::MODEL_USER))
+                        ->setParam('eventData', $eventData)
                         ->setParam('userId', $user->getId())
                         ->setParam('resource', 'users/'.$user->getId())
                         ->trigger();
@@ -555,7 +556,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                         ->setQueue('v1-webhooks')
                         ->setClass('WebhooksV1')
                         ->setParam('event', 'account.create')
-                        ->setParam('eventData', $response->output($user, Response::MODEL_USER))
+                        ->setParam('eventData', $eventData)
                         ->setParam('userId', $user->getId())
                         ->setParam('resource', 'users/'.$user->getId())
                         ->trigger();

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -543,7 +543,10 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                     $functionsEvent
                         ->setQueue('v1-functions')
                         ->setClass('FunctionsV1')
+                        ->setParam('event', 'account.create')
                         ->setParam('eventData', $response->output($user, Response::MODEL_USER))
+                        ->setParam('userId', $user->getId())
+                        ->setParam('resource', 'users/'.$user->getId())
                         ->trigger();
 
                     $webhookEvent = clone $events;
@@ -551,7 +554,10 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                     $webhookEvent
                         ->setQueue('v1-webhooks')
                         ->setClass('WebhooksV1')
+                        ->setParam('event', 'account.create')
                         ->setParam('eventData', $response->output($user, Response::MODEL_USER))
+                        ->setParam('userId', $user->getId())
+                        ->setParam('resource', 'users/'.$user->getId())
                         ->trigger();
                 } catch (Duplicate $th) {
                     throw new Exception('Account already exists', 409);

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -428,6 +428,8 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('success', $response['body']['result']);
 
+        sleep(5);
+
         // Check if function got executed.
 
         // Get latest execution logs

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -441,6 +441,7 @@ class FunctionsCustomServerTest extends Scope
         $latestExecution = $executions['body']['executions'][1];
 
         $this->assertEquals('event', $latestExecution['trigger']);
+        $this->assertStringContainsString('account.create', $latestExecution['stdout']);
 
         return [];
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR fixes a bug that event triggers are not being correctly fired when a new account is created with the OAuth endpoints.

## Related PRs and Issues

#2406 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have.
