### PR TITLE
Fix: enum AppwriteConsole UI

### DIFF
--- a/app/views/console/database/document.phtml
+++ b/app/views/console/database/document.phtml
@@ -169,8 +169,11 @@ $logs = $this->getParam('logs', null);
                                                             </template>
                                                             <template x-if="attr.format === 'enum'">
                                                                 <select
+                                                                    :required="attr.required"
                                                                     :name="attr.key"
                                                                     data-cast-to="string">
+                                                                    <option :disabled="attr.required" selected label=" "></option>
+
                                                                     <template x-for="element in attr.elements">
                                                                         <option
                                                                             :value="element"
@@ -261,9 +264,12 @@ $logs = $this->getParam('logs', null);
                                                                         </template>
                                                                         <template x-if="attr.format === 'enum'">
                                                                             <select
+                                                                                :required="attr.required"
                                                                                 :name="attr.key"
                                                                                 data-cast-to="string">
                                                                                 <template x-for="element in attr.elements">
+                                                                                    <option :disabled="attr.required" selected label=" "></option>
+
                                                                                     <option
                                                                                         :value="element"
                                                                                         x-text="element"


### PR DESCRIPTION
## What does this PR do?

Improve UI of required and optional enum by:

- Optional now have empty option
- Required also have empty option for new documents, but wont let you submit until selected
- Empty options during creating will become default value

## Test Plan

Manual QA:

https://user-images.githubusercontent.com/19310830/151188832-42e027c7-ff6f-441d-b101-4b77f6d8057d.mp4

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/2698

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
