### PR TITLE
fix: collection level permissions

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -207,7 +207,7 @@ App::shutdown(function ($utopia, $request, $response, $project, $events, $audits
 
         if ($project->getId() !== 'console') {
             $payload = new Document($response->getPayload());
-            $collection = new Document($events->getParam('collection'));
+            $collection = new Document($events->getParam('collection') ?? []);
 
             $target = Realtime::fromPayload(
                 event: $events->getParam('event'), 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -207,7 +207,14 @@ App::shutdown(function ($utopia, $request, $response, $project, $events, $audits
 
         if ($project->getId() !== 'console') {
             $payload = new Document($response->getPayload());
-            $target = Realtime::fromPayload($events->getParam('event'), $payload, $project);
+            $collection = new Document($events->getParam('collection'));
+
+            $target = Realtime::fromPayload(
+                event: $events->getParam('event'), 
+                payload: $payload, 
+                project: $project, 
+                collection: $collection
+            );
 
             Realtime::send(
                 $target['projectId'] ?? $project->getId(),

--- a/tests/e2e/Services/Database/DatabaseBase.php
+++ b/tests/e2e/Services/Database/DatabaseBase.php
@@ -19,8 +19,8 @@ trait DatabaseBase
         ]), [
             'collectionId' => 'unique()',
             'name' => 'Movies',
-            'read' => ['role:all'],
-            'write' => ['role:all'],
+            'read' => [],
+            'write' => [],
             'permission' => 'document',
         ]);
 
@@ -113,8 +113,8 @@ trait DatabaseBase
         ]), [
             'collectionId' => 'unique()',
             'name' => 'Response Models',
-            'read' => ['role:all'],
-            'write' => ['role:all'],
+            'read' => [],
+            'write' => [],
             'permission' => 'document',
         ]);
 
@@ -1229,8 +1229,8 @@ trait DatabaseBase
         ]), [
             'collectionId' => 'unique()',
             'name' => 'invalidDocumentStructure',
-            'read' => ['role:all'],
-            'write' => ['role:all'],
+            'read' => [],
+            'write' => [],
             'permission' => 'document',
         ]);
 
@@ -1829,13 +1829,41 @@ trait DatabaseBase
 
         $this->assertEquals(201, $document1['headers']['status-code']);
 
+        $document2 = $this->client->call(Client::METHOD_POST, '/database/collections/' . $collectionId . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'attribute' => 'one',
+            ],
+            'read' => [],
+            'write' => [$user],
+        ]);
+
+        $this->assertEquals(201, $document2['headers']['status-code']);
+
+        $document3 = $this->client->call(Client::METHOD_POST, '/database/collections/' . $collectionId . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'attribute' => 'one',
+            ],
+            'read' => [],
+            'write' => [],
+        ]);
+
+        $this->assertEquals(201, $document3['headers']['status-code']);
+
         $documents = $this->client->call(Client::METHOD_GET, '/database/collections/' . $collectionId . '/documents', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals(1, $documents['body']['sum']);
-        $this->assertCount(1, $documents['body']['documents']);
+        $this->assertEquals(3, $documents['body']['sum']);
+        $this->assertCount(3, $documents['body']['documents']);
 
         /*
          * Test for Failure
@@ -1894,7 +1922,7 @@ trait DatabaseBase
             'x-appwrite-project' => $this->getProject()['$id'],
         ]));
 
-        $this->assertEquals(404, $documents['headers']['status-code']);
+        $this->assertEquals(401, $documents['headers']['status-code']);
     }
 
     /**

--- a/tests/e2e/Services/Database/DatabasePermissionsTeamTest.php
+++ b/tests/e2e/Services/Database/DatabasePermissionsTeamTest.php
@@ -160,7 +160,7 @@ class DatabasePermissionsTeamTest extends Scope
         if ($success) {
             $this->assertCount(1, $documents['body']['documents']);
         } else {
-            $this->assertEquals(404, $documents['headers']['status-code']);
+            $this->assertEquals(401, $documents['headers']['status-code']);
         }
     }
 

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -77,9 +77,7 @@ class RealtimeCustomClientTest extends Scope
             'files',
             'files.1',
             'collections',
-            'collections.1',
             'collections.1.documents',
-            'collections.2',
             'collections.2.documents',
             'documents',
             'documents.1',
@@ -93,15 +91,13 @@ class RealtimeCustomClientTest extends Scope
         $this->assertEquals('connected', $response['type']);
         $this->assertNotEmpty($response['data']);
         $this->assertNotEmpty($response['data']['user']);
-        $this->assertCount(12, $response['data']['channels']);
+        $this->assertCount(10, $response['data']['channels']);
         $this->assertContains('account', $response['data']['channels']);
         $this->assertContains('account.' . $userId, $response['data']['channels']);
         $this->assertContains('files', $response['data']['channels']);
         $this->assertContains('files.1', $response['data']['channels']);
         $this->assertContains('collections', $response['data']['channels']);
-        $this->assertContains('collections.1', $response['data']['channels']);
         $this->assertContains('collections.1.documents', $response['data']['channels']);
-        $this->assertContains('collections.2', $response['data']['channels']);
         $this->assertContains('collections.2.documents', $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
         $this->assertContains('documents.1', $response['data']['channels']);
@@ -561,23 +557,10 @@ class RealtimeCustomClientTest extends Scope
         ]), [
             'collectionId' => 'unique()',
             'name' => 'Actors',
-            'read' => ['role:all'],
-            'write' => ['role:all'],
-            'permission' => 'collection'
+            'read' => [],
+            'write' => [],
+            'permission' => 'document'
         ]);
-
-        $response = json_decode($client->receive(), true);
-
-        $this->assertArrayHasKey('type', $response);
-        $this->assertArrayHasKey('data', $response);
-        $this->assertEquals('event', $response['type']);
-        $this->assertNotEmpty($response['data']);
-        $this->assertArrayHasKey('timestamp', $response['data']);
-        $this->assertCount(2, $response['data']['channels']);
-        $this->assertContains('collections', $response['data']['channels']);
-        $this->assertContains('collections.' . $actors['body']['$id'], $response['data']['channels']);
-        $this->assertEquals('database.collections.create', $response['data']['event']);
-        $this->assertNotEmpty($response['data']['payload']);
 
         $data = ['actorsId' => $actors['body']['$id']];
 
@@ -662,7 +645,6 @@ class RealtimeCustomClientTest extends Scope
 
         $this->assertEquals($response['data']['payload']['name'], 'Chris Evans 2');
 
-
         /**
          * Test Document Delete
          */
@@ -676,6 +658,166 @@ class RealtimeCustomClientTest extends Scope
             ],
             'read' => ['role:all'],
             'write' => ['role:all'],
+        ]);
+
+        $client->receive();
+
+        $this->client->call(Client::METHOD_DELETE, '/database/collections/' . $data['actorsId'] . '/documents/' . $document['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $response = json_decode($client->receive(), true);
+
+        $this->assertArrayHasKey('type', $response);
+        $this->assertArrayHasKey('data', $response);
+        $this->assertEquals('event', $response['type']);
+        $this->assertNotEmpty($response['data']);
+        $this->assertArrayHasKey('timestamp', $response['data']);
+        $this->assertCount(3, $response['data']['channels']);
+        $this->assertContains('documents', $response['data']['channels']);
+        $this->assertContains('documents.' . $document['body']['$id'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents', $response['data']['channels']);
+        $this->assertEquals('database.documents.delete', $response['data']['event']);
+        $this->assertNotEmpty($response['data']['payload']);
+        $this->assertEquals($response['data']['payload']['name'], 'Bradley Cooper');
+
+        $client->close();
+    }
+
+    public function testChannelDatabaseCollectionPermissions()
+    {
+        $user = $this->getUser();
+        $session = $user['session'] ?? '';
+        $projectId = $this->getProject()['$id'];
+
+        $client = $this->getWebsocket(['documents', 'collections'], [
+            'origin' => 'http://localhost',
+            'cookie' => 'a_session_'.$projectId.'=' . $session
+        ]);
+
+        $response = json_decode($client->receive(), true);
+
+        $this->assertArrayHasKey('type', $response);
+        $this->assertArrayHasKey('data', $response);
+        $this->assertEquals('connected', $response['type']);
+        $this->assertNotEmpty($response['data']);
+        $this->assertCount(2, $response['data']['channels']);
+        $this->assertContains('documents', $response['data']['channels']);
+        $this->assertContains('collections', $response['data']['channels']);
+        $this->assertNotEmpty($response['data']['user']);
+        $this->assertEquals($user['$id'], $response['data']['user']['$id']);
+
+        /**
+         * Test Collection Create
+         */
+        $actors = $this->client->call(Client::METHOD_POST, '/database/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'collectionId' => 'unique()',
+            'name' => 'Actors',
+            'read' => ['role:all'],
+            'write' => ['role:all'],
+            'permission' => 'collection'
+        ]);
+
+        $data = ['actorsId' => $actors['body']['$id']];
+
+        $name = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['actorsId'] . '/attributes/string', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'attributeId' => 'name',
+            'size' => 256,
+            'required' => true,
+        ]);
+
+        $this->assertEquals($name['headers']['status-code'], 201);
+        $this->assertEquals($name['body']['key'], 'name');
+        $this->assertEquals($name['body']['type'], 'string');
+        $this->assertEquals($name['body']['size'], 256);
+        $this->assertEquals($name['body']['required'], true);
+
+        sleep(2);
+
+        /**
+         * Test Document Create
+         */
+        $document = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['actorsId'] . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'name' => 'Chris Evans'
+            ],
+            'read' => [],
+            'write' => [],
+        ]);
+
+        $response = json_decode($client->receive(), true);
+
+        $this->assertArrayHasKey('type', $response);
+        $this->assertArrayHasKey('data', $response);
+        $this->assertEquals('event', $response['type']);
+        $this->assertNotEmpty($response['data']);
+        $this->assertArrayHasKey('timestamp', $response['data']);
+        $this->assertCount(3, $response['data']['channels']);
+        $this->assertContains('documents', $response['data']['channels']);
+        $this->assertContains('documents.' . $document['body']['$id'], $response['data']['channels']);
+        $this->assertContains('collections.' . $actors['body']['$id'] . '.documents', $response['data']['channels']);
+        $this->assertEquals('database.documents.create', $response['data']['event']);
+        $this->assertNotEmpty($response['data']['payload']);
+        $this->assertEquals($response['data']['payload']['name'], 'Chris Evans');
+
+        $data['documentId'] = $document['body']['$id'];
+
+        /**
+         * Test Document Update
+         */
+        $document = $this->client->call(Client::METHOD_PATCH, '/database/collections/' . $data['actorsId'] . '/documents/' . $data['documentId'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'data' => [
+                'name' => 'Chris Evans 2'
+            ],
+            'read' => [],
+            'write' => [],
+        ]);
+
+        $response = json_decode($client->receive(), true);
+
+        $this->assertArrayHasKey('type', $response);
+        $this->assertArrayHasKey('data', $response);
+        $this->assertEquals('event', $response['type']);
+        $this->assertNotEmpty($response['data']);
+        $this->assertArrayHasKey('timestamp', $response['data']);
+        $this->assertCount(3, $response['data']['channels']);
+        $this->assertContains('documents', $response['data']['channels']);
+        $this->assertContains('documents.' . $data['documentId'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents', $response['data']['channels']);
+        $this->assertEquals('database.documents.update', $response['data']['event']);
+        $this->assertNotEmpty($response['data']['payload']);
+
+        $this->assertEquals($response['data']['payload']['name'], 'Chris Evans 2');
+
+        /**
+         * Test Document Delete
+         */
+        $document = $this->client->call(Client::METHOD_POST, '/database/collections/' . $data['actorsId'] . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => 'unique()',
+            'data' => [
+                'name' => 'Bradley Cooper'
+            ],
+            'read' => [],
+            'write' => [],
         ]);
 
         $client->receive();

--- a/tests/unit/Messaging/MessagingTest.php
+++ b/tests/unit/Messaging/MessagingTest.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Tests;
 
-use Appwrite\Database\Document;
+use Utopia\Database\Document;
 use Appwrite\Messaging\Adapter\Realtime;
 use PHPUnit\Framework\TestCase;
 
@@ -194,5 +194,52 @@ class MessagingTest extends TestCase
         $this->assertArrayHasKey('account.123', $channels);
         $this->assertArrayHasKey('account', $channels);
         $this->assertArrayNotHasKey('account.456', $channels);
+    }
+
+    public function testFromPayloadCollectionLevelPermissions(): void
+    {
+        /**
+         * Test Collection Level Permissions
+         */
+        $result = Realtime::fromPayload(
+            event: 'database.documents.create',
+            payload: new Document([
+                '$id' => 'test',
+                '$collection' => 'collection',
+                '$read' => ['role:admin'],
+                '$write' => ['role:admin']
+            ]),
+            collection: new Document([
+                '$id' => 'collection',
+                '$read' => ['role:all'],
+                '$write' => ['role:all'],
+                'permission' => 'collection'
+            ])
+        );
+
+        $this->assertContains('role:all', $result['roles']);
+        $this->assertNotContains('role:admin', $result['roles']);
+
+        /**
+         * Test Document Level Permissions
+         */
+        $result = Realtime::fromPayload(
+            event: 'database.documents.create',
+            payload: new Document([
+                '$id' => 'test',
+                '$collection' => 'collection',
+                '$read' => ['role:all'],
+                '$write' => ['role:all']
+            ]),
+            collection: new Document([
+                '$id' => 'collection',
+                '$read' => ['role:admin'],
+                '$write' => ['role:admin'],
+                'permission' => 'document'
+            ])
+        );
+
+        $this->assertContains('role:all', $result['roles']);
+        $this->assertNotContains('role:admin', $result['roles']);
     }
 }


### PR DESCRIPTION
## What does this PR do?

When using Document Level Permissions, we are supposed to ignore Collection Level Permissions and vice versa.

- Getting the Collection document is now always skipping authorization
  - will not throw a `404` anymore, but a `401`
- fixed the returned `sum` on collection level permissions
- Fixed permission level for list, create, update and delete documents

Since this was discovered while I was working on Realtime, this PR also includes collection/document level permission for Realtime events:
- send the collection document as part of the event
- use collection permission or document permissions depending on the configured level

## Test Plan

- extended tests for the Database
- added realtime tests

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 