### PR TITLE
Fix Functions Usage Chart Typo

### DIFF
--- a/app/views/console/functions/function.phtml
+++ b/app/views/console/functions/function.phtml
@@ -259,7 +259,7 @@ $usageStatsEnabled = $this->getParam('usageStatsEnabled',true);
                     <div class="box margin-bottom-small">
                         <div class="margin-start-negative-small margin-end-negative-small margin-top-negative-small margin-bottom-negative-small">
                             <div class="chart margin-bottom-no">
-                                <input type="hidden" data-ls-bind="{{usage}}" data-forms-chart="CPU Time (seconds)=usage.compute.data" data-colors="orange" data-height="140" />
+                                <input type="hidden" data-ls-bind="{{usage}}" data-forms-chart="CPU Time (milliseconds)=usage.compute.data" data-colors="orange" data-height="140" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes a small typo within the usage charts for functions where the milliseconds the function was active for is called seconds.

## Related PRs and Issues

#2491 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have
