### PR TITLE
Stopping state change on canceling confirm box

### DIFF
--- a/public/dist/scripts/app-all.js
+++ b/public/dist/scripts/app-all.js
@@ -3872,7 +3872,8 @@ return result;};let resolve=function(target,prefix="param",data={}){if(!target){
 let args=getParams(target);return target.apply(target,args.map(function(value){let result=getValue(value,prefix,data);return result??undefined;}));};let exec=function(event){let parsedSuccess=expression.parse(success);let parsedFailure=expression.parse(failure);let parsedAction=expression.parse(action);parsedSuccess=parsedSuccess&&parsedSuccess!=""?parsedSuccess.split(",").map(element=>element.trim()):[];parsedFailure=parsedFailure&&parsedFailure!=""?parsedFailure.split(",").map(element=>element.trim()):[];element.$lsSkip=true;element.classList.add("load-service-start");if(!document.body.contains(element)){element=undefined;return false;}
 if(event){event.preventDefault();}
 if(running){return false;}
-running=true;element.style.backgroud='red';if(confirm){if(window.confirm(confirm)!==true){element.classList.add("load-service-end");element.$lsSkip=false;running=false;return false;}}
+running=true;element.style.backgroud='red';if(confirm){if(window.confirm(confirm)!==true){element.classList.add("load-service-end");element.$lsSkip=false;running=false;var childInput=element.querySelectorAll('[type=checkbox]');if(childInput.length===1){childInput[0].checked=childInput[0].checked?false:true;}
+return false;}}
 if(loading){loaderId=alerts.add({text:loading,class:""},0);}
 let method=container.path(scope+"."+parsedAction);if(!method){throw new Error('Method "'+scope+"."+parsedAction+'" not found');}
 let formData="FORM"===element.tagName?form.toJson(element):{};let result=resolve(method,"param",formData);if(!result){return;}

--- a/public/dist/scripts/app.js
+++ b/public/dist/scripts/app.js
@@ -724,7 +724,8 @@ return result;};let resolve=function(target,prefix="param",data={}){if(!target){
 let args=getParams(target);return target.apply(target,args.map(function(value){let result=getValue(value,prefix,data);return result??undefined;}));};let exec=function(event){let parsedSuccess=expression.parse(success);let parsedFailure=expression.parse(failure);let parsedAction=expression.parse(action);parsedSuccess=parsedSuccess&&parsedSuccess!=""?parsedSuccess.split(",").map(element=>element.trim()):[];parsedFailure=parsedFailure&&parsedFailure!=""?parsedFailure.split(",").map(element=>element.trim()):[];element.$lsSkip=true;element.classList.add("load-service-start");if(!document.body.contains(element)){element=undefined;return false;}
 if(event){event.preventDefault();}
 if(running){return false;}
-running=true;element.style.backgroud='red';if(confirm){if(window.confirm(confirm)!==true){element.classList.add("load-service-end");element.$lsSkip=false;running=false;return false;}}
+running=true;element.style.backgroud='red';if(confirm){if(window.confirm(confirm)!==true){element.classList.add("load-service-end");element.$lsSkip=false;running=false;var childInput=element.querySelectorAll('[type=checkbox]');if(childInput.length===1){childInput[0].checked=childInput[0].checked?false:true;}
+return false;}}
 if(loading){loaderId=alerts.add({text:loading,class:""},0);}
 let method=container.path(scope+"."+parsedAction);if(!method){throw new Error('Method "'+scope+"."+parsedAction+'" not found');}
 let formData="FORM"===element.tagName?form.toJson(element):{};let result=resolve(method,"param",formData);if(!result){return;}

--- a/public/scripts/views/service.js
+++ b/public/scripts/views/service.js
@@ -308,6 +308,11 @@
             element.classList.add("load-service-end");
             element.$lsSkip = false;
             running = false;
+            // Do not change checkbox status if confirm box is cancelled 
+            var childInput = element.querySelectorAll('[type=checkbox]');
+            if (childInput.length === 1) {
+              childInput[0].checked = childInput[0].checked? false: true;
+            }
             return false;
           }
         }


### PR DESCRIPTION
- added logic to preserve the checkbox state after canceling the confirm box
- compiled code from new changes

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Issue fix on home > settings > services page

## Test Plan

**Case - 1**

- Go to Home > Settings > Services page
- Click on any service checkbox
- A confirm box pop-up will come
- Click on the "cancel" button on confirm box
- The checkbox state should not change

**Case-2**

- Go to Home > Settings > Services page
- Click on any service checkbox
- A confirm box pop-up will come
- Click on the "ok" button on confirm box
- The checkbox state should change 

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/3412

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
