### PR TITLE
Fix: Increase execution substring limit

### DIFF
--- a/app/executor.php
+++ b/app/executor.php
@@ -500,8 +500,8 @@ App::post('/v1/execution')
             $execution = [
                 'status' => $functionStatus,
                 'statusCode' => $statusCode,
-                'stdout' => \utf8_encode(\mb_substr($stdout, -8000)),
-                'stderr' => \utf8_encode(\mb_substr($stderr, -8000)),
+                'stdout' => \utf8_encode(\mb_substr($stdout, -16384)),
+                'stderr' => \utf8_encode(\mb_substr($stderr, -16384)),
                 'time' => $executionTime,
             ];
 


### PR DESCRIPTION
## What does this PR do?

Increase limit from 8k to 16k. This is possible while staying in same database data-type.

## Test Plan

Current tests should pass.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/2917

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
