### PR TITLE
Feat: Added port listener for Gitpod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - --accesslog=true
     ports:
       - 80:80
+      - 8080:80
       - 443:443
       - 9500:8080
     volumes:


### PR DESCRIPTION
## What does this PR do?

To create a frictionless environment for Gitpod users, there is some work to do around setup.

This PR is the first step in the right direction and should not affect anything negatively. This change exposes Appwrite also on port 8080, because Gitpod refuses to use ports below 2014. This configuration will allow people to keep using port 80, but for Gitpod users there is also 8080 configuration.

In future we should also add `gitpod.yml`, but that is optional because it "only" speeds up workspace setup. This change is required, and I need to do it each time otherwise I cant use Appwrite.

## Test Plan

Manual QA on Gitpod

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
