### PR TITLE
feat: add support for using Gitpod for development

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,11 +1,17 @@
 FROM gitpod/workspace-full
 
+# Install and configure Deno
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-deno &&     echo 'export DENO_INSTALL="/home/gitpod/.deno"' >> /home/gitpod/.bashrc.d/90-deno &&     echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> /home/gitpod/.bashrc.d/90-deno
 
+# Disable current PHP installation
 RUN sudo a2dismod php7.4
 RUN sudo a2dismod mpm_prefork
+
+# Install apache2 (PHP install requires to do this first)
 RUN sudo apt --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install apache2
+
+# Update to PHP 8.0 with unattended installation
 RUN sudo apt --yes install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
 RUN sudo apt update
 RUN sudo apt --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install php8.0

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,6 +3,9 @@ FROM gitpod/workspace-full
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-deno &&     echo 'export DENO_INSTALL="/home/gitpod/.deno"' >> /home/gitpod/.bashrc.d/90-deno &&     echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> /home/gitpod/.bashrc.d/90-deno
 
-RUN sudo apt install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
+RUN sudo a2dismod php7.4
+RUN sudo a2dismod mpm_prefork
+RUN sudo apt --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install apache2
+RUN sudo apt --yes install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
 RUN sudo apt update
-RUN sudo apt --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install php8.0
+RUN sudo apt --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install php8.0

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,4 +3,6 @@ FROM gitpod/workspace-full
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-deno &&     echo 'export DENO_INSTALL="/home/gitpod/.deno"' >> /home/gitpod/.bashrc.d/90-deno &&     echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> /home/gitpod/.bashrc.d/90-deno
 
-RUN sudo apt-get install php8.0
+RUN sudo apt install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
+RUN sudo apt update
+RUN sudo apt upgrade -y

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+RUN curl -fsSL https://deno.land/x/install/install.sh | sh
+RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-deno &&     echo 'export DENO_INSTALL="/home/gitpod/.deno"' >> /home/gitpod/.bashrc.d/90-deno &&     echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> /home/gitpod/.bashrc.d/90-deno
+
+RUN sudo apt-get install php8.0

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,5 @@
 FROM gitpod/workspace-full
 
-# Install and configure Deno
-RUN curl -fsSL https://deno.land/x/install/install.sh | sh
-RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-deno &&     echo 'export DENO_INSTALL="/home/gitpod/.deno"' >> /home/gitpod/.bashrc.d/90-deno &&     echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> /home/gitpod/.bashrc.d/90-deno
-
 # Disable current PHP installation
 RUN sudo a2dismod php7.4
 RUN sudo a2dismod mpm_prefork

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,4 +5,4 @@ RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-den
 
 RUN sudo apt install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
 RUN sudo apt update
-RUN sudo apt upgrade -y
+RUN sudo apt upgrade -q -y --force-yes

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,4 +5,4 @@ RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-den
 
 RUN sudo apt install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
 RUN sudo apt update
-RUN sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php8.0
+RUN sudo apt --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install php8.0

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,4 +5,4 @@ RUN /home/gitpod/.deno/bin/deno completions bash > /home/gitpod/.bashrc.d/90-den
 
 RUN sudo apt install software-properties-common && sudo add-apt-repository ppa:ondrej/php -y
 RUN sudo apt update
-RUN sudo apt upgrade -q -y --force-yes
+RUN sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php8.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,13 @@
 tasks:
-  - init: docker-compose pull --include-deps mariadb:10.7 redis:6.2-alpine \
-      appwrite/influxdb:1.4.0 appwrite/telegraf:1.3.0 appwrite/mailcatcher:1.0.0 \
-      appwrite/requestcatcher:1.0.0 adminer
+  - init: docker pull mariadb:10.7 && \
+      docker pull redis:6.2-alpine && \
+      docker pull appwrite/influxdb:1.4.0 && \
+      docker pull appwrite/telegraf:1.3.0 && \
+      docker pull appwrite/mailcatcher:1.0.0 && \
+      docker pull appwrite/requestcatcher:1.0.0 &&
+      docker pull adminer
     command: |
-      docker-compose up -d
+      docker-compose up
 ports:
   - port: 8080
     onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,12 @@ tasks:
   - init: docker-compose pull &&
       docker-compose build
     command: |
-      docker-compose up -d
+      docker-compose up -d      
+  - init: docker-compose pull &&docker run --rm --interactive --tty \
+      --volume $PWD:/app \
+      composer update --ignore-platform-reqs \
+      --optimize-autoloader --no-plugins --no-scripts --prefer-dist
+
 ports:
   - port: 8080
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 tasks:
-  - init: docker-compose pull --include-deps mariadb redis appwrite/influxdb appwrite/telegraf appwrite/mailcatcher appwrite/requestcatcher
+  - init: docker-compose pull --include-deps mariadb redis 
+# appwrite/influxdb appwrite/telegraf appwrite/mailcatcher appwrite/requestcatcher
     command: |
       docker-compose up -d
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,9 @@
 tasks:
   - init: docker-compose pull &&
-      docker-compose build
+      docker-compose build &&
+      docker run --rm --interactive --tty --volume $PWD:/app composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
     command: |
-      docker-compose up -d      
-  - init: docker-compose pull &&docker run --rm --interactive --tty \
-      --volume $PWD:/app \
-      composer update --ignore-platform-reqs \
-      --optimize-autoloader --no-plugins --no-scripts --prefer-dist
+      docker-compose up -d
 
 ports:
   - port: 8080

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,12 +9,6 @@ ports:
   - port: 8080
     onOpen: ignore
     visibility: public
-  - port: 443
-    onOpen: ignore
-    visibility: public
-  - port: 3001
-    onOpen: ignore
-    visibility: public
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,14 +7,7 @@ tasks:
       docker pull appwrite/requestcatcher:1.0.0 &&
       docker pull adminer
     command: |
-      docker-compose up
-  # - init: docker--compose pull --include-deps mariadb:10.7 &&
-  #     docker pull redis:6.2-alpine && \
-  #     docker pull appwrite/influxdb:1.4.0 && \
-  #     docker pull appwrite/telegraf:1.3.0 && \
-  #     docker pull appwrite/mailcatcher:1.0.0 && \
-  #     docker pull appwrite/requestcatcher:1.0.0 && \
-  #     docker pull adminer
+      docker-compose up -d
 ports:
   - port: 8080
     onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,8 @@ tasks:
       docker pull adminer &&
       docker pull composer:2.0 &&
       docker pull node:16.13.2-alpine3.15 &&
-      docker pull php:8.0.14-cli-alpine3.15
+      docker pull php:8.0.14-cli-alpine3.15 &&
+      docker-compose build
     command: |
       docker-compose up -d
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,5 @@
 tasks:
-  - init: docker pull mariadb:10.7 &&
-      docker pull redis:6.2-alpine &&
-      docker pull appwrite/influxdb:1.4.0 &&
-      docker pull appwrite/telegraf:1.3.0 &&
-      docker pull appwrite/mailcatcher:1.0.0 &&
-      docker pull appwrite/requestcatcher:1.0.0 &&
-      docker pull adminer &&
-      docker pull composer:2.0 &&
-      docker pull node:16.13.2-alpine3.15 &&
-      docker pull php:8.0.14-cli-alpine3.15 &&
+  - init: docker-compose pull
       docker-compose build
     command: |
       docker-compose up -d

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 tasks:
-  - init: docker-compose pull --include-deps mariadb redis 
-# appwrite/influxdb appwrite/telegraf appwrite/mailcatcher appwrite/requestcatcher
+  - init: docker-compose pull --include-deps mariadb:10.7 redis:6.2-alpine \
+      appwrite/influxdb:1.4.0 appwrite/telegraf:1.3.0 appwrite/mailcatcher:1.0.0 \
+      appwrite/requestcatcher:1.0.0 adminer
     command: |
       docker-compose up -d
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,10 @@
 tasks:
-  - init: docker pull mariadb:10.7
-      docker pull redis:6.2-alpine
-      docker pull appwrite/influxdb:1.4.0
-      docker pull appwrite/telegraf:1.3.0
-      docker pull appwrite/mailcatcher:1.0.0
-      docker pull appwrite/requestcatcher:1.0.0
+  - init: docker pull mariadb:10.7 &&
+      docker pull redis:6.2-alpine &&
+      docker pull appwrite/influxdb:1.4.0 &&
+      docker pull appwrite/telegraf:1.3.0 &&
+      docker pull appwrite/mailcatcher:1.0.0 &&
+      docker pull appwrite/requestcatcher:1.0.0 &&
       docker pull adminer
     command: |
       docker-compose up

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,12 +5,15 @@ tasks:
       docker pull appwrite/telegraf:1.3.0 &&
       docker pull appwrite/mailcatcher:1.0.0 &&
       docker pull appwrite/requestcatcher:1.0.0 &&
-      docker pull adminer
+      docker pull adminer &&
+      docker pull composer:2.0 &&
+      docker pull node:16.13.2-alpine3.15 &&
+      docker pull php:8.0.14-cli-alpine3.15
     command: |
       docker-compose up -d
 ports:
   - port: 8080
-    onOpen: open-preview
+    onOpen: ignore
     visibility: public
   - port: 443
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: docker-compose pull
+  - init: docker-compose pull &&
       docker-compose build
     command: |
       docker-compose up -d

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ tasks:
       docker pull appwrite/influxdb:1.4.0 && \
       docker pull appwrite/telegraf:1.3.0 && \
       docker pull appwrite/mailcatcher:1.0.0 && \
-      docker pull appwrite/requestcatcher:1.0.0 &&
+      docker pull appwrite/requestcatcher:1.0.0 && \
       docker pull adminer
     command: |
       docker-compose up

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+tasks:
+  - init: docker-compose pull --include-deps mariadb redis appwrite/influxdb appwrite/telegraf appwrite/mailcatcher appwrite/requestcatcher
+    command: |
+      docker-compose up -d
+ports:
+  - port: 8080
+    onOpen: open-preview
+    visibility: public
+  - port: 443
+    onOpen: ignore
+    visibility: public
+  - port: 3001
+    onOpen: ignore
+    visibility: public
+
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
 tasks:
   - init: docker-compose pull &&
       docker-compose build &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,20 @@
 tasks:
-  - init: docker pull mariadb:10.7 && \
-      docker pull redis:6.2-alpine && \
-      docker pull appwrite/influxdb:1.4.0 && \
-      docker pull appwrite/telegraf:1.3.0 && \
-      docker pull appwrite/mailcatcher:1.0.0 && \
-      docker pull appwrite/requestcatcher:1.0.0 && \
+  - init: docker pull mariadb:10.7
+      docker pull redis:6.2-alpine
+      docker pull appwrite/influxdb:1.4.0
+      docker pull appwrite/telegraf:1.3.0
+      docker pull appwrite/mailcatcher:1.0.0
+      docker pull appwrite/requestcatcher:1.0.0
       docker pull adminer
     command: |
       docker-compose up
+  # - init: docker--compose pull --include-deps mariadb:10.7 &&
+  #     docker pull redis:6.2-alpine && \
+  #     docker pull appwrite/influxdb:1.4.0 && \
+  #     docker pull appwrite/telegraf:1.3.0 && \
+  #     docker pull appwrite/mailcatcher:1.0.0 && \
+  #     docker pull appwrite/requestcatcher:1.0.0 && \
+  #     docker pull adminer
 ports:
   - port: 8080
     onOpen: open-preview

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - --accesslog=true
     ports:
       - 80:80
+      - 8080:80
       - 443:443
       - 9500:8080
     volumes:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

This PR adds initial configuration for spinning up a dev environment for Appwrite with Gitpod. Developers can use the Gitpod browser extension "Open In Gitpod", or visit the https://gitpod.io/#https://github.com/appwrite/appwrite to launch a new instance. This will also allow us to enable prebuilds, so each commit to master will be built, allowing for faster startup times for new Gitpod workspaces.

- Appwrite runs on port 8080 instead of port 80 in Gitpod due to security reasons.
- PHP 8 is installed in Gitpod

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

Test this by going to https://gitpod.io/#https://github.com/appwrite/appwrite/pull/2891

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

cc: @Meldiron 