### PR TITLE
Bypass SMTP host check for admins adding team members

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -295,12 +295,12 @@ App::post('/v1/teams/:teamId/memberships')
     ->inject('events')
     ->action(function (string $teamId, string $email, array $roles, string $url, string $name, Response $response, Document $project, Document $user, Database $dbForProject, Locale $locale, EventAudit $audits, Mail $mails, Event $events) {
 
-        if (empty(App::getEnv('_APP_SMTP_HOST'))) {
-            throw new Exception('SMTP Disabled', 503, Exception::GENERAL_SMTP_DISABLED);
-        }
-
         $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
         $isAppUser = Auth::isAppUser(Authorization::getRoles());
+
+        if (!$isPrivilegedUser && !$isAppUser && empty(App::getEnv('_APP_SMTP_HOST'))) {
+            throw new Exception('SMTP Disabled', 503, Exception::GENERAL_SMTP_DISABLED);
+        }
 
         $email = \strtolower($email);
         $name = (empty($name)) ? $email : $name;


### PR DESCRIPTION
## What does this PR do?

Don't check the SMTP host env var when add team member API is called for admins/server SDKs since no email is actually sent.

## Test Plan

1. Set `_APP_SMTP_HOST` env var to empty string
2. Add a user to a team
3. Confirm successful API call

![Success](https://user-images.githubusercontent.com/1477010/170638221-ac663958-0a24-4880-80e2-7ac9f5711e36.png)

## Related PRs and Issues

Closes: https://github.com/appwrite/appwrite/issues/3283

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
