### PR TITLE
Fix: Runtimes version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -115,11 +115,11 @@
         },
         {
             "name": "appwrite/php-runtimes",
-            "version": "0.7.3",
+            "version": "0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/runtimes.git",
-                "reference": "a4c20be668c78f8a1ac03148de1c7c61d9bfde74"
+                "reference": "8e0972ecce6ad96f3701edab8d2c9a8af7074093"
             },
             "require": {
                 "php": ">=8.0",
@@ -154,7 +154,7 @@
                 "php",
                 "runtimes"
             ],
-            "time": "2022-02-21T23:55:23+00:00"
+            "time": "2022-02-26T11:38:09+00:00"
         },
         {
             "name": "chillerlan/php-qrcode",
@@ -3691,9 +3691,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -6577,5 +6574,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## What does this PR do?

Updates locker file to apply latest appwrite/runtimes changes - adding Dart 2.16

## Test Plan

Manually create 2.16 function and test hello world code:

![CleanShot 2022-03-02 at 14 03 45](https://user-images.githubusercontent.com/19310830/156366906-6ce22f21-54bd-4c27-9faa-fa78961df3ff.png)

![CleanShot 2022-03-02 at 14 03 50](https://user-images.githubusercontent.com/19310830/156366913-8face455-a3c7-493a-b97f-b220fca8a843.png)

![CleanShot 2022-03-02 at 14 03 53](https://user-images.githubusercontent.com/19310830/156366918-2d553202-9888-43fd-93f0-23d0a3a903fa.png)

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
