### PR TITLE
Fix: Zoom OAuth scopes

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Zoom.php
+++ b/src/Appwrite/Auth/OAuth2/Zoom.php
@@ -30,7 +30,7 @@ class Zoom extends OAuth2
      * @var array
      */
     protected array $scopes = [
-        'user_profile'
+        'user_info:read'
     ];
 
     /**


### PR DESCRIPTION
## What does this PR do?

Fixes a failing Zoom OAuth. problem seems to be related to the scope we request `user_profile`, which cannot be found in the Zoom dashboard:

<img width="1097" alt="CleanShot 2022-05-20 at 13 47 45@2x" src="https://user-images.githubusercontent.com/19310830/169523123-82e7303b-1227-4579-afd4-443cd5d1ad40.png">

I also found an unfinished discussion regarding this: https://devforum.zoom.us/t/has-user-profile-scope-been-removed/60857

After applying new scopes, I was able to successfully create a session:

<img width="1079" alt="CleanShot 2022-05-20 at 13 52 32@2x" src="https://user-images.githubusercontent.com/19310830/169523183-246e9e7d-2e3c-4b58-882c-0887c6c4eb5c.png">

## Test Plan

- [x] Manual QA

## Related PRs and Issues

Reported on Discord

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes