### PR TITLE
fixed: open new tab on click release notes link

### DIFF
--- a/app/views/layouts/default.phtml
+++ b/app/views/layouts/default.phtml
@@ -139,7 +139,7 @@ if(!empty($platforms)) {
                     <span data-ls-bind="{{alert.text}}"></span>
 
                     <span data-ls-if="undefined !== {{alert.link}}">
-                        <a data-ls-attrs="href={{alert.link}}" data-ls-bind="{{alert.label}}" data-remove></a>
+                        <a data-ls-attrs="href={{alert.link}}" data-ls-bind="{{alert.label}}" target="_blank" data-remove></a>
                     </span>
                 </div>
             </li>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When user clicks on release notes link on appwrite console page, the link will open on a new tab, previously it was opening on same tab.

## Test Plan

To test simply click on the release notes link on console page.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
