### PR TITLE
Fix 'magic URL' accounts from not being able to create a new password.

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -675,7 +675,7 @@ App::post('/v1/account/sessions/magic-url')
                 'emailVerification' => false,
                 'status' => true,
                 'password' => null,
-                'passwordUpdate' => \time(),
+                'passwordUpdate' => 0,
                 'registration' => \time(),
                 'reset' => false,
                 'prefs' => new \stdClass(),
@@ -946,7 +946,7 @@ App::post('/v1/account/sessions/anonymous')
             'emailVerification' => false,
             'status' => true,
             'password' => null,
-            'passwordUpdate' => \time(),
+            'passwordUpdate' => 0,
             'registration' => \time(),
             'reset' => false,
             'name' => null,
@@ -1376,6 +1376,7 @@ App::patch('/v1/account/password')
         /** @var Appwrite\Stats\Stats $usage */
 
         // Check old password only if its an existing user.
+
         if ($user->getAttribute('passwordUpdate') !== 0 && !Auth::passwordVerify($oldPassword, $user->getAttribute('password'))) { // Double check user password
             throw new Exception('Invalid credentials', 401, Exception::USER_INVALID_CREDENTIALS);
         }

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1376,7 +1376,6 @@ App::patch('/v1/account/password')
         /** @var Appwrite\Stats\Stats $usage */
 
         // Check old password only if its an existing user.
-
         if ($user->getAttribute('passwordUpdate') !== 0 && !Auth::passwordVerify($oldPassword, $user->getAttribute('password'))) { // Double check user password
             throw new Exception('Invalid credentials', 401, Exception::USER_INVALID_CREDENTIALS);
         }

--- a/docs/references/account/update-password.md
+++ b/docs/references/account/update-password.md
@@ -1,1 +1,1 @@
-Update currently logged in user password. For validation, user is required to pass in the new password, and the old password. For users created with OAuth and Team Invites, oldPassword is optional.
+Update currently logged in user password. For validation, user is required to pass in the new password, and the old password. For users created with OAuth, Team Invites and Magic URL, oldPassword is optional.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes magic URL generated accounts from not being able to set a new password by setting the 'passwordUpdate' field on account creation to 0.

This PR also updates Anonymous session's `passwordUpdate` field to be 0 on user creation to keep better inline with the other non-password methods.

## Test Plan

A new test has been added to `AccountBase.php` which will attempt to update the password after creating a new account using magicURL.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have
