### PR TITLE
Renamed deploy parameter to activate (on deployment)

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -1993,7 +1993,7 @@ $collections = [
                 'filters' => [],
             ],
             [
-                '$id' => 'deploy',
+                '$id' => 'activate',
                 'type' => Database::VAR_BOOLEAN,
                 'format' => '',
                 'size' => 0,

--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -1948,7 +1948,6 @@ $collections = [
                 'filters' => [],
             ],
             [
-                'array' => false,
                 '$id' => 'entrypoint',
                 'type' => Database::VAR_STRING,
                 'format' => '',

--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -1948,6 +1948,7 @@ $collections = [
                 'filters' => [],
             ],
             [
+                'array' => false,
                 '$id' => 'entrypoint',
                 'type' => Database::VAR_STRING,
                 'format' => '',

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -494,14 +494,14 @@ App::post('/v1/functions/:functionId/deployments')
     ->param('functionId', '', new UID(), 'Function ID.')
     ->param('entrypoint', '', new Text('1028'), 'Entrypoint File.')
     ->param('code', [], new File(), 'Gzip file with your code package. When used with the Appwrite CLI, pass the path to your code directory, and the CLI will automatically package your code. Use a path that is within the current directory.', false)
-    ->param('deploy', false, new Boolean(true), 'Automatically deploy the function when it is finished building.', false)
+    ->param('activate', false, new Boolean(true), 'Automatically activate the deployment when it is finished building.', false)
     ->inject('request')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('usage')
     ->inject('user')
     ->inject('project')
-    ->action(function ($functionId, $entrypoint, $file, $deploy, $request, $response, $dbForProject, $usage, $user, $project) {
+    ->action(function ($functionId, $entrypoint, $file, $activate, $request, $response, $dbForProject, $usage, $user, $project) {
         /** @var Utopia\Swoole\Request $request */
         /** @var Appwrite\Utopia\Response $response */
         /** @var Utopia\Database\Database $dbForProject */
@@ -550,16 +550,16 @@ App::post('/v1/functions/:functionId/deployments')
             throw new Exception('Failed moving file', 500);
         }
 
-        if ((bool) $deploy) {
+        if ((bool) $activate) {
             // Remove deploy for all other deployments.
             $deployments = $dbForProject->find('deployments', [
-                new Query('deploy', Query::TYPE_EQUAL, [true]),
+                new Query('activate', Query::TYPE_EQUAL, [true]),
                 new Query('resourceId', Query::TYPE_EQUAL, [$functionId]),
                 new Query('resourceType', Query::TYPE_EQUAL, ['functions'])
             ]);
 
             foreach ($deployments as $deployment) {
-                $deployment->setAttribute('deploy', false);
+                $deployment->setAttribute('activate', false);
                 $dbForProject->updateDocument('deployments', $deployment->getId(), $deployment);
             }
         }
@@ -576,7 +576,7 @@ App::post('/v1/functions/:functionId/deployments')
             'path' => $path,
             'size' => $size,
             'search' => implode(' ', [$deploymentId, $entrypoint]),
-            'deploy' => ($deploy === 'true'),
+            'activate' => ($activate === 'true'),
         ]));
 
         // Enqueue a message to start the build

--- a/app/executor.php
+++ b/app/executor.php
@@ -684,9 +684,7 @@ function runBuildStage(string $buildId, string $deploymentId, string $projectID)
 
         // Update deployment Status
         $build->setAttribute('status', 'building');
-        $deployment->setAttribute('status', 'building');
         $database->updateDocument('builds', $buildId, $build);
-        $database->updateDocument('deployments', $deploymentId, $deployment);
 
         // Check if runtime is active
         $runtime = $runtimes[$build->getAttribute('runtime', '')] ?? null;
@@ -881,14 +879,16 @@ function runBuildStage(string $buildId, string $deploymentId, string $projectID)
             $buildStdout = 'Build Successful!';
         }
 
+        $endTime = \time();
+
         $build
             ->setAttribute('outputPath', $path)
             ->setAttribute('status', 'ready')
             ->setAttribute('stdout',  \utf8_encode(\mb_substr($buildStdout, -4096)))
             ->setAttribute('stderr', \utf8_encode(\mb_substr($buildStderr, -4096)))
             ->setAttribute('startTime', $buildStart)
-            ->setAttribute('endTime', \time())
-            ->setAttribute('duration', \time() - $buildStart);
+            ->setAttribute('endTime', $endTime)
+            ->setAttribute('duration', $endTime - $buildStart);
 
         // Update build with built code attribute
         $build = $database->updateDocument('builds', $buildId, $build);
@@ -897,18 +897,18 @@ function runBuildStage(string $buildId, string $deploymentId, string $projectID)
 
         Console::info('Build Stage Ran in ' . ($buildEnd - $buildStart) . ' seconds');
     } catch (Exception $e) {
+        \var_dump($e->getTraceAsString());
+        $endTime = \time();
+
         $build
             ->setAttribute('status', 'failed')
             ->setAttribute('stdout',  \utf8_encode(\mb_substr($buildStdout, -4096)))
             ->setAttribute('stderr', \utf8_encode(\mb_substr($e->getMessage(), -4096)))
             ->setAttribute('startTime', $buildStart)
-            ->setAttribute('endTime', \microtime(true))
-            ->setAttribute('duration', \microtime(true) - $buildStart);
+            ->setAttribute('endTime', $endTime)
+            ->setAttribute('duration', $endTime - $buildStart);
 
         $build = $database->updateDocument('builds', $buildId, $build);
-
-        $deployment->setAttribute('status', 'failed');
-        $database->updateDocument('deployments', $deploymentId, $deployment);
 
         // also remove the container if it exists
         if (isset($id)) {
@@ -1150,8 +1150,8 @@ App::post('/v1/functions/:functionId/deployments/:deploymentId/builds/:buildId')
                 createRuntimeServer($functionId, $projectId, $deploymentId, $dbForProject);
             } catch (\Throwable $th) {
                 Console::error($th->getMessage());
-                $deployment->setAttribute('status', 'failed');
-                $deployment = $dbForProject->updateDocument('deployments', $deploymentId, $deployment);
+                $build->setAttribute('status', 'failed');
+                $build = $dbForProject->updateDocument('builds', $buildId, $build);
                 throw $th;
             }
         });

--- a/app/executor.php
+++ b/app/executor.php
@@ -1136,7 +1136,7 @@ App::post('/v1/functions/:functionId/deployments/:deploymentId/builds/:buildId')
                 throw new Exception('Build failed', 500);
             }
 
-            if ($deployment->getAttribute('deploy') === true) {
+            if ($deployment->getAttribute('activate') === true) {
                 // Update the function document setting the deployment as the active one
                 $function
                     ->setAttribute('deployment', $deployment->getId())

--- a/app/executor.php
+++ b/app/executor.php
@@ -135,7 +135,6 @@ try {
             $orchestrationPool->put($orchestration);
         }
 
-
         foreach ($residueList as $value) {
             go(fn () => $activeFunctions->set($value->getName(), [
                 'id' => $value->getId(),
@@ -149,7 +148,7 @@ try {
         Console::info(count($activeFunctions) . ' functions listed in ' . ($executionEnd - $executionStart) . ' seconds');
     });
 } catch (\Throwable $error) {
-    call_user_func($logError, $error, "startupError");
+    logError($error, 'startupError');
 }
 
 function createRuntimeServer(string $functionId, string $projectId, string $deploymentId, Database $database): void

--- a/app/executor.php
+++ b/app/executor.php
@@ -135,6 +135,7 @@ try {
             $orchestrationPool->put($orchestration);
         }
 
+
         foreach ($residueList as $value) {
             go(fn () => $activeFunctions->set($value->getName(), [
                 'id' => $value->getId(),
@@ -148,7 +149,7 @@ try {
         Console::info(count($activeFunctions) . ' functions listed in ' . ($executionEnd - $executionStart) . ' seconds');
     });
 } catch (\Throwable $error) {
-    logError($error, 'startupError');
+    call_user_func($logError, $error, "startupError");
 }
 
 function createRuntimeServer(string $functionId, string $projectId, string $deploymentId, Database $database): void

--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -118,15 +118,18 @@ class BuildsV1 extends Worker
                     '$id' => $buildId,
                     '$read' => [],
                     '$write' => [],
-                    'dateCreated' => time(),
+                    'startTime' => time(),
+                    'endTime' => 0,
+                    'duration' => 0,
                     'status' => 'processing',
                     'runtime' => $function->getAttribute('runtime'),
                     'outputPath' => '',
                     'source' => $deployment->getAttribute('path'),
                     'sourceType' => Storage::DEVICE_LOCAL,
                     'stdout' => '',
-                    'stderr' => '',
-                    'time' => 0,
+                    'stderr' => ''
+                    // TODO: Probably start using vars again, but from different source
+                    /*
                     'vars' => [
                         'ENTRYPOINT_NAME' => $deployment->getAttribute('entrypoint'),
                         'APPWRITE_FUNCTION_ID' => $function->getId(),
@@ -135,6 +138,7 @@ class BuildsV1 extends Worker
                         'APPWRITE_FUNCTION_RUNTIME_VERSION' => $runtime['version'],
                         'APPWRITE_FUNCTION_PROJECT_ID' => $projectId,
                     ]
+                    */
                 ]));
             } catch (\Throwable $th) {
                 $deployment->setAttribute('buildId', '');
@@ -153,6 +157,8 @@ class BuildsV1 extends Worker
             Console::error($th->getMessage());
             throw $th;
         }
+
+        // TODO: Update build's endTime and duration
 
         Console::success("[ SUCCESS ] Build id: $buildId started");
     }

--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -118,7 +118,7 @@ class BuildsV1 extends Worker
                     '$id' => $buildId,
                     '$read' => [],
                     '$write' => [],
-                    'startTime' => \time(),
+                    'startTime' => time(),
                     'endTime' => 0,
                     'duration' => 0,
                     'status' => 'processing',
@@ -157,6 +157,8 @@ class BuildsV1 extends Worker
             Console::error($th->getMessage());
             throw $th;
         }
+
+        // TODO: Update build's endTime and duration
 
         Console::success("[ SUCCESS ] Build id: $buildId started");
     }

--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -154,6 +154,8 @@ class BuildsV1 extends Worker
             throw $th;
         }
 
+        // TODO: We should activate tag after successful build
+
         Console::success("[ SUCCESS ] Build id: $buildId started");
     }
 

--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -118,7 +118,7 @@ class BuildsV1 extends Worker
                     '$id' => $buildId,
                     '$read' => [],
                     '$write' => [],
-                    'startTime' => time(),
+                    'startTime' => \time(),
                     'endTime' => 0,
                     'duration' => 0,
                     'status' => 'processing',
@@ -157,8 +157,6 @@ class BuildsV1 extends Worker
             Console::error($th->getMessage());
             throw $th;
         }
-
-        // TODO: Update build's endTime and duration
 
         Console::success("[ SUCCESS ] Build id: $buildId started");
     }

--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -118,18 +118,15 @@ class BuildsV1 extends Worker
                     '$id' => $buildId,
                     '$read' => [],
                     '$write' => [],
-                    'startTime' => time(),
-                    'endTime' => 0,
-                    'duration' => 0,
+                    'dateCreated' => time(),
                     'status' => 'processing',
                     'runtime' => $function->getAttribute('runtime'),
                     'outputPath' => '',
                     'source' => $deployment->getAttribute('path'),
                     'sourceType' => Storage::DEVICE_LOCAL,
                     'stdout' => '',
-                    'stderr' => ''
-                    // TODO: Probably start using vars again, but from different source
-                    /*
+                    'stderr' => '',
+                    'time' => 0,
                     'vars' => [
                         'ENTRYPOINT_NAME' => $deployment->getAttribute('entrypoint'),
                         'APPWRITE_FUNCTION_ID' => $function->getId(),
@@ -138,7 +135,6 @@ class BuildsV1 extends Worker
                         'APPWRITE_FUNCTION_RUNTIME_VERSION' => $runtime['version'],
                         'APPWRITE_FUNCTION_PROJECT_ID' => $projectId,
                     ]
-                    */
                 ]));
             } catch (\Throwable $th) {
                 $deployment->setAttribute('buildId', '');
@@ -157,8 +153,6 @@ class BuildsV1 extends Worker
             Console::error($th->getMessage());
             throw $th;
         }
-
-        // TODO: Update build's endTime and duration
 
         Console::success("[ SUCCESS ] Build id: $buildId started");
     }

--- a/src/Appwrite/Utopia/Response/Model/Deployment.php
+++ b/src/Appwrite/Utopia/Response/Model/Deployment.php
@@ -52,9 +52,9 @@ class Deployment extends Model
                 'default' => '',
                 'example' => '5e5ea5c16897e',
             ])
-            ->addRule('deploy', [
+            ->addRule('activate', [
                 'type' => self::TYPE_BOOLEAN,
-                'description' => 'Whether the deployment should be automatically deployed.',
+                'description' => 'Whether the deployment should be automatically activated.',
                 'default' => false,
                 'example' => true,
             ])


### PR DESCRIPTION
## What does this PR do?

After we renamed `builds` to `deployments`, we now have `deploy` boolean parameter on `createDeployment` endpoint, which is confusing. With this PR, parameter names now match our UI, following the process of `Activating a deployment`.

Other words we could use are `Promote deployment (to production)` or `Publish deployment`, but ours `Activate` sounds the best to me.
 
## Test Plan

Current tests need to pass if refactor was successful.

## Related PRs and Issues


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅