### PR TITLE
Fix: 1-element enum

### DIFF
--- a/app/views/console/database/collection.phtml
+++ b/app/views/console/database/collection.phtml
@@ -1040,7 +1040,7 @@ $logs = $this->getParam('logs', null);
             <div data-forms-clone="" data-label="Add Element" data-target="elements-section" data-first="1">
                 <div class="row responsive thin margin-bottom-tiny">
                     <div class="col span-11 margin-bottom-small">
-                        <input type="text" class="full-width" name="elements" required autocomplete="off" maxlength="128" />
+                        <input data-cast-to="array" type="text" class="full-width" name="elements" required autocomplete="off" maxlength="128" />
                     </div>
                     <div class="col span-1 margin-bottom-small">
                         <button type="button" data-remove class="dark danger small round pull-end" style="margin-top: 10px;"><i class="icon-cancel"></i></button>

--- a/composer.lock
+++ b/composer.lock
@@ -2250,16 +2250,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.19.9",
+            "version": "0.19.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/framework.git",
-                "reference": "4af9fc866edce1b8cff94731fb26c27599118e87"
+                "reference": "65ced168db8f6e188ceeb0d101f57552c3d8b2af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/framework/zipball/4af9fc866edce1b8cff94731fb26c27599118e87",
-                "reference": "4af9fc866edce1b8cff94731fb26c27599118e87",
+                "url": "https://api.github.com/repos/utopia-php/framework/zipball/65ced168db8f6e188ceeb0d101f57552c3d8b2af",
+                "reference": "65ced168db8f6e188ceeb0d101f57552c3d8b2af",
                 "shasum": ""
             },
             "require": {
@@ -2293,9 +2293,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/framework/issues",
-                "source": "https://github.com/utopia-php/framework/tree/0.19.9"
+                "source": "https://github.com/utopia-php/framework/tree/0.19.20"
             },
-            "time": "2022-04-14T15:39:47+00:00"
+            "time": "2022-04-14T15:42:37+00:00"
         },
         {
             "name": "utopia-php/image",


### PR DESCRIPTION
## What does this PR do?

Fixes a bug that didn't allow you to create enum with 1 element, because it was passed as string from frontend, instead of as array.

## Test Plan

- [x] Manual QA

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
