### PR TITLE
Fix: Database dates

### DIFF
--- a/app/views/console/databases/database.phtml
+++ b/app/views/console/databases/database.phtml
@@ -292,8 +292,8 @@
 
                         <ul class="margin-bottom-large text-fade text-size-small">
                             <li class="margin-bottom-small"><i class="icon-angle-circled-right margin-start-tiny margin-end-tiny"></i> <button data-ls-ui-trigger="open-json" class="link text-size-small">View as JSON</button></li>
-                            <li class="margin-bottom-small"><i class="icon-angle-circled-right margin-start-tiny margin-end-tiny"></i> Last Updated: <span data-ls-bind="{{project-database.dateUpdated|dateText}}"></span></li>
-                            <li class="margin-bottom-small"><i class="icon-angle-circled-right margin-start-tiny margin-end-tiny"></i> Created: <span data-ls-bind="{{project-database.dateCreated|dateText}}"></span></li>
+                            <li class="margin-bottom-small"><i class="icon-angle-circled-right margin-start-tiny margin-end-tiny"></i> Last Updated: <span data-ls-bind="{{project-database.$updatedAt|dateText}}"></span></li>
+                            <li class="margin-bottom-small"><i class="icon-angle-circled-right margin-start-tiny margin-end-tiny"></i> Created: <span data-ls-bind="{{project-database.$createdAt|dateText}}"></span></li>
                         </ul>
 
                             <form

--- a/src/Appwrite/Utopia/Response/Model/Database.php
+++ b/src/Appwrite/Utopia/Response/Model/Database.php
@@ -22,6 +22,18 @@ class Database extends Model
                 'default' => '',
                 'example' => 'My Database',
             ])
+            ->addRule('$createdAt', [
+                'type' => self::TYPE_INTEGER,
+                'description' => 'Collection creation date in Unix timestamp.',
+                'default' => 0,
+                'example' => 1592981250,
+            ])
+            ->addRule('$updatedAt', [
+                'type' => self::TYPE_INTEGER,
+                'description' => 'Collection update date in Unix timestamp.',
+                'default' => 0,
+                'example' => 1592981250,
+            ])
         ;
     }
 


### PR DESCRIPTION
## What does this PR do?

In 0.15 we refactored console into $createdAt and $updatedAt. There was one missing space which this PR fixes.

Also, the databases response model never exposed these 2 date attributes. Now it does.

## Test Plan

- [x] Manual QA

![CleanShot 2022-07-11 at 10 42 05](https://user-images.githubusercontent.com/19310830/178224261-c9a92e1b-62bd-4722-bc4f-7b71bc99298c.png)

![CleanShot 2022-07-11 at 10 42 02](https://user-images.githubusercontent.com/19310830/178224269-e978c349-931f-4426-864b-374951d044c7.png)


## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/3533

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
