### PR TITLE
Fix: Team User Creation

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -342,6 +342,7 @@ App::post('/v1/teams/:teamId/memberships')
                     'tokens' => [],
                     'memberships' => [],
                     'search' => implode(' ', [$userId, $email, $name]),
+                    'deleted' => false
                 ])));
             } catch (Duplicate $th) {
                 throw new Exception('Account already exists', 409, Exception::USER_ALREADY_EXISTS);


### PR DESCRIPTION
## What does this PR do?

At the moment, if you create a new user through membership, the `deleted`status is `NULL`:

![CleanShot 2022-05-06 at 13 04 24](https://user-images.githubusercontent.com/19310830/167119979-90d52763-4a72-430b-939e-faa7c0322b8a.png)

That is a problem because in a query for listing users we check if `deleted` is `false`, which isn't in the case of NULL. So we end up with only one user listed:

![CleanShot 2022-05-06 at 13 05 07](https://user-images.githubusercontent.com/19310830/167120088-563fc348-fb5f-488e-8ac7-f97b9ab18365.png)

By setting `deleted` to `false`, I can now see both users:

![CleanShot 2022-05-06 at 13 05 40](https://user-images.githubusercontent.com/19310830/167120187-a3ad9ef8-a46d-411f-a0ce-677260478b45.png)

This PR addresses this bug and ensures that the `deleted` key is properly set to `false`. I also double-checked other places where we create users, and this was the only place with the `deleted` attribute missing.

## Test Plan

- [x] Manual QA

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/3177

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
