### PR TITLE
ui: allow generating a new webhook signature

### DIFF
--- a/app/views/console/webhooks/webhook.phtml
+++ b/app/views/console/webhooks/webhook.phtml
@@ -30,7 +30,7 @@ sort($patterns);
     data-service="projects.getWebhook"
     data-name="project-webhook"
     data-scope="console"
-    data-event="load,projects.createWebhook, projects.deleteWebhook, projects.updateWebhook"
+    data-event="load,projects.createWebhook,projects.deleteWebhook,projects.updateWebhook,projects.updateWebhookSignature"
     data-param-project-id="{{router.params.project}}"
     data-param-webhook-id="{{router.params.id}}"
     data-success="trigger"
@@ -90,9 +90,6 @@ sort($patterns);
 
                         <label data-ls-attrs="for=url-{{webhook.$id}}">POST URL</label>
                         <input type="url" class="full-width" data-ls-attrs="id=url-{{project-webhook.$id}}" name="url" required autocomplete="off" placeholder="https://example.com/callback" data-ls-bind="{{project-webhook.url}}" />
-
-                        <label data-ls-attrs="for=signatureKey-{{webhook.$id}}">Signature Key</label>
-                        <input type="text" class="full-width" data-ls-attrs="id=signatureKey-{{project-webhook.$id}}" name="signatureKey" required autocomplete="off" placeholder="ad3d581ca230e2b7059c545e5a" data-ls-bind="{{project-webhook.signatureKey}}" />
 
                         <section class="margin-bottom-small" data-ls-attrs="x-init=load({{project-webhook.events}})">
                             <label class="margin-bottom-small">Events <span class="tooltip small" data-tooltip="Set events that will trigger your webhook."><i class="icon-info-circled"></i></span></label>
@@ -159,7 +156,53 @@ sort($patterns);
                         <input id="uid" type="text" autocomplete="off" placeholder="" data-ls-bind="{{project-webhook.$id}}" disabled data-forms-copy>
                     </div>
 
-                    <form class="margin-bottom" data-analytics data-analytics-activity data-analytics-event="submit" data-analytics-category="console" data-analytics-label="Delete Project Webhook" data-service="projects.deleteWebhook" data-scope="console" data-event="submit" data-confirm="Are you sure you want to delete this webhook?" data-success="alert,redirect" data-success-param-redirect-url="/console/webhooks?project={{router.params.project}}" data-success-param-alert-text="Deleted webhook successfully" data-success-param-trigger-events="projects.deleteWebhook" data-failure="alert" data-failure-param-alert-text="Failed to delete webhook" data-failure-param-alert-classname="error">
+                    <label>Signature Key <span class="tooltip small" data-tooltip="Can be used to validate your Webhooks."><i class="icon-info-circled"></i></span></label>
+                    <div class="input-copy margin-bottom">
+                        <input id="signatureKey" type="text" autocomplete="off" placeholder="" data-ls-bind="{{project-webhook.signatureKey}}" disabled data-forms-copy>
+                    </div>
+
+                    <form
+                        class="margin-bottom"
+                        data-analytics
+                        data-analytics-activity
+                        data-analytics-event="submit"
+                        data-analytics-category="console"
+                        data-analytics-label="Update Project Webhook Signature"
+                        data-service="projects.updateWebhookSignature"
+                        data-scope="console"
+                        data-event="submit"
+                        data-confirm="Are you sure you want to generate a new Signature Key?"
+                        data-success="trigger"
+                        data-success-param-alert-text="Updated webhook signature key successfully"
+                        data-success-param-trigger-events="projects.updateWebhookSignature"
+                        data-failure="alert"
+                        data-failure-param-alert-text="Failed to update webhook signature key"
+                        data-failure-param-alert-classname="error">
+
+                        <input type="hidden" name="projectId" data-ls-bind="{{router.params.project}}" />
+                        <input type="hidden" name="webhookId" data-ls-bind="{{project-webhook.$id}}" />
+
+                        <button class="fill">Update Signature Key</button>
+                    </form>
+
+                    <form
+                        class="margin-bottom"
+                        data-analytics
+                        data-analytics-activity
+                        data-analytics-event="submit"
+                        data-analytics-category="console"
+                        data-analytics-label="Delete Project Webhook"
+                        data-service="projects.deleteWebhook"
+                        data-scope="console"
+                        data-event="submit"
+                        data-confirm="Are you sure you want to delete this webhook?"
+                        data-success="alert,redirect"
+                        data-success-param-redirect-url="/console/webhooks?project={{router.params.project}}"
+                        data-success-param-alert-text="Deleted webhook successfully"
+                        data-success-param-trigger-events="projects.deleteWebhook"
+                        data-failure="alert"
+                        data-failure-param-alert-text="Failed to delete webhook"
+                        data-failure-param-alert-classname="error">
 
                         <input type="hidden" name="projectId" data-ls-bind="{{router.params.project}}" />
                         <input type="hidden" name="webhookId" data-ls-bind="{{project-webhook.$id}}" />


### PR DESCRIPTION
## What does this PR do?

- allow re-generating webhook signature

![Bildschirmfoto 2022-06-20 um 23 17 07](https://user-images.githubusercontent.com/1759475/174678746-489d24b4-8d85-4641-a919-23a5d5df4a87.png)

messed up my commits somehow, the API is on the target branch 🙃 

https://github.com/appwrite/appwrite/blob/feat-prepare-0-15/app/controllers/api/projects.php#L731-L768

## Test Plan

- manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 