### PR TITLE
set proper domain name while setting cookie in mock api

### DIFF
--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -353,10 +353,12 @@ App::get('/v1/mock/tests/general/set-cookie')
     ->label('sdk.response.model', Response::MODEL_MOCK)
     ->label('sdk.mock', true)
     ->inject('response')
-    ->action(function ($response) {
+    ->inject('request')
+    ->action(function ($response, $request) {
         /** @var Appwrite\Utopia\Response $response */
+        /** @var Appwrite\Utopia\Request $request */
 
-        $response->addCookie('cookieName', 'cookieValue', \time() + 31536000, '/', 'localhost', true, true);
+        $response->addCookie('cookieName', 'cookieValue', \time() + 31536000, '/', $request->getHostname(), true, true);
     });
 
 App::get('/v1/mock/tests/general/get-cookie')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Simple fix to set proper domain name in set cookie method in the mock API. Needed to pass the cookie test on SDKs

## Test Plan

N/A

## Related PRs and Issues

https://github.com/appwrite/sdk-generator/pull/322

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES
