### PR TITLE
Fix: Correct the order of OAuth providers

### DIFF
--- a/app/config/providers.php
+++ b/app/config/providers.php
@@ -211,6 +211,16 @@ return [ // Ordered by ABC.
         'beta' => false,
         'mock' => false,
     ],
+    'stripe' => [
+        'name' => 'Stripe',
+        'developers' => 'https://stripe.com/docs/api',
+        'icon' => 'icon-stripe',
+        'enabled' => true,
+        'sandbox' => false,
+        'form' => false,
+        'beta' => false,
+        'mock' => false
+    ],
     'tradeshift' => [
         'name' => 'Tradeshift',
         'developers' => 'https://developers.tradeshift.com/docs/api',
@@ -241,15 +251,15 @@ return [ // Ordered by ABC.
         'beta' => false,
         'mock' => false,
     ],
-    'zoom' => [
-        'name' => 'Zoom',
-        'developers' => 'https://marketplace.zoom.us/docs/guides/auth/oauth/',
-        'icon' => 'icon-zoom',
+    'wordpress' => [
+        'name' => 'WordPress',
+        'developers' => 'https://developer.wordpress.com/docs/oauth2/',
+        'icon' => 'icon-wordpress',
         'enabled' => true,
         'sandbox' => false,
         'form' => false,
         'beta' => false,
-        'mock' => false,
+        'mock' => false
     ],
     'yahoo' => [
         'name' => 'Yahoo',
@@ -297,25 +307,15 @@ return [ // Ordered by ABC.
     //     'beta' => false,
     //     'mock' => false,
     // ],
-    'wordpress' => [
-        'name' => 'WordPress',
-        'developers' => 'https://developer.wordpress.com/docs/oauth2/',
-        'icon' => 'icon-wordpress',
+    'zoom' => [
+        'name' => 'Zoom',
+        'developers' => 'https://marketplace.zoom.us/docs/guides/auth/oauth/',
+        'icon' => 'icon-zoom',
         'enabled' => true,
         'sandbox' => false,
         'form' => false,
         'beta' => false,
-        'mock' => false
-    ],
-    'stripe' => [
-        'name' => 'Stripe',
-        'developers' => 'https://stripe.com/docs/api',
-        'icon' => 'icon-stripe',
-        'enabled' => true,
-        'sandbox' => false,
-        'form' => false,
-        'beta' => false,
-        'mock' => false
+        'mock' => false,
     ],
     // Keep Last
     'mock' => [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Corrects the order of OAuth providers by returning them to A-Z alphabetical order

## Test Plan

- [x] Manual QA

### Before PR

<img width="811" alt="image" src="https://user-images.githubusercontent.com/31401437/173844551-806f3d09-badf-436f-b978-f614c4e14cc1.png">

### After PR

<img width="765" alt="image" src="https://user-images.githubusercontent.com/31401437/173844667-49e6ccdd-2d49-4707-a543-0a26dcea23c7.png">


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes