### PR TITLE
WIP Feat token events

### DIFF
--- a/app/config/events.php
+++ b/app/config/events.php
@@ -21,6 +21,13 @@ return [
             'delete' => [
                 '$description' => 'This event triggers when a session for a user is deleted.'
             ],
+            'magic' => [
+            '$model' => Response::MODEL_TOKEN,
+            '$resource' => false,
+            'create' => [
+                '$description' => 'This event triggers when a magic link token for a session is created.',
+            ],
+        ],
         ],
         'recovery' => [
             '$model' => Response::MODEL_TOKEN,

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -702,11 +702,7 @@ App::post('/v1/account/sessions/magic-url')
             ;
         }
 
-        $events
-            ->setParam('userId', $user->getId())
-            ->setParam('tokenId', $loginSecret)
-            ->setUser($user)
-            ->setPayload(
+        $events->setPayload(
             $response->output(
                 $token->setAttribute('secret', $loginSecret),
                 Response::MODEL_TOKEN

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -594,6 +594,7 @@ App::post('/v1/account/sessions/magic-url')
     ->desc('Create Magic URL session')
     ->groups(['api', 'account'])
     ->label('scope', 'public')
+    ->label('event', 'users.[userId].sessions.[tokenId].magic.create')
     ->label('auth.type', 'magic-url')
     ->label('sdk.auth', [])
     ->label('sdk.namespace', 'account')
@@ -698,7 +699,11 @@ App::post('/v1/account/sessions/magic-url')
             ->trigger()
         ;
 
-        $events->setPayload(
+        $events
+            ->setParam('userId', $user->getId())
+            ->setParam('tokenId', $token->getId())
+            ->setUser($user)
+            ->setPayload(
             $response->output(
                 $token->setAttribute('secret', $loginSecret),
                 Response::MODEL_TOKEN

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -420,18 +420,15 @@ App::post('/v1/teams/:teamId/memberships')
         ;
 
         $events
-            ->setParam('userId', $invitee->getId())
             ->setParam('teamId', $team->getId())
-            ->setParam('tokenId', $secret)
-            ->setUser($user)
             ->setParam('membershipId', $membership->getId())
             ->setPayload(
             $response->output(
-                $token->setAttribute('secret', $loginSecret),
-                Response::MODEL_TOKEN
+                $membership->setAttribute('secret', $secret),
+                Response::MODEL_MEMBERSHIP
             ));
         ;
-
+        
         $response->setStatusCode(Response::STATUS_CODE_CREATED);
         $response->dynamic(
             $membership

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -376,7 +376,7 @@ App::post('/v1/teams/:teamId/memberships')
             'invited' => \time(),
             'joined' => ($isPrivilegedUser || $isAppUser) ? \time() : 0,
             'confirm' => ($isPrivilegedUser || $isAppUser),
-            'secret' => Auth::hash($secret),
+            'secret' => $isAppUser ? Auth::hash($secret) : '',
             'search' => implode(' ', [$membershipId, $invitee->getId()])
         ]);
 
@@ -424,11 +424,11 @@ App::post('/v1/teams/:teamId/memberships')
             ->setParam('membershipId', $membership->getId())
             ->setPayload(
             $response->output(
-                $membership->setAttribute('secret', $secret),
+                $membership->setAttribute('secret', $isAppUser ? $secret : ''),
                 Response::MODEL_MEMBERSHIP
             ));
         ;
-        
+
         $response->setStatusCode(Response::STATUS_CODE_CREATED);
         $response->dynamic(
             $membership

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -298,6 +298,7 @@ App::post('/v1/teams/:teamId/memberships')
 
         $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
         $isAppUser = Auth::isAppUser(Authorization::getRoles());
+        $useEmail = App::getEnv('_APP_SMTP_USE_EMAIL', true);
 
         if (!$isPrivilegedUser && !$isAppUser && empty(App::getEnv('_APP_SMTP_HOST'))) {
             throw new Exception('SMTP Disabled', 503, Exception::GENERAL_SMTP_DISABLED);
@@ -401,7 +402,7 @@ App::post('/v1/teams/:teamId/memberships')
         $url['query'] = Template::mergeQuery(((isset($url['query'])) ? $url['query'] : ''), ['membershipId' => $membership->getId(), 'userId' => $invitee->getId(), 'secret' => $secret, 'teamId' => $teamId]);
         $url = Template::unParseURL($url);
 
-        if (!$isPrivilegedUser && !$isAppUser) { // No need of confirmation when in admin or app mode
+        if (!$isPrivilegedUser && !$isAppUser && $useEmail) { // No need of confirmation when in admin or app mode
             $mails
                 ->setType(MAIL_TYPE_INVITATION)
                 ->setRecipient($email)

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -420,8 +420,16 @@ App::post('/v1/teams/:teamId/memberships')
         ;
 
         $events
+            ->setParam('userId', $invitee->getId())
             ->setParam('teamId', $team->getId())
+            ->setParam('tokenId', $secret)
+            ->setUser($user)
             ->setParam('membershipId', $membership->getId())
+            ->setPayload(
+            $response->output(
+                $token->setAttribute('secret', $loginSecret),
+                Response::MODEL_TOKEN
+            ));
         ;
 
         $response->setStatusCode(Response::STATUS_CODE_CREATED);

--- a/src/Appwrite/Utopia/Response/Model/Membership.php
+++ b/src/Appwrite/Utopia/Response/Model/Membership.php
@@ -64,6 +64,12 @@ class Membership extends Model
                 'default' => 0,
                 'example' => 1592981250,
             ])
+            ->addRule('secret', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Token secret key. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'default' => '',
+                'example' => '',
+            ])
             ->addRule('joined', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Date, the user has accepted the invitation to join the team in Unix timestamp.',

--- a/tests/e2e/Services/Webhooks/WebhooksBase.php
+++ b/tests/e2e/Services/Webhooks/WebhooksBase.php
@@ -862,7 +862,11 @@ trait WebhooksBase
         $this->assertCount(2, $webhook['data']['roles']);
         $this->assertIsInt($webhook['data']['joined']);
         $this->assertEquals(('server' === $this->getSide()), $webhook['data']['confirm']);
-
+        
+        $this->assertEquals($team['body']['secret'], '');
+        if('server' === $this->getSide()) {
+            $this->assertNotEmpty($webhook['data']['secret']);
+        }
         /**
          * Test for FAILURE
          */

--- a/tests/e2e/Services/Webhooks/WebhooksCustomClientTest.php
+++ b/tests/e2e/Services/Webhooks/WebhooksCustomClientTest.php
@@ -687,6 +687,48 @@ class WebhooksCustomClientTest extends Scope
     }
 
     /**
+     * @depends testUpdateAccountPrefs
+     */
+    public function testCreateSessionMagic($data): array
+    {
+        $id = $data['id'] ?? '';
+        $email = $data['email'] ?? '';
+
+        $magic = $this->client->call(Client::METHOD_POST, '/account/sessions/magic-url', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'userId' => $id,
+            'email' => $email
+        ]);
+
+        $magicId = $magic['body']['$id'];
+
+        $this->assertEquals(201, $magic['headers']['status-code']);
+        $this->assertIsArray($magic['body']);
+
+        $webhook = $this->getLastRequest();
+        $signatureKey = $this->getProject()['signatureKey'];
+        $payload = json_encode($webhook['data']);
+        $url     = $webhook['url'];
+        $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
+
+        $this->assertEquals($webhook['method'], 'POST');
+        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
+        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertNotEmpty($webhook['data']['$id']);
+        $this->assertNotEmpty($webhook['data']['userId']);
+        $this->assertNotEmpty($webhook['data']['secret']);
+        $this->assertIsNumeric($webhook['data']['expire']);
+
+        $data['secret'] = $webhook['data']['secret'];
+
+        return $data;
+    }
+    
+
+    /**
      * @depends testCreateAccountRecovery
      */
     public function testUpdateAccountRecovery($data): array


### PR DESCRIPTION
## What does this PR do?

I'm working in this feature for my fork, and as I don't know if you are interesting in this feature I'll let it here to ask for help and to know you are interested too

Currently we can get a token using `account.recovery.create` and `account.verification.create`. Would be good to have the same behavior with `createMagicURL` and `createMembership`

It's is very useful and will solve the following issues

1. Customize emails sent by the system, there is not an easy way to do it now, with this new hooks we can implement our own way to send email

2. If you have multiples projects and domains, you can send emails from custom SMTP server/email address

3. We can have the ability to notificate a user with an external API like whatsapp, to recover the password or create a session with magic link.

There was one problem doing this, we should have a way to disable the current email. Many of us was adding wrong data to the SMTP server that way, the system do not send the email, but if we want to recover an admin account we will never get any email as the SMTP server have wrong data.

To solve this, I have added a new env var who will disable the notifications in the endpoints but not in the whole system

Finally have this two events/webhooks will add more consistency to the current API as there are two endponts doing that and two that can not

#### Features:

* adds `user.session.magic.create` event/webhook to get the token when `createMagicURL` is triggered
* adds `teams.membership.create` event/webhook to get the token when a membership is added to a team
* adds `_APP_SMTP_USE_EMAIL` env var to disable the emails with the client, but allowing keep using the SMTP to recover the admin account or any other thing that requires to send an email

The env var disable the following:

- Email when you ask for a magic URL session
- Email for password recovery
- Email to verificate your account
- Email to join to a team (add membership)



## Test Plan

I have added a test to get the secret when `createMagicURL` is called and a test to get the secret when create a team membership is call, however in the last one I'm having a problem, I'll comment in the code to see if some can help me

I wanted to test if the email wasn't send, but @Meldiron told me there is no way to enable or disable an env var from a test, so maybe you can help me with this too

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/3115 
https://github.com/appwrite/appwrite/issues/3120

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes 👀
