### PR TITLE
Fix: Orchestration Cleanup

### DIFF
--- a/app/executor.php
+++ b/app/executor.php
@@ -306,9 +306,24 @@ App::post('/v1/runtimes')
             Console::error('Build failed: ' . $th->getMessage() . $stdout);
             throw new Exception($th->getMessage() . $stdout, 500);
         } finally {
-            if (!empty($containerId) && $remove) {
-                $orchestration->remove($containerId, true);
+            // Container cleanup
+            if($remove) {
+                if (!empty($containerId)) {
+                    // If container properly created
+                    $orchestration->remove($containerId, true);
+                } else {
+                    // If whole creation failed, but container might have been initialized
+                    try {
+                        // Try to remove with contaier name instead of ID
+                        $orchestration->remove($runtimeId, true);
+                    } catch (Throwable $th) {
+                        // If fails, means initialization also failed.
+                        // Contianer is not there, no need to remove
+                    }
+                }
             }
+
+            // Release orchestration back to pool, we are done with it
             $orchestrationPool->put($orchestration);
         }
 


### PR DESCRIPTION
## What does this PR do?

If `orchestration->run` fails, but container was already initialized, the cleanup would fail. This PR makes sure cleanup also takes care of this edge-case.

## Test Plan

Manual QA for new edge-case, hard to simulate unless on a specific device (for instance Unbutu DO droplet with ENV set to MEMORY_SWAP=256.

Current tests should pass to ensure current cleanup works fine.

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅