### PR TITLE
Feat: Migrated event channel

### DIFF
--- a/src/Appwrite/Messaging/Adapter/Realtime.php
+++ b/src/Appwrite/Messaging/Adapter/Realtime.php
@@ -290,7 +290,7 @@ class Realtime extends Adapter
 
                 $channels[] = 'documents';
                 $channels[] = 'collections.' . $payload->getAttribute('$collection') . '.documents';
-                $channels[] = 'documents.' . $payload->getId();
+                $channels[] = 'collections.' . $payload->getAttribute('$collection') . '.documents.' . $payload->getId();
 
                 $roles = ($collection->getAttribute('permission') === 'collection') ? $collection->getRead() : $payload->getRead();
 

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -80,8 +80,8 @@ class RealtimeCustomClientTest extends Scope
             'collections.1.documents',
             'collections.2.documents',
             'documents',
-            'documents.1',
-            'documents.2',
+            'collections.1.documents.1',
+            'collections.2.documents.2',
         ], $headers);
 
         $response = json_decode($client->receive(), true);
@@ -100,8 +100,8 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains('collections.1.documents', $response['data']['channels']);
         $this->assertContains('collections.2.documents', $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.1', $response['data']['channels']);
-        $this->assertContains('documents.2', $response['data']['channels']);
+        $this->assertContains('collections.1.documents.1', $response['data']['channels']);
+        $this->assertContains('collections.2.documents.2', $response['data']['channels']);
         $this->assertEquals($userId, $response['data']['user']['$id']);
 
         $client->close();
@@ -606,7 +606,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('timestamp', $response['data']);
         $this->assertCount(3, $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.' . $document['body']['$id'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents.' . $document['body']['$id'], $response['data']['channels']);
         $this->assertContains('collections.' . $actors['body']['$id'] . '.documents', $response['data']['channels']);
         $this->assertEquals('database.documents.create', $response['data']['event']);
         $this->assertNotEmpty($response['data']['payload']);
@@ -638,7 +638,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('timestamp', $response['data']);
         $this->assertCount(3, $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.' . $data['documentId'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents.' . $data['documentId'], $response['data']['channels']);
         $this->assertContains('collections.' . $data['actorsId'] . '.documents', $response['data']['channels']);
         $this->assertEquals('database.documents.update', $response['data']['event']);
         $this->assertNotEmpty($response['data']['payload']);
@@ -676,7 +676,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('timestamp', $response['data']);
         $this->assertCount(3, $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.' . $document['body']['$id'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents.' . $document['body']['$id'], $response['data']['channels']);
         $this->assertContains('collections.' . $data['actorsId'] . '.documents', $response['data']['channels']);
         $this->assertEquals('database.documents.delete', $response['data']['event']);
         $this->assertNotEmpty($response['data']['payload']);
@@ -767,7 +767,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('timestamp', $response['data']);
         $this->assertCount(3, $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.' . $document['body']['$id'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents.' . $document['body']['$id'], $response['data']['channels']);
         $this->assertContains('collections.' . $actors['body']['$id'] . '.documents', $response['data']['channels']);
         $this->assertEquals('database.documents.create', $response['data']['event']);
         $this->assertNotEmpty($response['data']['payload']);
@@ -798,7 +798,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('timestamp', $response['data']);
         $this->assertCount(3, $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.' . $data['documentId'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents.' . $data['documentId'], $response['data']['channels']);
         $this->assertContains('collections.' . $data['actorsId'] . '.documents', $response['data']['channels']);
         $this->assertEquals('database.documents.update', $response['data']['event']);
         $this->assertNotEmpty($response['data']['payload']);
@@ -836,7 +836,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('timestamp', $response['data']);
         $this->assertCount(3, $response['data']['channels']);
         $this->assertContains('documents', $response['data']['channels']);
-        $this->assertContains('documents.' . $document['body']['$id'], $response['data']['channels']);
+        $this->assertContains('collections.' . $data['actorsId'] . '.documents.' . $document['body']['$id'], $response['data']['channels']);
         $this->assertContains('collections.' . $data['actorsId'] . '.documents', $response['data']['channels']);
         $this->assertEquals('database.documents.delete', $response['data']['event']);
         $this->assertNotEmpty($response['data']['payload']);


### PR DESCRIPTION
## What does this PR do?

Current implementation allows event `documents.[ID]` to listen to document changes. This is limiting in combination with Custom IDs, as you can have same custom ID in two different collections.

This PR adds collection ID into event alongside document ID.

## Test Plan

Updated relevant tests. Should pass before merging.

## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/2769

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
