### PR TITLE
Rename 'stdout' in executions to 'response'

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -2121,7 +2121,7 @@ $collections = [
                 'filters' => [],
             ],
             [
-                '$id' => 'stdout',
+                '$id' => 'response',
                 'type' => Database::VAR_STRING,
                 'format' => '',
                 'size' => 16384,

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -880,7 +880,7 @@ App::post('/v1/functions/:functionId/executions')
             'trigger' => 'http', // http / schedule / event
             'status' => 'waiting', // waiting / processing / completed / failed
             'statusCode' => 0,
-            'stdout' => '',
+            'response' => '',
             'stderr' => '',
             'time' => 0.0,
             'search' => implode(' ', [$functionId, $executionId]),
@@ -956,7 +956,7 @@ App::post('/v1/functions/:functionId/executions')
             /** Update execution status */
             $execution->setAttribute('status', $executionResponse['status']);
             $execution->setAttribute('statusCode', $executionResponse['statusCode']);
-            $execution->setAttribute('stdout', $executionResponse['stdout']);
+            $execution->setAttribute('response', $executionResponse['response']);
             $execution->setAttribute('stderr', $executionResponse['stderr']);
             $execution->setAttribute('time', $executionResponse['time']);
         } catch (\Throwable $th) {

--- a/app/executor.php
+++ b/app/executor.php
@@ -279,7 +279,7 @@ App::post('/v1/runtimes')
             $endTime = \time();
             $container = array_merge($container, [
                 'status' => 'ready',
-                'stdout' => \utf8_encode($stdout),
+                'response' => \utf8_encode($stdout),
                 'stderr' => \utf8_encode($stderr),
                 'startTime' => $startTime,
                 'endTime' => $endTime,
@@ -512,7 +512,7 @@ App::post('/v1/execution')
             $execution = [
                 'status' => $functionStatus,
                 'statusCode' => $statusCode,
-                'stdout' => \utf8_encode(\mb_substr($stdout, -16384)),
+                'response' => \utf8_encode(\mb_substr($stdout, -16384)),
                 'stderr' => \utf8_encode(\mb_substr($stderr, -16384)),
                 'time' => $executionTime,
             ];

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -254,7 +254,7 @@ class FunctionsV1 extends Worker
                     'trigger' => $trigger,
                     'status' => 'waiting',
                     'statusCode' => 0,
-                    'stdout' => '',
+                    'response' => '',
                     'stderr' => '',
                     'time' => 0.0,
                     'search' => implode(' ', [$functionId, $executionId]),
@@ -303,7 +303,7 @@ class FunctionsV1 extends Worker
             /** Update execution status */
             $execution->setAttribute('status', $executionResponse['status']);
             $execution->setAttribute('statusCode', $executionResponse['statusCode']);
-            $execution->setAttribute('stdout', $executionResponse['stdout']);
+            $execution->setAttribute('response', $executionResponse['response']);
             $execution->setAttribute('stderr', $executionResponse['stderr']);
             $execution->setAttribute('time', $executionResponse['time']);
         } catch (\Throwable $th) {

--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -53,9 +53,9 @@ class Execution extends Model
                 'default' => 0,
                 'example' => 0,
             ])
-            ->addRule('stdout', [
+            ->addRule('response', [
                 'type' => self::TYPE_STRING,
-                'description' => 'The script stdout output string. Logs the last 4,000 characters of the execution stdout output.',
+                'description' => 'The script response output string. Logs the last 4,000 characters of the execution response output.',
                 'default' => '',
                 'example' => '',
             ])

--- a/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
@@ -208,7 +208,7 @@ class FunctionsCustomClientTest extends Scope
             'x-appwrite-key' => $apikey,
         ]);
 
-        $output = json_decode($executions['body']['stdout'], true);
+        $output = json_decode($executions['body']['response'], true);
         $this->assertEquals(200, $executions['headers']['status-code']);
         $this->assertEquals('completed', $executions['body']['status']);
         $this->assertEquals($functionId, $output['APPWRITE_FUNCTION_ID']);
@@ -383,7 +383,7 @@ class FunctionsCustomClientTest extends Scope
             'async' => false
         ]);
 
-        $output = json_decode($execution['body']['stdout'], true);
+        $output = json_decode($execution['body']['response'], true);
         $this->assertEquals(201, $execution['headers']['status-code']);
         $this->assertEquals('completed', $execution['body']['status']);
         $this->assertEquals($functionId, $output['APPWRITE_FUNCTION_ID']);

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -490,7 +490,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals($data['functionId'], $execution['body']['functionId']);
         $this->assertEquals('waiting', $execution['body']['status']);
         $this->assertEquals(0, $execution['body']['statusCode']);
-        $this->assertEquals('', $execution['body']['stdout']);
+        $this->assertEquals('', $execution['body']['response']);
         $this->assertEquals('', $execution['body']['stderr']);
         $this->assertEquals(0, $execution['body']['time']);
 
@@ -507,13 +507,13 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals($data['functionId'], $execution['body']['functionId']);
         $this->assertEquals('completed', $execution['body']['status']);
         $this->assertEquals(200, $execution['body']['statusCode']);
-        $this->assertStringContainsString($execution['body']['functionId'], $execution['body']['stdout']);
-        $this->assertStringContainsString($data['deploymentId'], $execution['body']['stdout']);
-        $this->assertStringContainsString('Test1', $execution['body']['stdout']);
-        $this->assertStringContainsString('http', $execution['body']['stdout']);
-        $this->assertStringContainsString('PHP', $execution['body']['stdout']);
-        $this->assertStringContainsString('8.0', $execution['body']['stdout']);
-        // $this->assertStringContainsString('êä', $execution['body']['stdout']); // tests unknown utf-8 chars
+        $this->assertStringContainsString($execution['body']['functionId'], $execution['body']['response']);
+        $this->assertStringContainsString($data['deploymentId'], $execution['body']['response']);
+        $this->assertStringContainsString('Test1', $execution['body']['response']);
+        $this->assertStringContainsString('http', $execution['body']['response']);
+        $this->assertStringContainsString('PHP', $execution['body']['response']);
+        $this->assertStringContainsString('8.0', $execution['body']['response']);
+        // $this->assertStringContainsString('êä', $execution['body']['response']); // tests unknown utf-8 chars
         $this->assertEquals('', $execution['body']['stderr']);
         $this->assertLessThan(0.500, $execution['body']['time']);
 
@@ -596,11 +596,11 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(201, $execution['headers']['status-code']);
 
         $this->assertEquals('completed', $execution['body']['status']);
-        $this->assertStringContainsString($data['deploymentId'], $execution['body']['stdout']);
-        $this->assertStringContainsString('Test1', $execution['body']['stdout']);
-        $this->assertStringContainsString('http', $execution['body']['stdout']);
-        $this->assertStringContainsString('PHP', $execution['body']['stdout']);
-        $this->assertStringContainsString('8.0', $execution['body']['stdout']);
+        $this->assertStringContainsString($data['deploymentId'], $execution['body']['response']);
+        $this->assertStringContainsString('Test1', $execution['body']['response']);
+        $this->assertStringContainsString('http', $execution['body']['response']);
+        $this->assertStringContainsString('PHP', $execution['body']['response']);
+        $this->assertStringContainsString('8.0', $execution['body']['response']);
         // $this->assertStringContainsString('êä', $execution['body']['sdtout']); // tests unknown utf-8 chars
         $this->assertLessThan(0.500, $execution['body']['time']);
 
@@ -764,7 +764,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals($executions['body']['executions'][0]['statusCode'], 124);
         $this->assertGreaterThan(2, $executions['body']['executions'][0]['time']);
         $this->assertLessThan(3, $executions['body']['executions'][0]['time']);
-        $this->assertEquals($executions['body']['executions'][0]['stdout'], '');
+        $this->assertEquals($executions['body']['executions'][0]['response'], '');
         $this->assertEquals($executions['body']['executions'][0]['stderr'], 'Execution timed out.');
 
         // Cleanup : Delete function 
@@ -847,7 +847,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $output = json_decode($executions['body']['stdout'], true);
+        $output = json_decode($executions['body']['response'], true);
 
         $this->assertEquals(200, $executions['headers']['status-code']);
         $this->assertEquals('completed', $executions['body']['status']);
@@ -875,7 +875,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
         $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['stdout']);
+        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function 
         $response = $this->client->call(Client::METHOD_DELETE, '/functions/'. $functionId, [
@@ -952,7 +952,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $output = json_decode($executions['body']['stdout'], true);
+        $output = json_decode($executions['body']['response'], true);
 
         $this->assertEquals(200, $executions['headers']['status-code']);
         $this->assertEquals('completed', $executions['body']['status']);
@@ -981,7 +981,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
         $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['stdout']);
+        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function 
         $response = $this->client->call(Client::METHOD_DELETE, '/functions/'. $functionId, [
@@ -1057,7 +1057,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $output = json_decode($executions['body']['stdout'], true);
+        $output = json_decode($executions['body']['response'], true);
 
         $this->assertEquals(200, $executions['headers']['status-code']);
         $this->assertEquals('completed', $executions['body']['status']);
@@ -1086,7 +1086,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
         $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['stdout']);
+        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function 
         $response = $this->client->call(Client::METHOD_DELETE, '/functions/'. $functionId, [
@@ -1162,7 +1162,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $output = json_decode($executions['body']['stdout'], true);
+        $output = json_decode($executions['body']['response'], true);
 
         $this->assertEquals(200, $executions['headers']['status-code']);
         $this->assertEquals('completed', $executions['body']['status']);
@@ -1191,7 +1191,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
         $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['stdout']);
+        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function 
         $response = $this->client->call(Client::METHOD_DELETE, '/functions/'. $functionId, [
@@ -1267,7 +1267,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $output = json_decode($executions['body']['stdout'], true);
+        $output = json_decode($executions['body']['response'], true);
 
         $this->assertEquals(200, $executions['headers']['status-code']);
         $this->assertEquals('completed', $executions['body']['status']);
@@ -1296,7 +1296,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
         $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['stdout']);
+        $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function 
         $response = $this->client->call(Client::METHOD_DELETE, '/functions/'. $functionId, [
@@ -1372,7 +1372,7 @@ class FunctionsCustomServerTest extends Scope
     //         'x-appwrite-project' => $this->getProject()['$id'],
     //     ], $this->getHeaders()));
 
-    //     $output = json_decode($executions['body']['stdout'], true);
+    //     $output = json_decode($executions['body']['response'], true);
 
     //     $this->assertEquals(200, $executions['headers']['status-code']);
     //     $this->assertEquals('completed', $executions['body']['status']);
@@ -1401,7 +1401,7 @@ class FunctionsCustomServerTest extends Scope
     //     $this->assertCount(1, $executions['body']['executions']);
     //     $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
     //     $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-    //     $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['stdout']);
+    //     $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
     //     // Cleanup : Delete function 
     //     $response = $this->client->call(Client::METHOD_DELETE, '/functions/'. $functionId, [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR renamed 'stdout' to 'response' in the executions response model

## Test Plan

Tests have been updated to use 'response' instead of 'stdout' when testing functions, no tests have been added.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have.
