### PR TITLE
Fix: Main Domain

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -80,9 +80,10 @@ App::init(function ($utopia, $request, $response, $console, $project, $dbForCons
         } else {
             Authorization::disable();
 
+            $envDomain = App::getEnv('_APP_DOMAIN', '');
             $mainDomain = null;
-            if(!empty(App::getEnv('_APP_DOMAIN', ''))) {
-                $mainDomain = App::getEnv('_APP_DOMAIN', '');
+            if(!empty($envDomain) && $envDomain !== 'localhost') {
+                $mainDomain = $envDomain;
             } else {
                 $domainDocument = $dbForConsole->findOne('domains', [], 0, ['_id'], ['ASC']);
                 $mainDomain = $domainDocument ? $domainDocument->getAttribute('domain') : $domain->get();

--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -175,8 +175,9 @@ class CertificatesV1 extends Worker
      */
     private function getMainDomain(): ?string
     {
-        if (!empty(App::getEnv('_APP_DOMAIN', ''))) {
-            return App::getEnv('_APP_DOMAIN', '');
+        $envDomain = App::getEnv('_APP_DOMAIN', '');
+        if (!empty($envDomain) && $envDomain !== 'localhost') {
+            return $envDomain;
         } else {
             $domainDocument = $this->dbForConsole->findOne('domains', [], 0, ['_id'], ['ASC']);
             if ($domainDocument) {


### PR DESCRIPTION
## What does this PR do?

With this PR, if the domain in ENV is `localhost`, it will be ignored, and instead, we will use logic the same as if we didn't have any ENV domain set.

This is needed because `localhost` is the default value, and there is no way people want localhost to be their main domain 
(certificate for localhost won't work anyway).

With these changes, when using `localhost`, we still use the first visited domain as the main domain.

This PR also solves the DigitalOcean 1click setup so it properly generates SSL for the first domain without having to SSH into the server and updates ENV var.

## Test Plan

- [x] Manual QA (.env set to `localhost`)
![CleanShot 2022-05-18 at 11 04 21](https://user-images.githubusercontent.com/19310830/169001909-f696d582-c51c-4d58-9cd0-410041c3a866.png)


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
