### PR TITLE
fix: installation overriding default env variables

### DIFF
--- a/app/tasks/install.php
+++ b/app/tasks/install.php
@@ -92,6 +92,7 @@ $cli
                     $env = $service->getEnvironment()->list();
 
                     foreach ($env as $key => $value) {
+                        if (is_null($value)) continue;
                         foreach($vars as &$var) {
                             if($var['name'] === $key) {
                                 $var['default'] = $value;
@@ -108,6 +109,7 @@ $cli
                     $env = new Env($data);
 
                     foreach ($env->list() as $key => $value) {
+                        if (is_null($value)) continue;
                         foreach($vars as &$var) {
                             if($var['name'] === $key) {
                                 $var['default'] = $value;


### PR DESCRIPTION
## What does this PR do?

- when a variable was missing in `.env` - we override its default with an empty value instead of the default value from the config

## Test Plan

- manually tested

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 