### PR TITLE
Feat: Deprecate all parameter

### DIFF
--- a/app/tasks/install.php
+++ b/app/tasks/install.php
@@ -25,7 +25,7 @@ $cli
          * 2. Check for older setup and get older version - DONE
          *  2.1 If older version is equal or bigger(?) than current version, **stop setup**
          *  2.2. Get ENV vars - DONE
-         *   2.2.1 Fetch from older ompo.yml file
+         *   2.2.1 Fetch from older docker-compose.yml file
          *   2.2.2 Fetch from older .env file (manually parse)
          *  2.3 Use old ENV vars as default values
          *  2.4 Ask for all required vars not given as CLI args and if in interactive mode

--- a/app/tasks/install.php
+++ b/app/tasks/install.php
@@ -25,7 +25,7 @@ $cli
          * 2. Check for older setup and get older version - DONE
          *  2.1 If older version is equal or bigger(?) than current version, **stop setup**
          *  2.2. Get ENV vars - DONE
-         *   2.2.1 Fetch from older docker-compose.yml file
+         *   2.2.1 Fetch from older ompo.yml file
          *   2.2.2 Fetch from older .env file (manually parse)
          *  2.3 Use old ENV vars as default values
          *  2.4 Ask for all required vars not given as CLI args and if in interactive mode

--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -31,12 +31,6 @@ You can also fetch all the collections in your current project using
 appwrite init collection
 ```
 
-The CLI also comes with a convenient `--all` flag to perform both these steps at once.
-
-```sh
-appwrite init --all
-```
-
 * ### Creating and deploying cloud functions
 
 The CLI makes it extremely easy to create and deploy Appwrite's cloud functions. Initialise your new function using
@@ -81,12 +75,6 @@ Similarly, you can deploy all your collections to your Appwrite server using
 ```sh
 appwrite deploy collections
 ```
-
-The `deploy` command also comes with a convenient `--all` flag to deploy all your functions and collections at once.
-
-```sh
-appwrite deploy --all
-``` 
 
 > ### Note
 > By default, requests to domains with self signed SSL certificates (or no certificates) are disabled. If you trust the domain, you can bypass the certificate validation using


### PR DESCRIPTION
## What does this PR do?

`--all` for `init` and `deploy` was deprecated due to bug in `commander` library. Until we have proper solution, it will not be possible to use these parameters.

They were removed in favour of `deploy function --all` and `init collections --all` which are much more valuable commands. While those we deprecated can be achieved with 2 commands, replacing these mentioned would take a full-on bash script to list and init/deploy one by one.

## Test Plan

Not necessary.

## Related PRs and Issues

- https://github.com/appwrite/sdk-generator/pull/484
- https://github.com/appwrite/docs/pull/215

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
