### PR TITLE
Feat phoneauth msg91flow

### DIFF
--- a/app/init.php
+++ b/app/init.php
@@ -27,6 +27,7 @@ use Appwrite\Auth\Phone\Mock;
 use Appwrite\Auth\Phone\Telesign;
 use Appwrite\Auth\Phone\TextMagic;
 use Appwrite\Auth\Phone\Twilio;
+use Appwrite\Auth\Phone\Msg91;
 use Appwrite\DSN\DSN;
 use Appwrite\Event\Audit;
 use Appwrite\Event\Database as EventDatabase;
@@ -990,6 +991,7 @@ App::setResource('phone', function () {
         'twilio' => new Twilio($user, $secret),
         'text-magic' => new TextMagic($user, $secret),
         'telesign' => new Telesign($user, $secret),
+        'msg91' => new Msg91($user, $secret),
         default => null
     };
 });

--- a/app/workers/messaging.php
+++ b/app/workers/messaging.php
@@ -36,7 +36,7 @@ class MessagingV1 extends Worker
             'twilio' => new Twilio($user, $secret),
             'text-magic' => new TextMagic($user, $secret),
             'telesign' => new Telesign($user, $secret),
-            'msg91-flow' => new Msg91Flow($user, $secret),
+            'msg91' => new Msg91Flow($user, $secret),
             default => null
         };
 

--- a/app/workers/messaging.php
+++ b/app/workers/messaging.php
@@ -5,6 +5,7 @@ use Appwrite\Auth\Phone\Mock;
 use Appwrite\Auth\Phone\Telesign;
 use Appwrite\Auth\Phone\TextMagic;
 use Appwrite\Auth\Phone\Twilio;
+use Appwrite\Auth\Phone\Msg91;
 use Appwrite\DSN\DSN;
 use Appwrite\Resque\Worker;
 use Utopia\App;
@@ -36,7 +37,7 @@ class MessagingV1 extends Worker
             'twilio' => new Twilio($user, $secret),
             'text-magic' => new TextMagic($user, $secret),
             'telesign' => new Telesign($user, $secret),
-            'msg91' => new Msg91Flow($user, $secret),
+            'msg91' => new Msg91($user, $secret),
             default => null
         };
 

--- a/app/workers/messaging.php
+++ b/app/workers/messaging.php
@@ -36,6 +36,7 @@ class MessagingV1 extends Worker
             'twilio' => new Twilio($user, $secret),
             'text-magic' => new TextMagic($user, $secret),
             'telesign' => new Telesign($user, $secret),
+            'msg91-flow' => new Msg91Flow($user, $secret),
             default => null
         };
 

--- a/src/Appwrite/Auth/Phone/Msg91.php
+++ b/src/Appwrite/Auth/Phone/Msg91.php
@@ -7,7 +7,7 @@ use Appwrite\Auth\Phone;
 // Reference Material
 // https://docs.msg91.com/p/tf9GTextN/e/Irz7-x1PK/MSG91
 
-class Msg91Flow extends Phone
+class Msg91 extends Phone
 {
     /**
      * @var string
@@ -30,7 +30,7 @@ class Msg91Flow extends Phone
         $to = ltrim($to, '+');
         $this->request(
             method: 'POST',
-            url: $this->endpoint . '/messages',
+            url: $this->endpoint,
             payload: \http_build_query([
                 'sender' => $this->user,
                 'otp' => $message,

--- a/src/Appwrite/Auth/Phone/Msg91.php
+++ b/src/Appwrite/Auth/Phone/Msg91.php
@@ -31,7 +31,7 @@ class Msg91 extends Phone
         $this->request(
             method: 'POST',
             url: $this->endpoint,
-            payload: \http_build_query([
+            payload: json_encode([
                 'sender' => $this->user,
                 'otp' => $message,
                 'flow_id' => $from,

--- a/src/Appwrite/Auth/Phone/Msg91Flow.php
+++ b/src/Appwrite/Auth/Phone/Msg91Flow.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Appwrite\Auth\Phone;
+
+use Appwrite\Auth\Phone;
+
+// Reference Material
+// https://docs.msg91.com/p/tf9GTextN/e/Irz7-x1PK/MSG91
+
+class Msg91Flow extends Phone
+{
+    /**
+     * @var string
+     */
+    private string $endpoint = 'https://api.msg91.com/api/v5/flow/';
+
+    /**
+     * For Flow based sending SMS sender ID should not be set in flow
+     * In environment _APP_PHONE_PROVIDER format is 'phone://[senderID]:[authKey]@msg91-flow'.
+     * _APP_PHONE_FROM value is flow ID created in Msg91
+     * Eg. _APP_PHONE_PROVIDER = phone://DINESH:5e1e93cad6fc054d8e759a5b@msg91-flow
+     * _APP_PHONE_FROM = 3968636f704b303135323339
+     * @param string $from-> utilized from for flow id
+     * @param string $to
+     * @param string $message
+     * @return void
+     */
+    public function send(string $from, string $to, string $message): void
+    {
+        $to = ltrim($to, '+');
+        $this->request(
+            method: 'POST',
+            url: $this->endpoint . '/messages',
+            payload: \http_build_query([
+                'sender' => $this->user,
+                'otp' => $message,
+                'flow_id' => $from,
+                'mobiles' => $to
+            ]),
+            headers: [
+                "content-type: application/JSON",
+                "authkey: {$this->secret}",
+            ]
+        );
+    }
+}

--- a/src/Appwrite/Auth/Phone/Msg91Flow.php
+++ b/src/Appwrite/Auth/Phone/Msg91Flow.php
@@ -16,9 +16,9 @@ class Msg91Flow extends Phone
 
     /**
      * For Flow based sending SMS sender ID should not be set in flow
-     * In environment _APP_PHONE_PROVIDER format is 'phone://[senderID]:[authKey]@msg91-flow'.
+     * In environment _APP_PHONE_PROVIDER format is 'phone://[senderID]:[authKey]@msg91'.
      * _APP_PHONE_FROM value is flow ID created in Msg91
-     * Eg. _APP_PHONE_PROVIDER = phone://DINESH:5e1e93cad6fc054d8e759a5b@msg91-flow
+     * Eg. _APP_PHONE_PROVIDER = phone://DINESH:5e1e93cad6fc054d8e759a5b@msg91
      * _APP_PHONE_FROM = 3968636f704b303135323339
      * @param string $from-> utilized from for flow id
      * @param string $to


### PR DESCRIPTION
Hi I have integrated MSG91 service for phone adaptor. In MSG91 there are two modes of service 
1. Standard Transactional SMS
2. OTP service provided by them
This adaptor is based on first Standard Transactional SMS.

## What does this PR do?
This will provide phone authentication through MSG91 Flow service

## Test Plan
IN MSG91 service should create Flow based SMS with variable otp (Noted: Shouldn't set sender ID in flow since we are passing that as parameter)
In environment 
_APP_PHONE_PROVIDER value should be in format as phone://[senderID]:[authKey]@msg91
_APP_PHONE_FROM value should be flow ID created in Msg91(I have used this as place holder to pass flow ID)


## Related PRs and Issues

No

### Have you read the [Contributing Guidelines on issues]
Yes
