### PR TITLE
Feat: Allow date overriding

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2279,10 +2279,17 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
         $data = \array_merge($document->getArrayCopy(), $data);
 
         $data['$collection'] = $collection->getId(); // Make sure user don't switch collectionID
-        $data['$createdAt'] = $collection->getCreatedAt(); // Make sure user don't switch createdAt
         $data['$id'] = $document->getId(); // Make sure user don't switch document unique ID
         $data['$read'] = (is_null($read)) ? ($document->getRead() ?? []) : $read; // By default inherit read permissions
         $data['$write'] = (is_null($write)) ? ($document->getWrite() ?? []) : $write; // By default inherit write permissions
+
+        if(Authorization::isRole('role:' . Auth::USER_ROLE_APP)) {
+            // Is server, allow overriding creation date
+            $data['$createdAt'] = $data['$createdAt'] ?? $collection->getCreatedAt();
+        } else {
+            // Is client, force previous creation date
+            $data['$createdAt'] = $collection->getCreatedAt();
+        }
 
         // Users can only add their roles to documents, API keys and Admin users can add any
         $roles = Authorization::getRoles();

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2283,7 +2283,7 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
         $data['$read'] = (is_null($read)) ? ($document->getRead() ?? []) : $read; // By default inherit read permissions
         $data['$write'] = (is_null($write)) ? ($document->getWrite() ?? []) : $write; // By default inherit write permissions
 
-        if(Authorization::isRole('role:' . Auth::USER_ROLE_APP)) {
+        if (Authorization::isRole('role:' . Auth::USER_ROLE_APP)) {
             // Is server, allow overriding creation date
             $data['$createdAt'] = $data['$createdAt'] ?? $collection->getCreatedAt();
         } else {


### PR DESCRIPTION
## What does this PR do?

Allows server SDK to do changes to `$createdAt` attribute of all collections. Use cases:

- I had `updated` field. I migrated to 0.15. I want to switch to `$createdAt` so I don't need Appwrite Function anymore. I need to migrate current dates from the custom field into `$createdAt`
- Invoice document was created, and `$createdAt` is used as information for when it was issued. An acconting team needs to update the date for legal reasons. Tho this edge-case, 99% of the time the `createdAt` is correct.

## Test Plan

- [ ] Implement new tests

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
