### PR TITLE
fix(database): casting of float values

### DIFF
--- a/app/init.php
+++ b/app/init.php
@@ -181,7 +181,7 @@ if(!empty($user) || !empty($pass)) {
  */
 Database::addFilter('casting',
     function($value) {
-        return json_encode(['value' => $value]);
+        return json_encode(['value' => $value], JSON_PRESERVE_ZERO_FRACTION);
     },
     function($value) {
         if (is_null($value)) {

--- a/app/workers/database.php
+++ b/app/workers/database.php
@@ -71,6 +71,11 @@ class DatabaseV1 extends Worker
         $dbForConsole = $this->getConsoleDB();
         $dbForProject = $this->getProjectDB($projectId);
 
+        /**
+         * Fetch attribute from the database, since with Resque float values are loosing informations.
+         */
+        $attribute = $dbForProject->getDocument('attributes', $attribute->getId());
+
         $event = 'database.attributes.update';
         $collectionId = $collection->getId();
         $key = $attribute->getAttribute('key', '');

--- a/tests/e2e/Services/Database/DatabaseBase.php
+++ b/tests/e2e/Services/Database/DatabaseBase.php
@@ -1428,6 +1428,7 @@ trait DatabaseBase
         ]), [
             'key' => 'probability',
             'required' => false,
+            'default' => 0,
             'min' => 0,
             'max' => 1,
         ]);


### PR DESCRIPTION
## What does this PR do?

- JSON encoding will loose trailing 0 values on floats - passing a flag to preserve them
- Fetch attribute again on database worker - since these values get lost as well in resque

## Test Plan

- extended test

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-kotlin/issues/20

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 