### PR TITLE
disable email notification on membership create, add secret to response

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -298,6 +298,7 @@ App::post('/v1/teams/:teamId/memberships')
 
         $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
         $isAppUser = Auth::isAppUser(Authorization::getRoles());
+        $useEmail = App::getEnv('_APP_SMTP_USE_EMAIL', false);
 
         if (!$isPrivilegedUser && !$isAppUser && empty(App::getEnv('_APP_SMTP_HOST'))) {
             throw new Exception('SMTP Disabled', 503, Exception::GENERAL_SMTP_DISABLED);
@@ -401,7 +402,7 @@ App::post('/v1/teams/:teamId/memberships')
         $url['query'] = Template::mergeQuery(((isset($url['query'])) ? $url['query'] : ''), ['membershipId' => $membership->getId(), 'userId' => $invitee->getId(), 'secret' => $secret, 'teamId' => $teamId]);
         $url = Template::unParseURL($url);
 
-        if (!$isPrivilegedUser && !$isAppUser) { // No need of confirmation when in admin or app mode
+        if (!$isPrivilegedUser && !$isAppUser && $useEmail) { // No need of confirmation when in admin or app mode
             $mails
                 ->setType(MAIL_TYPE_INVITATION)
                 ->setRecipient($email)
@@ -421,6 +422,12 @@ App::post('/v1/teams/:teamId/memberships')
         $events
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId())
+            ->setPayload(
+                $response->output(
+                    $membership->setAttribute('secret', $secret),
+                    Response::MODEL_MEMBERSHIP
+                )
+            );
         ;
 
         $response->setStatusCode(Response::STATUS_CODE_CREATED);

--- a/src/Appwrite/Utopia/Response/Model/Membership.php
+++ b/src/Appwrite/Utopia/Response/Model/Membership.php
@@ -64,6 +64,12 @@ class Membership extends Model
                 'default' => 0,
                 'example' => 1592981250,
             ])
+            ->addRule('secret', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Token secret key. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'default' => '',
+                'example' => '',
+            ])
             ->addRule('joined', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Date, the user has accepted the invitation to join the team in Unix timestamp.',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Disable email verification for membership.create. Add secret to event response.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
