### PR TITLE
Fix: OAuth duplication error

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -540,7 +540,11 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
 
         Authorization::setRole('user:' . $user->getId());
 
-        $dbForProject->updateDocument('users', $user->getId(), $user);
+        try {
+            $dbForProject->updateDocument('users', $user->getId(), $user);
+        } catch (Duplicate $th) {
+            throw new Exception('Account already exists', 409, Exception::USER_ALREADY_EXISTS);
+        }
 
         $session = $dbForProject->createDocument('sessions', $session
             ->setAttribute('$read', ['user:' . $user->getId()])


### PR DESCRIPTION
## What does this PR do?

When claiming an anonymous account with an OAuth2 provider, if an account with such an email exists, you end up with a 500 error. With this PR, we throw a proper error message.

For developers, a solution is to first delete the anonymous session before signing in, to go through the signing flow instead of the account claiming flow.

## Test Plan

- [ ] Manual QA

## Related PRs and Issues

Reported on Discord as unexpected behavior.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
