### PR TITLE
Fix: 0.12 LetsEncrypt generation

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -543,8 +543,8 @@ App::get('/.well-known/acme-challenge')
         $filePath = '/.well-known/acme-challenge' . $token;
 
         $base = \realpath(APP_STORAGE_CERTIFICATES);
-        $path = \str_replace('/.well-known/acme-challenge/', '', $request->getURI());
-        $absolute = \realpath($base.'/.well-known/acme-challenge/'.$filePath);
+        $path = \str_replace('/.well-known/acme-challenge/', '', $filePath);
+        $absolute = \realpath($base.'/.well-known/acme-challenge/'.$path);
 
         if (!$base) {
             throw new Exception('Storage error', 500);

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -540,11 +540,8 @@ App::get('/.well-known/acme-challenge')
             throw new Exception('Invalid challenge token.', 400);
         }
 
-        $filePath = '/.well-known/acme-challenge' . $token;
-
         $base = \realpath(APP_STORAGE_CERTIFICATES);
-        $path = \str_replace('/.well-known/acme-challenge/', '', $filePath);
-        $absolute = \realpath($base.'/.well-known/acme-challenge/'.$path);
+        $absolute = \realpath($base.'/.well-known/acme-challenge/'.$token);
 
         if (!$base) {
             throw new Exception('Storage error', 500);


### PR DESCRIPTION
## What does this PR do?

During last release, we created bug that made LetsEncrypt challenges fail. This PR fixes it.

## Test Plan

Manual QA on DO droplet:

![CleanShot 2022-02-23 at 12 29 36](https://user-images.githubusercontent.com/19310830/155311096-6a3f4c4c-3462-4116-b019-51d3d2f1d168.png)


## Related PRs and Issues


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅