### PR TITLE
Fix: Updated environment secrets

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -344,6 +344,7 @@ services:
       - _APP_STORAGE_DO_SPACES_BUCKET
       - _APP_LOGGING_PROVIDER
       - _APP_LOGGING_CONFIG
+      - _APP_EXECUTOR_SECRET
 
   appwrite-worker-certificates:
     image: <?php echo $organization; ?>/<?php echo $image; ?>:<?php echo $version."\n"; ?>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,6 +280,7 @@ services:
       - _APP_STORAGE_DO_SPACES_BUCKET
       - _APP_LOGGING_PROVIDER
       - _APP_LOGGING_CONFIG
+      - _APP_EXECUTOR_SECRET
 
   appwrite-worker-database:
     entrypoint: worker-database


### PR DESCRIPTION
## What does this PR do?

`_APP_EXECUTOR_SECRET` was not present in deletes worker, but he needs it for `$executor->deleteRuntime($projectId, $deploymentId);`. This PR adds configuration of this ENV var in there.

## Test Plan

No tests, nothing should break.

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
