### PR TITLE
Fixed boolean request filters on listDocuments

### DIFF
--- a/src/Appwrite/Utopia/Request/Filters/V12.php
+++ b/src/Appwrite/Utopia/Request/Filters/V12.php
@@ -141,7 +141,13 @@ class V12 extends Filter
                 if(isset($usedOperator)) {
                     [ $attributeKey, $filterValue ] = \explode($usedOperator, $filter);
 
-                    $filterValue = \is_numeric($filterValue) ? $filterValue : '"' . $filterValue . '"';
+                    if($filterValue === 'true' || $filterValue === 'false') {
+                        // Let's keep it at true and false string, but without "" around
+                        // No action needed
+                    } else {
+                        $filterValue =\is_numeric($filterValue) ? $filterValue : '"' . $filterValue . '"';
+                    }
+
                     $query = $attributeKey . '.' . $operators[$usedOperator] . '(' . $filterValue . ')';
                     \array_push($queries, $query);
                 }
@@ -152,7 +158,6 @@ class V12 extends Filter
         unset($content['search']);
 
         unset($content['filters']);
-        unset($content['search']);
         $content['queries'] = $queries;
 
         return $content;

--- a/src/Appwrite/Utopia/Request/Filters/V12.php
+++ b/src/Appwrite/Utopia/Request/Filters/V12.php
@@ -145,7 +145,7 @@ class V12 extends Filter
                         // Let's keep it at true and false string, but without "" around
                         // No action needed
                     } else {
-                        $filterValue =\is_numeric($filterValue) ? $filterValue : '"' . $filterValue . '"';
+                        $filterValue = \is_numeric($filterValue) ? $filterValue : '"' . $filterValue . '"';
                     }
 
                     $query = $attributeKey . '.' . $operators[$usedOperator] . '(' . $filterValue . ')';


### PR DESCRIPTION
## What does this PR do?

When using 0.11 SDK, the `listDocuments` didn't function properly on boolean filters. Now the problem is resolved.

## Test Plan

Manual testing

![CleanShot 2022-01-07 at 09 33 18](https://user-images.githubusercontent.com/19310830/148515761-2213889d-c17e-4157-aa41-d11a42741e1e.png)

![CleanShot 2022-01-07 at 09 32 23](https://user-images.githubusercontent.com/19310830/148515764-b703f35a-e790-4485-a591-1f3167c22962.png)


## Related PRs and Issues



### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
