### PR TITLE
Modified document list description to mention the 5000 cap on sum

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/BaseList.php
+++ b/src/Appwrite/Utopia/Response/Model/BaseList.php
@@ -34,7 +34,7 @@ class BaseList extends Model
         if ($paging) {
             $this->addRule('sum', [
                 'type' => self::TYPE_INTEGER,
-                'description' => 'Total number of documents in the collection. When the total number of document in the collection 5000+, the sum returned will be capped at 5000.',
+                'description' => 'Total number of items available in the server. When the total number of items available is 5000+, the sum returned will be capped at 5000.',
                 'default' => 0,
                 'example' => 5,
             ]);

--- a/src/Appwrite/Utopia/Response/Model/BaseList.php
+++ b/src/Appwrite/Utopia/Response/Model/BaseList.php
@@ -34,7 +34,7 @@ class BaseList extends Model
         if ($paging) {
             $this->addRule('sum', [
                 'type' => self::TYPE_INTEGER,
-                'description' => 'Total number of items available on the server.',
+                'description' => 'Total number of documents in the collection. When the total number of document in the collection 5000+, the sum returned will be capped at 5000.',
                 'default' => 0,
                 'example' => 5,
             ]);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The fact that sum is capped at 5000 is not mentioned in the documentation anywhere. This PR adds a short description to the documentation, so people will not be confused when they see `sum: 5000` for their collection with more than 5000 documents.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

Non that I know of.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
