### PR TITLE
Fix: createdAt bug after updating document

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2279,7 +2279,7 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
         $data = \array_merge($document->getArrayCopy(), $data);
 
         $data['$collection'] = $collection->getId(); // Make sure user don't switch collectionID
-        $data['$createdAt'] = $collection->getCreatedAt(); // Make sure user don't switch createdAt
+        $data['$createdAt'] = $document->getCreatedAt(); // Make sure user don't switch createdAt
         $data['$id'] = $document->getId(); // Make sure user don't switch document unique ID
         $data['$read'] = (is_null($read)) ? ($document->getRead() ?? []) : $read; // By default inherit read permissions
         $data['$write'] = (is_null($write)) ? ($document->getWrite() ?? []) : $write; // By default inherit write permissions


### PR DESCRIPTION
## What does this PR do?

When you create a document, both $createdAt and $updatedAt are as expected. When you update the document tho, $createdAt is set to a weird date, but $updatedAt is updated as expected.

Later I found out that $createdAt is set to collection creation date, instead of the document. This PR fixes it.

## Test Plan

- Tests will be written afterwards

## Related PRs and Issues

x
### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
