### PR TITLE
Fix list collections when passing `search` parameter

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -102,6 +102,13 @@ $collections = [
                 'lengths' => [1024],
                 'orders' => [Database::ORDER_ASC],
             ],
+            [
+                '$id' => '_fulltext_name',
+                'type' => Database::INDEX_FULLTEXT,
+                'attributes' => ['name'],
+                'lengths' => [256],
+                'orders' => [Database::ORDER_ASC],
+            ],
         ],
     ],
 

--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -102,13 +102,6 @@ $collections = [
                 'lengths' => [1024],
                 'orders' => [Database::ORDER_ASC],
             ],
-            [
-                '$id' => '_fulltext_name',
-                'type' => Database::INDEX_FULLTEXT,
-                'attributes' => ['name'],
-                'lengths' => [256],
-                'orders' => [Database::ORDER_ASC],
-            ],
         ],
     ],
 

--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -230,7 +230,7 @@ App::get('/v1/database/collections')
         $queries = [];
 
         if (!empty($search)) {
-            $queries[] = new Query('name', Query::TYPE_SEARCH, [$search]);
+            $queries[] = new Query('search', Query::TYPE_SEARCH, [$search]);
         }
 
         $usage->setParam('database.collections.read', 1);

--- a/tests/e2e/Services/Database/DatabaseCustomServerTest.php
+++ b/tests/e2e/Services/Database/DatabaseCustomServerTest.php
@@ -126,6 +126,39 @@ class DatabaseCustomServerTest extends Scope
         $this->assertEmpty($collections['body']['collections']);
 
         /**
+         * Test for Search
+         */
+        $collections = $this->client->call(Client::METHOD_GET, '/database/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'search' => 'first'
+        ]);
+
+        $this->assertEquals(1, $collections['body']['sum']);
+        $this->assertEquals('first', $collections['body']['collections'][0]['$id']);
+
+        $collections = $this->client->call(Client::METHOD_GET, '/database/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'search' => 'Test'
+        ]);
+        
+        $this->assertEquals(2, $collections['body']['sum']);
+        $this->assertEquals('Test 1', $collections['body']['collections'][0]['name']);
+        $this->assertEquals('Test 2', $collections['body']['collections'][1]['name']);
+
+        $collections = $this->client->call(Client::METHOD_GET, '/database/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'search' => 'Nonexistent'
+        ]);
+        
+        $this->assertEquals(0, $collections['body']['sum']);
+
+        /**
          * Test for FAILURE
          */
         $response = $this->client->call(Client::METHOD_GET, '/database/collections', array_merge([


### PR DESCRIPTION
## What does this PR do?

Add fulltext index for collections collection `name` column to fix `listCollections` when using the `search` parameter.

Currently throws a PDOException:

```
[Error] File: /usr/src/code/vendor/utopia-php/framework/src/App.php
[Error] Line: 756
[Error] Type: PDOException
[Error] Message: Can't find FULLTEXT index matching the column list
[Error] File: @swoole-src/library/core/Database/PDOStatementProxy.php
[Error] Line: 64
```

## Test Plan

Used the `listCollections` function from SDK's passing a value for the `search` parameter

## Related PRs and Issues

Closes https://github.com/appwrite/sdk-for-kotlin/issues/18
