### PR TITLE
fix: empty build logs

### DIFF
--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -174,7 +174,7 @@ class BuildsV1 extends Worker
             $build->setAttribute('status', $response['status']);
             $build->setAttribute('outputPath', $response['outputPath']);
             $build->setAttribute('stderr', $response['stderr']);
-            $build->setAttribute('stdout', $response['stdout']);
+            $build->setAttribute('stdout', $response['response']);
 
             Console::success("Build id: $buildId created");
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The response from the executor no longer contains the `stdout` key. It was replaced by `response`

## Test Plan

Existing tests & Manual QA

### Before
![Screenshot 2022-05-20 at 3 45 03 AM](https://user-images.githubusercontent.com/20852629/169421731-c64834c3-edd8-4b79-bb5c-450a3bf42085.png)

### After
![Screenshot 2022-05-20 at 3 45 25 AM](https://user-images.githubusercontent.com/20852629/169421765-d0b60182-53ee-44f1-94cd-8966593dfadf.png)


## Related PRs and Issues
N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES
