### PR TITLE
Fix function authorization exception

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -714,7 +714,7 @@ App::post('/v1/functions/:functionId/executions')
             throw new Exception('Tag not found. Deploy tag before trying to execute a function', 404);
         }
 
-        $validator = new Authorization($function, 'execute');
+        $validator = new Authorization('execute');
 
         if (!$validator->isValid($function->getAttribute('execute'))) { // Check if user has write access to execute function
             throw new Exception($validator->getDescription(), 401);

--- a/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
@@ -218,6 +218,32 @@ class FunctionsCustomClientTest extends Scope
         ];
     }
 
+    public function testCreateExecutionUnauthorized():array
+    {
+        $function = $this->client->call(Client::METHOD_POST, '/functions', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'functionId' => 'unique()',
+            'name' => 'Test',
+            'execute' => [],
+            'runtime' => 'php-8.0',
+            'timeout' => 10,
+        ]);
+
+        $execution = $this->client->call(Client::METHOD_POST, '/functions/'.$function['body']['$id'].'/executions', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], [
+            'async' => 1,
+        ]);
+
+        $this->assertEquals(401, $execution['headers']['status-code']);
+
+        return [];
+    }
+
     /**
      * @depends testCreateCustomExecution
      */


### PR DESCRIPTION
## What does this PR do?

Fixes an exception thrown when a function is executed without any execute permissions:

```
appwrite  | [Error] Method: POST
appwrite  | [Error] URL: /v1/functions/:functionId/executions
appwrite  | [Error] Type: Error
appwrite  | [Error] Message: Object of class Utopia\Database\Document could not be converted to string
appwrite  | [Error] File: /usr/src/code/vendor/utopia-php/database/src/Database/Validator/Authorization.php
appwrite  | [Error] Line: 61
```

Due to the `Authorization` implementation being updated to utopia-php/database from appwrite, where the appwrite implementation used to take a `Document` as the first parameter.

## Test Plan

Test added in `e2e/Services/Functions/FunctionsCustomClientTest.php` that creates a function with no execution permissions then checks that attempting to execute said function response with a 401.
