### PR TITLE
Fix PDOException double event log

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -321,6 +321,10 @@ App::error(function ($error, $utopia, $request, $response, $layout, $project, $l
     $version = App::getEnv('_APP_VERSION', 'UNKNOWN');
     $route = $utopia->match($request);
 
+    if ($error instanceof PDOException) {
+        throw $error;
+    }
+
     if($logger) {
         if($error->getCode() >= 500 || $error->getCode() === 0) {
             try {
@@ -368,10 +372,6 @@ App::error(function ($error, $utopia, $request, $response, $layout, $project, $l
             $responseCode = $logger->addLog($log);
             Console::info('Log pushed with status code: '.$responseCode);
         }
-    }
-
-    if ($error instanceof PDOException) {
-        throw $error;
     }
 
     $code = $error->getCode();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR will move the throw that causes the double event log to before the first logger in called, this makes it so only the second logger will log the PDOException instead of both of them

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have
