### PR TITLE
Fix: GH issue url

### DIFF
--- a/app/views/console/comps/footer.phtml
+++ b/app/views/console/comps/footer.phtml
@@ -26,7 +26,7 @@ $version = $this->getParam('version', '') . '.' . APP_CACHE_BUSTER;
                 data-analytics-event="click"
                 data-analytics-category="console/footer"
                 data-analytics-label="New GitHub Issue"
-                href="https://github.com/appwrite/appwrite/issues/new/choose" target="_blank" rel="noopener">Open an Issue</a>
+                href="https://github.com/appwrite/appwrite/issues/new?assignees=&labels=bug&template=bug.yaml&title=[<?php echo $version; ?>]%20%F0%9F%90%9B+Bug+Report%3A+" target="_blank" rel="noopener">Open an Issue</a>
         </li>
         <li>
             <a class="link-animation-enabled"

--- a/app/views/console/comps/footer.phtml
+++ b/app/views/console/comps/footer.phtml
@@ -26,7 +26,7 @@ $version = $this->getParam('version', '') . '.' . APP_CACHE_BUSTER;
                 data-analytics-event="click"
                 data-analytics-category="console/footer"
                 data-analytics-label="New GitHub Issue"
-                href="https://github.com/appwrite/appwrite/issues/new?body=%0A%0A%0A---%0AAppwrite Version:%20<?php echo $version; ?>" target="_blank" rel="noopener">Open an Issue</a>
+                href="https://github.com/appwrite/appwrite/issues/new/choose" target="_blank" rel="noopener">Open an Issue</a>
         </li>
         <li>
             <a class="link-animation-enabled"


### PR DESCRIPTION
## What does this PR do?

GH issue URL in Appwrite Console does not show template options. Now it does.

## Test Plan

- [x] Manual QA with GitPod:

<img width="1078" alt="CleanShot 2022-03-22 at 09 53 08@2x" src="https://user-images.githubusercontent.com/19310830/159443229-9a2f1346-6110-4e70-a2ec-b888707cc6ae.png">


## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/2976

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅
