### PR TITLE
Fix usage tests

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1109,7 +1109,7 @@ App::get('/v1/users/usage')
             ];
 
             $metrics = [
-                'users.$all.requests.count',
+                'users.$all.count.total',
                 'users.$all.requests.create',
                 'users.$all.requests.read',
                 'users.$all.requests.update',
@@ -1161,7 +1161,7 @@ App::get('/v1/users/usage')
 
             $usage = new Document([
                 'range' => $range,
-                'usersCount' => $stats['users.$all.requests.count'] ?? [],
+                'usersCount' => $stats['users.$all.count.total'] ?? [],
                 'usersCreate' => $stats['users.$all.requests.create'] ?? [],
                 'usersRead' => $stats['users.$all.requests.read'] ?? [],
                 'usersUpdate' => $stats['users.$all.requests.update'] ?? [],

--- a/src/Appwrite/Usage/Calculators/TimeSeries.php
+++ b/src/Appwrite/Usage/Calculators/TimeSeries.php
@@ -298,7 +298,7 @@ class TimeSeries extends Calculator
      *
      * @return void
      */
-    private function createOrUpdateMetric(string $projectId, int $time, string $period, string $metric, int $value, int $type): void
+    private function createOrUpdateMetric(string $projectId, string $time, string $period, string $metric, int $value, int $type): void
     {
         $id = \md5("{$time}_{$period}_{$metric}");
         $this->database->setNamespace('_console');
@@ -347,9 +347,9 @@ class TimeSeries extends Calculator
     {
         $start = DateTime::createFromFormat('U', \strtotime($period['startTime']))->format(DateTime::RFC3339);
         if (!empty($this->latestTime[$metric][$period['key']])) {
-            $start = DateTime::createFromFormat('U', $this->latestTime[$metric][$period['key']])->format(DateTime::RFC3339);
+            $start = $this->latestTime[$metric][$period['key']];
         }
-        $end = DateTime::createFromFormat('U', \strtotime('now'))->format(DateTime::RFC3339);
+        $end = (new DateTime())->format(DateTime::RFC3339);
 
         $table = $options['table']; //Which influxdb table to query for this metric
         $groupBy = empty($options['groupBy']) ? '' : ', ' . implode(', ', array_map(fn($groupBy) => '"' . $groupBy . '" ', $options['groupBy'])); //Some sub level metrics may be grouped by other tags like collectionId, bucketId, etc
@@ -387,12 +387,11 @@ class TimeSeries extends Calculator
                         }
                     }
 
-                    $time = DateTime::createFromFormat('U', \strtotime($point['time']))->format(DateTime::RFC3339);
                     $value = (!empty($point['value'])) ? $point['value'] : 0;
 
                     $this->createOrUpdateMetric(
                         $projectId,
-                        $time,
+                        $point['time'],
                         $period['key'],
                         $metricUpdated,
                         $value,


### PR DESCRIPTION
## What does this PR do?

Fix usage bugs.

## Test Plan

Updated tests/e2e/General/UsageTest.php

<img width="244" alt="image" src="https://user-images.githubusercontent.com/1477010/186781649-00fcaa45-b3dd-4d43-a099-0c257ce48627.png">

<details><summary>Full test log</summary>

```shell
$ docker compose exec appwrite test 
PHPUnit 9.5.20 #StandWithUkraine

Tests\Unit\Auth\AuthTest::testCookieName ended in 0.39877 milliseconds
.Tests\Unit\Auth\AuthTest::testEncodeDecodeSession ended in 0.05043 milliseconds
.Tests\Unit\Auth\AuthTest::testHash ended in 0.42204 milliseconds
.Tests\Unit\Auth\AuthTest::testPassword ended in 6044.478105 milliseconds
.Tests\Unit\Auth\AuthTest::testUnknownAlgo ended in 0.10568 milliseconds
.Tests\Unit\Auth\AuthTest::testPasswordGenerator ended in 0.051569 milliseconds
.Tests\Unit\Auth\AuthTest::testTokenGenerator ended in 0.037231 milliseconds
.Tests\Unit\Auth\AuthTest::testCodeGenerator ended in 0.3148 milliseconds
.Tests\Unit\Auth\AuthTest::testSessionVerify ended in 0.20214 milliseconds
.Tests\Unit\Auth\AuthTest::testTokenVerify ended in 0.48876 milliseconds
.Tests\Unit\Auth\AuthTest::testIsPrivilegedUser ended in 0.047911 milliseconds
.Tests\Unit\Auth\AuthTest::testIsAppUser ended in 0.34092 milliseconds
.Tests\Unit\Auth\AuthTest::testGuestRoles ended in 0.062909 milliseconds
.Tests\Unit\Auth\AuthTest::testUserRoles ended in 0.057389 milliseconds
.Tests\Unit\Auth\AuthTest::testPrivilegedUserRoles ended in 0.050651 milliseconds
.Tests\Unit\Auth\AuthTest::testAppUserRoles ended in 0.168791 milliseconds
.Tests\Unit\Auth\Validator\PasswordTest::testValues ended in 0.049649 milliseconds
.Tests\Unit\Auth\Validator\PhoneTest::testValues ended in 0.366751 milliseconds
.Tests\Unit\DSN\DSNTest::testSuccess ended in 0.25275 milliseconds
.Tests\Unit\DSN\DSNTest::testFail ended in 0.05355 milliseconds
.Tests\Unit\Detector\DetectorTest::testGetOS ended in 414.109146 milliseconds
.Tests\Unit\Detector\DetectorTest::testGetClient ended in 4.822101 milliseconds
.Tests\Unit\Detector\DetectorTest::testGetDevice ended in 4.247609 milliseconds
.Tests\Unit\Docker\ComposeTest::testVersion ended in 1.39437 milliseconds
.Tests\Unit\Docker\ComposeTest::testServices ended in 1.19947 milliseconds
.Tests\Unit\Docker\ComposeTest::testNetworks ended in 0.81704 milliseconds
.Tests\Unit\Docker\ComposeTest::testVolumes ended in 1.090669 milliseconds
.Tests\Unit\Docker\EnvTest::testVars ended in 0.31223 milliseconds
.Tests\Unit\Docker\EnvTest::testExport ended in 0.07301 milliseconds
.Tests\Unit\Event\EventTest::testQueue ended in 0.07699 milliseconds
.Tests\Unit\Event\EventTest::testClass ended in 0.04809 milliseconds
.Tests\Unit\Event\EventTest::testParams ended in 2.01971 milliseconds
.Tests\Unit\Event\EventTest::testReset ended in 0.103129 milliseconds
.Tests\Unit\Event\EventTest::testGenerateEvents ended in 1.53254 milliseconds
.Tests\Unit\Event\Validator\EventValidatorTest::testValues ended in 0.81107 milliseconds
.Tests\Unit\General\CollectionsTest::testDuplicateRules ended in 0.79672 milliseconds
.Tests\Unit\General\ExtensionsTest::testPHPRedis ended in 0.04944 milliseconds
.Tests\Unit\General\ExtensionsTest::testSwoole ended in 0.03785 milliseconds
.Tests\Unit\General\ExtensionsTest::testYAML ended in 0.02247 milliseconds
.Tests\Unit\General\ExtensionsTest::testOPCache ended in 0.02265 milliseconds
.Tests\Unit\General\ExtensionsTest::testDOM ended in 0.02495 milliseconds
.Tests\Unit\General\ExtensionsTest::testPDO ended in 0.0325 milliseconds
.Tests\Unit\General\ExtensionsTest::testImagick ended in 0.02838 milliseconds
.Tests\Unit\General\ExtensionsTest::testJSON ended in 0.02231 milliseconds
.Tests\Unit\General\ExtensionsTest::testCURL ended in 0.01954 milliseconds
.Tests\Unit\General\ExtensionsTest::testMBString ended in 0.02856 milliseconds
.Tests\Unit\General\ExtensionsTest::testOPENSSL ended in 0.18069 milliseconds
.Tests\Unit\General\ExtensionsTest::testZLIB ended in 0.0224 milliseconds
.Tests\Unit\General\ExtensionsTest::testSockets ended in 0.0205 milliseconds
.Tests\Unit\General\ExtensionsTest::testMaxminddb ended in 0.02016 milliseconds
.Tests\Unit\Messaging\MessagingChannelsTest::testSubscriptions ended in 4.62666 milliseconds
.Tests\Unit\Messaging\MessagingChannelsTest::testWildcardPermission ended in 2.20407 milliseconds
.Tests\Unit\Messaging\MessagingChannelsTest::testRolePermissions ended in 1.80324 milliseconds
.Tests\Unit\Messaging\MessagingChannelsTest::testUserPermissions ended in 1.69465 milliseconds
.Tests\Unit\Messaging\MessagingChannelsTest::testTeamPermissions ended in 1.96415 milliseconds
.Tests\Unit\Messaging\MessagingGuestTest::testGuest ended in 0.06928 milliseconds
.Tests\Unit\Messaging\MessagingTest::testUser ended in 0.14109 milliseconds
.Tests\Unit\Messaging\MessagingTest::testConvertChannelsGuest ended in 0.04836 milliseconds
.Tests\Unit\Messaging\MessagingTest::testConvertChannelsUser ended in 0.05126 milliseconds
.Tests\Unit\Messaging\MessagingTest::testFromPayloadPermissions ended in 0.17488 milliseconds
.Tests\Unit\Messaging\MessagingTest::testFromPayloadBucketLevelPermissions ended in 0.15123 milliseconds
.Tests\Unit\Migration\MigrationV12Test::testMigrationProjects ended in 0.13424 milliseconds
.Tests\Unit\Migration\MigrationV12Test::testMigrationUsers ended in 0.03984 milliseconds
.  63 / 565 ( 11%)
Tests\Unit\Migration\MigrationV12Test::testMigrationTeams ended in 0.03419 milliseconds
.Tests\Unit\Migration\MigrationV12Test::testMigrationFunctions ended in 0.03303 milliseconds
.Tests\Unit\Migration\MigrationV12Test::testMigrationExecutions ended in 0.03802 milliseconds
.Tests\Unit\Migration\MigrationV12Test::testMigrationVersions ended in 6.86473 milliseconds
.Tests\Unit\Migration\MigrationV12Test::testHasDifference ended in 0.25951 milliseconds
.Tests\Unit\Migration\MigrationV13Test::testMigrateFunctions ended in 0.08723 milliseconds
.Tests\Unit\Migration\MigrationV13Test::testMigrationWebhooks ended in 0.06554 milliseconds
.Tests\Unit\Migration\MigrationV13Test::testMigrationVersions ended in 0.05658 milliseconds
.Tests\Unit\Migration\MigrationV13Test::testHasDifference ended in 0.0402 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateProjects ended in 0.0947 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateKeys ended in 0.05801 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateWebhooks ended in 0.08602 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateUsers ended in 0.31641 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigratePlatforms ended in 0.07659 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateFunctions ended in 0.04697 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateDeployments ended in 0.19888 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateExecutions ended in 0.05334 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateTeams ended in 0.058171 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateAudits ended in 0.043969 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrateStats ended in 0.037051 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testMigrationVersions ended in 0.0513 milliseconds
.Tests\Unit\Migration\MigrationV14Test::testHasDifference ended in 0.030931 milliseconds
.Tests\Unit\Network\Validators\CNAMETest::testValues ended in 450.457967 milliseconds
.Tests\Unit\Network\Validators\DomainTest::testIsValid ended in 0.071229 milliseconds
.Tests\Unit\Network\Validators\EmailTest::testIsValid ended in 0.825471 milliseconds
.Tests\Unit\Network\Validators\HostTest::testIsValid ended in 0.1799 milliseconds
.Tests\Unit\Network\Validators\IPTest::testIsValidIP ended in 0.058991 milliseconds
.Tests\Unit\Network\Validators\IPTest::testIsValidIPALL ended in 0.04374 milliseconds
.Tests\Unit\Network\Validators\IPTest::testIsValidIPV4 ended in 0.03774 milliseconds
.Tests\Unit\Network\Validators\IPTest::testIsValidIPV6 ended in 0.041409 milliseconds
.Tests\Unit\Network\Validators\OriginTest::testValues ended in 0.34336 milliseconds
.Tests\Unit\Network\Validators\URLTest::testIsValid ended in 0.04506 milliseconds
.Tests\Unit\Network\Validators\URLTest::testIsValidAllowedSchemes ended in 1.16439 milliseconds
.Tests\Unit\OpenSSL\OpenSSLTest::testEncryptionAndDecryption ended in 0.19128 milliseconds
.Tests\Unit\Task\Validator\CronTest::testValues ended in 0.204921 milliseconds
.Tests\Unit\Template\TemplateTest::testRender ended in 0.31838 milliseconds
.Tests\Unit\Template\TemplateTest::testParseURL ended in 0.02796 milliseconds
.Tests\Unit\Template\TemplateTest::testUnParseURL ended in 0.022289 milliseconds
.Tests\Unit\Template\TemplateTest::testMergeQuery ended in 0.046491 milliseconds
.Tests\Unit\Template\TemplateTest::testFromCamelCaseToSnake ended in 0.106931 milliseconds
.Tests\Unit\Template\TemplateTest::testFromCamelCaseToDash ended in 0.078689 milliseconds
.Tests\Unit\URL\URLTest::testParse ended in 0.0602 milliseconds
.Tests\Unit\URL\URLTest::testUnparse ended in 0.047469 milliseconds
.Tests\Unit\URL\URLTest::testParseQuery ended in 0.028731 milliseconds
.Tests\Unit\URL\URLTest::testUnParseQuery ended in 0.038471 milliseconds
.Tests\Unit\Stats\StatsTest::testNamespace ended in 2.39875 milliseconds
.Tests\Unit\Stats\StatsTest::testParams ended in 1.07756 milliseconds
.Tests\Unit\Stats\StatsTest::testReset ended in 0.03017 milliseconds
.Tests\Unit\Utopia\Database\Validator\CustomIdTest::testValues ended in 0.20383 milliseconds
.Tests\Unit\Utopia\ResponseTest::testSetFilter ended in 1.6805 milliseconds
.Tests\Unit\Utopia\ResponseTest::testResponseModel ended in 1.10955 milliseconds
.Tests\Unit\Utopia\ResponseTest::testResponseModelRequired ended in 1.406051 milliseconds
.Tests\Unit\Utopia\ResponseTest::testResponseModelRequiredException ended in 0.5995 milliseconds
.Tests\Unit\Utopia\ResponseTest::testResponseModelLists ended in 0.86456 milliseconds
.Tests\Unit\Utopia\ResponseTest::testResponseModelNested ended in 0.537331 milliseconds
.Tests\E2E\General\HTTPTest::testOptions ended in 9.01235 milliseconds
.Tests\E2E\General\HTTPTest::testError ended in 7.26475 milliseconds
.Tests\E2E\General\HTTPTest::testManifest ended in 34.28054 milliseconds
.Tests\E2E\General\HTTPTest::testHumans ended in 3.81081 milliseconds
.Tests\E2E\General\HTTPTest::testRobots ended in 3.87985 milliseconds
.Tests\E2E\General\HTTPTest::testAcmeChallenge ended in 8.254251 milliseconds
.Tests\E2E\General\HTTPTest::testSpecOpenAPI3 ended in 12899.519197 milliseconds
.Tests\E2E\General\HTTPTest::testVersions ended in 3.28768 milliseconds
. 126 / 565 ( 22%)
Tests\E2E\General\UsageTest::testUsersStats ended in 38628.567901 milliseconds
.Tests\E2E\General\UsageTest::testStorageStats ended in 38084.473052 milliseconds
.Tests\E2E\General\UsageTest::testDatabaseStats ended in 46135.568498 milliseconds
.Tests\E2E\General\UsageTest::testFunctionsStats ended in 55942.123042 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testCreateAccount ended in 409.667867 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testCreateAccountSession ended in 1024.565797 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testGetAccount ended in 47.199081 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testGetAccountPrefs ended in 5.35426 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testGetAccountSessions ended in 13.0367 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testGetAccountLogs ended in 10053.762819 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountName ended in 16.44226 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountPassword ended in 692.326501 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountEmail ended in 250.365134 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountPrefs ended in 1045.048727 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testCreateAccountVerification ended in 3031.080971 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountVerification ended in 21.266501 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testDeleteAccountSession ended in 173.464143 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testDeleteAccountSessionCurrent ended in 149.776412 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testDeleteAccountSessions ended in 115.822382 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testCreateAccountRecovery ended in 3053.260021 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountRecovery ended in 219.412664 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testCreateMagicUrl ended in 3023.77307 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testCreateSessionWithMagicUrl ended in 34.853401 milliseconds
.Tests\E2E\Services\Account\AccountConsoleClientTest::testUpdateAccountPasswordWithMagicUrl ended in 1014.101337 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testBlockedAccount ended in 1272.856342 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testSelfBlockedAccount ended in 555.374719 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateJWT ended in 411.418927 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateAnonymousAccount ended in 28.019871 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAnonymousAccountPassword ended in 14.72623 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAnonymousAccountEmail ended in 3.016539 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testConvertAnonymousAccount ended in 798.252934 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testConvertAnonymousAccountOAuth2 ended in 3167.521563 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testGetSessionByID ended in 36.833981 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreatePhone ended in 16.40122 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateSessionWithPhone ended in 41.640851 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testConvertPhoneToPassword ended in 289.452645 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdatePhone ended in 175.352203 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testPhoneVerification ended in 4.588799 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdatePhoneVerification ended in 27.837701 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateAccount ended in 328.203556 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateAccountSession ended in 540.972059 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateOAuth2AccountSession ended in 56.05314 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testGetAccount ended in 9.07823 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testGetAccountPrefs ended in 4.71443 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testGetAccountSessions ended in 4.81313 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testGetAccountLogs ended in 10054.345 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountName ended in 22.9973 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountNameSearch ended in 16.16959 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountPassword ended in 1111.143729 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountEmail ended in 426.392657 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountEmailSearch ended in 73.867242 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountPrefs ended in 1054.068828 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateAccountVerification ended in 3022.892901 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountVerification ended in 60.102651 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testDeleteAccountSession ended in 171.561953 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testDeleteAccountSessionCurrent ended in 178.542573 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testDeleteAccountSessions ended in 188.401173 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateAccountRecovery ended in 3036.311731 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountRecovery ended in 284.261625 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateMagicUrl ended in 3037.161861 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testCreateSessionWithMagicUrl ended in 68.418872 milliseconds
.Tests\E2E\Services\Account\AccountCustomClientTest::testUpdateAccountPasswordWithMagicUrl ended in 985.471246 milliseconds
.Tests\E2E\Services\Account\AccountCustomServerTest::testCreateAccount ended in 507.699838 milliseconds
. 189 / 565 ( 33%)
Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testManualAuthentication ended in 1201.17128 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testAttributes ended in 120.806302 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testIndexes ended in 124.258513 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testDeleteIndex ended in 22.82094 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testDeleteAttribute ended in 40.456011 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testConnection ended in 5.33431 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testConnectionFailureMissingChannels ended in 256.753664 milliseconds
.Tests\E2E\Services\Realtime\RealtimeConsoleClientTest::testConnectionFailureUnknownProject ended in 255.180084 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelParsing ended in 997.356506 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testManualAuthentication ended in 69.491822 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testConnectionPlatform ended in 254.807544 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelAccount ended in 7120.25526 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelDatabase ended in 2158.680307 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelDatabaseCollectionPermissions ended in 2220.615838 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelFiles ended in 144.597123 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelExecutions ended in 11226.8308 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelTeams ended in 71.263351 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testChannelMemberships ended in 29.172401 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testConnection ended in 5.178731 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testConnectionFailureMissingChannels ended in 255.411815 milliseconds
.Tests\E2E\Services\Realtime\RealtimeCustomClientTest::testConnectionFailureUnknownProject ended in 255.404344 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetCreditCard ended in 489.056749 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetBrowser ended in 1262.286601 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetFlag ended in 216.336243 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetImage ended in 3444.362999 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetFavicon ended in 1728.152149 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetQR ended in 394.244306 milliseconds
.Tests\E2E\Services\Avatars\AvatarsConsoleClientTest::testGetInitials ended in 165.783903 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetCreditCard ended in 892.648965 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetBrowser ended in 1190.03135 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetFlag ended in 249.292764 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetImage ended in 3088.213042 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetFavicon ended in 1871.084952 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetQR ended in 463.993478 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomClientTest::testGetInitials ended in 122.158392 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetCreditCard ended in 941.759505 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetBrowser ended in 1202.17108 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetFlag ended in 266.613395 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetImage ended in 3033.927731 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetFavicon ended in 1761.044269 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetQR ended in 624.31244 milliseconds
.Tests\E2E\Services\Avatars\AvatarsCustomServerTest::testGetInitials ended in 190.206994 milliseconds
.Tests\E2E\Services\Databases\DatabasesConsoleClientTest::testCreateCollection ended in 847.007434 milliseconds
.Tests\E2E\Services\Databases\DatabasesConsoleClientTest::testGetCollectionUsage ended in 26.635401 milliseconds
.Tests\E2E\Services\Databases\DatabasesConsoleClientTest::testGetCollectionLogs ended in 26.73202 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testUpdateWithoutPermission ended in 5167.601756 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testCreateDatabase ended in 28.16926 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testCreateCollection ended in 26.771431 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testDisableCollection ended in 38.54926 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testCreateAttributes ended in 2113.999196 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testAttributeResponseModels ended in 30298.17802 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testCreateIndexes ended in 2098.826555 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testCreateDocument ended in 90.105131 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testListDocuments ended in 86.875012 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testCreateCollectionAlias ended in 98.538111 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testListDocumentsAlias ended in 7.56812 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testGetDocument ended in 14.677011 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testListDocumentsAfterPagination ended in 99.137781 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testListDocumentsBeforePagination ended in 86.952452 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testListDocumentsLimitAndOffset ended in 12.45326 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testDocumentsListQueries ended in 110.157722 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testUpdateDocument ended in 105.897972 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testDeleteDocument ended in 83.590831 milliseconds
. 252 / 565 ( 44%)
Tests\E2E\Services\Databases\DatabasesCustomClientTest::testInvalidDocumentStructure ended in 3826.915305 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testDefaultPermissions ended in 71.258271 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testEnforceCollectionAndDocumentPermissions ended in 6683.428963 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testEnforceCollectionPermissions ended in 6802.111134 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testUniqueIndexDuplicate ended in 2101.508526 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testPersistantCreatedAt ended in 2020.694095 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomClientTest::testUpdatePermissionsWithEmptyPayload ended in 2142.577316 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListDatabases ended in 594.97679 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testGetDatabase ended in 3.342911 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDeleteDatabase ended in 28.62783 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListCollections ended in 204.838993 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDeleteAttribute ended in 6141.021313 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDeleteIndex ended in 2017.715094 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDeleteIndexOnDeleteAttribute ended in 6061.991512 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCleanupDuplicateIndexOnDeleteAttribute ended in 6258.367466 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDeleteCollection ended in 719.342263 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testAttributeRowWidthLimit ended in 5618.162175 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testIndexLimitException ended in 30248.24969 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCreateDatabase ended in 52.460411 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCreateCollection ended in 45.504451 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDisableCollection ended in 55.292011 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCreateAttributes ended in 2121.555096 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testAttributeResponseModels ended in 30445.123204 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCreateIndexes ended in 2111.475696 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCreateDocument ended in 112.235192 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListDocuments ended in 42.605601 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testCreateCollectionAlias ended in 199.726393 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListDocumentsAlias ended in 10.358861 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testGetDocument ended in 29.455421 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListDocumentsAfterPagination ended in 70.574621 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListDocumentsBeforePagination ended in 69.278841 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testListDocumentsLimitAndOffset ended in 12.740451 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDocumentsListQueries ended in 92.919271 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testUpdateDocument ended in 73.010362 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDeleteDocument ended in 43.61656 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testInvalidDocumentStructure ended in 3757.327794 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testDefaultPermissions ended in 82.389571 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testEnforceCollectionAndDocumentPermissions ended in 7017.773969 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testEnforceCollectionPermissions ended in 6790.821644 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testUniqueIndexDuplicate ended in 2038.653305 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testPersistantCreatedAt ended in 2028.110354 milliseconds
.Tests\E2E\Services\Databases\DatabasesCustomServerTest::testUpdatePermissionsWithEmptyPayload ended in 2137.738796 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsGuestTest::testReadDocuments with data set #0 (array('read("any")')) ended in 3116.256343 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsGuestTest::testReadDocuments with data set #1 (array('read("users")')) ended in 2098.616665 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsGuestTest::testReadDocuments with data set #2 (array('update("any")', 'delete("any")')) ended in 2099.377985 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsGuestTest::testReadDocuments with data set #3 (array('read("any")', 'update("any")', 'delete("any")')) ended in 2087.876205 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsGuestTest::testReadDocuments with data set #4 (array('read("users")', 'update("users")', 'delete("users")')) ended in 2134.376476 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsGuestTest::testReadDocuments with data set #5 (array('read("any")', 'update("users")', 'delete("users")')) ended in 2076.307605 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testSetupDatabase ended in 4573.410826 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #0 (array('read("any")'), 1, 1, 1) ended in 87.165761 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #1 (array('read("users")'), 2, 2, 2) ended in 112.482092 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #2 (array('read("user:random")'), 3, 3, 2) ended in 96.083542 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #3 (array('read("user:lorem")', 'update("user:lorem")', 'delete("user:lorem")'), 4, 4, 2) ended in 99.218462 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #4 (array('read("user:dolor")', 'update("user:dolor")', 'delete("user:dolor")'), 5, 5, 2) ended in 104.850302 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #5 (array('read("user:dolor")', 'read("user:lorem")', 'update("user:dolor")', 'delete("user:dolor")'), 6, 6, 2) ended in 123.077432 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #6 (array('update("any")', 'delete("any")'), 7, 7, 2) ended in 79.413012 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #7 (array('read("any")', 'update("any")', 'delete("any")'), 8, 8, 3) ended in 107.397381 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #8 (array('read("any")', 'update("users")', 'delete("users")'), 9, 9, 4) ended in 98.596883 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #9 (array('read("user:user1")'), 10, 10, 5) ended in 107.098931 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsMemberTest::testReadDocuments with data set #10 (array('read("user:user1")', 'read("user:user1")'), 11, 11, 6) ended in 103.506322 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testSetupDatabase ended in 5131.788806 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testReadDocuments with data set #0 ('user1', 'collection1', true) ended in 12.30832 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testReadDocuments with data set #1 ('user2', 'collection1', false) ended in 7.12777 milliseconds
. 315 / 565 ( 55%)
Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testReadDocuments with data set #2 ('user3', 'collection1', true) ended in 9.712391 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testReadDocuments with data set #3 ('user1', 'collection2', false) ended in 6.5557 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testReadDocuments with data set #4 ('user2', 'collection2', true) ended in 18.63315 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testReadDocuments with data set #5 ('user3', 'collection2', true) ended in 11.1718 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testWriteDocuments with data set #0 ('user1', 'collection1', true) ended in 8.44994 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testWriteDocuments with data set #1 ('user2', 'collection1', false) ended in 12.067181 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testWriteDocuments with data set #2 ('user3', 'collection1', false) ended in 6.15817 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testWriteDocuments with data set #3 ('user1', 'collection2', false) ended in 3.96649 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testWriteDocuments with data set #4 ('user2', 'collection2', true) ended in 5.83812 milliseconds
.Tests\E2E\Services\Databases\DatabasesPermissionsTeamTest::testWriteDocuments with data set #5 ('user3', 'collection2', false) ended in 21.66621 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testHTTPSuccess ended in 785.002604 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testDBSuccess ended in 3.97374 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testCacheSuccess ended in 3.77421 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testTimeSuccess ended in 18.27625 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testWebhooksSuccess ended in 10.71425 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testLogsSuccess ended in 14.420451 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testCertificatesSuccess ended in 6.923531 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testStorageLocalSuccess ended in 4.81997 milliseconds
.Tests\E2E\Services\Health\HealthCustomServerTest::testStorageAntiVirusSuccess ended in 9.457691 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetLocale ended in 687.300682 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetCountries ended in 14.21862 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetCountriesEU ended in 6.75745 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetCountriesPhones ended in 4.61027 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetContinents ended in 6.87188 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetCurrencies ended in 4.18374 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testGetLanguages ended in 4.10048 milliseconds
.Tests\E2E\Services\Locale\LocaleConsoleClientTest::testLanguages ended in 979.267487 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetLocale ended in 1420.585504 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetCountries ended in 26.7482 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetCountriesEU ended in 17.318991 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetCountriesPhones ended in 5.488459 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetContinents ended in 7.61857 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetCurrencies ended in 4.890169 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testGetLanguages ended in 4.139461 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomClientTest::testLanguages ended in 1116.263809 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetLocale ended in 749.569072 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetCountries ended in 24.535111 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetCountriesEU ended in 7.69287 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetCountriesPhones ended in 3.91342 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetContinents ended in 6.37781 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetCurrencies ended in 3.58943 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testGetLanguages ended in 3.23756 milliseconds
.Tests\E2E\Services\Locale\LocaleCustomServerTest::testLanguages ended in 946.099406 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testCreateProject ended in 639.372071 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testListProject ended in 939.067005 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testGetProject ended in 28.75925 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testGetProjectUsage ended in 29.898681 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProject ended in 91.132431 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectOAuth ended in 1108.224909 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectAuthStatus ended in 1295.951231 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectAuthLimit ended in 670.620991 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectServiceStatusAdmin ended in 1553.190446 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectServiceStatus ended in 953.546666 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectServiceStatusServer ended in 554.098769 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testCreateProjectWebhook ended in 43.218331 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testListProjectWebhook ended in 18.64719 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testGetProjectWebhook ended in 9.492151 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectWebhook ended in 55.855982 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectWebhookSignature ended in 22.51683 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testDeleteProjectWebhook ended in 35.2181 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testCreateProjectKey ended in 77.019922 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testListProjectKey ended in 12.2089 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testGetProjectKey ended in 43.131011 milliseconds
. 378 / 565 ( 66%)
Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testValidateProjectKey ended in 66.622971 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectKey ended in 47.920411 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testDeleteProjectKey ended in 32.72489 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testCreateProjectPlatform ended in 170.394393 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testListProjectPlatform ended in 1022.708087 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testGetProjectPlatform ended in 43.123081 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectPlatform ended in 183.082123 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testDeleteProjectPlatform ended in 264.912415 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testCreateProjectDomain ended in 15.29932 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testListProjectDomain ended in 11.68436 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testGetProjectDomain ended in 27.650631 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testUpdateProjectDomain ended in 61.649041 milliseconds
.Tests\E2E\Services\Projects\ProjectsConsoleClientTest::testDeleteProjectDomain ended in 22.99791 milliseconds
.Tests\E2E\Services\Projects\ProjectsCustomClientTest::testMock ended in 0.06093 milliseconds
.Tests\E2E\Services\Projects\ProjectsCustomServerTest::testMock ended in 0.0414 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testGetStorageUsage ended in 984.057417 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testGetStorageBucketUsage ended in 104.569511 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testCreateBucketFile ended in 8473.894243 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testListBucketFiles ended in 16.410341 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testGetBucketFile ended in 1487.679825 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testFilePreviewCache ended in 1832.606811 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testUpdateBucketFile ended in 781.045503 milliseconds
.Tests\E2E\Services\Storage\StorageConsoleClientTest::testDeleteBucketFile ended in 29.205941 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testBucketAnyPermissions ended in 2031.629674 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testBucketUsersPermissions ended in 448.396617 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testBucketUserPermissions ended in 1372.746063 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testBucketTeamPermissions ended in 2223.098467 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testFileAnyPermissions ended in 451.734107 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testFileUsersPermissions ended in 596.11098 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testFileUserPermissions ended in 1343.026983 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testFileTeamPermissions ended in 2327.367489 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testCreateFileDefaultPermissions ended in 166.177163 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testCreateFileAbusePermissions ended in 81.773561 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testUpdateFileAbusePermissions ended in 14.972621 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testCreateBucketFile ended in 8500.166263 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testListBucketFiles ended in 10.15274 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testGetBucketFile ended in 1735.48668 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testFilePreviewCache ended in 1955.847482 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testUpdateBucketFile ended in 55.68723 milliseconds
.Tests\E2E\Services\Storage\StorageCustomClientTest::testDeleteBucketFile ended in 28.118171 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testCreateBucket ended in 1728.125759 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testListBucket ended in 30.965571 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testGetBucket ended in 29.078271 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testUpdateBucket ended in 57.01692 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testDeleteBucket ended in 29.444561 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testCreateBucketFile ended in 8906.9684 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testListBucketFiles ended in 16.49846 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testGetBucketFile ended in 1692.458869 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testFilePreviewCache ended in 2001.822044 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testUpdateBucketFile ended in 829.447534 milliseconds
.Tests\E2E\Services\Storage\StorageCustomServerTest::testDeleteBucketFile ended in 32.12585 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testRequestHeader ended in 100.843622 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testCreateTeam ended in 51.648381 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testGetTeam ended in 4.60796 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testListTeams ended in 88.451671 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testUpdateTeam ended in 27.81458 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testDeleteTeam ended in 59.295061 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testGetTeamMemberships ended in 27.39112 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testCreateTeamMembership ended in 3377.843347 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testListTeamMemberships ended in 22.94619 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testUpdateTeamMembership ended in 1316.081223 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testUpdateTeamMembershipRoles ended in 79.910121 milliseconds
.Tests\E2E\Services\Teams\TeamsConsoleClientTest::testDeleteTeamMembership ended in 88.667752 milliseconds
. 441 / 565 ( 78%)
Tests\E2E\Services\Teams\TeamsCustomClientTest::testCreateTeam ended in 1696.607118 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testGetTeam ended in 5.18794 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testListTeams ended in 109.036042 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testUpdateTeam ended in 73.619671 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testDeleteTeam ended in 96.548802 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testGetTeamMemberships ended in 78.523641 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testCreateTeamMembership ended in 3349.122388 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testListTeamMemberships ended in 34.26845 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testUpdateTeamMembership ended in 1383.443524 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testUpdateTeamMembershipRoles ended in 59.670482 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomClientTest::testDeleteTeamMembership ended in 163.537932 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testCreateTeam ended in 1301.424691 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testGetTeam ended in 16.022391 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testListTeams ended in 122.013182 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testUpdateTeam ended in 43.865471 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testDeleteTeam ended in 46.26645 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testGetTeamMemberships ended in 6.98127 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testCreateTeamMembership ended in 533.051279 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testUpdateMembershipRoles ended in 81.182102 milliseconds
.Tests\E2E\Services\Teams\TeamsCustomServerTest::testDeleteUserUpdatesTeamMembershipCount ended in 5061.927936 milliseconds
.Tests\E2E\Services\Users\UsersConsoleClientTest::testGetUsersUsage ended in 1104.309839 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testCreateUser ended in 1933.836412 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testCreateUserSessionHashed ended in 5362.003671 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testCreateUserTypes ended in 1236.639561 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testListUsers ended in 344.234395 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testGetUser ended in 85.195862 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateUserName ended in 50.895581 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateUserNameSearch ended in 18.87299 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateUserEmail ended in 64.528321 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateUserEmailSearch ended in 27.941691 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateUserPassword ended in 802.565353 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateUserStatus ended in 90.618611 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateEmailVerification ended in 41.06155 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testUpdateAndGetUserPrefs ended in 61.891471 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testGetLogs ended in 116.944552 milliseconds
.Tests\E2E\Services\Users\UsersCustomServerTest::testDeleteUser ended in 53.893261 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateAccount ended in 3610.533532 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteAccount ended in 2666.062916 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateAccountSession ended in 2295.758719 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteAccountSession ended in 2268.065418 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteAccountSessions ended in 2875.238949 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateAccountName ended in 2047.437664 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateAccountPassword ended in 2619.716825 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateAccountEmail ended in 2442.95088 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateAccountPrefs ended in 2021.089045 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateAccountRecovery ended in 2057.336625 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateAccountRecovery ended in 2368.99343 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateAccountVerification ended in 2018.161024 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateAccountVerification ended in 2039.390325 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateCollection ended in 2152.289457 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateAttributes ended in 14121.586059 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateDocument ended in 2718.619505 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateDocument ended in 2012.992043 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteDocument ended in 2032.058395 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateStorageBucket ended in 2115.819446 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateStorageBucket ended in 2012.451713 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateBucketFile ended in 2049.837504 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateBucketFile ended in 2018.480764 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteBucketFile ended in 2029.528395 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteStorageBucket ended in 2010.885803 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateTeam ended in 2013.573954 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateTeam ended in 2017.979354 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteTeam ended in 2079.246445 milliseconds
. 504 / 565 ( 89%)
Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateTeamMembership ended in 5433.405502 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testUpdateTeamMembership ended in 2048.456785 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testDeleteTeamMembership ended in 2404.478041 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteCollection ended in 2950.44775 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateUser ended in 2244.294658 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateUserPrefs ended in 2017.277524 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateUserStatus ended in 2074.092425 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteUser ended in 2011.831023 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateFunction ended in 2048.207544 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateFunction ended in 2043.854345 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateDeployment ended in 7078.045909 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateDeployment ended in 7028.574349 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testExecutions ended in 14070.516327 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteDeployment ended in 2014.219324 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteFunction ended in 2013.797924 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateCollection ended in 2178.702047 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateAttributes ended in 14054.528488 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateCollection ended in 2045.711614 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateDeleteIndexes ended in 9117.978173 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateDocument ended in 2014.126294 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateDocument ended in 2053.136705 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteDocument ended in 2024.141934 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateStorageBucket ended in 2058.616065 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateStorageBucket ended in 2018.192784 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateBucketFile ended in 2022.960634 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateBucketFile ended in 2022.601264 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteBucketFile ended in 2063.869015 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteStorageBucket ended in 2010.375963 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateTeam ended in 2035.364545 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testUpdateTeam ended in 2024.111115 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteTeam ended in 2080.874835 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateTeamMembership ended in 5435.051041 milliseconds
.Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testDeleteTeamMembership ended in 2496.201103 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreate ended in 827.779194 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testList ended in 83.155191 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testGet ended in 9.23416 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testUpdate ended in 7.16149 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateDeployment ended in 30095.316237 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateDeploymentLarge ended in 2848.940398 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testUpdateDeployment ended in 36.992111 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testListDeployments ended in 55.484101 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testGetDeployment ended in 27.76793 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateExecution ended in 15029.112692 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testListExecutions ended in 20.068941 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testSyncCreateExecution ended in 57.214381 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testGetExecution ended in 10.36707 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testDeleteDeployment ended in 16.33654 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testDelete ended in 9.46202 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testTimeout ended in 30087.691467 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomPHPExecution ended in 20118.32878 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomNodeExecution ended in 20174.769901 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomPythonExecution ended in 60049.852223 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomDartExecution ended in 50059.106212 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomRubyExecution ended in 40074.026136 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomServerTest::testGetRuntimes ended in 3.90879 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomClientTest::testCreate ended in 1657.617928 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomClientTest::testCreateExecution ended in 10151.471112 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomClientTest::testCreateCustomExecution ended in 20079.756476 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomClientTest::testCreateExecutionUnauthorized ended in 9.037741 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomClientTest::testListExecutions ended in 10040.378602 milliseconds
.Tests\E2E\Services\Functions\FunctionsCustomClientTest::testSynchronousExecution ended in 11352.480402 milliseconds
.   565 / 565 (100%)

Time: 18:46.188, Memory: 56.01 MB

OK (565 tests, 54367 assertions)
```
</details>

## Related PRs and Issues

To be merged into

- https://github.com/appwrite/appwrite/pull/3700

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
