### PR TITLE
fix for null issue during document create event

### DIFF
--- a/public/scripts/services/form.js
+++ b/public/scripts/services/form.js
@@ -20,7 +20,7 @@
                     value = parseFloat(value);
                     break;
                 case 'string':
-                    value = value.toString();
+                    value = (typeof value === 'undefined' || value === null) ? "": value.toString();
                     if (value.length === 0) {
                         value = null;
                     }


### PR DESCRIPTION
- Added null & undefined type check in form.js

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix for the defect. It does the null check on value for array type field.

## Test Plan
Pre-requisite:
- Go to 'Database' page and create a new 'Collection'
- Create attributes, here at least one attribute should be marked 'Array' as required & 'Required' as optional.
- Once 'Collection' is created.

Test case - 1:
1) Go to Create a new 'Document' page
2) Click on 'Add Attribute' for 'Array' attribute minimum 2 times
3) Do not enter anything in the Value field
4) Create the Document and the document should be created with empty values

Test case - 2:
1) Go to Create a new 'Document' page
2) Click on 'Add Attribute' for 'Array' attribute 1 time
3) Do not enter anything in the Value field
4) Create the Document and the document should be created with empty values

Test case - 3:
1) Select any existing document
2) Update data with different values.
3) document should be updated

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/3528

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
