### PR TITLE
Feat: Improved SSL issue&renew

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -2268,6 +2268,17 @@ $collections = [
                 'array' => false,
                 'filters' => [],
             ],
+            [
+                '$id' => 'result',
+                'type' => Database::VAR_STRING, 
+                'format' => '',
+                'size' => 256,
+                'signed' => true,
+                'required' => true,
+                'default' => '',
+                'array' => false,
+                'filters' => [],
+            ],
         ],
         'indexes' => [
             [

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -2,6 +2,7 @@
 
 use Appwrite\Auth\Auth;
 use Appwrite\Auth\Validator\Password;
+use Appwrite\Event\Event;
 use Appwrite\Network\Validator\CNAME;
 use Appwrite\Network\Validator\Domain as DomainValidator;
 use Appwrite\Network\Validator\Origin;
@@ -1389,7 +1390,8 @@ App::patch('/v1/projects/:projectId/domains/:domainId/verification')
         $dbForConsole->deleteCachedDocument('projects', $project->getId());
 
         // Issue a TLS certificate when domain is verified
-        Resque::enqueue('v1-certificates', 'CertificatesV1', [
+        Resque::enqueue(Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
+            'type' => CERTIFICATE_TYPE_ISSUE,
             'document' => $domain->getArrayCopy(),
             'domain' => $domain->getAttribute('domain'),
         ]);

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -12,6 +12,7 @@ use Appwrite\Extend\Exception;
 use Utopia\Config\Config;
 use Utopia\Domains\Domain;
 use Appwrite\Auth\Auth;
+use Appwrite\Event\Event;
 use Appwrite\Network\Validator\Origin;
 use Appwrite\Utopia\Response\Filters\V11 as ResponseV11;
 use Appwrite\Utopia\Response\Filters\V12 as ResponseV12;
@@ -90,7 +91,8 @@ App::init(function ($utopia, $request, $response, $console, $project, $dbForCons
 
                 Console::info('Issuing a TLS certificate for the master domain (' . $domain->get() . ') in a few seconds...');
 
-                Resque::enqueue('v1-certificates', 'CertificatesV1', [
+                Resque::enqueue(Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
+                    'type' => CERTIFICATE_TYPE_ISSUE,
                     'document' => $domainDocument,
                     'domain' => $domain->get(),
                     'validateTarget' => false,

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -103,6 +103,7 @@ App::init(function ($utopia, $request, $response, $console, $project, $dbForCons
                     Console::info('Issuing a TLS certificate for the main domain (' . $domain->get() . ') in a few seconds...');
     
                     Resque::enqueue(Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
+                        'type' => CERTIFICATE_TYPE_ISSUE,
                         'document' => $domainDocument,
                         'domain' => $domain->get(),
                         'validateTarget' => false,

--- a/app/init.php
+++ b/app/init.php
@@ -122,6 +122,9 @@ const DELETE_TYPE_CERTIFICATES = 'certificates';
 const DELETE_TYPE_USAGE = 'usage';
 const DELETE_TYPE_REALTIME = 'realtime';
 const DELETE_TYPE_BUCKETS = 'buckets';
+// Certificate Types
+const CERTIFICATE_TYPE_ISSUE = 'issue';
+const CERTIFICATE_TYPE_RENEW = 'renew';
 // Mail Types
 const MAIL_TYPE_VERIFICATION = 'verification';
 const MAIL_TYPE_MAGIC_SESSION = 'magicSession';

--- a/app/tasks/ssl.php
+++ b/app/tasks/ssl.php
@@ -15,6 +15,7 @@ $cli
             Make sure your domain points to your server or restart to try again.');
 
         ResqueScheduler::enqueueAt(\time() + 30, 'v1-certificates', 'CertificatesV1', [
+            'type' => 'issue',
             'document' => [],
             'domain' => $domain,
             'validateTarget' => false,

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -1,7 +1,9 @@
 <?php
 
+use Appwrite\Event\Event;
 use Appwrite\Network\Validator\CNAME;
 use Appwrite\Resque\Worker;
+use PHPUnit\Framework\Constraint\Operator;
 use Utopia\App;
 use Utopia\CLI\Console;
 use Utopia\Database\Document;
@@ -16,18 +18,62 @@ Console::success(APP_NAME . ' certificates worker v1 has started');
 
 class CertificatesV1 extends Worker
 {
+    // Refference: https://letsencrypt.org/docs/rate-limits/
+    const LETSENCRYPT_API_LIMIT = 300; // 30 orders
+    const LETSENCRYPT_API_LIMIT_INTERVAL = 10800; // 3 hours
+
     public function getName(): string {
         return "certificates";
     }
 
     public function init(): void
     {
+        // We trigger once, to start recursive renewal loop
+        $this->renewCertificate();
     }
 
     public function run(): void
     {
+        Authorization::disable();
+
+        $type = $this->args['type'] ?? '';
+        switch (strval($type)) {
+            case CERTIFICATE_TYPE_RENEW:
+                $this->renewCertificate();
+                break;
+            case CERTIFICATE_TYPE_ISSUE:
+                $this->issueCertificate($this->args);
+                break;
+        }
+
+        Authorization::reset();
+    }
+
+    // This is recursive function
+    protected function renewCertificate() {
         $dbForConsole = $this->getConsoleDB();
 
+        // We will renew all certs older than 60 days
+        // Refference: https://letsencrypt.org/docs/faq/
+        // "Our certificates are valid for 90 days. We recommend automatically renewing your certificates every 60 days."
+        $certificateForRenewal = $dbForConsole->findOne("certificates", [
+            new Query('result', Query::TYPE_EQUAL, ['done', 'apiLimit']),
+            new Query('updated', Query::TYPE_LESSEREQUAL, [ \time() - 5184000 ]), // - 60 days
+        ]);
+
+        if($certificateForRenewal) {
+            $this->issueCertificate([
+                'domain' => $certificateForRenewal->getAttribute('domain'),
+            ]);
+        }
+
+        // When done, schedule again in 1 minute. This creates makes the function recursive.
+        ResqueScheduler::enqueueAt(\time() + 60, Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
+            'type' => CERTIFICATE_TYPE_RENEW
+        ]);
+    }
+
+    protected function issueCertificate($args) {
         /**
          * 1. Get new domain document - DONE
          *  1.1. Validate domain is valid, public suffix is known and CNAME records are verified - DONE
@@ -40,15 +86,15 @@ class CertificatesV1 extends Worker
          *  3.5. Schedule to renew certificate in 60 days
          */
 
-        Authorization::disable();
+        $dbForConsole = $this->getConsoleDB();
 
         // Args
-        $document = $this->args['document'];
-        $domain = $this->args['domain'];
+        $document = $args['document'];
+        $domain = $args['domain'];
 
         // Validation Args
-        $validateTarget = $this->args['validateTarget'] ?? true;
-        $validateCNAME = $this->args['validateCNAME'] ?? true;
+        $validateTarget = $args['validateTarget'] ?? true;
+        $validateCNAME = $args['validateCNAME'] ?? true;
 
         // Options
         $domain = new Domain((!empty($domain)) ? $domain : '');
@@ -91,12 +137,12 @@ class CertificatesV1 extends Worker
 
         // throw new Exception('cert issued at'.date('d.m.Y H:i', $certificate['issueDate']).' | renew date is: '.date('d.m.Y H:i', ($certificate['issueDate'] + ($expiry))).' | condition is '.$condition);
 
-        $certificate = (!empty($certificate) && $certificate instanceof $certificate) ? $certificate->getArrayCopy() : [];
+        $certificateArray = (!empty($certificate) && $certificate instanceof $certificate) ? $certificate->getArrayCopy() : [];
 
         if (
-            !empty($certificate)
-            && isset($certificate['issueDate'])
-            && (($certificate['issueDate'] + ($expiry)) > \time())
+            !empty($certificateArray)
+            && isset($certificateArray['issueDate'])
+            && (($certificateArray['issueDate'] + ($expiry)) > \time())
         ) { // Check last issue time
             throw new Exception('Renew isn\'t required');
         }
@@ -108,87 +154,130 @@ class CertificatesV1 extends Worker
             throw new Exception('You must set a valid security email address (_APP_SYSTEM_SECURITY_EMAIL_ADDRESS) to issue an SSL certificate');
         }
 
-        $stdout = '';
-        $stderr = '';
-
-        $exit = Console::execute("certbot certonly --webroot --noninteractive --agree-tos{$staging}"
-            . " --email " . $email
-            . " -w " . APP_STORAGE_CERTIFICATES
-            . " -d {$domain->get()}", '', $stdout, $stderr);
-
-        if ($exit !== 0) {
-            throw new Exception('Failed to issue a certificate with message: ' . $stderr);
-        }
-
-        $path = APP_STORAGE_CERTIFICATES . '/' . $domain->get();
-
-        if (!\is_readable($path)) {
-            if (!\mkdir($path, 0755, true)) {
-                throw new Exception('Failed to create path...');
+        try {
+            $stdout = '';
+            $stderr = '';
+    
+            $exit = Console::execute("certbot certonly --webroot --noninteractive --agree-tos{$staging}"
+                . " --email " . $email
+                . " -w " . APP_STORAGE_CERTIFICATES
+                . " -d {$domain->get()}", '', $stdout, $stderr);
+    
+            if ($exit !== 0) {
+                throw new Exception('Failed to issue a certificate with message: ' . $stderr);
             }
-        }
-
-        if(!@\rename('/etc/letsencrypt/live/'.$domain->get().'/cert.pem', APP_STORAGE_CERTIFICATES.'/'.$domain->get().'/cert.pem')) {
-            throw new Exception('Failed to rename certificate cert.pem: '.\json_encode($stdout));
-        }
-
-        if (!@\rename('/etc/letsencrypt/live/' . $domain->get() . '/chain.pem', APP_STORAGE_CERTIFICATES . '/' . $domain->get() . '/chain.pem')) {
-            throw new Exception('Failed to rename certificate chain.pem: ' . \json_encode($stdout));
-        }
-
-        if (!@\rename('/etc/letsencrypt/live/' . $domain->get() . '/fullchain.pem', APP_STORAGE_CERTIFICATES . '/' . $domain->get() . '/fullchain.pem')) {
-            throw new Exception('Failed to rename certificate fullchain.pem: ' . \json_encode($stdout));
-        }
-
-        if (!@\rename('/etc/letsencrypt/live/' . $domain->get() . '/privkey.pem', APP_STORAGE_CERTIFICATES . '/' . $domain->get() . '/privkey.pem')) {
-            throw new Exception('Failed to rename certificate privkey.pem: ' . \json_encode($stdout));
-        }
-
-        $certificate = new Document(\array_merge($certificate, [
-            'domain' => $domain->get(),
-            'issueDate' => \time(),
-            'renewDate' => $renew,
-            'attempts' => 0,
-            'log' => \json_encode($stdout),
-        ]));
-
-        $certificate = $dbForConsole->createDocument('certificates', $certificate);
-
-        if (!$certificate) {
-            throw new Exception('Failed saving certificate to DB');
-        }
-
-        if(!empty($document)) {
-            $certificate = new Document(\array_merge($document, [
-                'updated' => \time(),
-                'certificateId' => $certificate->getId(),
-            ]));
-
-            $certificate = $dbForConsole->updateDocument('domains', $certificate->getId(), $certificate);
-
-            if(!$certificate) {
-                throw new Exception('Failed saving domain to DB');
+    
+            $path = APP_STORAGE_CERTIFICATES . '/' . $domain->get();
+    
+            if (!\is_readable($path)) {
+                if (!\mkdir($path, 0755, true)) {
+                    throw new Exception('Failed to create path...');
+                }
             }
+    
+            if(!@\rename('/etc/letsencrypt/live/'.$domain->get().'/cert.pem', APP_STORAGE_CERTIFICATES.'/'.$domain->get().'/cert.pem')) {
+                throw new Exception('Failed to rename certificate cert.pem: '.\json_encode($stdout));
+            }
+    
+            if (!@\rename('/etc/letsencrypt/live/' . $domain->get() . '/chain.pem', APP_STORAGE_CERTIFICATES . '/' . $domain->get() . '/chain.pem')) {
+                throw new Exception('Failed to rename certificate chain.pem: ' . \json_encode($stdout));
+            }
+    
+            if (!@\rename('/etc/letsencrypt/live/' . $domain->get() . '/fullchain.pem', APP_STORAGE_CERTIFICATES . '/' . $domain->get() . '/fullchain.pem')) {
+                throw new Exception('Failed to rename certificate fullchain.pem: ' . \json_encode($stdout));
+            }
+    
+            if (!@\rename('/etc/letsencrypt/live/' . $domain->get() . '/privkey.pem', APP_STORAGE_CERTIFICATES . '/' . $domain->get() . '/privkey.pem')) {
+                throw new Exception('Failed to rename certificate privkey.pem: ' . \json_encode($stdout));
+            }
+    
+            if(empty($certificateArray)) {
+                $certificate = new Document([
+                    'domain' => $domain->get(),
+                    'issueDate' => \time(),
+                    'renewDate' => $renew,
+                    'attempts' => 0,
+                    'result' => 'done',
+                    'log' => \json_encode($stdout),
+                ]);
+    
+                $certificate = $dbForConsole->createDocument('certificates', $certificate);
+            } else {
+                $certificate = new Document(\array_merge($certificateArray, [
+                    'issueDate' => \time(),
+                    'renewDate' => $renew,
+                    'attempts' => 0,
+                    'result' => 'done',
+                    'log' => \json_encode($stdout),
+                ]));
+    
+                $certificate = $dbForConsole->updateDocument('certificates', $certificate->getId(), $certificate);
+            }
+    
+            if (!$certificate) {
+                throw new Exception('Failed saving certificate to DB');
+            }
+    
+            if(!empty($document)) {
+                $certificate = new Document(\array_merge($document, [
+                    'updated' => \time(),
+                    'certificateId' => $certificate->getId()
+                ]));
+    
+                $certificate = $dbForConsole->updateDocument('domains', $certificate->getId(), $certificate);
+    
+                if(!$certificate) {
+                    throw new Exception('Failed saving domain to DB');
+                }
+            }
+    
+            $config =
+    "tls:
+      certificates:
+        - certFile: /storage/certificates/{$domain->get()}/fullchain.pem
+          keyFile: /storage/certificates/{$domain->get()}/privkey.pem";
+    
+            if (!\file_put_contents(APP_STORAGE_CONFIG . '/' . $domain->get() . '.yml', $config)) {
+                throw new Exception('Failed to save SSL configuration');
+            }
+        } catch(Exception $err) {
+            $errorType = 'error';
+
+            // TODO: set errorType to apiLimit, if it is apiLimit
+
+            if(empty($certificate)) {
+                $certificate = new Document([
+                    'domain' => $domain->get(),
+                    'issueDate' => \time(),
+                    'renewDate' => $renew,
+                    'attempts' => 0,
+                    'result' => $errorType,
+                    'log' => \json_encode([
+                        'exception' => $err->getTraceAsString()
+                    ]),
+                ]);
+    
+                $certificate = $dbForConsole->createDocument('certificates', $certificate);
+            } else {
+                $certificate = new Document(\array_merge($certificateArray, [
+                    'issueDate' => \time(),
+                    'renewDate' => $renew,
+                    'attempts' => ((int) $certificateArray['attempts']) + 1,
+                    'result' => $errorType,
+                    'log' => \json_encode([
+                        'exception' => $err->getTraceAsString()
+                    ]),
+                ]));
+    
+                $certificate = $dbForConsole->updateDocument('certificates', $certificate->getId(), $certificate);
+            }
+    
+            if (!$certificate) {
+                throw new Exception('Failed saving failed certificate to DB');
+            }
+
+            throw $err;
         }
-
-        $config =
-"tls:
-  certificates:
-    - certFile: /storage/certificates/{$domain->get()}/fullchain.pem
-      keyFile: /storage/certificates/{$domain->get()}/privkey.pem";
-
-        if (!\file_put_contents(APP_STORAGE_CONFIG . '/' . $domain->get() . '.yml', $config)) {
-            throw new Exception('Failed to save SSL configuration');
-        }
-
-        ResqueScheduler::enqueueAt($renew + $safety, 'v1-certificates', 'CertificatesV1', [
-            'document' => [],
-            'domain' => $domain->get(),
-            'validateTarget' => $validateTarget,
-            'validateCNAME' => $validateCNAME,
-        ]);  // Async task rescheduale
-
-        Authorization::reset();
     }
 
     public function shutdown(): void

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -28,8 +28,6 @@ class CertificatesV1 extends Worker
 
     public function init(): void
     {
-        // We trigger once, to start recursive renewal loop
-        $this->renewCertificate();
     }
 
     public function run(): void
@@ -78,7 +76,7 @@ class CertificatesV1 extends Worker
         }
 
         // When done, schedule again in 1 minute. This creates makes the function recursive.
-        ResqueScheduler::enqueueAt(\time() + 60, Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
+        ResqueScheduler::enqueueIn(60, Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
             'type' => CERTIFICATE_TYPE_RENEW
         ]);
     }
@@ -296,3 +294,8 @@ class CertificatesV1 extends Worker
     {
     }
 }
+
+// We trigger once, to start recursive renewal loop. 5 second delay to stay safe with startup
+ResqueScheduler::enqueueIn(5, Event::CERTIFICATES_QUEUE_NAME, Event::CERTIFICATES_CLASS_NAME, [
+    'type' => CERTIFICATE_TYPE_RENEW
+]);


### PR DESCRIPTION
🚨 CHANGE BASE TO MASTER BEFORE MERGING 🚨

## What does this PR do?

- We now use scheduled queue as non-persistent, with way shorter durations
- We now only have one certificate document per domain. Previously we had more and created inconsistencies in IDs (that only worked because they both pointed to the same SSL path because path only has a domain)
- We now retry to issue certificates that failed (caused by 5XX from letsEnrypt, or API limits) with sane attempts limit
- We now to prioritize domains closer to expiration, making it more ready for scaling
- We now try to properly respect API limit as much as possible, to prevent unnecessary failures. We can still hit the API limit if too many new domains request certificates. No worries tho, future renewal task will fix it
- We continue to renew certs gradually, instead of a bunch at once. This prevents hitting API limits

## Test Plan

TODO: Test properly, as much as I can

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
