### PR TITLE
Fix: Lock $createdAt

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2221,6 +2221,7 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
         $data = \array_merge($document->getArrayCopy(), $data);
 
         $data['$collection'] = $collection->getId(); // Make sure user don't switch collectionID
+        $data['$createdAt'] = $collection->getCreatedAt(); // Make sure user don't switch createdAt
         $data['$id'] = $document->getId(); // Make sure user don't switch document unique ID
         $data['$read'] = (is_null($read)) ? ($document->getRead() ?? []) : $read; // By default inherit read permissions
         $data['$write'] = (is_null($write)) ? ($document->getWrite() ?? []) : $write; // By default inherit write permissions

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -1320,6 +1320,7 @@ trait DatabasesBase
                 'title' => 'Thor: Ragnaroc',
                 'releaseYear' => 2017,
                 'actors' => [],
+                '$createdAt' => 5 // Should be ignored
             ],
             'read' => ['user:' . $this->getUser()['$id']],
             'write' => ['user:' . $this->getUser()['$id']],
@@ -1330,6 +1331,7 @@ trait DatabasesBase
         $this->assertEquals($document['headers']['status-code'], 201);
         $this->assertEquals($document['body']['title'], 'Thor: Ragnaroc');
         $this->assertEquals($document['body']['releaseYear'], 2017);
+        $this->assertNotEquals($document['body']['$createdAt'], 5);
         $this->assertEquals('user:' . $this->getUser()['$id'], $document['body']['$read'][0]);
         $this->assertEquals('user:' . $this->getUser()['$id'], $document['body']['$write'][0]);
 


### PR DESCRIPTION
## What does this PR do?

Disallow user to change $createdAt in `updateDocument`.

## Test Plan

- [x] Updated tests

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
