### PR TITLE
Use validator on order attributes

### DIFF
--- a/app/controllers/api/database.php
+++ b/app/controllers/api/database.php
@@ -19,6 +19,7 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Key;
 use Utopia\Database\Validator\Permissions;
 use Utopia\Database\Validator\QueryValidator;
+use Utopia\Database\Validator\OrderAttributes;
 use Utopia\Database\Validator\Queries as QueriesValidator;
 use Utopia\Database\Validator\Structure;
 use Utopia\Database\Validator\UID;
@@ -1730,6 +1731,13 @@ App::get('/v1/database/collections/:collectionId/documents')
 
             return $query;
         }, $queries);
+
+        if(!empty($orderAttributes)) {
+            $validator = new OrderAttributes($collection->getAttribute('attributes', []), $collection->getAttribute('indexes', []), true);
+            if (!$validator->isValid($orderAttributes)) {
+                throw new Exception($validator->getDescription(), 400);
+            }
+        }
 
         if (!empty($queries)) {
             $validator = new QueriesValidator(new QueryValidator($collection->getAttribute('attributes', [])), $collection->getAttribute('indexes', []), true);


### PR DESCRIPTION
## What does this PR do?

Takes newly created `SortAttributes` validator and runs sort attributes through it. Thanks to this validator, we now force indexes on attributes user want to sort on, and prevent usage of unwanted attributes such as `_uid`.

## Test Plan

TODO: We probably need to add bunch of tests

## Related PRs and Issues

https://github.com/utopia-php/database/pull/106

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
