### PR TITLE
fix: escape order attribute names

### DIFF
--- a/public/scripts/dependencies/appwrite.js
+++ b/public/scripts/dependencies/appwrite.js
@@ -1831,7 +1831,7 @@
                         payload['cursorDirection'] = cursorDirection;
                     }
                     if (typeof orderAttributes !== 'undefined') {
-                        payload['orderAttributes'] = orderAttributes;
+                        payload['orderAttributes'] = orderAttributes.map((orderAttribute) => '`' + orderAttribute + '`');
                     }
                     if (typeof orderTypes !== 'undefined') {
                         payload['orderTypes'] = orderTypes;


### PR DESCRIPTION
## What does this PR do?

Escapes `orderAttributes` order attributes to handle potential collision of order attributes names with SQL keywords.

## Test Plan

No tests should break

## Related PRs and Issues

#3250 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
