### PR TITLE
Implemented updateDocument date tests

### DIFF
--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -2359,6 +2359,65 @@ trait DatabasesBase
         return $data;
     }
 
+    /**
+     * @depends testUniqueIndexDuplicate
+     */
+    public function testPersistantCreatedAt(array $data): array
+    {
+        $headers = $this->getSide() === 'client' ? array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()) : [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ];
+
+        $document = $this->client->call(Client::METHOD_POST, '/databases/' . $data['databaseId'] . '/collections/' . $data['moviesId'] . '/documents', $headers, [
+            'documentId' => 'unique()',
+            'data' => [
+                'title' => 'Creation Date Test',
+                'releaseYear' => 2000
+            ]
+        ]);
+
+        $this->assertEquals($document['body']['title'], 'Creation Date Test');
+
+        $documentId = $document['body']['$id'];
+        $createdAt = $document['body']['$createdAt'];
+        $updatedAt = $document['body']['$updatedAt'];
+
+        \sleep(1);
+
+        $document = $this->client->call(Client::METHOD_PATCH, '/databases/' . $data['databaseId'] . '/collections/' . $data['moviesId'] . '/documents/' . $documentId, $headers, [
+            'data' => [
+                'title' => 'Updated Date Test',
+            ]
+        ]);
+
+        $updatedAtSecond = $document['body']['$updatedAt'];
+
+        $this->assertEquals($document['body']['title'], 'Updated Date Test');
+        $this->assertEquals($document['body']['$createdAt'], $createdAt);
+        $this->assertNotEquals($document['body']['$updatedAt'], $updatedAt);
+
+        \sleep(1);
+
+        $document = $this->client->call(Client::METHOD_PATCH, '/databases/' . $data['databaseId'] . '/collections/' . $data['moviesId'] . '/documents/' . $documentId, $headers, [
+            'data' => [
+                'title' => 'Again Updated Date Test',
+                '$createdAt' => 1657271810 // Try to update it, should not work
+            ]
+        ]);
+
+        $this->assertEquals($document['body']['title'], 'Again Updated Date Test');
+        $this->assertEquals($document['body']['$createdAt'], $createdAt);
+        $this->assertNotEquals($document['body']['$updatedAt'], $updatedAt);
+        $this->assertNotEquals($document['body']['$updatedAt'], $updatedAtSecond);
+
+        return $data;
+    }
+
     public function testUpdatePermissionsWithEmptyPayload(): array
     {
         // Create Database

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -2406,7 +2406,8 @@ trait DatabasesBase
         $document = $this->client->call(Client::METHOD_PATCH, '/databases/' . $data['databaseId'] . '/collections/' . $data['moviesId'] . '/documents/' . $documentId, $headers, [
             'data' => [
                 'title' => 'Again Updated Date Test',
-                '$createdAt' => 1657271810 // Try to update it, should not work
+                '$createdAt' => 1657271810, // Try to update it, should not work
+                '$updatedAt' => 1657271810 // Try to update it, should not work
             ]
         ]);
 
@@ -2414,6 +2415,7 @@ trait DatabasesBase
         $this->assertEquals($document['body']['$createdAt'], $createdAt);
         $this->assertNotEquals($document['body']['$updatedAt'], $updatedAt);
         $this->assertNotEquals($document['body']['$updatedAt'], $updatedAtSecond);
+        $this->assertNotEquals($document['body']['$updatedAt'], 1657271810);
 
         return $data;
     }


### PR DESCRIPTION
## What does this PR do?

In 0.15.1 there was a bug when updating a document that changed `$createdAt` date: https://github.com/appwrite/appwrite/pull/3500

We quickly fixed this bug and released a new version.

This PR improves the PR above by adding tests to prevent this bug in the future.

## Test Plan

- [x] Implemented new tests

## Related PRs and Issues

- PR above

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
