### PR TITLE
Update PHP Docker Image to v8.0.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY public /usr/local/src/public
 RUN npm ci
 RUN npm run build
 
-FROM php:8.0.17-cli-alpine3.15 as compile
+FROM php:8.0.18-cli-alpine3.15 as compile
 
 ARG DEBUG=false
 ENV DEBUG=$DEBUG

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN \
   ./configure && \
   make && make install
 
-FROM php:8.0.17-cli-alpine3.15 as final
+FROM php:8.0.18-cli-alpine3.15 as final
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
## What does this PR do?

Updates the PHP base image from 8.0.17 to 8.0.18

Release notes here: https://www.php.net/ChangeLog-8.php#PHP_8_0

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
