### PR TITLE
Fix delete collection using wrong ID

### DIFF
--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -129,7 +129,7 @@ class DeletesV1 extends Worker
 
         $dbForProject = $this->getProjectDB($projectId);
 
-        $dbForProject->deleteCollection('collection_' . $collectionId);
+        $dbForProject->deleteCollection('collection_' . $document->getInternalId());
 
         $this->deleteByGroup('attributes', [
             new Query('collectionId', Query::TYPE_EQUAL, [$collectionId])


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix delete worker deleting collection using wrong ID, causing dangling tables and inability to re-create attributes for existing collection IDs
