### PR TITLE
Fix: pin PHP to patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM node:16-alpine3.15 as node
+FROM node:16.13.2-alpine3.15 as node
 
 WORKDIR /usr/local/src/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY public /usr/local/src/public
 RUN npm ci
 RUN npm run build
 
-FROM php:8.0-cli-alpine as compile
+FROM php:8.0.14-cli-alpine as compile
 
 ARG DEBUG=false
 ENV DEBUG=$DEBUG
@@ -123,7 +123,7 @@ RUN \
   ./configure && \
   make && make install
 
-FROM php:8.0-cli-alpine as final
+FROM php:8.0.14-cli-alpine as final
 
 LABEL maintainer="team@appwrite.io"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM node:16-alpine as node
+FROM node:16-alpine3.15 as node
 
 WORKDIR /usr/local/src/
 
@@ -24,7 +24,7 @@ COPY public /usr/local/src/public
 RUN npm ci
 RUN npm run build
 
-FROM php:8.0.14-cli-alpine as compile
+FROM php:8.0.14-cli-alpine3.15 as compile
 
 ARG DEBUG=false
 ENV DEBUG=$DEBUG
@@ -123,7 +123,7 @@ RUN \
   ./configure && \
   make && make install
 
-FROM php:8.0.14-cli-alpine as final
+FROM php:8.0.14-cli-alpine3.15 as final
 
 LABEL maintainer="team@appwrite.io"
 

--- a/tests/e2e/Services/Realtime/RealtimeBase.php
+++ b/tests/e2e/Services/Realtime/RealtimeBase.php
@@ -66,6 +66,7 @@ trait RealtimeBase
         $this->assertEquals('error', $payload['type']);
         $this->assertEquals(1008, $payload['data']['code']);
         $this->assertEquals('Missing or unknown project ID', $payload['data']['message']);
+        \usleep(250000); // 250ms
         $this->expectException(ConnectionException::class); // Check if server disconnnected client
         $client->close();
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Pins to specific PHP and Alpine versions to avoid per-patch regressions.

## Test Plan

Needed to add a small sleep to realtime tests which is unrelated to pinned versions.

Successful compilation and existing test suite are sufficient.

## Pending questions

- [x] Should we be specific in pinning node? We can do this, and may want to since we're running build scripts, but I didn't yet because 👇🏻 
- [x] Should we be specific in pinning composer? We can only pin to composer versions, not PHP, but we aren't actually running scripts, just fetching code.

## Related PRs and Issues

https://github.com/php/php-src/issues/7978

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
