### PR TITLE
fix parent folder being copied in linux

### DIFF
--- a/app/tasks/sdks.php
+++ b/app/tasks/sdks.php
@@ -218,7 +218,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                         git fetch && \
                         git pull '.$gitUrl.' && \
                         rm -rf '.$target.'/* && \
-                        cp -r '.$result.'/ '.$target.'/ && \
+                        cp -r '.$result.'/* '.$target.'/ && \
                         git add . && \
                         git commit -m "'.$message.'" && \
                         git push -u origin '.$gitBranch.'


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes SDK CLI script that's causing parent folder to be pushed to git on linux

## Test Plan

N/A

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES