### PR TITLE
Fix-prefs-response

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/User.php
+++ b/src/Appwrite/Utopia/Response/Model/User.php
@@ -4,7 +4,6 @@ namespace Appwrite\Utopia\Response\Model;
 
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
-use stdClass;
 use Utopia\Database\Document;
 
 class User extends Model

--- a/src/Appwrite/Utopia/Response/Model/User.php
+++ b/src/Appwrite/Utopia/Response/Model/User.php
@@ -4,6 +4,8 @@ namespace Appwrite\Utopia\Response\Model;
 
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
+use stdClass;
+use Utopia\Database\Document;
 
 class User extends Model
 {
@@ -59,6 +61,24 @@ class User extends Model
                 'example' => ['theme' => 'pink', 'timezone' => 'UTC'],
             ])
         ;
+    }
+
+    /**
+     * Get Collection
+     * 
+     * @return string
+     */
+    public function filter(Document $document): Document
+    {
+        $prefs = $document->getAttribute('prefs');
+        if($prefs instanceof Document) {
+            $prefs = $prefs->getArrayCopy();
+        }
+
+        if(is_array($prefs) && empty($prefs)) {
+            $document->setAttribute('prefs', new stdClass);
+        }
+        return $document;
     }
 
     /**

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -151,10 +151,11 @@ class Client
      * @param string $path
      * @param array $params
      * @param array $headers
+     * @param bool $decode
      * @return array|string
      * @throws Exception
      */
-    public function call(string $method, string $path = '', array $headers = [], array $params = [])
+    public function call(string $method, string $path = '', array $headers = [], array $params = [], bool $decode = true)
     {
         $headers            = array_merge($this->headers, $headers);
         $ch                 = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
@@ -216,17 +217,19 @@ class Client
         $responseType   = $responseHeaders['content-type'] ?? '';
         $responseStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        switch (substr($responseType, 0, strpos($responseType, ';'))) {
-            case 'application/json':
-                $json = json_decode($responseBody, true);
-
-                if ($json === null) {
-                    throw new Exception('Failed to parse response: '.$responseBody);
-                }
-
-                $responseBody = $json;
-                $json = null;
-            break;
+        if($decode) {
+            switch (substr($responseType, 0, strpos($responseType, ';'))) {
+                case 'application/json':
+                    $json = json_decode($responseBody, true);
+    
+                    if ($json === null) {
+                        throw new Exception('Failed to parse response: '.$responseBody);
+                    }
+    
+                    $responseBody = $json;
+                    $json = null;
+                break;
+            }
         }
 
         if ((curl_errno($ch)/* || 200 != $responseStatus*/)) {

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -20,13 +20,20 @@ trait UsersBase
             'email' => 'cristiano.ronaldo@manchester-united.co.uk',
             'password' => 'password',
             'name' => 'Cristiano Ronaldo',
-        ]);
+        ], false);
+
+        // Test empty prefs is object not array
+        $bodyString = $user['body'];
+        $prefs = substr($bodyString, strpos($bodyString, '"prefs":')+8,2);
+        $this->assertEquals('{}', $prefs);
+        
+        $body = json_decode($bodyString, true);
 
         $this->assertEquals($user['headers']['status-code'], 201);
-        $this->assertEquals($user['body']['name'], 'Cristiano Ronaldo');
-        $this->assertEquals($user['body']['email'], 'cristiano.ronaldo@manchester-united.co.uk');
-        $this->assertEquals($user['body']['status'], true);
-        $this->assertGreaterThan(0, $user['body']['registration']);
+        $this->assertEquals($body['name'], 'Cristiano Ronaldo');
+        $this->assertEquals($body['email'], 'cristiano.ronaldo@manchester-united.co.uk');
+        $this->assertEquals($body['status'], true);
+        $this->assertGreaterThan(0, $body['registration']);
 
         /**
          * Test Create with Custom ID for SUCCESS
@@ -48,7 +55,7 @@ trait UsersBase
         $this->assertEquals(true, $res['body']['status']);
         $this->assertGreaterThan(0, $res['body']['registration']);
 
-        return ['userId' => $user['body']['$id']];
+        return ['userId' => $body['$id']];
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix: Force empty preferences to be object instead of array

## Test Plan

- Not sure how to test as in php it would still be array. Verified manually by making a request that an object is returned instead of array

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
