### PR TITLE
fix: update default for retention logs on activity pages

### DIFF
--- a/app/controllers/web/console.php
+++ b/app/controllers/web/console.php
@@ -218,7 +218,7 @@ App::get('/console/database/collection')
         $logs = new View(__DIR__.'/../../views/console/comps/logs.phtml');
 
         $logs
-            ->setParam('interval', App::getEnv('_APP_MAINTENANCE_RETENTION_AUDIT', 0))
+            ->setParam('interval', App::getEnv('_APP_MAINTENANCE_RETENTION_AUDIT', 1209600))
             ->setParam('method', 'database.listCollectionLogs')
             ->setParam('params', [
                 'collection-id' => '{{router.params.id}}',
@@ -253,7 +253,7 @@ App::get('/console/database/document')
         $logs = new View(__DIR__.'/../../views/console/comps/logs.phtml');
 
         $logs
-            ->setParam('interval', App::getEnv('_APP_MAINTENANCE_RETENTION_AUDIT', 0))
+            ->setParam('interval', App::getEnv('_APP_MAINTENANCE_RETENTION_AUDIT', 1209600))
             ->setParam('method', 'database.listDocumentLogs')
             ->setParam('params', [
                 'collection-id' => '{{router.params.collection}}',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

By default, unless provided in the `.env`, the _APP_MAINTENANCE_RETENTION_AUDIT defaults to 0 which is displayed in the activity logs for documents and collections.

This fix updates the defaults provided to the Appwrite Console to 14 days in milliseconds for the retention duration for logs.

BEFORE:

![Screen Shot 2022-04-19 at 9 21 08 AM](https://user-images.githubusercontent.com/42211/164026342-4b2fd5b2-cbaf-453b-94e6-869cc6441613.png)

AFTER:

![Screen Shot 2022-04-19 at 9 13 07 AM](https://user-images.githubusercontent.com/42211/164026293-db35955b-e815-4002-b959-229b6c30c739.png)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
