### PR TITLE
Fix:  Validation regex for custom ID

### DIFF
--- a/app/views/console/comps/header.phtml
+++ b/app/views/console/comps/header.phtml
@@ -211,7 +211,7 @@
             required
             maxlength="36"
             class=""
-            pattern="^[a-zA-Z0-9][a-zA-Z0-9_.-]{1,36}$"
+            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
             name="projectId" />
 
         <label>Name</label>

--- a/app/views/console/comps/header.phtml
+++ b/app/views/console/comps/header.phtml
@@ -211,7 +211,7 @@
             required
             maxlength="36"
             class=""
-            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
+            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$"
             name="projectId" />
 
         <label>Name</label>

--- a/app/views/console/database/collection.phtml
+++ b/app/views/console/database/collection.phtml
@@ -627,7 +627,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="string-key">Attribute ID</label>
-        <input id="string-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="string-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <label for="string-length">Size</label>
@@ -683,7 +683,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="integer-key">Attribute ID</label>
-        <input id="integer-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="integer-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -748,7 +748,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="float-key">Attribute ID</label>
-        <input id="float-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="float-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -813,7 +813,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="email-key">Attribute ID</label>
-        <input id="email-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="128" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="email-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="128" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -866,7 +866,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="boolean-key">Attribute ID</label>
-        <input id="boolean-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="boolean-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -923,7 +923,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="ip-key">Attribute ID</label>
-        <input id="ip-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="ip-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -976,7 +976,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="url-key">Attribute ID</label>
-        <input id="url-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="url-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -1029,7 +1029,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="enum-key">Attribute ID</label>
-        <input id="enum-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="enum-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <label>Elements</label>
@@ -1107,7 +1107,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="index-key">Index Key</label>
-        <input id="index-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+        <input id="index-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <label for="index-type">Type</label>

--- a/app/views/console/database/collection.phtml
+++ b/app/views/console/database/collection.phtml
@@ -627,7 +627,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="string-key">Attribute ID</label>
-        <input id="string-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="string-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <label for="string-length">Size</label>
@@ -683,7 +683,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="integer-key">Attribute ID</label>
-        <input id="integer-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="integer-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -748,7 +748,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="float-key">Attribute ID</label>
-        <input id="float-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="float-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -813,7 +813,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="email-key">Attribute ID</label>
-        <input id="email-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="128" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="email-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="128" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -866,7 +866,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="boolean-key">Attribute ID</label>
-        <input id="boolean-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="boolean-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -923,7 +923,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="ip-key">Attribute ID</label>
-        <input id="ip-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="ip-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -976,7 +976,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="url-key">Attribute ID</label>
-        <input id="url-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="url-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <div class="margin-bottom">
@@ -1029,7 +1029,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="enum-key">Attribute ID</label>
-        <input id="enum-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="enum-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <label>Elements</label>
@@ -1107,7 +1107,7 @@ $logs = $this->getParam('logs', null);
         <input type="hidden" name="collectionId" data-ls-bind="{{router.params.id}}" />
 
         <label for="index-key">Index Key</label>
-        <input id="index-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+        <input id="index-key" type="text" class="full-width" name="key" required autocomplete="off" maxlength="36" pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
         <div class="text-fade text-size-xs margin-top-negative-small margin-bottom">Allowed Characters A-Z, a-z, 0-9, and non-leading underscore, hyphen and dot</div>
 
         <label for="index-type">Type</label>

--- a/app/views/console/database/document.phtml
+++ b/app/views/console/database/document.phtml
@@ -83,7 +83,7 @@ $logs = $this->getParam('logs', null);
                                             name="documentId"
                                             id="documentId"
                                             maxlength="36"
-                                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$" />
+                                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
                                     <?php endif; ?>
 
                                     <fieldset name="data" data-cast-to="object" data-ls-attrs="x-init=doc = {{project-document}}" x-data="{doc: {}}">

--- a/app/views/console/database/document.phtml
+++ b/app/views/console/database/document.phtml
@@ -83,7 +83,7 @@ $logs = $this->getParam('logs', null);
                                             name="documentId"
                                             id="documentId"
                                             maxlength="36"
-                                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$" />
+                                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
                                     <?php endif; ?>
 
                                     <fieldset name="data" data-cast-to="object" data-ls-attrs="x-init=doc = {{project-document}}" x-data="{doc: {}}">

--- a/app/views/console/database/index.phtml
+++ b/app/views/console/database/index.phtml
@@ -102,7 +102,7 @@
                             data-validator="database.getCollection"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$"
                             name="collectionId" />
 
                         <label for="collection-name">Name</label>

--- a/app/views/console/database/index.phtml
+++ b/app/views/console/database/index.phtml
@@ -102,7 +102,7 @@
                             data-validator="database.getCollection"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
                             name="collectionId" />
 
                         <label for="collection-name">Name</label>

--- a/app/views/console/functions/index.phtml
+++ b/app/views/console/functions/index.phtml
@@ -113,7 +113,7 @@ $runtimes = $this->getParam('runtimes', []);
                                 data-validator="functions.get"
                                 required
                                 maxlength="36"
-                                pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
+                                pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$"
                                 name="functionId" />
 
                             <label for="name">Name</label>

--- a/app/views/console/functions/index.phtml
+++ b/app/views/console/functions/index.phtml
@@ -113,7 +113,7 @@ $runtimes = $this->getParam('runtimes', []);
                                 data-validator="functions.get"
                                 required
                                 maxlength="36"
-                                pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$"
+                                pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
                                 name="functionId" />
 
                             <label for="name">Name</label>

--- a/app/views/console/storage/index.phtml
+++ b/app/views/console/storage/index.phtml
@@ -101,7 +101,7 @@
                             data-validator="storage.getBucket"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$"
                             name="bucketId" 
                             id="bucketId" />
 

--- a/app/views/console/storage/index.phtml
+++ b/app/views/console/storage/index.phtml
@@ -101,7 +101,7 @@
                             data-validator="storage.getBucket"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
                             name="bucketId" 
                             id="bucketId" />
 

--- a/app/views/console/users/index.phtml
+++ b/app/views/console/users/index.phtml
@@ -165,7 +165,7 @@ $smtpEnabled = $this->getParam('smtpEnabled', false);
                             data-validator="users.get"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$"
                             id="userId"
                             name="userId" />
 
@@ -313,7 +313,7 @@ $smtpEnabled = $this->getParam('smtpEnabled', false);
                             data-validator="teams.get"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$"
                             id="teamId"
                             name="teamId" />
 

--- a/app/views/console/users/index.phtml
+++ b/app/views/console/users/index.phtml
@@ -165,7 +165,7 @@ $smtpEnabled = $this->getParam('smtpEnabled', false);
                             data-validator="users.get"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
                             id="userId"
                             name="userId" />
 
@@ -313,7 +313,7 @@ $smtpEnabled = $this->getParam('smtpEnabled', false);
                             data-validator="teams.get"
                             required
                             maxlength="36"
-                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{1,36}$"
+                            pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,36}$"
                             id="teamId"
                             name="teamId" />
 

--- a/composer.lock
+++ b/composer.lock
@@ -478,16 +478,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.1",
+            "version": "7.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79"
+                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
-                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ac1ec1cd9b5624694c3a40be801d94137afb12b4",
+                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4",
                 "shasum": ""
             },
             "require": {
@@ -582,7 +582,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.2"
             },
             "funding": [
                 {
@@ -598,7 +598,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-06T18:43:05+00:00"
+            "time": "2022-03-20T14:16:28+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -686,16 +686,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.1.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "089edd38f5b8abba6cb01567c2a8aaa47cec4c72"
+                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/089edd38f5b8abba6cb01567c2a8aaa47cec4c72",
-                "reference": "089edd38f5b8abba6cb01567c2a8aaa47cec4c72",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c94a94f120803a18554c1805ef2e539f8285f9a2",
+                "reference": "c94a94f120803a18554c1805ef2e539f8285f9a2",
                 "shasum": ""
             },
             "require": {
@@ -719,7 +719,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -781,7 +781,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.1.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.2.1"
             },
             "funding": [
                 {
@@ -797,7 +797,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-06T17:43:30+00:00"
+            "time": "2022-03-20T21:55:58+00:00"
         },
         {
             "name": "influxdb/influxdb-php",
@@ -6580,5 +6580,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## What does this PR do?

![image](https://user-images.githubusercontent.com/19310830/159283270-c243bef7-ca96-4431-a91a-7d7bcd392009.png)

The current frontend regex we use does not allow 1 letter attribute IDs, even tho backend allows it.

This PR fixed the regex to allow 1 letter IDs.

## Test Plan

- [x] Manual QA:
![CleanShot 2022-03-21 at 15 54 56](https://user-images.githubusercontent.com/19310830/159287993-9ba2a35f-7481-4545-ad54-e70782bc99f7.png)


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅