### PR TITLE
Fix: Default values

### DIFF
--- a/app/views/console/database/collection.phtml
+++ b/app/views/console/database/collection.phtml
@@ -224,7 +224,7 @@ $logs = $this->getParam('logs', null);
                                                         </div>
                                                     </div>
 
-                                                    <div data-ls-if="{{attribute.default}}">
+                                                    <div data-ls-if="{{attribute.default}} || {{attribute.default}} === false">
                                                         <label>Default Value</label>
                                                         <input type="text" data-ls-bind="{{attribute.default}}" class="full-width" disabled />
                                                     </div>

--- a/app/views/console/database/document.phtml
+++ b/app/views/console/database/document.phtml
@@ -86,7 +86,7 @@ $logs = $this->getParam('logs', null);
                                             pattern="^[a-zA-Z0-9][a-zA-Z0-9._-]{0,35}$" />
                                     <?php endif; ?>
 
-                                    <fieldset name="data" data-cast-to="object" data-ls-attrs="x-init=doc = {{project-document}}" x-data="{doc: {}}">
+                                    <fieldset name="data" data-cast-to="object" data-ls-attrs="x-init=col = {{project-collection}}; hasId = '{{router.params.id}}'.length !== 0; prepareDoc({{project-document}})" x-data="{ doc: {}, col: {}, hasId: false, prepareDoc: function(doc) { this.doc = Object.assign({}, this.getDefaults(), this.hasId ? doc : {}); }, getDefaults: function() { const defs = {}; this.col.attributes.forEach(function(attr) { if (attr.default !== undefined && attr.default !== null) { defs[attr.key] = attr.default; } }); return defs; } }">
                                         <ul data-ls-attrs="x-init=attributes = {{project-collection.attributes}}" x-data="{attributes: []}">
                                             <template x-for="attr in attributes.filter(a => a.status === 'available')">
                                                 <li>


### PR DESCRIPTION
## What does this PR do?

I created Draft PR to start the discussion. We are trying to address 2 scenarios:

### 1. Defaults in UI

Currently, if you have string attribute with default 'Matej', and visit document creation page, you can see empty field. No indication of detault value. Then when you create document leaving input empty, value is set. This was fine, but now that we redirect to list page instead of document page, it might be unexpected to see changes to data I created.

Following that, boolean attributes are even more confusing. If I have boolean attribute with default true, and I visit create document page, input is toggled off. Then I create document, and toggle is suddenly on (true on document). This could be solved with "unset" state of toggle button, but I think we should address all default values (string example above).

### 2. Defaults in database

Default values do not use MariaDB native functionality of default values for columns, instead, we store it as metadata and manage defaults ourselves. This means, there is no data migration by default when adding new column.

Let's say I have 10 documents. I add string attribute 'age' with default 'Unset'. Sadly, all my existing documents have age 'n/a` - the default was not applied.

Solution here would be to run one HUGE update query on collection after attribute is added, something like `UPDATE profiles SET age = 'Unset' WHERE age IS NULL;`

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/2768

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
