### PR TITLE
Fix assertion ordering

### DIFF
--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -39,7 +39,7 @@ class AccountCustomClientTest extends Scope
             'secret' => $secret,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account/sessions/oauth2/' . $provider, array_merge([
             'origin' => 'http://localhost',
@@ -78,7 +78,7 @@ class AccountCustomClientTest extends Scope
 
         $id = $response['body']['$id'];
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -89,7 +89,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         $sessionId = $response['body']['$id'];
         $session = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
@@ -101,7 +101,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_PATCH, '/users/' . $id . '/status', [
             'content-type' => 'application/json',
@@ -111,7 +111,7 @@ class AccountCustomClientTest extends Scope
             'status' => false,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
             'origin' => 'http://localhost',
@@ -120,7 +120,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -131,7 +131,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         return [];
     }
@@ -159,7 +159,7 @@ class AccountCustomClientTest extends Scope
 
         $id = $response['body']['$id'];
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -170,7 +170,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         $session = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
 
@@ -181,7 +181,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_PATCH, '/account/status', [
             'content-type' => 'application/json',
@@ -191,7 +191,7 @@ class AccountCustomClientTest extends Scope
             'status' => false,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
             'origin' => 'http://localhost',
@@ -200,7 +200,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -211,7 +211,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         return [];
     }
@@ -238,7 +238,7 @@ class AccountCustomClientTest extends Scope
 
         $id = $response['body']['$id'];
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -249,7 +249,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         $sessionId = $response['body']['$id'];
         $session = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
@@ -261,7 +261,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/jwt', array_merge([
             'origin' => 'http://localhost',
@@ -270,8 +270,8 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 201);
-        $this->assertEquals($response['headers']['x-ratelimit-remaining'], 99);
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals(99, $response['headers']['x-ratelimit-remaining']);
         $this->assertNotEmpty($response['body']['jwt']);
         $this->assertIsString($response['body']['jwt']);
 
@@ -284,7 +284,7 @@ class AccountCustomClientTest extends Scope
             'x-appwrite-jwt' => 'wrong-token',
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
             'origin' => 'http://localhost',
@@ -293,7 +293,7 @@ class AccountCustomClientTest extends Scope
             'x-appwrite-jwt' => $jwt,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_DELETE, '/account/sessions/' . $sessionId, array_merge([
             'origin' => 'http://localhost',
@@ -302,7 +302,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 204);
+        $this->assertEquals(204, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
             'origin' => 'http://localhost',
@@ -311,7 +311,7 @@ class AccountCustomClientTest extends Scope
             'x-appwrite-jwt' => $jwt,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         return [];
     }
@@ -425,7 +425,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 409);
+        $this->assertEquals(409, $response['headers']['status-code']);
 
         /**
          * Test for SUCCESS
@@ -442,7 +442,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
@@ -458,7 +458,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         return [];
     }
@@ -480,7 +480,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $userId = $response['body']['$id'] ?? '';
 
@@ -495,7 +495,7 @@ class AccountCustomClientTest extends Scope
             'secret' => $secret,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account/sessions/oauth2/' . $provider, array_merge([
             'origin' => 'http://localhost',
@@ -519,14 +519,14 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals($response['body']['$id'], $userId);
-        $this->assertEquals($response['body']['name'], 'User Name');
-        $this->assertEquals($response['body']['email'], 'useroauth@localhost.test');
+        $this->assertEquals('User Name', $response['body']['name']);
+        $this->assertEquals('useroauth@localhost.test', $response['body']['email']);
 
         // Since we only support one oauth user, let's also check updateSession here
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account/sessions/current', array_merge([
             'origin' => 'http://localhost',
@@ -570,8 +570,8 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals($response['body']['provider'], 'anonymous');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('anonymous', $response['body']['provider']);
 
         $sessionID = $response['body']['$id'];
 
@@ -582,8 +582,8 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals($response['body']['provider'], 'anonymous');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('anonymous', $response['body']['provider']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account/sessions/97823askjdkasd80921371980', array_merge([
             'origin' => 'http://localhost',
@@ -592,7 +592,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 404);
+        $this->assertEquals(404, $response['headers']['status-code']);
     }
 
     /**
@@ -615,7 +615,7 @@ class AccountCustomClientTest extends Scope
             'search' => $newName
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['users']);
         $this->assertCount(1, $response['body']['users']);
@@ -629,7 +629,7 @@ class AccountCustomClientTest extends Scope
             'search' => $id
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['users']);
         $this->assertCount(1, $response['body']['users']);
@@ -655,7 +655,7 @@ class AccountCustomClientTest extends Scope
             'search' => '"' . $email . '"'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['users']);
         $this->assertCount(1, $response['body']['users']);
@@ -669,7 +669,7 @@ class AccountCustomClientTest extends Scope
             'search' => $id
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['users']);
         $this->assertCount(1, $response['body']['users']);
@@ -781,7 +781,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertIsNumeric($response['body']['registration']);
@@ -831,7 +831,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
@@ -847,7 +847,7 @@ class AccountCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         return $data;
     }
@@ -873,7 +873,7 @@ class AccountCustomClientTest extends Scope
             'password' => 'new-password'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
@@ -889,7 +889,7 @@ class AccountCustomClientTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 401);
+        $this->assertEquals(401, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_PATCH, '/account/phone', array_merge([
             'origin' => 'http://localhost',
@@ -898,7 +898,7 @@ class AccountCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]), []);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         $data['phone'] = $newPhone;
 

--- a/tests/e2e/Services/Databases/DatabasesConsoleClientTest.php
+++ b/tests/e2e/Services/Databases/DatabasesConsoleClientTest.php
@@ -40,8 +40,8 @@ class DatabasesConsoleClientTest extends Scope
             'permission' => 'document',
         ]);
 
-        $this->assertEquals($movies['headers']['status-code'], 201);
-        $this->assertEquals($movies['body']['name'], 'Movies');
+        $this->assertEquals(201, $movies['headers']['status-code']);
+        $this->assertEquals('Movies', $movies['body']['name']);
 
         return ['moviesId' => $movies['body']['$id'], 'databaseId' => $databaseId];
     }
@@ -109,7 +109,7 @@ class DatabasesConsoleClientTest extends Scope
             'range' => '32h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/randomCollectionId/usage', array_merge([
             'content-type' => 'application/json',
@@ -118,7 +118,7 @@ class DatabasesConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 404);
+        $this->assertEquals(404, $response['headers']['status-code']);
 
         /**
          * Test for SUCCESS
@@ -130,9 +130,9 @@ class DatabasesConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals(count($response['body']), 6);
-        $this->assertEquals($response['body']['range'], '24h');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(6, count($response['body']));
+        $this->assertEquals('24h', $response['body']['range']);
         $this->assertIsArray($response['body']['documentsCount']);
         $this->assertIsArray($response['body']['documentsCreate']);
         $this->assertIsArray($response['body']['documentsRead']);
@@ -154,7 +154,7 @@ class DatabasesConsoleClientTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($logs['headers']['status-code'], 200);
+        $this->assertEquals(200, $logs['headers']['status-code']);
         $this->assertIsArray($logs['body']['logs']);
         $this->assertIsNumeric($logs['body']['total']);
 
@@ -165,7 +165,7 @@ class DatabasesConsoleClientTest extends Scope
             'limit' => 1
         ]);
 
-        $this->assertEquals($logs['headers']['status-code'], 200);
+        $this->assertEquals(200, $logs['headers']['status-code']);
         $this->assertIsArray($logs['body']['logs']);
         $this->assertLessThanOrEqual(1, count($logs['body']['logs']));
         $this->assertIsNumeric($logs['body']['total']);
@@ -177,7 +177,7 @@ class DatabasesConsoleClientTest extends Scope
             'offset' => 1
         ]);
 
-        $this->assertEquals($logs['headers']['status-code'], 200);
+        $this->assertEquals(200, $logs['headers']['status-code']);
         $this->assertIsArray($logs['body']['logs']);
         $this->assertIsNumeric($logs['body']['total']);
 
@@ -189,7 +189,7 @@ class DatabasesConsoleClientTest extends Scope
             'limit' => 1
         ]);
 
-        $this->assertEquals($logs['headers']['status-code'], 200);
+        $this->assertEquals(200, $logs['headers']['status-code']);
         $this->assertIsArray($logs['body']['logs']);
         $this->assertLessThanOrEqual(1, count($logs['body']['logs']));
         $this->assertIsNumeric($logs['body']['total']);

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -392,7 +392,7 @@ class DatabasesCustomServerTest extends Scope
             'cursor' => 'unknown',
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         // This collection already exists
         $response = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections', array_merge([
@@ -407,7 +407,7 @@ class DatabasesCustomServerTest extends Scope
             'permission' => 'document'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 409);
+        $this->assertEquals(409, $response['headers']['status-code']);
     }
 
     public function testDeleteAttribute(): array
@@ -441,8 +441,8 @@ class DatabasesCustomServerTest extends Scope
             'permission' => 'document'
         ]);
 
-        $this->assertEquals($actors['headers']['status-code'], 201);
-        $this->assertEquals($actors['body']['name'], 'Actors');
+        $this->assertEquals(201, $actors['headers']['status-code']);
+        $this->assertEquals('Actors', $actors['body']['name']);
 
         $firstName = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $actors['body']['$id'] . '/attributes/string', array_merge([
             'content-type' => 'application/json',
@@ -516,7 +516,7 @@ class DatabasesCustomServerTest extends Scope
 
         $unneededId = $unneeded['body']['key'];
 
-        $this->assertEquals($collection['headers']['status-code'], 200);
+        $this->assertEquals(200, $collection['headers']['status-code']);
         $this->assertIsArray($collection['body']['attributes']);
         $this->assertCount(3, $collection['body']['attributes']);
         $this->assertEquals($collection['body']['attributes'][0]['key'], $firstName['body']['key']);
@@ -532,7 +532,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($attribute['headers']['status-code'], 204);
+        $this->assertEquals(204, $attribute['headers']['status-code']);
 
         sleep(2);
 
@@ -551,7 +551,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]), []);
 
-        $this->assertEquals($collection['headers']['status-code'], 200);
+        $this->assertEquals(200, $collection['headers']['status-code']);
         $this->assertIsArray($collection['body']['attributes']);
         $this->assertCount(2, $collection['body']['attributes']);
         $this->assertEquals($collection['body']['attributes'][0]['key'], $firstName['body']['key']);
@@ -576,7 +576,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($index['headers']['status-code'], 204);
+        $this->assertEquals(204, $index['headers']['status-code']);
 
         // Wait for database worker to finish deleting index
         sleep(2);
@@ -660,7 +660,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($deleted['headers']['status-code'], 204);
+        $this->assertEquals(204, $deleted['headers']['status-code']);
 
         // wait for database worker to complete
         sleep(2);
@@ -686,7 +686,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($deleted['headers']['status-code'], 204);
+        $this->assertEquals(204, $deleted['headers']['status-code']);
 
         return $data;
     }
@@ -784,7 +784,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($deleted['headers']['status-code'], 204);
+        $this->assertEquals(204, $deleted['headers']['status-code']);
 
         // wait for database worker to complete
         sleep(2);
@@ -810,7 +810,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($deleted['headers']['status-code'], 204);
+        $this->assertEquals(204, $deleted['headers']['status-code']);
     }
 
     /**
@@ -848,21 +848,21 @@ class DatabasesCustomServerTest extends Scope
             'write' => ['user:' . $this->getUser()['$id']],
         ]);
 
-        $this->assertEquals($document1['headers']['status-code'], 201);
+        $this->assertEquals(201, $document1['headers']['status-code']);
         $this->assertIsArray($document1['body']['$read']);
         $this->assertIsArray($document1['body']['$write']);
         $this->assertCount(1, $document1['body']['$read']);
         $this->assertCount(1, $document1['body']['$write']);
-        $this->assertEquals($document1['body']['firstName'], 'Tom');
-        $this->assertEquals($document1['body']['lastName'], 'Holland');
+        $this->assertEquals('Tom', $document1['body']['firstName']);
+        $this->assertEquals('Holland', $document1['body']['lastName']);
 
-        $this->assertEquals($document2['headers']['status-code'], 201);
+        $this->assertEquals(201, $document2['headers']['status-code']);
         $this->assertIsArray($document2['body']['$read']);
         $this->assertIsArray($document2['body']['$write']);
         $this->assertCount(1, $document2['body']['$read']);
         $this->assertCount(1, $document2['body']['$write']);
-        $this->assertEquals($document2['body']['firstName'], 'Samuel');
-        $this->assertEquals($document2['body']['lastName'], 'Jackson');
+        $this->assertEquals('Samuel', $document2['body']['firstName']);
+        $this->assertEquals('Jackson', $document2['body']['lastName']);
 
         // Delete the actors collection
         $response = $this->client->call(Client::METHOD_DELETE, '/databases/' . $databaseId . '/collections/' . $collectionId, array_merge([
@@ -871,8 +871,8 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ], $this->getHeaders()));
 
-        $this->assertEquals($response['headers']['status-code'], 204);
-        $this->assertEquals($response['body'], "");
+        $this->assertEquals(204, $response['headers']['status-code']);
+        $this->assertEquals("", $response['body']);
 
         // Try to get the collection and check if it has been deleted
         $response = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $collectionId, array_merge([
@@ -880,7 +880,7 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id']
         ], $this->getHeaders()));
 
-        $this->assertEquals($response['headers']['status-code'], 404);
+        $this->assertEquals(404, $response['headers']['status-code']);
     }
 
     // Adds several minutes to test to replicate coverage in Utopia\Database unit tests
@@ -963,8 +963,8 @@ class DatabasesCustomServerTest extends Scope
             'permission' => 'document',
         ]);
 
-        $this->assertEquals($collection['headers']['status-code'], 201);
-        $this->assertEquals($collection['body']['name'], 'attributeRowWidthLimit');
+        $this->assertEquals(201, $collection['headers']['status-code']);
+        $this->assertEquals('attributeRowWidthLimit', $collection['body']['name']);
 
         $collectionId = $collection['body']['$id'];
 
@@ -980,7 +980,7 @@ class DatabasesCustomServerTest extends Scope
                 'required' => true,
             ]);
 
-            $this->assertEquals($attribute['headers']['status-code'], 201);
+            $this->assertEquals(201, $attribute['headers']['status-code']);
         }
 
         sleep(5);
@@ -1025,8 +1025,8 @@ class DatabasesCustomServerTest extends Scope
             'permission' => 'document',
         ]);
 
-        $this->assertEquals($collection['headers']['status-code'], 201);
-        $this->assertEquals($collection['body']['name'], 'testLimitException');
+        $this->assertEquals(201, $collection['headers']['status-code']);
+        $this->assertEquals('testLimitException', $collection['body']['name']);
 
         $collectionId = $collection['body']['$id'];
 
@@ -1043,7 +1043,7 @@ class DatabasesCustomServerTest extends Scope
                 'required' => true,
             ]);
 
-            $this->assertEquals($attribute['headers']['status-code'], 201);
+            $this->assertEquals(201, $attribute['headers']['status-code']);
         }
 
         sleep(20);
@@ -1054,8 +1054,8 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($collection['headers']['status-code'], 200);
-        $this->assertEquals($collection['body']['name'], 'testLimitException');
+        $this->assertEquals(200, $collection['headers']['status-code']);
+        $this->assertEquals('testLimitException', $collection['body']['name']);
         $this->assertIsArray($collection['body']['attributes']);
         $this->assertIsArray($collection['body']['indexes']);
         $this->assertCount(64, $collection['body']['attributes']);
@@ -1092,8 +1092,8 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]));
 
-        $this->assertEquals($collection['headers']['status-code'], 200);
-        $this->assertEquals($collection['body']['name'], 'testLimitException');
+        $this->assertEquals(200, $collection['headers']['status-code']);
+        $this->assertEquals('testLimitException', $collection['body']['name']);
         $this->assertIsArray($collection['body']['attributes']);
         $this->assertIsArray($collection['body']['indexes']);
         $this->assertCount(64, $collection['body']['attributes']);

--- a/tests/e2e/Services/Functions/FunctionsConsoleClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsConsoleClientTest.php
@@ -92,9 +92,9 @@ class FunctionsConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals(count($response['body']), 4);
-        $this->assertEquals($response['body']['range'], '24h');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(4, count($response['body']));
+        $this->assertEquals('24h', $response['body']['range']);
         $this->assertIsArray($response['body']['functionsExecutions']);
         $this->assertIsArray($response['body']['functionsFailures']);
         $this->assertIsArray($response['body']['functionsCompute']);

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -90,9 +90,9 @@ class FunctionsCustomServerTest extends Scope
             'search' => $data['functionId']
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(1, $response['body']['functions']);
-        $this->assertEquals($response['body']['functions'][0]['name'], 'Test');
+        $this->assertEquals('Test', $response['body']['functions'][0]['name']);
 
         $response = $this->client->call(Client::METHOD_GET, '/functions', array_merge([
             'content-type' => 'application/json',
@@ -101,7 +101,7 @@ class FunctionsCustomServerTest extends Scope
             'search' => 'Test'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(1, $response['body']['functions']);
         $this->assertEquals($response['body']['functions'][0]['$id'], $data['functionId']);
 
@@ -112,7 +112,7 @@ class FunctionsCustomServerTest extends Scope
             'search' => 'php-8.0'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(1, $response['body']['functions']);
         $this->assertEquals($response['body']['functions'][0]['$id'], $data['functionId']);
 
@@ -145,12 +145,12 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($functions['headers']['status-code'], 200);
-        $this->assertEquals($functions['body']['total'], 2);
+        $this->assertEquals(200, $functions['headers']['status-code']);
+        $this->assertEquals(2, $functions['body']['total']);
         $this->assertIsArray($functions['body']['functions']);
         $this->assertCount(2, $functions['body']['functions']);
-        $this->assertEquals($functions['body']['functions'][0]['name'], 'Test');
-        $this->assertEquals($functions['body']['functions'][1]['name'], 'Test 2');
+        $this->assertEquals('Test', $functions['body']['functions'][0]['name']);
+        $this->assertEquals('Test 2', $functions['body']['functions'][1]['name']);
 
         $response = $this->client->call(Client::METHOD_GET, '/functions', array_merge([
             'content-type' => 'application/json',
@@ -159,9 +159,9 @@ class FunctionsCustomServerTest extends Scope
             'cursor' => $functions['body']['functions'][0]['$id']
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(1, $response['body']['functions']);
-        $this->assertEquals($response['body']['functions'][0]['name'], 'Test 2');
+        $this->assertEquals('Test 2', $response['body']['functions'][0]['name']);
 
         $response = $this->client->call(Client::METHOD_GET, '/functions', array_merge([
             'content-type' => 'application/json',
@@ -171,9 +171,9 @@ class FunctionsCustomServerTest extends Scope
             'cursorDirection' => Database::CURSOR_BEFORE
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(1, $response['body']['functions']);
-        $this->assertEquals($response['body']['functions'][0]['name'], 'Test');
+        $this->assertEquals('Test', $response['body']['functions'][0]['name']);
 
         /**
          * Test for FAILURE
@@ -185,7 +185,7 @@ class FunctionsCustomServerTest extends Scope
             'cursor' => 'unknown',
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         return $data;
     }
@@ -203,8 +203,8 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
-        $this->assertEquals($function['body']['name'], 'Test');
+        $this->assertEquals(200, $function['headers']['status-code']);
+        $this->assertEquals('Test', $function['body']['name']);
 
         /**
          * Test for FAILURE
@@ -214,7 +214,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 404);
+        $this->assertEquals(404, $function['headers']['status-code']);
 
         return $data;
     }
@@ -389,8 +389,8 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
-        $this->assertEquals($function['body']['total'], 2);
+        $this->assertEquals(200, $function['headers']['status-code']);
+        $this->assertEquals(2, $function['body']['total']);
         $this->assertIsArray($function['body']['deployments']);
         $this->assertCount(2, $function['body']['deployments']);
 
@@ -404,7 +404,7 @@ class FunctionsCustomServerTest extends Scope
             'search' => $data['functionId']
         ]));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
+        $this->assertEquals(200, $function['headers']['status-code']);
         $this->assertEquals(2, $function['body']['total']);
         $this->assertIsArray($function['body']['deployments']);
         $this->assertCount(2, $function['body']['deployments']);
@@ -417,7 +417,7 @@ class FunctionsCustomServerTest extends Scope
             'search' => 'Test'
         ]));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
+        $this->assertEquals(200, $function['headers']['status-code']);
         $this->assertEquals(2, $function['body']['total']);
         $this->assertIsArray($function['body']['deployments']);
         $this->assertCount(2, $function['body']['deployments']);
@@ -430,7 +430,7 @@ class FunctionsCustomServerTest extends Scope
             'search' => 'php-8.0'
         ]));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
+        $this->assertEquals(200, $function['headers']['status-code']);
         $this->assertEquals(2, $function['body']['total']);
         $this->assertIsArray($function['body']['deployments']);
         $this->assertCount(2, $function['body']['deployments']);
@@ -462,7 +462,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 404);
+        $this->assertEquals(404, $function['headers']['status-code']);
 
         return $data;
     }
@@ -540,8 +540,8 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
-        $this->assertEquals($function['body']['total'], 1);
+        $this->assertEquals(200, $function['headers']['status-code']);
+        $this->assertEquals(1, $function['body']['total']);
         $this->assertIsArray($function['body']['executions']);
         $this->assertCount(1, $function['body']['executions']);
         $this->assertEquals($function['body']['executions'][0]['$id'], $data['executionId']);
@@ -622,7 +622,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 200);
+        $this->assertEquals(200, $function['headers']['status-code']);
         $this->assertEquals($function['body']['$id'], $data['executionId']);
 
         /**
@@ -633,7 +633,7 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($function['headers']['status-code'], 404);
+        $this->assertEquals(404, $function['headers']['status-code']);
 
         return $data;
     }
@@ -756,19 +756,19 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($executions['headers']['status-code'], 200);
-        $this->assertEquals($executions['body']['total'], 1);
+        $this->assertEquals(200, $executions['headers']['status-code']);
+        $this->assertEquals(1, $executions['body']['total']);
         $this->assertIsArray($executions['body']['executions']);
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
-        $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
-        $this->assertEquals($executions['body']['executions'][0]['status'], 'failed');
-        $this->assertEquals($executions['body']['executions'][0]['statusCode'], 500);
+        $this->assertEquals('http', $executions['body']['executions'][0]['trigger']);
+        $this->assertEquals('failed', $executions['body']['executions'][0]['status']);
+        $this->assertEquals(500, $executions['body']['executions'][0]['statusCode']);
         $this->assertGreaterThan(2, $executions['body']['executions'][0]['time']);
         $this->assertLessThan(6, $executions['body']['executions'][0]['time']);
         $this->assertGreaterThan(4, $executions['body']['executions'][0]['time']);
-        $this->assertEquals($executions['body']['executions'][0]['response'], '');
-        $this->assertEquals($executions['body']['executions'][0]['stderr'], 'An internal curl error has occurred within the executor! Error Msg: Operation timed out');
+        $this->assertEquals('', $executions['body']['executions'][0]['response']);
+        $this->assertEquals('An internal curl error has occurred within the executor! Error Msg: Operation timed out', $executions['body']['executions'][0]['stderr']);
 
         // Cleanup : Delete function
         $response = $this->client->call(Client::METHOD_DELETE, '/functions/' . $functionId, [
@@ -872,12 +872,12 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($executions['headers']['status-code'], 200);
-        $this->assertEquals($executions['body']['total'], 1);
+        $this->assertEquals(200, $executions['headers']['status-code']);
+        $this->assertEquals(1, $executions['body']['total']);
         $this->assertIsArray($executions['body']['executions']);
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
-        $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
+        $this->assertEquals('http', $executions['body']['executions'][0]['trigger']);
         $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function
@@ -978,12 +978,12 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($executions['headers']['status-code'], 200);
-        $this->assertEquals($executions['body']['total'], 1);
+        $this->assertEquals(200, $executions['headers']['status-code']);
+        $this->assertEquals(1, $executions['body']['total']);
         $this->assertIsArray($executions['body']['executions']);
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
-        $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
+        $this->assertEquals('http', $executions['body']['executions'][0]['trigger']);
         $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function
@@ -1083,12 +1083,12 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($executions['headers']['status-code'], 200);
-        $this->assertEquals($executions['body']['total'], 1);
+        $this->assertEquals(200, $executions['headers']['status-code']);
+        $this->assertEquals(1, $executions['body']['total']);
         $this->assertIsArray($executions['body']['executions']);
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
-        $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
+        $this->assertEquals('http', $executions['body']['executions'][0]['trigger']);
         $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function
@@ -1188,12 +1188,12 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($executions['headers']['status-code'], 200);
-        $this->assertEquals($executions['body']['total'], 1);
+        $this->assertEquals(200, $executions['headers']['status-code']);
+        $this->assertEquals(1, $executions['body']['total']);
         $this->assertIsArray($executions['body']['executions']);
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
-        $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
+        $this->assertEquals('http', $executions['body']['executions'][0]['trigger']);
         $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function
@@ -1293,12 +1293,12 @@ class FunctionsCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($executions['headers']['status-code'], 200);
-        $this->assertEquals($executions['body']['total'], 1);
+        $this->assertEquals(200, $executions['headers']['status-code']);
+        $this->assertEquals(1, $executions['body']['total']);
         $this->assertIsArray($executions['body']['executions']);
         $this->assertCount(1, $executions['body']['executions']);
         $this->assertEquals($executions['body']['executions'][0]['$id'], $executionId);
-        $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
+        $this->assertEquals('http', $executions['body']['executions'][0]['trigger']);
         $this->assertStringContainsString('foobar', $executions['body']['executions'][0]['response']);
 
         // Cleanup : Delete function

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -109,11 +109,11 @@ class ProjectsConsoleClientTest extends Scope
             'search' => $id
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals($response['body']['total'], 1);
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(1, $response['body']['total']);
         $this->assertIsArray($response['body']['projects']);
         $this->assertCount(1, $response['body']['projects']);
-        $this->assertEquals($response['body']['projects'][0]['name'], 'Project Test');
+        $this->assertEquals('Project Test', $response['body']['projects'][0]['name']);
 
         $response = $this->client->call(Client::METHOD_GET, '/projects', array_merge([
             'content-type' => 'application/json',
@@ -122,8 +122,8 @@ class ProjectsConsoleClientTest extends Scope
             'search' => 'Project Test'
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals($response['body']['total'], 1);
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(1, $response['body']['total']);
         $this->assertIsArray($response['body']['projects']);
         $this->assertCount(1, $response['body']['projects']);
         $this->assertEquals($response['body']['projects'][0]['$id'], $data['projectId']);
@@ -268,7 +268,7 @@ class ProjectsConsoleClientTest extends Scope
         ], $this->getHeaders()));
 
         $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals(count($response['body']), 8);
+        $this->assertEquals(8, count($response['body']));
         $this->assertNotEmpty($response['body']);
         $this->assertEquals('30d', $response['body']['range']);
         $this->assertIsArray($response['body']['requests']);
@@ -478,7 +478,7 @@ class ProjectsConsoleClientTest extends Scope
             'name' => $name,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals(501, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
             'content-type' => 'application/json',
@@ -504,7 +504,7 @@ class ProjectsConsoleClientTest extends Scope
             'url' => 'http://localhost:5000/join-us#title'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals(501, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/jwt', array_merge([
             'content-type' => 'application/json',
@@ -512,7 +512,7 @@ class ProjectsConsoleClientTest extends Scope
             'cookie' => 'a_session_' . $id . '=' . $session,
         ]));
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals(501, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -523,7 +523,7 @@ class ProjectsConsoleClientTest extends Scope
             'password' => $originalPassword,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals(501, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/anonymous', array_merge([
             'origin' => 'http://localhost',
@@ -531,7 +531,7 @@ class ProjectsConsoleClientTest extends Scope
             'x-appwrite-project' => $id,
         ]), []);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals(501, $response['headers']['status-code']);
 
         // Cleanup
 
@@ -585,7 +585,7 @@ class ProjectsConsoleClientTest extends Scope
             'name' => $name,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals(501, $response['headers']['status-code']);
 
         /**
          * Test for FAILURE
@@ -611,7 +611,7 @@ class ProjectsConsoleClientTest extends Scope
             'name' => $name,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 201);
+        $this->assertEquals(201, $response['headers']['status-code']);
 
         return $data;
     }

--- a/tests/e2e/Services/Realtime/RealtimeConsoleClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeConsoleClientTest.php
@@ -177,11 +177,11 @@ class RealtimeConsoleClientTest extends Scope
 
         $attributeKey = $name['body']['key'];
 
-        $this->assertEquals($name['headers']['status-code'], 201);
-        $this->assertEquals($name['body']['key'], 'name');
-        $this->assertEquals($name['body']['type'], 'string');
-        $this->assertEquals($name['body']['size'], 256);
-        $this->assertEquals($name['body']['required'], true);
+        $this->assertEquals(201, $name['headers']['status-code']);
+        $this->assertEquals('name', $name['body']['key']);
+        $this->assertEquals('string', $name['body']['type']);
+        $this->assertEquals(256, $name['body']['size']);
+        $this->assertEquals(true, $name['body']['required']);
         $response = json_decode($client->receive(), true);
 
         $this->assertArrayHasKey('type', $response);
@@ -266,7 +266,7 @@ class RealtimeConsoleClientTest extends Scope
             ],
         ]);
 
-        $this->assertEquals($index['headers']['status-code'], 201);
+        $this->assertEquals(201, $index['headers']['status-code']);
         $indexKey = $index['body']['key'];
 
         $response = json_decode($client->receive(), true);
@@ -342,7 +342,7 @@ class RealtimeConsoleClientTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($attribute['headers']['status-code'], 204);
+        $this->assertEquals(204, $attribute['headers']['status-code']);
         $indexKey = 'key_name';
         $response = json_decode($client->receive(), true);
 
@@ -398,7 +398,7 @@ class RealtimeConsoleClientTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($attribute['headers']['status-code'], 204);
+        $this->assertEquals(204, $attribute['headers']['status-code']);
         $attributeKey = 'name';
         $response = json_decode($client->receive(), true);
 

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -661,11 +661,11 @@ class RealtimeCustomClientTest extends Scope
             'required' => true,
         ]);
 
-        $this->assertEquals($name['headers']['status-code'], 201);
-        $this->assertEquals($name['body']['key'], 'name');
-        $this->assertEquals($name['body']['type'], 'string');
-        $this->assertEquals($name['body']['size'], 256);
-        $this->assertEquals($name['body']['required'], true);
+        $this->assertEquals(201, $name['headers']['status-code']);
+        $this->assertEquals('name', $name['body']['key']);
+        $this->assertEquals('string', $name['body']['type']);
+        $this->assertEquals(256, $name['body']['size']);
+        $this->assertEquals(true, $name['body']['required']);
 
         sleep(2);
 
@@ -710,7 +710,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("databases.{$databaseId}", $response['data']['events']);
         $this->assertContains("databases.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
-        $this->assertEquals($response['data']['payload']['name'], 'Chris Evans');
+        $this->assertEquals('Chris Evans', $response['data']['payload']['name']);
 
         /**
          * Test Document Update
@@ -752,7 +752,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("databases.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
 
-        $this->assertEquals($response['data']['payload']['name'], 'Chris Evans 2');
+        $this->assertEquals('Chris Evans 2', $response['data']['payload']['name']);
 
         /**
          * Test Document Delete
@@ -802,7 +802,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("databases.{$databaseId}", $response['data']['events']);
         $this->assertContains("databases.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
-        $this->assertEquals($response['data']['payload']['name'], 'Bradley Cooper');
+        $this->assertEquals('Bradley Cooper', $response['data']['payload']['name']);
 
         $client->close();
     }
@@ -871,11 +871,11 @@ class RealtimeCustomClientTest extends Scope
             'required' => true,
         ]);
 
-        $this->assertEquals($name['headers']['status-code'], 201);
-        $this->assertEquals($name['body']['key'], 'name');
-        $this->assertEquals($name['body']['type'], 'string');
-        $this->assertEquals($name['body']['size'], 256);
-        $this->assertEquals($name['body']['required'], true);
+        $this->assertEquals(201, $name['headers']['status-code']);
+        $this->assertEquals('name', $name['body']['key']);
+        $this->assertEquals('string', $name['body']['type']);
+        $this->assertEquals(256, $name['body']['size']);
+        $this->assertEquals(true, $name['body']['required']);
 
         sleep(2);
 
@@ -920,7 +920,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("databases.{$databaseId}", $response['data']['events']);
         $this->assertContains("databases.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
-        $this->assertEquals($response['data']['payload']['name'], 'Chris Evans');
+        $this->assertEquals('Chris Evans', $response['data']['payload']['name']);
 
         /**
          * Test Document Update
@@ -961,7 +961,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("databases.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
 
-        $this->assertEquals($response['data']['payload']['name'], 'Chris Evans 2');
+        $this->assertEquals('Chris Evans 2', $response['data']['payload']['name']);
 
         /**
          * Test Document Delete
@@ -1011,7 +1011,7 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("databases.{$databaseId}", $response['data']['events']);
         $this->assertContains("databases.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
-        $this->assertEquals($response['data']['payload']['name'], 'Bradley Cooper');
+        $this->assertEquals('Bradley Cooper', $response['data']['payload']['name']);
 
         $client->close();
     }
@@ -1201,7 +1201,7 @@ class RealtimeCustomClientTest extends Scope
 
         $functionId = $function['body']['$id'] ?? '';
 
-        $this->assertEquals($function['headers']['status-code'], 201);
+        $this->assertEquals(201, $function['headers']['status-code']);
         $this->assertNotEmpty($function['body']['$id']);
 
         $folder = 'timeout';
@@ -1222,7 +1222,7 @@ class RealtimeCustomClientTest extends Scope
 
         $deploymentId = $deployment['body']['$id'] ?? '';
 
-        $this->assertEquals($deployment['headers']['status-code'], 201);
+        $this->assertEquals(201, $deployment['headers']['status-code']);
         $this->assertNotEmpty($deployment['body']['$id']);
 
         // Wait for deployment to be built.
@@ -1234,7 +1234,7 @@ class RealtimeCustomClientTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]), []);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
 
         $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', array_merge([
@@ -1242,7 +1242,7 @@ class RealtimeCustomClientTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id']
         ], $this->getHeaders()), []);
 
-        $this->assertEquals($execution['headers']['status-code'], 201);
+        $this->assertEquals(201, $execution['headers']['status-code']);
         $this->assertNotEmpty($execution['body']['$id']);
 
         $response = json_decode($client->receive(), true);
@@ -1370,7 +1370,7 @@ class RealtimeCustomClientTest extends Scope
             'name' => 'Manchester'
         ]);
 
-        $this->assertEquals($team['headers']['status-code'], 200);
+        $this->assertEquals(200, $team['headers']['status-code']);
         $this->assertNotEmpty($team['body']['$id']);
 
         $response = json_decode($client->receive(), true);

--- a/tests/e2e/Services/Storage/StorageConsoleClientTest.php
+++ b/tests/e2e/Services/Storage/StorageConsoleClientTest.php
@@ -25,7 +25,7 @@ class StorageConsoleClientTest extends Scope
             'range' => '32h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         /**
          * Test for SUCCESS
@@ -37,9 +37,9 @@ class StorageConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals(count($response['body']), 13);
-        $this->assertEquals($response['body']['range'], '24h');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(13, count($response['body']));
+        $this->assertEquals('24h', $response['body']['range']);
         $this->assertIsArray($response['body']['filesStorage']);
         $this->assertIsArray($response['body']['filesCount']);
     }
@@ -69,7 +69,7 @@ class StorageConsoleClientTest extends Scope
             'range' => '32h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         // TODO: Uncomment once we implement check for missing bucketId in the usage endpoint.
 
@@ -80,7 +80,7 @@ class StorageConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 404);
+        $this->assertEquals(404, $response['headers']['status-code']);
 
         /**
          * Test for SUCCESS
@@ -92,9 +92,9 @@ class StorageConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals(count($response['body']), 7);
-        $this->assertEquals($response['body']['range'], '24h');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(7, count($response['body']));
+        $this->assertEquals('24h', $response['body']['range']);
         $this->assertIsArray($response['body']['filesCount']);
         $this->assertIsArray($response['body']['filesCreate']);
         $this->assertIsArray($response['body']['filesRead']);

--- a/tests/e2e/Services/Storage/StorageCustomClientTest.php
+++ b/tests/e2e/Services/Storage/StorageCustomClientTest.php
@@ -47,7 +47,7 @@ class StorageCustomClientTest extends Scope
         ]);
 
         $fileId = $file['body']['$id'];
-        $this->assertEquals($file['headers']['status-code'], 201);
+        $this->assertEquals(201, $file['headers']['status-code']);
         $this->assertNotEmpty($fileId);
         $this->assertIsInt($file['body']['$createdAt']);
         $this->assertEquals('permissions.png', $file['body']['name']);
@@ -93,7 +93,7 @@ class StorageCustomClientTest extends Scope
             'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/logo.png'), 'image/png', 'permissions.png'),
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 401);
+        $this->assertEquals(401, $file['headers']['status-code']);
 
         /**
          * Test for SUCCESS
@@ -134,7 +134,7 @@ class StorageCustomClientTest extends Scope
             'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/logo.png'), 'image/png', 'permissions.png'),
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 201);
+        $this->assertEquals(201, $file['headers']['status-code']);
         $this->assertNotEmpty($file['body']['$id']);
         $this->assertContains('user:' . $this->getUser()['$id'], $file['body']['$read']);
         $this->assertContains('user:' . $this->getUser()['$id'], $file['body']['$write']);
@@ -180,7 +180,7 @@ class StorageCustomClientTest extends Scope
             'write' => ['user:notme']
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 400);
+        $this->assertEquals(400, $file['headers']['status-code']);
         $this->assertStringStartsWith('Write permissions must be one of:', $file['body']['message']);
         $this->assertStringContainsString('role:all', $file['body']['message']);
         $this->assertStringContainsString('role:member', $file['body']['message']);
@@ -197,7 +197,7 @@ class StorageCustomClientTest extends Scope
             'write' => ['user:notme']
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 400);
+        $this->assertEquals(400, $file['headers']['status-code']);
         $this->assertStringStartsWith('Read permissions must be one of:', $file['body']['message']);
         $this->assertStringContainsString('role:all', $file['body']['message']);
         $this->assertStringContainsString('role:member', $file['body']['message']);
@@ -219,7 +219,7 @@ class StorageCustomClientTest extends Scope
             'read' => ['user:notme']
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 400);
+        $this->assertEquals(400, $file['headers']['status-code']);
         $this->assertStringStartsWith('Read permissions must be one of:', $file['body']['message']);
         $this->assertStringContainsString('role:all', $file['body']['message']);
         $this->assertStringContainsString('role:member', $file['body']['message']);
@@ -232,7 +232,7 @@ class StorageCustomClientTest extends Scope
             'write' => ['user:notme']
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 400);
+        $this->assertEquals(400, $file['headers']['status-code']);
         $this->assertStringStartsWith('Write permissions must be one of:', $file['body']['message']);
         $this->assertStringContainsString('role:all', $file['body']['message']);
         $this->assertStringContainsString('role:member', $file['body']['message']);
@@ -246,7 +246,7 @@ class StorageCustomClientTest extends Scope
             'write' => ['user:notme']
         ]);
 
-        $this->assertEquals($file['headers']['status-code'], 400);
+        $this->assertEquals(400, $file['headers']['status-code']);
         $this->assertStringStartsWith('Read permissions must be one of:', $file['body']['message']);
         $this->assertStringContainsString('role:all', $file['body']['message']);
         $this->assertStringContainsString('role:member', $file['body']['message']);

--- a/tests/e2e/Services/Users/UsersConsoleClientTest.php
+++ b/tests/e2e/Services/Users/UsersConsoleClientTest.php
@@ -26,7 +26,7 @@ class UsersConsoleClientTest extends Scope
             'provider' => 'email'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/users/usage', array_merge([
             'content-type' => 'application/json',
@@ -36,7 +36,7 @@ class UsersConsoleClientTest extends Scope
             'provider' => 'some-random-provider'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 400);
+        $this->assertEquals(400, $response['headers']['status-code']);
 
         /**
          * Test for SUCCESS
@@ -49,9 +49,9 @@ class UsersConsoleClientTest extends Scope
             'provider' => 'email'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals(count($response['body']), 9);
-        $this->assertEquals($response['body']['range'], '24h');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(9, count($response['body']));
+        $this->assertEquals('24h', $response['body']['range']);
         $this->assertIsArray($response['body']['usersCount']);
         $this->assertIsArray($response['body']['usersCreate']);
         $this->assertIsArray($response['body']['usersRead']);
@@ -68,9 +68,9 @@ class UsersConsoleClientTest extends Scope
             'range' => '24h'
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
-        $this->assertEquals(count($response['body']), 9);
-        $this->assertEquals($response['body']['range'], '24h');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(9, count($response['body']));
+        $this->assertEquals('24h', $response['body']['range']);
         $this->assertIsArray($response['body']['usersCount']);
         $this->assertIsArray($response['body']['usersCreate']);
         $this->assertIsArray($response['body']['usersRead']);

--- a/tests/e2e/Services/Webhooks/WebhooksCustomClientTest.php
+++ b/tests/e2e/Services/Webhooks/WebhooksCustomClientTest.php
@@ -35,7 +35,7 @@ class WebhooksCustomClientTest extends Scope
 
         $id = $account['body']['$id'];
 
-        $this->assertEquals($account['headers']['status-code'], 201);
+        $this->assertEquals(201, $account['headers']['status-code']);
         $this->assertNotEmpty($account['body']);
 
         $webhook = $this->getLastRequest();
@@ -44,9 +44,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("users.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -54,14 +54,14 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id']), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id']));
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertEquals($webhook['data']['name'], $name);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], true);
+        $this->assertEquals(true, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $email);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], []);
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([], $webhook['data']['prefs']);
 
         return [
             'id' => $id,
@@ -100,7 +100,7 @@ class WebhooksCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($accountSession['headers']['status-code'], 201);
+        $this->assertEquals(201, $accountSession['headers']['status-code']);
 
         $id = $account['body']['$id'];
         $session = $this->client->parseCookie((string)$accountSession['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
@@ -112,7 +112,7 @@ class WebhooksCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($account['headers']['status-code'], 200);
+        $this->assertEquals(200, $account['headers']['status-code']);
 
         $webhook = $this->getLastRequest();
         $signatureKey = $this->getProject()['signatureKey'];
@@ -120,9 +120,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.status', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("users.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -134,10 +134,10 @@ class WebhooksCustomClientTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertEquals($webhook['data']['name'], $name);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], false);
+        $this->assertEquals(false, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $email);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], []);
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([], $webhook['data']['prefs']);
 
         return [];
     }
@@ -163,7 +163,7 @@ class WebhooksCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($accountSession['headers']['status-code'], 201);
+        $this->assertEquals(201, $accountSession['headers']['status-code']);
 
         $sessionId = $accountSession['body']['$id'];
         $session = $this->client->parseCookie((string)$accountSession['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
@@ -174,9 +174,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.sessions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.sessions.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -190,20 +190,20 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id']), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id']));
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertNotEmpty($webhook['data']['userId']);
         $this->assertIsInt($webhook['data']['expire']);
-        $this->assertEquals($webhook['data']['ip'], '127.0.0.1');
+        $this->assertEquals('127.0.0.1', $webhook['data']['ip']);
         $this->assertNotEmpty($webhook['data']['osCode']);
         $this->assertIsString($webhook['data']['osCode']);
         $this->assertNotEmpty($webhook['data']['osName']);
         $this->assertIsString($webhook['data']['osName']);
         $this->assertNotEmpty($webhook['data']['osVersion']);
         $this->assertIsString($webhook['data']['osVersion']);
-        $this->assertEquals($webhook['data']['clientType'], 'browser');
-        $this->assertEquals($webhook['data']['clientCode'], 'CH');
-        $this->assertEquals($webhook['data']['clientName'], 'Chrome');
+        $this->assertEquals('browser', $webhook['data']['clientType']);
+        $this->assertEquals('CH', $webhook['data']['clientCode']);
+        $this->assertEquals('Chrome', $webhook['data']['clientName']);
         $this->assertNotEmpty($webhook['data']['clientVersion']);
         $this->assertIsString($webhook['data']['clientVersion']);
         $this->assertNotEmpty($webhook['data']['clientEngine']);
@@ -214,7 +214,7 @@ class WebhooksCustomClientTest extends Scope
         $this->assertIsString($webhook['data']['deviceModel']);
         $this->assertIsString($webhook['data']['countryCode']);
         $this->assertIsString($webhook['data']['countryName']);
-        $this->assertEquals($webhook['data']['current'], true);
+        $this->assertEquals(true, $webhook['data']['current']);
 
         return array_merge($data, [
             'sessionId' => $sessionId,
@@ -246,7 +246,7 @@ class WebhooksCustomClientTest extends Scope
         $sessionId = $accountSession['body']['$id'];
         $session = $this->client->parseCookie((string)$accountSession['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
 
-        $this->assertEquals($accountSession['headers']['status-code'], 201);
+        $this->assertEquals(201, $accountSession['headers']['status-code']);
 
         $accountSession = $this->client->call(Client::METHOD_DELETE, '/account/sessions/' . $sessionId, array_merge([
             'origin' => 'http://localhost',
@@ -255,7 +255,7 @@ class WebhooksCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($accountSession['headers']['status-code'], 204);
+        $this->assertEquals(204, $accountSession['headers']['status-code']);
 
         $webhook = $this->getLastRequest();
         $signatureKey = $this->getProject()['signatureKey'];
@@ -263,9 +263,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.sessions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.sessions.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -283,16 +283,16 @@ class WebhooksCustomClientTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertNotEmpty($webhook['data']['userId']);
         $this->assertIsInt($webhook['data']['expire']);
-        $this->assertEquals($webhook['data']['ip'], '127.0.0.1');
+        $this->assertEquals('127.0.0.1', $webhook['data']['ip']);
         $this->assertNotEmpty($webhook['data']['osCode']);
         $this->assertIsString($webhook['data']['osCode']);
         $this->assertNotEmpty($webhook['data']['osName']);
         $this->assertIsString($webhook['data']['osName']);
         $this->assertNotEmpty($webhook['data']['osVersion']);
         $this->assertIsString($webhook['data']['osVersion']);
-        $this->assertEquals($webhook['data']['clientType'], 'browser');
-        $this->assertEquals($webhook['data']['clientCode'], 'CH');
-        $this->assertEquals($webhook['data']['clientName'], 'Chrome');
+        $this->assertEquals('browser', $webhook['data']['clientType']);
+        $this->assertEquals('CH', $webhook['data']['clientCode']);
+        $this->assertEquals('Chrome', $webhook['data']['clientName']);
         $this->assertNotEmpty($webhook['data']['clientVersion']);
         $this->assertIsString($webhook['data']['clientVersion']);
         $this->assertNotEmpty($webhook['data']['clientEngine']);
@@ -303,7 +303,7 @@ class WebhooksCustomClientTest extends Scope
         $this->assertIsString($webhook['data']['deviceModel']);
         $this->assertIsString($webhook['data']['countryCode']);
         $this->assertIsString($webhook['data']['countryName']);
-        $this->assertEquals($webhook['data']['current'], true);
+        $this->assertEquals(true, $webhook['data']['current']);
 
         return $data;
     }
@@ -332,7 +332,7 @@ class WebhooksCustomClientTest extends Scope
         $sessionId = $accountSession['body']['$id'];
         $session = $this->client->parseCookie((string)$accountSession['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
 
-        $this->assertEquals($accountSession['headers']['status-code'], 201);
+        $this->assertEquals(201, $accountSession['headers']['status-code']);
 
         $accountSession = $this->client->call(Client::METHOD_DELETE, '/account/sessions', array_merge([
             'origin' => 'http://localhost',
@@ -341,7 +341,7 @@ class WebhooksCustomClientTest extends Scope
             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]));
 
-        $this->assertEquals($accountSession['headers']['status-code'], 204);
+        $this->assertEquals(204, $accountSession['headers']['status-code']);
 
         $webhook = $this->getLastRequest();
         $signatureKey = $this->getProject()['signatureKey'];
@@ -349,9 +349,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.sessions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.sessions.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -369,16 +369,16 @@ class WebhooksCustomClientTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertNotEmpty($webhook['data']['userId']);
         $this->assertIsInt($webhook['data']['expire']);
-        $this->assertEquals($webhook['data']['ip'], '127.0.0.1');
+        $this->assertEquals('127.0.0.1', $webhook['data']['ip']);
         $this->assertNotEmpty($webhook['data']['osCode']);
         $this->assertIsString($webhook['data']['osCode']);
         $this->assertNotEmpty($webhook['data']['osName']);
         $this->assertIsString($webhook['data']['osName']);
         $this->assertNotEmpty($webhook['data']['osVersion']);
         $this->assertIsString($webhook['data']['osVersion']);
-        $this->assertEquals($webhook['data']['clientType'], 'browser');
-        $this->assertEquals($webhook['data']['clientCode'], 'CH');
-        $this->assertEquals($webhook['data']['clientName'], 'Chrome');
+        $this->assertEquals('browser', $webhook['data']['clientType']);
+        $this->assertEquals('CH', $webhook['data']['clientCode']);
+        $this->assertEquals('Chrome', $webhook['data']['clientName']);
         $this->assertNotEmpty($webhook['data']['clientVersion']);
         $this->assertIsString($webhook['data']['clientVersion']);
         $this->assertNotEmpty($webhook['data']['clientEngine']);
@@ -389,7 +389,7 @@ class WebhooksCustomClientTest extends Scope
         $this->assertIsString($webhook['data']['deviceModel']);
         $this->assertIsString($webhook['data']['countryCode']);
         $this->assertIsString($webhook['data']['countryName']);
-        $this->assertEquals($webhook['data']['current'], true);
+        $this->assertEquals(true, $webhook['data']['current']);
 
         $accountSession = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
             'origin' => 'http://localhost',
@@ -400,7 +400,7 @@ class WebhooksCustomClientTest extends Scope
             'password' => $password,
         ]);
 
-        $this->assertEquals($accountSession['headers']['status-code'], 201);
+        $this->assertEquals(201, $accountSession['headers']['status-code']);
 
         $sessionId = $accountSession['body']['$id'];
         $session = $this->client->parseCookie((string)$accountSession['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
@@ -430,7 +430,7 @@ class WebhooksCustomClientTest extends Scope
             'name' => $newName
         ]);
 
-        $this->assertEquals($account['headers']['status-code'], 200);
+        $this->assertEquals(200, $account['headers']['status-code']);
         $this->assertIsArray($account['body']);
 
         $webhook = $this->getLastRequest();
@@ -440,9 +440,9 @@ class WebhooksCustomClientTest extends Scope
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.name', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -456,10 +456,10 @@ class WebhooksCustomClientTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertEquals($webhook['data']['name'], $newName);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], true);
+        $this->assertEquals(true, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $email);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], []);
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([], $webhook['data']['prefs']);
 
         return $data;
     }
@@ -484,7 +484,7 @@ class WebhooksCustomClientTest extends Scope
             'oldPassword' => $password,
         ]);
 
-        $this->assertEquals($account['headers']['status-code'], 200);
+        $this->assertEquals(200, $account['headers']['status-code']);
         $this->assertIsArray($account['body']);
 
         $webhook = $this->getLastRequest();
@@ -493,9 +493,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.password', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -507,12 +507,12 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
         $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
         $this->assertNotEmpty($webhook['data']['$id']);
-        $this->assertEquals($webhook['data']['name'], 'New Name');
+        $this->assertEquals('New Name', $webhook['data']['name']);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], true);
+        $this->assertEquals(true, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $email);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], []);
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([], $webhook['data']['prefs']);
 
         $data['password'] = 'new-password';
 
@@ -539,7 +539,7 @@ class WebhooksCustomClientTest extends Scope
             'password' => 'new-password',
         ]);
 
-        $this->assertEquals($account['headers']['status-code'], 200);
+        $this->assertEquals(200, $account['headers']['status-code']);
         $this->assertIsArray($account['body']);
 
         $webhook = $this->getLastRequest();
@@ -548,9 +548,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.email', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -562,12 +562,12 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
         $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
         $this->assertNotEmpty($webhook['data']['$id']);
-        $this->assertEquals($webhook['data']['name'], 'New Name');
+        $this->assertEquals('New Name', $webhook['data']['name']);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], true);
+        $this->assertEquals(true, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $newEmail);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], []);
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([], $webhook['data']['prefs']);
 
         $data['email'] = $newEmail;
 
@@ -595,7 +595,7 @@ class WebhooksCustomClientTest extends Scope
             ]
         ]);
 
-        $this->assertEquals($account['headers']['status-code'], 200);
+        $this->assertEquals(200, $account['headers']['status-code']);
         $this->assertIsArray($account['body']);
 
         $webhook = $this->getLastRequest();
@@ -604,9 +604,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.prefs', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -618,15 +618,15 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
         $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
         $this->assertNotEmpty($webhook['data']['$id']);
-        $this->assertEquals($webhook['data']['name'], 'New Name');
+        $this->assertEquals('New Name', $webhook['data']['name']);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], true);
+        $this->assertEquals(true, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $email);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], [
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([
             'prefKey1' => 'prefValue1',
             'prefKey2' => 'prefValue2',
-        ]);
+        ], $webhook['data']['prefs']);
 
         return $data;
     }
@@ -659,9 +659,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.recovery.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.recovery.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -719,9 +719,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.recovery.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.recovery.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -735,7 +735,7 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id']), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id']));
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertNotEmpty($webhook['data']['userId']);
         $this->assertNotEmpty($webhook['data']['secret']);
@@ -775,9 +775,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.verification.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.verification.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -833,9 +833,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.verification.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.verification.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -891,9 +891,9 @@ class WebhooksCustomClientTest extends Scope
         $url     = $webhook['url'];
         $signatureExpected = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('teams.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('teams.*.memberships.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('teams.*.memberships.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -911,7 +911,7 @@ class WebhooksCustomClientTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''));
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertNotEmpty($webhook['data']['userId']);
         $this->assertNotEmpty($webhook['data']['teamId']);

--- a/tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php
+++ b/tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php
@@ -35,15 +35,15 @@ class WebhooksCustomServerTest extends Scope
             'permission' => 'document',
         ]);
 
-        $this->assertEquals($actors['headers']['status-code'], 200);
+        $this->assertEquals(200, $actors['headers']['status-code']);
         $this->assertNotEmpty($actors['body']['$id']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("databases.{$databaseId}.collections.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -51,9 +51,9 @@ class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''));
         $this->assertNotEmpty($webhook['data']['$id']);
-        $this->assertEquals($webhook['data']['name'], 'Actors1');
+        $this->assertEquals('Actors1', $webhook['data']['name']);
         $this->assertIsArray($webhook['data']['$read']);
         $this->assertIsArray($webhook['data']['$write']);
         $this->assertCount(1, $webhook['data']['$read']);
@@ -82,8 +82,8 @@ class WebhooksCustomServerTest extends Scope
         ]);
 
         $indexKey = $index['body']['key'];
-        $this->assertEquals($index['headers']['status-code'], 201);
-        $this->assertEquals($index['body']['key'], 'fullname');
+        $this->assertEquals(201, $index['headers']['status-code']);
+        $this->assertEquals('fullname', $index['body']['key']);
 
         // wait for database worker to create index
         sleep(5);
@@ -91,9 +91,9 @@ class WebhooksCustomServerTest extends Scope
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*.indexes.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*.indexes.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -103,7 +103,7 @@ class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''));
 
         // Remove index
         $this->client->call(Client::METHOD_DELETE, '/databases/' . $databaseId . '/collections/' . $data['actorsId'] . '/indexes/' . $index['body']['key'], array_merge([
@@ -117,8 +117,8 @@ class WebhooksCustomServerTest extends Scope
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
         // $this->assertEquals($webhook['method'], 'DELETE');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*.indexes.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*.indexes.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -128,7 +128,7 @@ class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''));
 
         return $data;
     }
@@ -166,7 +166,7 @@ class WebhooksCustomServerTest extends Scope
 
         $id = $actors['body']['$id'];
 
-        $this->assertEquals($actors['headers']['status-code'], 201);
+        $this->assertEquals(201, $actors['headers']['status-code']);
         $this->assertNotEmpty($actors['body']['$id']);
 
         $actors = $this->client->call(Client::METHOD_DELETE, '/databases/' . $databaseId . '/collections/' . $actors['body']['$id'], array_merge([
@@ -175,14 +175,14 @@ class WebhooksCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]), []);
 
-        $this->assertEquals($actors['headers']['status-code'], 204);
+        $this->assertEquals(204, $actors['headers']['status-code']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('databases.' . $databaseId . '.collections.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("databases.{$databaseId}.collections.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -190,9 +190,9 @@ class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), true);
+        $this->assertEquals(true, empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''));
         $this->assertNotEmpty($webhook['data']['$id']);
-        $this->assertEquals($webhook['data']['name'], 'Demo');
+        $this->assertEquals('Demo', $webhook['data']['name']);
         $this->assertIsArray($webhook['data']['$read']);
         $this->assertIsArray($webhook['data']['$write']);
         $this->assertCount(1, $webhook['data']['$read']);
@@ -220,7 +220,7 @@ class WebhooksCustomServerTest extends Scope
             'name' => $name,
         ]);
 
-        $this->assertEquals($user['headers']['status-code'], 201);
+        $this->assertEquals(201, $user['headers']['status-code']);
         $this->assertNotEmpty($user['body']['$id']);
 
         $id = $user['body']['$id'];
@@ -228,9 +228,9 @@ class WebhooksCustomServerTest extends Scope
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("users.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -242,10 +242,10 @@ class WebhooksCustomServerTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertEquals($webhook['data']['name'], $name);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], true);
+        $this->assertEquals(true, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $email);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs'], []);
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals([], $webhook['data']['prefs']);
 
         /**
          * Test for FAILURE
@@ -270,15 +270,15 @@ class WebhooksCustomServerTest extends Scope
             'prefs' => ['a' => 'b']
         ]);
 
-        $this->assertEquals($user['headers']['status-code'], 200);
-        $this->assertEquals($user['body']['a'], 'b');
+        $this->assertEquals(200, $user['headers']['status-code']);
+        $this->assertEquals('b', $user['body']['a']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.prefs', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -289,7 +289,7 @@ class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
         $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
-        $this->assertEquals($webhook['data']['a'], 'b');
+        $this->assertEquals('b', $webhook['data']['a']);
 
         return $data;
     }
@@ -311,15 +311,15 @@ class WebhooksCustomServerTest extends Scope
             'status' => false,
         ]);
 
-        $this->assertEquals($user['headers']['status-code'], 200);
+        $this->assertEquals(200, $user['headers']['status-code']);
         $this->assertNotEmpty($user['body']['$id']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.update.status', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -333,10 +333,10 @@ class WebhooksCustomServerTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertEquals($webhook['data']['name'], $data['name']);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], false);
+        $this->assertEquals(false, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $data['email']);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs']['a'], 'b');
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals('b', $webhook['data']['prefs']['a']);
 
         return $data;
     }
@@ -356,14 +356,14 @@ class WebhooksCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($user['headers']['status-code'], 204);
+        $this->assertEquals(204, $user['headers']['status-code']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('users.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('users.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("users.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -375,10 +375,10 @@ class WebhooksCustomServerTest extends Scope
         $this->assertNotEmpty($webhook['data']['$id']);
         $this->assertEquals($webhook['data']['name'], $data['name']);
         $this->assertIsInt($webhook['data']['registration']);
-        $this->assertEquals($webhook['data']['status'], false);
+        $this->assertEquals(false, $webhook['data']['status']);
         $this->assertEquals($webhook['data']['email'], $data['email']);
-        $this->assertEquals($webhook['data']['emailVerification'], false);
-        $this->assertEquals($webhook['data']['prefs']['a'], 'b');
+        $this->assertEquals(false, $webhook['data']['emailVerification']);
+        $this->assertEquals('b', $webhook['data']['prefs']['a']);
 
         return $data;
     }
@@ -401,15 +401,15 @@ class WebhooksCustomServerTest extends Scope
 
         $id = $function['body']['$id'] ?? '';
 
-        $this->assertEquals($function['headers']['status-code'], 201);
+        $this->assertEquals(201, $function['headers']['status-code']);
         $this->assertNotEmpty($function['body']['$id']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("functions.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -449,16 +449,16 @@ class WebhooksCustomServerTest extends Scope
             ]
         ]);
 
-        $this->assertEquals($function['headers']['status-code'], 200);
+        $this->assertEquals(200, $function['headers']['status-code']);
         $this->assertEquals($function['body']['$id'], $data['functionId']);
-        $this->assertEquals($function['body']['vars'], ['key1' => 'value1']);
+        $this->assertEquals(['key1' => 'value1'], $function['body']['vars']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("functions.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -475,7 +475,7 @@ class WebhooksCustomServerTest extends Scope
             'execute' => [ 'not-valid-permission' ]
         ]);
 
-        $this->assertEquals($function['headers']['status-code'], 400);
+        $this->assertEquals(400, $function['headers']['status-code']);
 
         return $data;
     }
@@ -505,15 +505,15 @@ class WebhooksCustomServerTest extends Scope
         $id = $data['functionId'] ?? '';
         $deploymentId = $deployment['body']['$id'] ?? '';
 
-        $this->assertEquals($deployment['headers']['status-code'], 201);
+        $this->assertEquals(201, $deployment['headers']['status-code']);
         $this->assertNotEmpty($deployment['body']['$id']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.deployments.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("functions.*.deployments.{$deploymentId}", $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -545,7 +545,7 @@ class WebhooksCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), []);
 
-        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
 
         // Wait for deployment to be built.
@@ -554,9 +554,9 @@ class WebhooksCustomServerTest extends Scope
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.deployments.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.deployments.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -595,14 +595,14 @@ class WebhooksCustomServerTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        $this->assertEquals($execution['headers']['status-code'], 201);
+        $this->assertEquals(201, $execution['headers']['status-code']);
         $this->assertNotEmpty($execution['body']['$id']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.executions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.executions.*.create', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -623,9 +623,9 @@ class WebhooksCustomServerTest extends Scope
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.executions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.executions.*.update', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -662,15 +662,15 @@ class WebhooksCustomServerTest extends Scope
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
-        $this->assertEquals($deployment['headers']['status-code'], 204);
+        $this->assertEquals(204, $deployment['headers']['status-code']);
         $this->assertEmpty($deployment['body']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.deployments.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.deployments.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
@@ -713,9 +713,9 @@ class WebhooksCustomServerTest extends Scope
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
 
-        $this->assertEquals($webhook['method'], 'POST');
-        $this->assertEquals($webhook['headers']['Content-Type'], 'application/json');
-        $this->assertEquals($webhook['headers']['User-Agent'], 'Appwrite-Server vdev. Please report abuse at security@appwrite.io');
+        $this->assertEquals('POST', $webhook['method']);
+        $this->assertEquals('application/json', $webhook['headers']['Content-Type']);
+        $this->assertEquals('Appwrite-Server vdev. Please report abuse at security@appwrite.io', $webhook['headers']['User-Agent']);
         $this->assertStringContainsString('functions.*', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString('functions.*.delete', $webhook['headers']['X-Appwrite-Webhook-Events']);
         $this->assertStringContainsString("functions.{$id}", $webhook['headers']['X-Appwrite-Webhook-Events']);

--- a/tests/unit/Auth/AuthTest.php
+++ b/tests/unit/Auth/AuthTest.php
@@ -43,7 +43,7 @@ class AuthTest extends TestCase
     public function testHash()
     {
         $secret = 'secret';
-        $this->assertEquals(Auth::hash($secret), '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b');
+        $this->assertEquals('2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b', Auth::hash($secret));
     }
 
     public function testPassword()
@@ -52,20 +52,20 @@ class AuthTest extends TestCase
         $static = '$2y$08$PDbMtV18J1KOBI9tIYabBuyUwBrtXPGhLxCy9pWP6xkldVOKLrLKy';
         $dynamic = Auth::passwordHash($secret);
 
-        $this->assertEquals(Auth::passwordVerify($secret, $dynamic), true);
-        $this->assertEquals(Auth::passwordVerify($secret, $static), true);
+        $this->assertEquals(true, Auth::passwordVerify($secret, $dynamic));
+        $this->assertEquals(true, Auth::passwordVerify($secret, $static));
     }
 
     public function testPasswordGenerator()
     {
-        $this->assertEquals(\mb_strlen(Auth::passwordGenerator()), 40);
-        $this->assertEquals(\mb_strlen(Auth::passwordGenerator(5)), 10);
+        $this->assertEquals(40, \mb_strlen(Auth::passwordGenerator()));
+        $this->assertEquals(10, \mb_strlen(Auth::passwordGenerator(5)));
     }
 
     public function testTokenGenerator()
     {
-        $this->assertEquals(\mb_strlen(Auth::tokenGenerator()), 256);
-        $this->assertEquals(\mb_strlen(Auth::tokenGenerator(5)), 10);
+        $this->assertEquals(256, \mb_strlen(Auth::tokenGenerator()));
+        $this->assertEquals(10, \mb_strlen(Auth::tokenGenerator(5)));
     }
 
     public function testSessionVerify()
@@ -106,10 +106,10 @@ class AuthTest extends TestCase
             ]),
         ];
 
-        $this->assertEquals(Auth::sessionVerify($tokens1, $secret), 'token1');
-        $this->assertEquals(Auth::sessionVerify($tokens1, 'false-secret'), false);
-        $this->assertEquals(Auth::sessionVerify($tokens2, $secret), false);
-        $this->assertEquals(Auth::sessionVerify($tokens2, 'false-secret'), false);
+        $this->assertEquals('token1', Auth::sessionVerify($tokens1, $secret));
+        $this->assertEquals(false, Auth::sessionVerify($tokens1, 'false-secret'));
+        $this->assertEquals(false, Auth::sessionVerify($tokens2, $secret));
+        $this->assertEquals(false, Auth::sessionVerify($tokens2, 'false-secret'));
     }
 
     public function testTokenVerify()
@@ -161,12 +161,12 @@ class AuthTest extends TestCase
             ]),
         ];
 
-        $this->assertEquals(Auth::tokenVerify($tokens1, Auth::TOKEN_TYPE_RECOVERY, $secret), 'token1');
-        $this->assertEquals(Auth::tokenVerify($tokens1, Auth::TOKEN_TYPE_RECOVERY, 'false-secret'), false);
-        $this->assertEquals(Auth::tokenVerify($tokens2, Auth::TOKEN_TYPE_RECOVERY, $secret), false);
-        $this->assertEquals(Auth::tokenVerify($tokens2, Auth::TOKEN_TYPE_RECOVERY, 'false-secret'), false);
-        $this->assertEquals(Auth::tokenVerify($tokens3, Auth::TOKEN_TYPE_RECOVERY, $secret), false);
-        $this->assertEquals(Auth::tokenVerify($tokens3, Auth::TOKEN_TYPE_RECOVERY, 'false-secret'), false);
+        $this->assertEquals('token1', Auth::tokenVerify($tokens1, Auth::TOKEN_TYPE_RECOVERY, $secret));
+        $this->assertEquals(false, Auth::tokenVerify($tokens1, Auth::TOKEN_TYPE_RECOVERY, 'false-secret'));
+        $this->assertEquals(false, Auth::tokenVerify($tokens2, Auth::TOKEN_TYPE_RECOVERY, $secret));
+        $this->assertEquals(false, Auth::tokenVerify($tokens2, Auth::TOKEN_TYPE_RECOVERY, 'false-secret'));
+        $this->assertEquals(false, Auth::tokenVerify($tokens3, Auth::TOKEN_TYPE_RECOVERY, $secret));
+        $this->assertEquals(false, Auth::tokenVerify($tokens3, Auth::TOKEN_TYPE_RECOVERY, 'false-secret'));
     }
 
     public function testIsPrivilegedUser()

--- a/tests/unit/Auth/Validator/PasswordTest.php
+++ b/tests/unit/Auth/Validator/PasswordTest.php
@@ -23,16 +23,16 @@ class PasswordTest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals($this->object->isValid(false), false);
-        $this->assertEquals($this->object->isValid(null), false);
-        $this->assertEquals($this->object->isValid(''), false);
-        $this->assertEquals($this->object->isValid('1'), false);
-        $this->assertEquals($this->object->isValid('12'), false);
-        $this->assertEquals($this->object->isValid('123'), false);
-        $this->assertEquals($this->object->isValid('1234'), false);
-        $this->assertEquals($this->object->isValid('12345'), false);
-        $this->assertEquals($this->object->isValid('123456'), false);
-        $this->assertEquals($this->object->isValid('1234567'), false);
-        $this->assertEquals($this->object->isValid('WUnOZcn0piQMN8Mh31xw4KQPF0gcNGVA'), true);
+        $this->assertEquals(false, $this->object->isValid(false));
+        $this->assertEquals(false, $this->object->isValid(null));
+        $this->assertEquals(false, $this->object->isValid(''));
+        $this->assertEquals(false, $this->object->isValid('1'));
+        $this->assertEquals(false, $this->object->isValid('12'));
+        $this->assertEquals(false, $this->object->isValid('123'));
+        $this->assertEquals(false, $this->object->isValid('1234'));
+        $this->assertEquals(false, $this->object->isValid('12345'));
+        $this->assertEquals(false, $this->object->isValid('123456'));
+        $this->assertEquals(false, $this->object->isValid('1234567'));
+        $this->assertEquals(true, $this->object->isValid('WUnOZcn0piQMN8Mh31xw4KQPF0gcNGVA'));
     }
 }

--- a/tests/unit/Auth/Validator/PhoneTest.php
+++ b/tests/unit/Auth/Validator/PhoneTest.php
@@ -20,23 +20,23 @@ class PhoneTest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals($this->object->isValid(false), false);
-        $this->assertEquals($this->object->isValid(null), false);
-        $this->assertEquals($this->object->isValid(''), false);
-        $this->assertEquals($this->object->isValid('+1'), false);
-        $this->assertEquals($this->object->isValid('8989829304'), false);
-        $this->assertEquals($this->object->isValid('786-307-3615'), false);
-        $this->assertEquals($this->object->isValid('+16308A520397'), false);
-        $this->assertEquals($this->object->isValid('+0415553452342'), false);
-        $this->assertEquals($this->object->isValid('+14 155 5524564'), false);
-        $this->assertEquals($this->object->isValid(+14155552456), false);
+        $this->assertEquals(false, $this->object->isValid(false));
+        $this->assertEquals(false, $this->object->isValid(null));
+        $this->assertEquals(false, $this->object->isValid(''));
+        $this->assertEquals(false, $this->object->isValid('+1'));
+        $this->assertEquals(false, $this->object->isValid('8989829304'));
+        $this->assertEquals(false, $this->object->isValid('786-307-3615'));
+        $this->assertEquals(false, $this->object->isValid('+16308A520397'));
+        $this->assertEquals(false, $this->object->isValid('+0415553452342'));
+        $this->assertEquals(false, $this->object->isValid('+14 155 5524564'));
+        $this->assertEquals(false, $this->object->isValid(+14155552456));
 
-        $this->assertEquals($this->object->isValid('+14155552'), true);
-        $this->assertEquals($this->object->isValid('+141555526'), true);
-        $this->assertEquals($this->object->isValid('+16308520394'), true);
-        $this->assertEquals($this->object->isValid('+163085205339'), true);
-        $this->assertEquals($this->object->isValid('+5511552563253'), true);
-        $this->assertEquals($this->object->isValid('+55115525632534'), true);
-        $this->assertEquals($this->object->isValid('+919367788755111'), true);
+        $this->assertEquals(true, $this->object->isValid('+14155552'));
+        $this->assertEquals(true, $this->object->isValid('+141555526'));
+        $this->assertEquals(true, $this->object->isValid('+16308520394'));
+        $this->assertEquals(true, $this->object->isValid('+163085205339'));
+        $this->assertEquals(true, $this->object->isValid('+5511552563253'));
+        $this->assertEquals(true, $this->object->isValid('+55115525632534'));
+        $this->assertEquals(true, $this->object->isValid('+919367788755111'));
     }
 }

--- a/tests/unit/Detector/DetectorTest.php
+++ b/tests/unit/Detector/DetectorTest.php
@@ -23,31 +23,31 @@ class DetectorTest extends TestCase
 
     public function testGetOS()
     {
-        $this->assertEquals($this->object->getOS(), [
+        $this->assertEquals([
             'osCode' => 'WIN',
             'osName' => 'Windows',
             'osVersion' => '7',
-        ]);
+        ], $this->object->getOS());
     }
 
     public function testGetClient()
     {
-        $this->assertEquals($this->object->getClient(), [
+        $this->assertEquals([
             'clientType' => 'browser',
             'clientCode' => 'FF',
             'clientName' => 'Firefox',
             'clientVersion' => '47.0',
             'clientEngine' => 'Gecko',
             'clientEngineVersion' => '47.0',
-        ]);
+        ], $this->object->getClient());
     }
 
     public function testGetDevice()
     {
-        $this->assertEquals($this->object->getDevice(), [
+        $this->assertEquals([
             'deviceName' => 'desktop',
             'deviceBrand' => '',
             'deviceModel' => '',
-        ]);
+        ], $this->object->getDevice());
     }
 }

--- a/tests/unit/Event/EventTest.php
+++ b/tests/unit/Event/EventTest.php
@@ -66,7 +66,7 @@ class EventTest extends TestCase
         $this->assertEquals('eventValue1', $this->object->getParam('eventKey1'));
         $this->assertEquals('eventValue2', $this->object->getParam('eventKey2'));
         $this->assertEquals(null, $this->object->getParam('eventKey3'));
-        $this->assertEquals(\Resque::size($this->queue), 1);
+        $this->assertEquals(1, \Resque::size($this->queue));
     }
 
     public function testReset()

--- a/tests/unit/Migration/MigrationV12Test.php
+++ b/tests/unit/Migration/MigrationV12Test.php
@@ -26,8 +26,8 @@ class MigrationV12Test extends MigrationTest
             'search' => ''
         ]));
 
-        $this->assertEquals($document->getAttribute('version'), '0.13.0');
-        $this->assertEquals($document->getAttribute('search'), 'project Appwrite');
+        $this->assertEquals('0.13.0', $document->getAttribute('version'));
+        $this->assertEquals('project Appwrite', $document->getAttribute('search'));
     }
 
     public function testMigrationUsers()
@@ -39,7 +39,7 @@ class MigrationV12Test extends MigrationTest
             'name' => 'Torsten Dittmann'
         ]));
 
-        $this->assertEquals($document->getAttribute('search'), 'user test@appwrite.io Torsten Dittmann');
+        $this->assertEquals('user test@appwrite.io Torsten Dittmann', $document->getAttribute('search'));
     }
 
     public function testMigrationTeams()
@@ -50,7 +50,7 @@ class MigrationV12Test extends MigrationTest
             'name' => 'Appwrite'
         ]));
 
-        $this->assertEquals($document->getAttribute('search'), 'team Appwrite');
+        $this->assertEquals('team Appwrite', $document->getAttribute('search'));
     }
 
     public function testMigrationFunctions()
@@ -62,7 +62,7 @@ class MigrationV12Test extends MigrationTest
             'runtime' => 'php-8.0'
         ]));
 
-        $this->assertEquals($document->getAttribute('search'), 'function My Function php-8.0');
+        $this->assertEquals('function My Function php-8.0', $document->getAttribute('search'));
     }
 
     public function testMigrationExecutions()
@@ -73,6 +73,6 @@ class MigrationV12Test extends MigrationTest
             'functionId' => 'function'
         ]));
 
-        $this->assertEquals($document->getAttribute('search'), 'execution function');
+        $this->assertEquals('execution function', $document->getAttribute('search'));
     }
 }

--- a/tests/unit/Migration/MigrationV13Test.php
+++ b/tests/unit/Migration/MigrationV13Test.php
@@ -25,7 +25,7 @@ class MigrationV13Test extends MigrationTest
             'events' => ['account.create', 'users.create']
         ]));
 
-        $this->assertEquals($document->getAttribute('events'), ['users.*.create']);
+        $this->assertEquals(['users.*.create'], $document->getAttribute('events'));
     }
 
     public function testMigrationWebhooks()
@@ -36,6 +36,6 @@ class MigrationV13Test extends MigrationTest
             'events' => ['account.create', 'users.create']
         ]));
 
-        $this->assertEquals($document->getAttribute('events'), ['users.*.create']);
+        $this->assertEquals(['users.*.create'], $document->getAttribute('events'));
     }
 }

--- a/tests/unit/Migration/MigrationV14Test.php
+++ b/tests/unit/Migration/MigrationV14Test.php
@@ -24,8 +24,8 @@ class MigrationV14Test extends MigrationTest
             'version' => '0.14.0'
         ]));
 
-        $this->assertEquals($document->getAttribute('version'), '0.15.0');
-        $this->assertEquals($document->getAttribute('version'), '0.15.0');
+        $this->assertEquals('0.15.0', $document->getAttribute('version'));
+        $this->assertEquals('0.15.0', $document->getAttribute('version'));
     }
 
     public function testMigrateKeys()
@@ -36,7 +36,7 @@ class MigrationV14Test extends MigrationTest
         ]));
 
         $this->assertArrayHasKey('expire', $document->getArrayCopy());
-        $this->assertEquals($document->getAttribute('expire'), 0);
+        $this->assertEquals(0, $document->getAttribute('expire'));
     }
 
     public function testMigrateWebhooks()
@@ -47,7 +47,7 @@ class MigrationV14Test extends MigrationTest
         ]));
 
         $this->assertArrayHasKey('signatureKey', $document->getArrayCopy());
-        $this->assertEquals(strlen($document->getAttribute('signatureKey')), 128);
+        $this->assertEquals(128, strlen($document->getAttribute('signatureKey')));
     }
 
     public function testMigrateUsers()
@@ -73,8 +73,8 @@ class MigrationV14Test extends MigrationTest
             'dateUpdated' => 987654321
         ]));
 
-        $this->assertEquals($document->getCreatedAt(), 123456789);
-        $this->assertEquals($document->getUpdatedAt(), 987654321);
+        $this->assertEquals(123456789, $document->getCreatedAt());
+        $this->assertEquals(987654321, $document->getUpdatedAt());
     }
 
     public function testMigrateFunctions()
@@ -88,8 +88,8 @@ class MigrationV14Test extends MigrationTest
             'dateUpdated' => 987654321
         ]));
 
-        $this->assertEquals($document->getCreatedAt(), 123456789);
-        $this->assertEquals($document->getUpdatedAt(), 987654321);
+        $this->assertEquals(123456789, $document->getCreatedAt());
+        $this->assertEquals(987654321, $document->getUpdatedAt());
     }
 
     public function testMigrateDeployments()
@@ -101,7 +101,7 @@ class MigrationV14Test extends MigrationTest
             'dateCreated' => 123456789,
         ]));
 
-        $this->assertEquals($document->getCreatedAt(), 123456789);
+        $this->assertEquals(123456789, $document->getCreatedAt());
     }
 
     public function testMigrateExecutions()
@@ -113,7 +113,7 @@ class MigrationV14Test extends MigrationTest
             'dateCreated' => 123456789,
         ]));
 
-        $this->assertEquals($document->getCreatedAt(), 123456789);
+        $this->assertEquals(123456789, $document->getCreatedAt());
     }
 
     public function testMigrateTeams()
@@ -125,7 +125,7 @@ class MigrationV14Test extends MigrationTest
             'dateCreated' => 123456789,
         ]));
 
-        $this->assertEquals($document->getCreatedAt(), 123456789);
+        $this->assertEquals(123456789, $document->getCreatedAt());
     }
 
     public function testMigrateAudits()
@@ -137,8 +137,8 @@ class MigrationV14Test extends MigrationTest
             'event' => 'collections.movies.create'
         ]));
 
-        $this->assertEquals($document->getAttribute('resource'), 'database/default/collection/movies');
-        $this->assertEquals($document->getAttribute('event'), 'databases.default.collections.movies.create');
+        $this->assertEquals('database/default/collection/movies', $document->getAttribute('resource'));
+        $this->assertEquals('databases.default.collections.movies.create', $document->getAttribute('event'));
 
         $document = $this->fixDocument(new Document([
             '$id' => 'appwrite',
@@ -147,8 +147,8 @@ class MigrationV14Test extends MigrationTest
             'event' => 'collections.movies.documents.avatar.create'
         ]));
 
-        $this->assertEquals($document->getAttribute('resource'), 'database/default/collection/movies/document/avatar');
-        $this->assertEquals($document->getAttribute('event'), 'databases.default.collections.movies.documents.avatar.create');
+        $this->assertEquals('database/default/collection/movies/document/avatar', $document->getAttribute('resource'));
+        $this->assertEquals('databases.default.collections.movies.documents.avatar.create', $document->getAttribute('event'));
     }
 
     public function testMigrateStats()
@@ -159,7 +159,7 @@ class MigrationV14Test extends MigrationTest
             'metric' => 'database.collections.62b2039844d4277495d0.documents.create'
         ]));
 
-        $this->assertEquals($document->getAttribute('metric'), 'databases.default.collections.62b2039844d4277495d0.documents.create');
+        $this->assertEquals('databases.default.collections.62b2039844d4277495d0.documents.create', $document->getAttribute('metric'));
 
         $document = $this->fixDocument(new Document([
             '$id' => 'appwrite',
@@ -167,6 +167,6 @@ class MigrationV14Test extends MigrationTest
             'metric' => 'users.create'
         ]));
 
-        $this->assertEquals($document->getAttribute('metric'), 'users.create');
+        $this->assertEquals('users.create', $document->getAttribute('metric'));
     }
 }

--- a/tests/unit/Network/Validators/CNAMETest.php
+++ b/tests/unit/Network/Validators/CNAMETest.php
@@ -23,10 +23,10 @@ class CNAMETest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals($this->object->isValid(''), false);
-        $this->assertEquals($this->object->isValid(null), false);
-        $this->assertEquals($this->object->isValid(false), false);
-        $this->assertEquals($this->object->isValid('cname-unit-test.appwrite.org'), true);
-        $this->assertEquals($this->object->isValid('test1.appwrite.org'), false);
+        $this->assertEquals(false, $this->object->isValid(''));
+        $this->assertEquals(false, $this->object->isValid(null));
+        $this->assertEquals(false, $this->object->isValid(false));
+        $this->assertEquals(true, $this->object->isValid('cname-unit-test.appwrite.org'));
+        $this->assertEquals(false, $this->object->isValid('test1.appwrite.org'));
     }
 }

--- a/tests/unit/Network/Validators/EmailTest.php
+++ b/tests/unit/Network/Validators/EmailTest.php
@@ -67,6 +67,6 @@ class EmailTest extends TestCase
         $this->assertEquals(false, $this->email->isValid('email@-domain.com')); // Leading dash in front of domain is invalid
         $this->assertEquals(false, $this->email->isValid('email@111.222.333.44444')); // Invalid IP format
         $this->assertEquals(false, $this->email->isValid('email@domain..com')); // Multiple dot in the domain portion is invalid
-        $this->assertEquals($this->email->getType(), 'string');
+        $this->assertEquals('string', $this->email->getType());
     }
 }

--- a/tests/unit/Network/Validators/HostTest.php
+++ b/tests/unit/Network/Validators/HostTest.php
@@ -36,11 +36,11 @@ class HostTest extends TestCase
     public function testIsValid()
     {
         // Assertions
-        $this->assertEquals($this->host->isValid('https://appwrite.io/link'), true);
-        $this->assertEquals($this->host->isValid('https://localhost'), true);
-        $this->assertEquals($this->host->isValid('localhost'), false);
-        $this->assertEquals($this->host->isValid('http://subdomain.appwrite.test/path'), true);
-        $this->assertEquals($this->host->isValid('http://test.subdomain.appwrite.test/path'), false);
-        $this->assertEquals($this->host->getType(), 'string');
+        $this->assertEquals(true, $this->host->isValid('https://appwrite.io/link'));
+        $this->assertEquals(true, $this->host->isValid('https://localhost'));
+        $this->assertEquals(false, $this->host->isValid('localhost'));
+        $this->assertEquals(true, $this->host->isValid('http://subdomain.appwrite.test/path'));
+        $this->assertEquals(false, $this->host->isValid('http://test.subdomain.appwrite.test/path'));
+        $this->assertEquals('string', $this->host->getType());
     }
 }

--- a/tests/unit/Network/Validators/IPTest.php
+++ b/tests/unit/Network/Validators/IPTest.php
@@ -28,14 +28,14 @@ class IPTest extends TestCase
         $validator = new IP();
 
         // Assertions
-        $this->assertEquals($validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'), true);
-        $this->assertEquals($validator->isValid('109.67.204.101'), true);
-        $this->assertEquals($validator->isValid(23.5), false);
-        $this->assertEquals($validator->isValid('23.5'), false);
-        $this->assertEquals($validator->isValid(null), false);
-        $this->assertEquals($validator->isValid(true), false);
-        $this->assertEquals($validator->isValid(false), false);
-        $this->assertEquals($validator->getType(), 'string');
+        $this->assertEquals(true, $validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'));
+        $this->assertEquals(true, $validator->isValid('109.67.204.101'));
+        $this->assertEquals(false, $validator->isValid(23.5));
+        $this->assertEquals(false, $validator->isValid('23.5'));
+        $this->assertEquals(false, $validator->isValid(null));
+        $this->assertEquals(false, $validator->isValid(true));
+        $this->assertEquals(false, $validator->isValid(false));
+        $this->assertEquals('string', $validator->getType());
     }
 
     public function testIsValidIPALL()
@@ -43,13 +43,13 @@ class IPTest extends TestCase
         $validator = new IP(IP::ALL);
 
         // Assertions
-        $this->assertEquals($validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'), true);
-        $this->assertEquals($validator->isValid('109.67.204.101'), true);
-        $this->assertEquals($validator->isValid(23.5), false);
-        $this->assertEquals($validator->isValid('23.5'), false);
-        $this->assertEquals($validator->isValid(null), false);
-        $this->assertEquals($validator->isValid(true), false);
-        $this->assertEquals($validator->isValid(false), false);
+        $this->assertEquals(true, $validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'));
+        $this->assertEquals(true, $validator->isValid('109.67.204.101'));
+        $this->assertEquals(false, $validator->isValid(23.5));
+        $this->assertEquals(false, $validator->isValid('23.5'));
+        $this->assertEquals(false, $validator->isValid(null));
+        $this->assertEquals(false, $validator->isValid(true));
+        $this->assertEquals(false, $validator->isValid(false));
     }
 
     public function testIsValidIPV4()
@@ -57,13 +57,13 @@ class IPTest extends TestCase
         $validator = new IP(IP::V4);
 
         // Assertions
-        $this->assertEquals($validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'), false);
-        $this->assertEquals($validator->isValid('109.67.204.101'), true);
-        $this->assertEquals($validator->isValid(23.5), false);
-        $this->assertEquals($validator->isValid('23.5'), false);
-        $this->assertEquals($validator->isValid(null), false);
-        $this->assertEquals($validator->isValid(true), false);
-        $this->assertEquals($validator->isValid(false), false);
+        $this->assertEquals(false, $validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'));
+        $this->assertEquals(true, $validator->isValid('109.67.204.101'));
+        $this->assertEquals(false, $validator->isValid(23.5));
+        $this->assertEquals(false, $validator->isValid('23.5'));
+        $this->assertEquals(false, $validator->isValid(null));
+        $this->assertEquals(false, $validator->isValid(true));
+        $this->assertEquals(false, $validator->isValid(false));
     }
 
     public function testIsValidIPV6()
@@ -71,12 +71,12 @@ class IPTest extends TestCase
         $validator = new IP(IP::V6);
 
         // Assertions
-        $this->assertEquals($validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'), true);
-        $this->assertEquals($validator->isValid('109.67.204.101'), false);
-        $this->assertEquals($validator->isValid(23.5), false);
-        $this->assertEquals($validator->isValid('23.5'), false);
-        $this->assertEquals($validator->isValid(null), false);
-        $this->assertEquals($validator->isValid(true), false);
-        $this->assertEquals($validator->isValid(false), false);
+        $this->assertEquals(true, $validator->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'));
+        $this->assertEquals(false, $validator->isValid('109.67.204.101'));
+        $this->assertEquals(false, $validator->isValid(23.5));
+        $this->assertEquals(false, $validator->isValid('23.5'));
+        $this->assertEquals(false, $validator->isValid(null));
+        $this->assertEquals(false, $validator->isValid(true));
+        $this->assertEquals(false, $validator->isValid(false));
     }
 }

--- a/tests/unit/Network/Validators/OriginTest.php
+++ b/tests/unit/Network/Validators/OriginTest.php
@@ -30,35 +30,35 @@ class OriginTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals($validator->isValid('https://localhost'), true);
-        $this->assertEquals($validator->isValid('http://localhost'), true);
-        $this->assertEquals($validator->isValid('http://localhost:80'), true);
+        $this->assertEquals(true, $validator->isValid('https://localhost'));
+        $this->assertEquals(true, $validator->isValid('http://localhost'));
+        $this->assertEquals(true, $validator->isValid('http://localhost:80'));
 
-        $this->assertEquals($validator->isValid('https://appwrite.io'), true);
-        $this->assertEquals($validator->isValid('http://appwrite.io'), true);
-        $this->assertEquals($validator->isValid('http://appwrite.io:80'), true);
+        $this->assertEquals(true, $validator->isValid('https://appwrite.io'));
+        $this->assertEquals(true, $validator->isValid('http://appwrite.io'));
+        $this->assertEquals(true, $validator->isValid('http://appwrite.io:80'));
 
-        $this->assertEquals($validator->isValid('https://appwrite.test'), true);
-        $this->assertEquals($validator->isValid('http://appwrite.test'), true);
-        $this->assertEquals($validator->isValid('http://appwrite.test:80'), true);
+        $this->assertEquals(true, $validator->isValid('https://appwrite.test'));
+        $this->assertEquals(true, $validator->isValid('http://appwrite.test'));
+        $this->assertEquals(true, $validator->isValid('http://appwrite.test:80'));
 
-        $this->assertEquals($validator->isValid('https://example.com'), false);
-        $this->assertEquals($validator->isValid('http://example.com'), false);
-        $this->assertEquals($validator->isValid('http://example.com:80'), false);
+        $this->assertEquals(false, $validator->isValid('https://example.com'));
+        $this->assertEquals(false, $validator->isValid('http://example.com'));
+        $this->assertEquals(false, $validator->isValid('http://example.com:80'));
 
-        $this->assertEquals($validator->isValid('appwrite-ios://com.company.appname'), false);
-        $this->assertEquals($validator->getDescription(), 'Invalid Origin. Register your new client (com.company.appname) as a new iOS platform on your project console dashboard');
+        $this->assertEquals(false, $validator->isValid('appwrite-ios://com.company.appname'));
+        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new iOS platform on your project console dashboard', $validator->getDescription());
 
-        $this->assertEquals($validator->isValid('appwrite-android://com.company.appname'), false);
-        $this->assertEquals($validator->getDescription(), 'Invalid Origin. Register your new client (com.company.appname) as a new Android platform on your project console dashboard');
+        $this->assertEquals(false, $validator->isValid('appwrite-android://com.company.appname'));
+        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Android platform on your project console dashboard', $validator->getDescription());
 
-        $this->assertEquals($validator->isValid('appwrite-macos://com.company.appname'), false);
-        $this->assertEquals($validator->getDescription(), 'Invalid Origin. Register your new client (com.company.appname) as a new macOS platform on your project console dashboard');
+        $this->assertEquals(false, $validator->isValid('appwrite-macos://com.company.appname'));
+        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new macOS platform on your project console dashboard', $validator->getDescription());
 
-        $this->assertEquals($validator->isValid('appwrite-linux://com.company.appname'), false);
-        $this->assertEquals($validator->getDescription(), 'Invalid Origin. Register your new client (com.company.appname) as a new Linux platform on your project console dashboard');
+        $this->assertEquals(false, $validator->isValid('appwrite-linux://com.company.appname'));
+        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Linux platform on your project console dashboard', $validator->getDescription());
 
-        $this->assertEquals($validator->isValid('appwrite-windows://com.company.appname'), false);
-        $this->assertEquals($validator->getDescription(), 'Invalid Origin. Register your new client (com.company.appname) as a new Windows platform on your project console dashboard');
+        $this->assertEquals(false, $validator->isValid('appwrite-windows://com.company.appname'));
+        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Windows platform on your project console dashboard', $validator->getDescription());
     }
 }

--- a/tests/unit/Task/Validator/CronTest.php
+++ b/tests/unit/Task/Validator/CronTest.php
@@ -23,17 +23,17 @@ class CronTest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals($this->object->isValid('0 2 * * *'), true); // execute at 2am daily
-        $this->assertEquals($this->object->isValid('0 5,17 * * *'), true); // execute twice a day
-        $this->assertEquals($this->object->isValid('* * * * *'), true); // execute on every minutes
+        $this->assertEquals(true, $this->object->isValid('0 2 * * *')); // execute at 2am daily
+        $this->assertEquals(true, $this->object->isValid('0 5,17 * * *')); // execute twice a day
+        $this->assertEquals(true, $this->object->isValid('* * * * *')); // execute on every minutes
         // $this->assertEquals($this->object->isValid('0 17 * * sun'), true); // execute on every Sunday at 5 PM
-        $this->assertEquals($this->object->isValid('*/10 * * * *'), true); // execute on every 10 minutes
+        $this->assertEquals(true, $this->object->isValid('*/10 * * * *')); // execute on every 10 minutes
         // $this->assertEquals($this->object->isValid('* * * jan,may,aug *'), true); // execute on selected months
         // $this->assertEquals($this->object->isValid('0 17 * * sun,fri'), true); // execute on selected days
         // $this->assertEquals($this->object->isValid('0 2 * * sun'), true); // execute on first sunday of every month
-        $this->assertEquals($this->object->isValid('0 */4 * * *'), true); //  execute on every four hours
+        $this->assertEquals(true, $this->object->isValid('0 */4 * * *')); //  execute on every four hours
         // $this->assertEquals($this->object->isValid('0 4,17 * * sun,mon'), true); // execute twice on every Sunday and Monday
-        $this->assertEquals($this->object->isValid('bad expression'), false);
+        $this->assertEquals(false, $this->object->isValid('bad expression'));
         $this->assertEquals(null, false);
         $this->assertEquals('', false);
     }

--- a/tests/unit/Template/TemplateTest.php
+++ b/tests/unit/Template/TemplateTest.php
@@ -26,16 +26,16 @@ class TemplateTest extends TestCase
 
     public function testRender()
     {
-        $this->assertEquals($this->object->render(), 'Hello WORLD');
+        $this->assertEquals('Hello WORLD', $this->object->render());
     }
 
     public function testParseURL()
     {
         $url = $this->object->parseURL('https://appwrite.io/demo');
 
-        $this->assertEquals($url['scheme'], 'https');
-        $this->assertEquals($url['host'], 'appwrite.io');
-        $this->assertEquals($url['path'], '/demo');
+        $this->assertEquals('https', $url['scheme']);
+        $this->assertEquals('appwrite.io', $url['host']);
+        $this->assertEquals('/demo', $url['path']);
     }
 
     public function testUnParseURL()
@@ -46,12 +46,12 @@ class TemplateTest extends TestCase
         $url['host'] = 'example.com';
         $url['path'] = '/new';
 
-        $this->assertEquals($this->object->unParseURL($url), 'http://example.com/new');
+        $this->assertEquals('http://example.com/new', $this->object->unParseURL($url));
     }
 
     public function testMergeQuery()
     {
-        $this->assertEquals($this->object->mergeQuery('key1=value1&key2=value2', ['key1' => 'value3', 'key4' => 'value4']), 'key1=value3&key2=value2&key4=value4');
+        $this->assertEquals('key1=value3&key2=value2&key4=value4', $this->object->mergeQuery('key1=value1&key2=value2', ['key1' => 'value3', 'key4' => 'value4']));
     }
 
     public function testFromCamelCaseToSnake()

--- a/tests/unit/Utopia/Database/Validator/CustomIdTest.php
+++ b/tests/unit/Utopia/Database/Validator/CustomIdTest.php
@@ -23,19 +23,19 @@ class CustomIdTest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals($this->object->isValid('unique()'), true);
-        $this->assertEquals($this->object->isValid('unique)'), false);
-        $this->assertEquals($this->object->isValid('else()'), false);
-        $this->assertEquals($this->object->isValid('dasda asdasd'), false);
-        $this->assertEquals($this->object->isValid('dasda_asdasd'), true);
-        $this->assertEquals($this->object->isValid('asdasdasdas'), true);
-        $this->assertEquals($this->object->isValid('_asdasdasdas'), false);
-        $this->assertEquals($this->object->isValid('as$$5dasdasdas'), false);
-        $this->assertEquals($this->object->isValid(false), false);
-        $this->assertEquals($this->object->isValid(null), false);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeAndRestSubscribers'), false);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeAndRSubscriber'), false);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscribe'), true);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscrib'), true);
+        $this->assertEquals(true, $this->object->isValid('unique()'));
+        $this->assertEquals(false, $this->object->isValid('unique)'));
+        $this->assertEquals(false, $this->object->isValid('else()'));
+        $this->assertEquals(false, $this->object->isValid('dasda asdasd'));
+        $this->assertEquals(true, $this->object->isValid('dasda_asdasd'));
+        $this->assertEquals(true, $this->object->isValid('asdasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as$$5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid(false));
+        $this->assertEquals(false, $this->object->isValid(null));
+        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeAndRestSubscribers'));
+        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeAndRSubscriber'));
+        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribe'));
+        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscrib'));
     }
 }

--- a/tests/unit/Utopia/ResponseTest.php
+++ b/tests/unit/Utopia/ResponseTest.php
@@ -21,13 +21,13 @@ class ResponseTest extends TestCase
 
     public function testSetFilter()
     {
-        $this->assertEquals($this->object->hasFilter(), false);
-        $this->assertEquals($this->object->getFilter(), null);
+        $this->assertEquals(false, $this->object->hasFilter());
+        $this->assertEquals(null, $this->object->getFilter());
 
         $filter = new V11();
         $this->object->setFilter($filter);
 
-        $this->assertEquals($this->object->hasFilter(), true);
+        $this->assertEquals(true, $this->object->hasFilter());
         $this->assertEquals($this->object->getFilter(), $filter);
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Fixes assertion ordering for all `assertEquals` cases (thanks to PHPStorm global inspections).
- No changes outside of `tests` directory

## Test Plan

Existing tests

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
