### PR TITLE
Fix: Unnecessary execution delays

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -187,7 +187,7 @@ class Executor
                         $response = $this->call(self::METHOD_POST, $route, $headers, $params, true, $requestTimeout);
                         $status = $response['headers']['status-code'];
 
-                        if($status < 400) {
+                        if ($status < 400) {
                             return $response['body'];
                         }
                         break;
@@ -195,7 +195,7 @@ class Executor
                         $response = $this->call(self::METHOD_POST, $route, $headers, $params, true, $requestTimeout);
                         $status = $response['headers']['status-code'];
 
-                        if($status < 400) {
+                        if ($status < 400) {
                             return $response['body'];
                         }
                         break;

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -186,10 +186,18 @@ class Executor
                         );
                         $response = $this->call(self::METHOD_POST, $route, $headers, $params, true, $requestTimeout);
                         $status = $response['headers']['status-code'];
+
+                        if($status < 400) {
+                            return $response['body'];
+                        }
                         break;
                     case $status === 406:
                         $response = $this->call(self::METHOD_POST, $route, $headers, $params, true, $requestTimeout);
                         $status = $response['headers']['status-code'];
+
+                        if($status < 400) {
+                            return $response['body'];
+                        }
                         break;
                     default:
                         throw new \Exception($response['body']['message'], $status);


### PR DESCRIPTION
## What does this PR do?

Prevents unnecessary run of `sleep(2)` when executing a function for the first time (without runtime ready). Affects both `async=true/false`, but only really visible with `async=false`.

## Test Plan

- [X] Manual QA. Without this PR, I first received realtime update, then 1 second delay, then execution response. With this PR, they both come in at the same time.

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/3332

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes ✅
