### PR TITLE
feat: support managed redis 6+ userpass auth over TLS 

### DIFF
--- a/app/init.php
+++ b/app/init.php
@@ -152,10 +152,11 @@ Config::load('storage-outputs', __DIR__.'/config/storage/outputs.php');
 
 $user = App::getEnv('_APP_REDIS_USER','');
 $pass = App::getEnv('_APP_REDIS_PASS','');
+$scheme = (App::getEnv('_APP_REDIS_TLS', '') === 'enabled') ? 'tls' : 'redis';
 if(!empty($user) || !empty($pass)) {
-    Resque::setBackend('redis://'.$user.':'.$pass.'@'.App::getEnv('_APP_REDIS_HOST', '').':'.App::getEnv('_APP_REDIS_PORT', ''));
+    Resque::setBackend($scheme.'://'.$user.':'.$pass.'@'.App::getEnv('_APP_REDIS_HOST', '').':'.App::getEnv('_APP_REDIS_PORT', ''));
 } else {
-    Resque::setBackend(App::getEnv('_APP_REDIS_HOST', '').':'.App::getEnv('_APP_REDIS_PORT', ''));
+    Resque::setBackend($scheme.'://'.App::getEnv('_APP_REDIS_HOST', '').':'.App::getEnv('_APP_REDIS_PORT', ''));
 }
 
 /**

--- a/app/init.php
+++ b/app/init.php
@@ -509,7 +509,18 @@ $register->set('db', function () { // This is usually for our workers or CLI com
 });
 $register->set('cache', function () { // This is usually for our workers or CLI commands scope
     $redis = new Redis();
-    $redis->pconnect(App::getEnv('_APP_REDIS_HOST', ''), App::getEnv('_APP_REDIS_PORT', ''));
+    $host = App::getEnv('_APP_REDIS_HOST', '');
+    $port = App::getEnv('_APP_REDIS_PORT', '');
+    $user = App::getEnv('_APP_REDIS_USER','');
+    $pass = App::getEnv('_APP_REDIS_PASS','');
+    $scheme = (App::getEnv('_APP_REDIS_TLS', '') === 'enabled') ? 'tls' : 'redis';
+
+    $redis->pconnect($scheme.'://'.$host, $port);
+    if ($pass) {
+        $auth = ($user) ? [$user, $pass] : $pass;
+        $redis->auth($auth);
+    }
+
     $redis->setOption(Redis::OPT_READ_TIMEOUT, -1);
 
     return $redis;

--- a/bin/schedule
+++ b/bin/schedule
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=1 REDIS_BACKEND=$REDIS_BACKEND RESQUE_PHP='/usr/src/code/vendor/autoload.php' php /usr/src/code/vendor/bin/resque-scheduler
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=1 RESQUE_PHP='/usr/src/code/vendor/autoload.php' php /usr/src/code/vendor/bin/resque-scheduler

--- a/bin/worker-audits
+++ b/bin/worker-audits
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=1 QUEUE='v1-audits' APP_INCLUDE='/usr/src/code/app/workers/audits.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=1 QUEUE='v1-audits' APP_INCLUDE='/usr/src/code/app/workers/audits.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/bin/worker-certificates
+++ b/bin/worker-certificates
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=1 QUEUE='v1-certificates' APP_INCLUDE='/usr/src/code/app/workers/certificates.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=1 QUEUE='v1-certificates' APP_INCLUDE='/usr/src/code/app/workers/certificates.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/bin/worker-database
+++ b/bin/worker-database
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=0.1 QUEUE='v1-database' APP_INCLUDE='/usr/src/code/app/workers/database.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=0.1 QUEUE='v1-database' APP_INCLUDE='/usr/src/code/app/workers/database.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/bin/worker-deletes
+++ b/bin/worker-deletes
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=1 QUEUE='v1-deletes' APP_INCLUDE='/usr/src/code/app/workers/deletes.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=1 QUEUE='v1-deletes' APP_INCLUDE='/usr/src/code/app/workers/deletes.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/bin/worker-functions
+++ b/bin/worker-functions
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=0.1 QUEUE='v1-functions' APP_INCLUDE='/usr/src/code/app/workers/functions.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=0.1 QUEUE='v1-functions' APP_INCLUDE='/usr/src/code/app/workers/functions.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/bin/worker-mails
+++ b/bin/worker-mails
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=1 QUEUE='v1-mails' APP_INCLUDE='/usr/src/code/app/workers/mails.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=1 QUEUE='v1-mails' APP_INCLUDE='/usr/src/code/app/workers/mails.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/bin/worker-webhooks
+++ b/bin/worker-webhooks
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+if [[ "$_APP_REDIS_TLS" == "enabled" ]]
 then
-    REDIS_BACKEND="${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="tls"
 else
-    REDIS_BACKEND="redis://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+    REDIS_SCHEME="redis"
 fi
 
-INTERVAL=0.1 QUEUE='v1-webhooks' APP_INCLUDE='/usr/src/code/app/workers/webhooks.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php
+if [ -z "$_APP_REDIS_USER" ] && [ -z "$_APP_REDIS_PASS" ]
+then
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+else
+    REDIS_BACKEND="${REDIS_SCHEME}://${_APP_REDIS_USER}:${_APP_REDIS_PASS}@${_APP_REDIS_HOST}:${_APP_REDIS_PORT}"
+fi
+
+REDIS_BACKEND=$REDIS_BACKEND INTERVAL=0.1 QUEUE='v1-webhooks' APP_INCLUDE='/usr/src/code/app/workers/webhooks.php' php /usr/src/code/vendor/bin/resque -dopcache.preload=opcache.preload=/usr/src/code/app/preload.php

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "utopia-php/websocket": "0.1.0",
         "utopia-php/image": "0.5.*",
 
-        "resque/php-resque": "1.3.6",
+        "resque/php-resque": "dev-tls_connections as 1.3.7",
         "matomo/device-detector": "5.0.1",
         "dragonmantank/cron-expression": "3.1.0",
         "influxdb/influxdb-php": "1.15.2",
@@ -73,6 +73,16 @@
         "textalk/websocket": "1.5.5",
         "vimeo/psalm": "4.13.1"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/kodumbeats/php-resque"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/kodumbeats/credis"
+        }
+    ],
     "provide": {
         "ext-phpiredis": "*"
     },
@@ -80,5 +90,7 @@
         "platform": {
             "php": "8.0"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab493f0a7f01a1105f8bc5caaf9b928b",
+    "content-hash": "acb2c628f3f1b43381901c23d783d77d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -311,17 +311,11 @@
         },
         {
             "name": "colinmollenhour/credis",
-            "version": "v1.12.1",
+            "version": "dev-feat-auth-username",
             "source": {
                 "type": "git",
-                "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "c27faa11724229986335c23f4b6d0f1d8d6547fb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/c27faa11724229986335c23f4b6d0f1d8d6547fb",
-                "reference": "c27faa11724229986335c23f4b6d0f1d8d6547fb",
-                "shasum": ""
+                "url": "https://github.com/kodumbeats/credis",
+                "reference": "73750d4812e9bb14445c8ed06bd76464ca15c0b0"
             },
             "require": {
                 "php": ">=5.4.0"
@@ -335,7 +329,6 @@
                     "Module.php"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -347,11 +340,7 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "support": {
-                "issues": "https://github.com/colinmollenhour/credis/issues",
-                "source": "https://github.com/colinmollenhour/credis/tree/v1.12.1"
-            },
-            "time": "2020-11-06T16:09:14+00:00"
+            "time": "2022-02-08T16:42:43+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -1033,12 +1022,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "MongoDB\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "MongoDB\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1452,20 +1441,14 @@
         },
         {
             "name": "resque/php-resque",
-            "version": "v1.3.6",
+            "version": "dev-tls_connections",
             "source": {
                 "type": "git",
-                "url": "https://github.com/resque/php-resque.git",
-                "reference": "fe41c04763699b1318d97ed14cc78583e9380161"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/resque/php-resque/zipball/fe41c04763699b1318d97ed14cc78583e9380161",
-                "reference": "fe41c04763699b1318d97ed14cc78583e9380161",
-                "shasum": ""
+                "url": "https://github.com/kodumbeats/php-resque",
+                "reference": "e607a2d3e51a9d2ecf05c0402582d078d883d2c8"
             },
             "require": {
-                "colinmollenhour/credis": "~1.7",
+                "colinmollenhour/credis": "dev-feat-auth-username as 1.12.2",
                 "php": ">=5.6.0",
                 "psr/log": "~1.0"
             },
@@ -1493,7 +1476,6 @@
                     "ResqueScheduler": "lib"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1527,11 +1509,7 @@
                 "redis",
                 "resque"
             ],
-            "support": {
-                "issues": "https://github.com/resque/php-resque/issues",
-                "source": "https://github.com/resque/php-resque/tree/v1.3.6"
-            },
-            "time": "2020-04-16T16:39:50+00:00"
+            "time": "2022-02-01T22:15:27+00:00"
         },
         {
             "name": "slickdeals/statsd",
@@ -1766,12 +1744,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2141,16 +2119,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "2f2527bb080cf578fba327ea2ec637064561d403"
+                "reference": "ecc143f2cfe16b23675407035c6b5375ba263285"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/2f2527bb080cf578fba327ea2ec637064561d403",
-                "reference": "2f2527bb080cf578fba327ea2ec637064561d403",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/ecc143f2cfe16b23675407035c6b5375ba263285",
+                "reference": "ecc143f2cfe16b23675407035c6b5375ba263285",
                 "shasum": ""
             },
             "require": {
@@ -2198,9 +2176,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.14.0"
+                "source": "https://github.com/utopia-php/database/tree/0.14.1"
             },
-            "time": "2022-01-21T16:34:34+00:00"
+            "time": "2022-01-25T13:01:20+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -2688,16 +2666,16 @@
         },
         {
             "name": "utopia-php/swoole",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/swoole.git",
-                "reference": "2b714eddf77cd5eda1889219c9656d7c0a63ce73"
+                "reference": "8312df69233b5dcd3992de88f131f238002749de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/swoole/zipball/2b714eddf77cd5eda1889219c9656d7c0a63ce73",
-                "reference": "2b714eddf77cd5eda1889219c9656d7c0a63ce73",
+                "url": "https://api.github.com/repos/utopia-php/swoole/zipball/8312df69233b5dcd3992de88f131f238002749de",
+                "reference": "8312df69233b5dcd3992de88f131f238002749de",
                 "shasum": ""
             },
             "require": {
@@ -2738,9 +2716,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/swoole/issues",
-                "source": "https://github.com/utopia-php/swoole/tree/0.3.2"
+                "source": "https://github.com/utopia-php/swoole/tree/0.3.3"
             },
-            "time": "2021-12-13T15:37:41+00:00"
+            "time": "2022-01-20T09:58:43+00:00"
         },
         {
             "name": "utopia-php/system",
@@ -3037,12 +3015,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Amp\\ByteStream\\": "lib"
-                },
                 "files": [
                     "lib/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3132,23 +3110,23 @@
         },
         {
             "name": "composer/pcre",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2"
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/3d322d715c43a1ac36c7fe215fa59336265500f2",
-                "reference": "3d322d715c43a1ac36c7fe215fa59336265500f2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1",
+                "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
@@ -3183,7 +3161,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.0"
+                "source": "https://github.com/composer/pcre/tree/1.0.1"
             },
             "funding": [
                 {
@@ -3199,27 +3177,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-06T15:17:27+00:00"
+            "time": "2022-01-21T20:24:37+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.2.7",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "deac27056b57e46faf136fae7b449eeaa71661ee"
+                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/deac27056b57e46faf136fae7b449eeaa71661ee",
-                "reference": "deac27056b57e46faf136fae7b449eeaa71661ee",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.54",
+                "phpstan/phpstan": "^1.4",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
@@ -3264,7 +3242,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.7"
+                "source": "https://github.com/composer/semver/tree/3.2.9"
             },
             "funding": [
                 {
@@ -3280,7 +3258,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T09:57:54+00:00"
+            "time": "2022-02-04T13:58:43+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -3710,12 +3688,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3963,16 +3941,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/15a90844ad40f127afd244c0cad228de2a80052a",
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a",
                 "shasum": ""
             },
             "require": {
@@ -4008,9 +3986,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.1.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-07T21:56:48+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4619,11 +4597,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5721,16 +5699,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dd434fa8d69325e5d210f63070014d889511fcb3"
+                "reference": "22e8efd019c3270c4f79376234a3f8752cd25490"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dd434fa8d69325e5d210f63070014d889511fcb3",
-                "reference": "dd434fa8d69325e5d210f63070014d889511fcb3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/22e8efd019c3270c4f79376234a3f8752cd25490",
+                "reference": "22e8efd019c3270c4f79376234a3f8752cd25490",
                 "shasum": ""
             },
             "require": {
@@ -5796,7 +5774,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.2"
+                "source": "https://github.com/symfony/console/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -5812,7 +5790,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-27T21:05:08+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -5845,12 +5823,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5926,12 +5904,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -6090,12 +6068,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6222,16 +6200,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "bae261d0c3ac38a1f802b4dfed42094296100631"
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bae261d0c3ac38a1f802b4dfed42094296100631",
-                "reference": "bae261d0c3ac38a1f802b4dfed42094296100631",
+                "url": "https://api.github.com/repos/symfony/string/zipball/522144f0c4c004c80d56fa47e40e17028e2eefc2",
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2",
                 "shasum": ""
             },
             "require": {
@@ -6287,7 +6265,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.2"
+                "source": "https://github.com/symfony/string/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -6303,7 +6281,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T22:13:01+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "textalk/websocket",
@@ -6406,16 +6384,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.14.10",
+            "version": "v2.14.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "95fb194cd4dd6ac373a27af2bde2bad5d3f27aba"
+                "reference": "66baa66f29ee30e487e05f1679903e36eb01d727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/95fb194cd4dd6ac373a27af2bde2bad5d3f27aba",
-                "reference": "95fb194cd4dd6ac373a27af2bde2bad5d3f27aba",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/66baa66f29ee30e487e05f1679903e36eb01d727",
+                "reference": "66baa66f29ee30e487e05f1679903e36eb01d727",
                 "shasum": ""
             },
             "require": {
@@ -6470,7 +6448,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v2.14.10"
+                "source": "https://github.com/twigphp/Twig/tree/v2.14.11"
             },
             "funding": [
                 {
@@ -6482,7 +6460,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-03T21:13:26+00:00"
+            "time": "2022-02-04T06:57:25+00:00"
         },
         {
             "name": "vimeo/psalm",
@@ -6561,13 +6539,13 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Psalm\\": "src/Psalm/"
-                },
                 "files": [
                     "src/functions.php",
                     "src/spl_object_id.php"
-                ]
+                ],
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6642,10 +6620,19 @@
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
-    "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
-    "prefer-stable": false,
+    "aliases": [
+        {
+            "package": "resque/php-resque",
+            "version": "dev-tls_connections",
+            "alias": "1.3.7",
+            "alias_normalized": "1.3.7.0"
+        }
+    ],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "resque/php-resque": 20
+    },
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.0.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -166,6 +167,9 @@ services:
       - _APP_OPENSSL_KEY_V1
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
+      - _APP_REDIS_USER
+      - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -185,6 +189,7 @@ services:
     volumes:
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-audits:/usr/local/bin/worker-audits
     depends_on:
       - redis
       - mariadb
@@ -194,6 +199,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -212,6 +218,7 @@ services:
     volumes:
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-webhooks:/usr/local/bin/worker-webhooks
     depends_on:
       - redis
       - mariadb
@@ -223,6 +230,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_LOGGING_PROVIDER
       - _APP_LOGGING_CONFIG
 
@@ -240,6 +248,7 @@ services:
       - appwrite-certificates:/storage/certificates:rw
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-deletes:/usr/local/bin/worker-deletes
     depends_on:
       - redis
       - mariadb
@@ -249,6 +258,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -267,6 +277,7 @@ services:
     volumes: 
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-database:/usr/local/bin/worker-database
       # - ./vendor/utopia-php/database:/usr/src/code/vendor/utopia-php/database
     depends_on:
       - redis
@@ -277,6 +288,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -297,6 +309,7 @@ services:
       - appwrite-certificates:/storage/certificates:rw
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-certificates:/usr/local/bin/worker-certificates
     depends_on:
       - redis
       - mariadb
@@ -308,6 +321,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -329,6 +343,7 @@ services:
       - /tmp:/tmp:rw
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-functions:/usr/local/bin/worker-functions
     depends_on:
       - redis
       - mariadb
@@ -339,6 +354,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_DB_HOST
       - _APP_DB_PORT
       - _APP_DB_SCHEMA
@@ -368,6 +384,7 @@ services:
     volumes:
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      # - ./bin/worker-mails:/usr/local/bin/worker-mails
     depends_on:
       - redis
       - maildev
@@ -380,6 +397,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_SMTP_HOST
       - _APP_SMTP_PORT
       - _APP_SMTP_SECURE
@@ -406,6 +424,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
       - _APP_MAINTENANCE_INTERVAL
       - _APP_MAINTENANCE_RETENTION_EXECUTION
       - _APP_MAINTENANCE_RETENTION_ABUSE
@@ -456,6 +475,7 @@ services:
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
       - _APP_REDIS_PASS
+      - _APP_REDIS_TLS
 
   mariadb:
     image: mariadb:10.7 # fix issues when upgrading using: mysql_upgrade -u root -p


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Uses patches for `phpresque` and `credis` to bring userpass auth support over TLS, both of which are necessary to connect to managed Redis 6+ servers running ACL authentication.

## Problems

- [ ] As mentioned in https://github.com/utopia-php/swoole/pull/16, when I try to import the new `Utopia\Swoole\Database` classes, all containers that try to autoload crash or max out on CPU. I have no idea what I did 🙃 

## Test Plan

Successful when existing test suite can be run against a managed Redis database.

## Related PRs and Issues

https://github.com/utopia-php/swoole/pull/16

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
