### PR TITLE
Fix get collection usage alias

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2669,7 +2669,7 @@ App::get('/v1/databases/:databaseId/usage')
     });
 
 App::get('/v1/databases/:databaseId/collections/:collectionId/usage')
-    ->alias('/v1/database/collections/:collectionId/documents', ['databaseId' => 'default'])
+    ->alias('/v1/database/:collectionId/usage', ['databaseId' => 'default'])
     ->desc('Get usage stats for a collection')
     ->groups(['api', 'database'])
     ->label('scope', 'collections.read')


### PR DESCRIPTION
## What does this PR do?

Fix the get collection usage API alias so it doesn't conflict with list documents

## Test Plan

1. Created e2e test
2. Manual test

Before fix:

![image](https://user-images.githubusercontent.com/1477010/177433020-d302750c-b74e-4233-a51b-e00379111d24.png)

After fix:

![image](https://user-images.githubusercontent.com/1477010/177433065-762dbbae-90bb-4b37-a856-50ee81c8d3fb.png)

## Related PRs and Issues

#3504 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
