### PR TITLE
Fix non-json responding OAuth providers

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Bitly.php
+++ b/src/Appwrite/Auth/OAuth2/Bitly.php
@@ -78,10 +78,10 @@ class Bitly extends OAuth2
                 ])
             );
 
-        $output = [];
-        \parse_str($response, $output);
-        $this->tokens = $output;
-    }
+            $output = [];
+            \parse_str($response, $output);
+            $this->tokens = $output;
+        }
 
         return $this->tokens;
     }

--- a/src/Appwrite/Auth/OAuth2/Bitly.php
+++ b/src/Appwrite/Auth/OAuth2/Bitly.php
@@ -65,7 +65,7 @@ class Bitly extends OAuth2
     protected function getTokens(string $code): array
     {
         if(empty($this->tokens)) {
-            $this->tokens = \json_decode($this->request(
+            $response = $this->request(
                 'POST',
                 $this->resourceEndpoint . 'oauth/access_token',
                 ["Content-Type: application/x-www-form-urlencoded"],
@@ -76,8 +76,12 @@ class Bitly extends OAuth2
                     "redirect_uri" => $this->callback,
                     "state" => \json_encode($this->state)
                 ])
-            ), true);
-        }
+            );
+
+        $output = [];
+        \parse_str($response, $output);
+        $this->tokens = $output;
+    }
 
         return $this->tokens;
     }
@@ -89,7 +93,7 @@ class Bitly extends OAuth2
      */
     public function refreshTokens(string $refreshToken):array
     {
-        $this->tokens = \json_decode($this->request(
+        $response = $this->request(
             'POST',
             $this->resourceEndpoint . 'oauth/access_token',
             ["Content-Type: application/x-www-form-urlencoded"],
@@ -99,7 +103,11 @@ class Bitly extends OAuth2
                 "refresh_token" => $refreshToken,
                 'grant_type' => 'refresh_token'
             ])
-        ), true);
+        );
+
+        $output = [];
+        \parse_str($response, $output);
+        $this->tokens = $output;
 
         if(empty($this->tokens['refresh_token'])) {
             $this->tokens['refresh_token'] = $refreshToken;

--- a/src/Appwrite/Auth/OAuth2/Github.php
+++ b/src/Appwrite/Auth/OAuth2/Github.php
@@ -80,7 +80,7 @@ class Github extends OAuth2
      */
     public function refreshTokens(string $refreshToken):array
     {
-        $this->tokens = \json_decode($this->request(
+        $response = $this->request(
             'POST',
             'https://github.com/login/oauth/access_token',
             [],
@@ -90,7 +90,11 @@ class Github extends OAuth2
                 'grant_type' => 'refresh_token',
                 'refresh_token' => $refreshToken
             ])
-        ), true);
+        );
+
+        $output = [];
+        \parse_str($response, $output);
+        $this->tokens = $output;
 
         if(empty($this->tokens['refresh_token'])) {
             $this->tokens['refresh_token'] = $refreshToken;

--- a/src/Appwrite/Auth/OAuth2/Github.php
+++ b/src/Appwrite/Auth/OAuth2/Github.php
@@ -53,7 +53,7 @@ class Github extends OAuth2
     protected function getTokens(string $code): array
     {
         if(empty($this->tokens)) {
-            $this->tokens = \json_decode($this->request(
+            $response = $this->request(
                 'POST',
                 'https://github.com/login/oauth/access_token',
                 [],
@@ -63,7 +63,11 @@ class Github extends OAuth2
                     'client_secret' => $this->appSecret,
                     'code' => $code
                 ])
-            ), true);
+            );
+
+            $output = [];
+            \parse_str($response, $output);
+            $this->tokens = $output;
         }
 
         return $this->tokens;


### PR DESCRIPTION
## What does this PR do?

After the last OAuth refactor, Bitly and GitHub providers were not working properly, since they do not respond with JSON code. This PR fixes it.

## Test Plan

Not sure if testing oauths other than manually is possible.

## Related PRs and Issues


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅