### PR TITLE
Fix: function usage missing

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -806,7 +806,8 @@ App::post('/v1/functions/:functionId/executions')
     ->inject('dbForProject')
     ->inject('user')
     ->inject('events')
-    ->action(function (string $functionId, string $data, bool $async, Response $response, Document $project, Database $dbForProject, Document $user, Event $events) {
+    ->inject('usage')
+    ->action(function (string $functionId, string $data, bool $async, Response $response, Document $project, Database $dbForProject, Document $user, Event $events, Stats $usage) {
 
         $function = Authorization::skip(fn () => $dbForProject->getDocument('functions', $functionId));
 
@@ -957,6 +958,12 @@ App::post('/v1/functions/:functionId/executions')
         }
 
         Authorization::skip(fn () => $dbForProject->updateDocument('executions', $executionId, $execution));
+
+        $usage
+            ->setParam('functionId', $function->getId())
+            ->setParam('functionExecution', 1)
+            ->setParam('functionStatus', $execution->getAttribute('status', ''))
+            ->setParam('functionExecutionTime', $execution->getAttribute('time') * 1000); // ms
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)


### PR DESCRIPTION
## What does this PR do?

In the dashboard of the project, I can only see functions counter for executions made from the console manually (with async=true). In my app, I set async=false, and those are not counted.

This PR addresses the problem above.

## Test Plan

- [x] Manual QA. Made a bunch of async=false executions using Insomnia. Waited 30 min. Got new stats.

![CleanShot 2022-07-13 at 12 30 39](https://user-images.githubusercontent.com/19310830/178713456-7feb1fad-3ad6-4b11-ac4f-5855eb5527a3.png)

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
