### PR TITLE
Fix appwrite-executor in compose.phtml

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -173,6 +173,7 @@ services:
     image: <?php echo $organization; ?>/<?php echo $image; ?>:<?php echo $version."\n"; ?>
     entrypoint: executor
     container_name: appwrite-executor
+    restart: unless-stopped
     stop_signal: SIGINT
     networks:
       appwrite:


### PR DESCRIPTION
## What does this PR do?

Updates the docker-compose.yml template to ensure the appwrite-executor container starts after server restart just like the other services.

## Test Plan

I updated my docker-compose.yml to add the same line to ensure the appwrite-executor container started after server restart.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/2932

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
