### PR TITLE
Fix: Certificates in general

### DIFF
--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -11,6 +11,8 @@ use Utopia\Domains\Domain;
 
 require_once __DIR__.'/../init.php';
 
+Authorization::disable();
+
 Console::title('Certificates V1 Worker');
 Console::success(APP_NAME . ' certificates worker v1 has started');
 
@@ -39,8 +41,6 @@ class CertificatesV1 extends Worker
          *  3.4. Set retry on failure
          *  3.5. Schedule to renew certificate in 60 days
          */
-
-        Authorization::disable();
 
         // Args
         $document = $this->args['document'];
@@ -206,8 +206,6 @@ class CertificatesV1 extends Worker
             'validateTarget' => $validateTarget,
             'validateCNAME' => $validateCNAME,
         ]);  // Async task rescheduale
-
-        Authorization::reset();
     }
 
     public function shutdown(): void

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -11,8 +11,6 @@ use Utopia\Domains\Domain;
 
 require_once __DIR__.'/../init.php';
 
-Authorization::disable();
-
 Console::title('Certificates V1 Worker');
 Console::success(APP_NAME . ' certificates worker v1 has started');
 
@@ -41,6 +39,8 @@ class CertificatesV1 extends Worker
          *  3.4. Set retry on failure
          *  3.5. Schedule to renew certificate in 60 days
          */
+
+        Authorization::disable();
 
         // Args
         $document = $this->args['document'];
@@ -206,6 +206,8 @@ class CertificatesV1 extends Worker
             'validateTarget' => $validateTarget,
             'validateCNAME' => $validateCNAME,
         ]);  // Async task rescheduale
+
+        Authorization::reset();
     }
 
     public function shutdown(): void

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -99,8 +99,8 @@ class CertificatesV1 extends Worker
             && (($certificate['issueDate'] + ($expiry)) > \time())
         ) { // Check last issue time
             
-            // Update document anyway, if needed
-            // This occurs when a cert is already generated because a different project is using the domain
+            // Update document anyway, if needed.
+            // This occurs when a cert is already generated because a different project is using the domain.
             // By updating here we ensure all domains has certificateId assigned (share same certificate document)
             if(!isset($document['certificateId'])) {
                 $certificate = new Document($certificate);

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -98,6 +98,23 @@ class CertificatesV1 extends Worker
             && isset($certificate['issueDate'])
             && (($certificate['issueDate'] + ($expiry)) > \time())
         ) { // Check last issue time
+            
+            // Update document anyway, if needed
+            // This occurs when a cert is already generated because a different project is using the domain
+            // By updating here we ensure all domains has certificateId assigned (share same certificate document)
+            if(!isset($document['certificateId'])) {
+                $certificate = new Document(\array_merge($document, [
+                    'updated' => \time(),
+                    'certificateId' => $certificate->getId(),
+                ]));
+    
+                $certificate = $dbForConsole->updateDocument('domains', $certificate->getId(), $certificate);
+    
+                if(!$certificate) {
+                    throw new Exception('Failed saving domain to DB');
+                }
+            }
+
             throw new Exception('Renew isn\'t required');
         }
 

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -103,12 +103,14 @@ class CertificatesV1 extends Worker
             // This occurs when a cert is already generated because a different project is using the domain
             // By updating here we ensure all domains has certificateId assigned (share same certificate document)
             if(!isset($document['certificateId'])) {
-                $certificate = new Document(\array_merge($document, [
+                $certificate = new Document($certificate);
+
+                $domain = new Document(\array_merge($document, [
                     'updated' => \time(),
                     'certificateId' => $certificate->getId(),
                 ]));
     
-                $certificate = $dbForConsole->updateDocument('domains', $certificate->getId(), $certificate);
+                $domain = $dbForConsole->updateDocument('domains', $domain->getId(), $domain);
     
                 if(!$certificate) {
                     throw new Exception('Failed saving domain to DB');

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -18,6 +18,9 @@ use Utopia\Audit\Audit;
 
 require_once __DIR__ . '/../init.php';
 
+Authorization::disable();
+Authorization::setDefaultStatus(false);
+
 Console::title('Deletes V1 Worker');
 Console::success(APP_NAME . ' deletes worker v1 has started' . "\n");
 
@@ -38,7 +41,6 @@ class DeletesV1 extends Worker
 
     public function run(): void
     {
-        Authorization::disable();
 
         $projectId = $this->args['projectId'] ?? '';
         $type = $this->args['type'] ?? '';
@@ -113,8 +115,6 @@ class DeletesV1 extends Worker
                 Console::error('No delete operation for type: ' . $type);
                 break;
         }
-
-        Authorization::reset();
     }
 
     public function shutdown(): void

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -536,6 +536,13 @@ class DeletesV1 extends Worker
                 new Query('certificateId', Query::TYPE_EQUAL, [$document['certificateId']])
             ]);
 
+            if(!$domainUsingCertificate) {
+                $mainDomain = App::getEnv('_APP_DOMAIN_TARGET', '');
+                if($mainDomain === $document->getAttribute('domain')) {
+                    $domainUsingCertificate = $mainDomain;
+                }
+            }
+
             // If certificate is still used by some domain, mark we can't delete.
             // Current domain should not be found, because we only have copy. Original domain is already deleted from database.
             if($domainUsingCertificate) {


### PR DESCRIPTION
## What does this PR do?

I noticed multiple problems with certificates on custom domains, and addressed them all in this PR.

#### ✅ 1. Allow using same domain on multiple projects

Currently, your second project would be stuck at `in progress` of cert creation, because `Renew isn't required`, which is true. This PR makes sure to set certificate ID on the domain, even tho renew isn't required.

https://user-images.githubusercontent.com/19310830/159718472-8c29373a-d6bb-4a90-a45e-fbd276f5b7bc.mp4

#### ✅ 2. Delete certificate document when deleting certificate file

We currently only remove files, which results in Appwrite still thinking certificate is there (and renewal isn't required), even tho file is already missing and Traefik cannot communicate over HTTPS.

https://user-images.githubusercontent.com/19310830/159723802-5ae4466d-8302-404a-beb4-4c5405a24b34.mp4

#### ✅ 3. Only delete certificate if no other domain is using it

With step 2 fixed, now if you delete a domain, it deletes the certificate too. Problem is, another project could still be using it. Let's not remove it! In deletes worker, we check if no domain is using certificate before deleting it.

https://user-images.githubusercontent.com/19310830/159730642-4f9560d4-6239-4f88-a048-ef218964a925.mp4

## Test Plan

The PR was created from DO droplet, where I was manually testing the solution is working before pushing to git.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/2933

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅