### PR TITLE
fix: migration for leftover documents on deleted projects

### DIFF
--- a/src/Appwrite/Migration/Version/V11.php
+++ b/src/Appwrite/Migration/Version/V11.php
@@ -487,8 +487,9 @@ class V11 extends Migration
 
                 if (!empty($document->getAttribute('usersAuthLimit'))) {
                     $newAuths['limit'] = $document->getAttribute('usersAuthLimit');
-                    $document->removeAttribute('usersAuthLimit');
                 }
+
+                $document->removeAttribute('usersAuthLimit');
 
                 $document->setAttribute('auths', $newProviders);
 

--- a/src/Appwrite/Migration/Version/V11.php
+++ b/src/Appwrite/Migration/Version/V11.php
@@ -194,7 +194,7 @@ class V11 extends Migration
 
                 $new = $this->fixDocument($document);
 
-                if (empty($new->getId())) {
+                if (is_null($new) || empty($new->getId())) {
                     Console::warning('Skipped Document due to missing ID.');
                     continue;
                 }
@@ -496,6 +496,10 @@ class V11 extends Migration
             case OldDatabase::SYSTEM_COLLECTION_PLATFORMS:
                 $projectId = $this->getProjectIdFromReadPermissions($document);
 
+                if (is_null($projectId)) {
+                    return null;
+                }
+
                 /**
                  * Set Project ID
                  */
@@ -533,6 +537,10 @@ class V11 extends Migration
             case OldDatabase::SYSTEM_COLLECTION_DOMAINS:
                 $projectId = $this->getProjectIdFromReadPermissions($document);
 
+                if (is_null($projectId)) {
+                    return null;
+                }
+
                 /**
                  * Set Project ID
                  */
@@ -556,6 +564,10 @@ class V11 extends Migration
                 break;
             case OldDatabase::SYSTEM_COLLECTION_KEYS:
                 $projectId = $this->getProjectIdFromReadPermissions($document);
+
+                if (is_null($projectId)) {
+                    return null;
+                }
 
                 /**
                  * Set Project ID
@@ -584,6 +596,10 @@ class V11 extends Migration
                 break;
             case OldDatabase::SYSTEM_COLLECTION_WEBHOOKS:
                 $projectId = $this->getProjectIdFromReadPermissions($document);
+
+                if (is_null($projectId)) {
+                    return null;
+                }
 
                 /**
                  * Set Project ID
@@ -780,7 +796,7 @@ class V11 extends Migration
     }
 
     /**
-     * @param Document $document 
+     * @param Document $document
      * @return string|null 
      * @throws Exception 
      */
@@ -788,11 +804,17 @@ class V11 extends Migration
     {
         $readPermissions = $document->getRead();
         $teamId = str_replace('team:', '', reset($readPermissions));
-        return $this->oldConsoleDB->getCollectionFirst([
+        $project = $this->oldConsoleDB->getCollectionFirst([
             'filters' => [
                 '$collection=' . OldDatabase::SYSTEM_COLLECTION_PROJECTS,
                 'teamId=' . $teamId
             ]
-        ])->getId();
+        ]);
+
+        if (!$project) {
+            return null;
+        }
+
+        return $project->getId();
     }
 }

--- a/src/Appwrite/Migration/Version/V11.php
+++ b/src/Appwrite/Migration/Version/V11.php
@@ -413,10 +413,10 @@ class V11 extends Migration
      * Migrates single docuemnt.
      *
      * @param OldDocument $oldDocument 
-     * @return Document 
+     * @return Document|null
      * @throws Exception 
      */
-    protected function fixDocument(OldDocument $oldDocument): Document
+    protected function fixDocument(OldDocument $oldDocument): Document|null
     {
         $document = new Document($oldDocument->getArrayCopy());
         $document = $this->migratePermissions($document);


### PR DESCRIPTION
## What does this PR do?

- some documents can be left for previously deleted projects, this PR skips them
