### PR TITLE
Append stdout to function build error log

### DIFF
--- a/app/executor.php
+++ b/app/executor.php
@@ -303,8 +303,8 @@ App::post('/v1/runtimes')
             Console::success('Build Stage completed in ' . ($endTime - $startTime) . ' seconds');
         
         } catch (Throwable $th) {
-            Console::error('Build failed: ' . $th->getMessage());
-            throw new Exception($th->getMessage(), 500);
+            Console::error('Build failed: ' . $th->getMessage() . $stdout);
+            throw new Exception($th->getMessage() . $stdout, 500);
         } finally {
             if (!empty($containerId) && $remove) {
                 $orchestration->remove($containerId, true);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Appends stdout to stderr when throwing a function runtime build error. In some cases, actual errors are in stdout instead of stderr.

## Test Plan

Covered by existing tests

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
