### PR TITLE
Feat: Improve Gitpod preloading

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@ tasks:
     init: |
       docker compose pull
       docker compose build
+      docker pull composer
     command: |
       docker run --rm --interactive --tty \
       --volume $PWD:/app \


### PR DESCRIPTION
## What does this PR do?

Currently when you start Gitpod, it downloads preload, and then pull composer (to then update dependencies). With this change, image would be downloaded during rebuild, making Gitpod workspace a little bit faster.

## Test Plan

- [x] Manual QA

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
