### PR TITLE
Fix platform type mismatch in origin validation

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -4,6 +4,7 @@ use Appwrite\Auth\Auth;
 use Appwrite\Auth\Validator\Password;
 use Appwrite\Network\Validator\CNAME;
 use Appwrite\Network\Validator\Domain as DomainValidator;
+use Appwrite\Network\Validator\Origin;
 use Appwrite\Network\Validator\URL;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
@@ -1002,7 +1003,7 @@ App::post('/v1/projects/:projectId/platforms')
     ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
     ->label('sdk.response.model', Response::MODEL_PLATFORM)
     ->param('projectId', null, new UID(), 'Project unique ID.')
-    ->param('type', null, new WhiteList(['web', 'flutter-ios', 'flutter-android', 'flutter-linux', 'flutter-macos', 'flutter-windows', 'apple-ios', 'apple-macos', 'apple-watchos', 'apple-tvos', 'android', 'unity'], true), 'Platform type.')
+    ->param('type', null, new WhiteList([Origin::CLIENT_TYPE_WEB, Origin::CLIENT_TYPE_FLUTTER_IOS, Origin::CLIENT_TYPE_FLUTTER_ANDROID, Origin::CLIENT_TYPE_FLUTTER_LINUX, Origin::CLIENT_TYPE_FLUTTER_MACOS, Origin::CLIENT_TYPE_FLUTTER_WINDOWS, Origin::CLIENT_TYPE_APPLE_IOS, Origin::CLIENT_TYPE_APPLE_MACOS,  Origin::CLIENT_TYPE_APPLE_WATCHOS, Origin::CLIENT_TYPE_APPLE_TVOS, Origin::CLIENT_TYPE_ANDROID, Origin::CLIENT_TYPE_UNITY], true), 'Platform type.')
     ->param('name', null, new Text(128), 'Platform name. Max length: 128 chars.')
     ->param('key', '', new Text(256), 'Package name for Android or bundle ID for iOS or macOS. Max length: 256 chars.', true)
     ->param('store', '', new Text(256), 'App store or Google Play store ID. Max length: 256 chars.', true)

--- a/src/Appwrite/Network/Validator/Origin.php
+++ b/src/Appwrite/Network/Validator/Origin.php
@@ -13,8 +13,12 @@ class Origin extends Validator
     public const CLIENT_TYPE_FLUTTER_MACOS = 'flutter-macos';
     public const CLIENT_TYPE_FLUTTER_WINDOWS = 'flutter-windows';
     public const CLIENT_TYPE_FLUTTER_LINUX = 'flutter-linux';
+    public const CLIENT_TYPE_APPLE_IOS = 'apple-ios';
+    public const CLIENT_TYPE_APPLE_MACOS = 'apple-macos';
+    public const CLIENT_TYPE_APPLE_WATCHOS = 'apple-watchos';
+    public const CLIENT_TYPE_APPLE_TVOS = 'apple-tvos';
     public const CLIENT_TYPE_ANDROID = 'android';
-    public const CLIENT_TYPE_IOS = 'ios';
+    public const CLIENT_TYPE_UNITY = 'unity';
 
 
     public const SCHEME_TYPE_HTTP = 'http';
@@ -73,7 +77,7 @@ class Origin extends Validator
                 case self::CLIENT_TYPE_FLUTTER_WINDOWS:
                 case self::CLIENT_TYPE_FLUTTER_LINUX:
                 case self::CLIENT_TYPE_ANDROID:
-                case self::CLIENT_TYPE_IOS:
+                case self::CLIENT_TYPE_APPLE_IOS:
                     $this->clients[] = (isset($platform['key'])) ? $platform['key'] : '';
                     break;
 


### PR DESCRIPTION
## What does this PR do?

Switch to using constants in the Appwrite platform whitelist to prevent mismatch in platform types during origin validation.

## Test Plan

1. Add an Apple iOS platform
2. Make a POST API call using the added platform
3. Ensure there is no Invalid Origin error

## Related PRs and Issues

[Invalid Origin for iOS Flutter App](https://github.com/appwrite/appwrite/issues/2898)

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
