### PR TITLE
Fixing #3583 - create team membership to return added person name and…

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -427,8 +427,8 @@ App::post('/v1/teams/:teamId/memberships')
         $response->dynamic(
             $membership
             ->setAttribute('teamName', $team->getAttribute('name'))
-            ->setAttribute('userName', $name)
-            ->setAttribute('userEmail', $email),
+            ->setAttribute('userName', $invitee->getAttribute('name'))
+            ->setAttribute('userEmail', $invitee->getAttribute('email')),
             Response::MODEL_MEMBERSHIP
         );
     });

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -427,8 +427,8 @@ App::post('/v1/teams/:teamId/memberships')
         $response->dynamic(
             $membership
             ->setAttribute('teamName', $team->getAttribute('name'))
-            ->setAttribute('userName', $user->getAttribute('name'))
-            ->setAttribute('userEmail', $user->getAttribute('email')),
+            ->setAttribute('userName', $name)
+            ->setAttribute('userEmail', $email),
             Response::MODEL_MEMBERSHIP
         );
     });

--- a/tests/e2e/Services/Teams/TeamsBaseClient.php
+++ b/tests/e2e/Services/Teams/TeamsBaseClient.php
@@ -107,6 +107,8 @@ trait TeamsBaseClient
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertNotEmpty($response['body']['userId']);
+        $this->assertEquals($name, $response['body']['userName']);
+        $this->assertEquals($email, $response['body']['userEmail']);
         $this->assertNotEmpty($response['body']['teamId']);
         $this->assertNotEmpty($response['body']['teamName']);
         $this->assertCount(2, $response['body']['roles']);

--- a/tests/e2e/Services/Teams/TeamsBaseServer.php
+++ b/tests/e2e/Services/Teams/TeamsBaseServer.php
@@ -57,6 +57,8 @@ trait TeamsBaseServer
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertNotEmpty($response['body']['userId']);
+        $this->assertEquals('Friend User', $response['body']['userName']);
+        $this->assertEquals($email, $response['body']['userEmail']);
         $this->assertNotEmpty($response['body']['teamId']);
         $this->assertCount(2, $response['body']['roles']);
         $this->assertIsInt($response['body']['joined']);


### PR DESCRIPTION
## What does this PR do?
Hi, this PR should fix the issue where the info of the person who's creating the membership is returned instead of the person being added information.

## Test Plan

I've added two assertions in both `TeamsBaseServer` and `TeamsBaseClient` to ensure that data of the user being added are returned as expected.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/3583

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES
