### PR TITLE
Improve duplicate exception messages

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1858,7 +1858,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/documents')
         } catch (StructureException $exception) {
             throw new Exception(Exception::DOCUMENT_INVALID_STRUCTURE, $exception->getMessage());
         } catch (DuplicateException $exception) {
-            throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS);
+            throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS, $exception->getMessage());
         }
 
         $events
@@ -2269,7 +2269,7 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
         } catch (AuthorizationException $exception) {
             throw new Exception(Exception::USER_UNAUTHORIZED);
         } catch (DuplicateException $exception) {
-            throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS);
+            throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS, $exception->getMessage());
         } catch (StructureException $exception) {
             throw new Exception(Exception::DOCUMENT_INVALID_STRUCTURE, $exception->getMessage());
         }

--- a/composer.lock
+++ b/composer.lock
@@ -3524,23 +3524,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.15",
+            "version": "9.2.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2593003befdcc10db5e213f9f28814f5aa8ac073",
+                "reference": "2593003befdcc10db5e213f9f28814f5aa8ac073",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.13.0",
+                "nikic/php-parser": "^4.14",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3589,7 +3589,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.16"
             },
             "funding": [
                 {
@@ -3597,7 +3597,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-07T09:28:20+00:00"
+            "time": "2022-08-20T05:26:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5370,5 +5370,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## What does this PR do?

In the current implementation, there are 2 problems:

- It always says ID is duplicated for all duplication errors
- It doesn't tell you any info if your custom unique index fails

I addressed this by giving more info on the duplicate error for databases service.

Before:

```js
{"message":"Document with the requested ID already exists.","code":409,"type":"document_already_exists"}
```

After:

```js
{"message":"Duplicated document: Duplicate entry 'Matej' for key 'name'","code":409,"type":"document_already_exists"}
```

A problem that was created is a message about duplicate ID:

```
Duplicated document: Duplicate entry '123' for key '_index1'
```

This may be solved on library-level by giving indexes a proper name depending on what they hold: https://github.com/utopia-php/database/pull/171

New message would be:

```
Duplicated document: Duplicate entry '123' for key '_uid'
```

## Test Plan

Current tests must pass.

## Related PRs and Issues

Issues:
- https://github.com/appwrite/appwrite/issues/3627

PRs:
- https://github.com/utopia-php/database/pull/171

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes 💪
