### PR TITLE
chore: remove starting Appwrite from Gitpod, handle forks

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,14 +5,20 @@ tasks:
   - init: docker-compose pull &&
       docker-compose build &&
       docker run --rm --interactive --tty --volume $PWD:/app composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
-    command: |
-      docker-compose up -d
 
 ports:
   - port: 8080
-    onOpen: ignore
+    onOpen: open-preview
     visibility: public
 
 vscode:
   extensions:
     - ms-azuretools.vscode-docker
+
+github:
+  # https://www.gitpod.io/docs/prebuilds#github-specific-configuration
+  prebuilds:
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: false


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Removes automatically starting Appwrite after the container is built
  - Starting up is still done with `docker-compose up -d` inside Gitpod
- Opens Appwrite in a preview pane after its started

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
