### PR TITLE
fix: 404 OAuth2 docs url for Yammer

### DIFF
--- a/app/config/providers.php
+++ b/app/config/providers.php
@@ -273,7 +273,7 @@ return [ // Ordered by ABC.
     ],
     'yammer' => [
         'name' => 'Yammer',
-        'developers' => 'https://developer.yammer.com/docs/oauth-2',
+        'developers' => 'https://docs.microsoft.com/en-us/rest/api/yammer/oauth-2/',
         'icon' => 'icon-yammer',
         'enabled' => true,
         'sandbox' => false,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Currently the OAuth2 docs URL in the providers section for **Yammer** leads to a deadlink (404 error). Seems that the documentation has been moved to a different URL which this PR addresses.

## Test Plan

- [x] Manual


## Related PRs and Issues

NIL

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
