### PR TITLE
Reduce how long some tests take

### DIFF
--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -429,7 +429,23 @@ trait DatabasesBase
         $this->assertEquals(null, $datetime['body']['default']);
 
         // wait for database worker to create attributes
-        sleep(30);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $collectionId . '/attributes', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey']
+            ]));
+            $attributes = $response['body']['attributes'];
+            $ready = true;
+            foreach ($attributes as $attribute) {
+                if ($attribute['status'] !== 'available') {
+                    $ready = false;
+                    break;
+                }
+            }
+            $i++;
+        } while ($i < 100 && !$ready);
 
         $stringResponse = $this->client->call(Client::METHOD_GET, $attributesPath . '/' . $string['body']['key'], array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -1082,13 +1082,23 @@ class DatabasesCustomServerTest extends Scope
             $this->assertEquals(202, $attribute['headers']['status-code']);
         }
 
-        sleep(20);
-
-        $collection = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $collectionId, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-            'x-appwrite-key' => $this->getProject()['apiKey']
-        ]));
+        $i = 0;
+        do {
+            $collection = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $collectionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey']
+            ]));
+            $attributes = $collection['body']['attributes'];
+            $ready = true;
+            foreach ($attributes as $attribute) {
+                if ($attribute['status'] !== 'available') {
+                    $ready = false;
+                    break;
+                }
+            }
+            $i++;
+        } while ($i < 100 && !$ready);
 
         $this->assertEquals(200, $collection['headers']['status-code']);
         $this->assertEquals($collection['body']['name'], 'testLimitException');
@@ -1120,7 +1130,23 @@ class DatabasesCustomServerTest extends Scope
             $this->assertEquals("key_attribute{$i}", $index['body']['key']);
         }
 
-        sleep(5);
+        $i = 0;
+        do {
+            $collection = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $collectionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey']
+            ]));
+            $indexes = $collection['body']['indexes'];
+            $ready = true;
+            foreach ($indexes as $index) {
+                if ($index['status'] !== 'available') {
+                    $ready = false;
+                    break;
+                }
+            }
+            $i++;
+        } while ($i < 100 && !$ready);
 
         $collection = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $collectionId, array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
@@ -179,7 +179,17 @@ class FunctionsCustomClientTest extends Scope
         $deploymentId = $deployment['body']['$id'] ?? '';
 
         // Wait for deployment to be built.
-        sleep(10);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
@@ -202,7 +212,14 @@ class FunctionsCustomClientTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(10);
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'completed');
 
         $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, [
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -300,7 +300,17 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals('index.php', $deployment['body']['entrypoint']);
 
         // Wait for deployment to build.
-        sleep(30);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $data['functionId'] . '/deployments', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         return array_merge($data, ['deploymentId' => $deploymentId]);
     }
@@ -497,12 +507,14 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals('', $execution['body']['stderr']);
         $this->assertEquals(0, $execution['body']['time']);
 
-        sleep(5);
-
-        $execution = $this->client->call(Client::METHOD_GET, '/functions/' . $data['functionId'] . '/executions/' . $executionId, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()));
+        $i = 0;
+        do {
+            $execution = $this->client->call(Client::METHOD_GET, '/functions/' . $data['functionId'] . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $execution['body']['status'] !== 'completed');
 
         $this->assertNotEmpty($execution['body']['$id']);
         $this->assertNotEmpty($execution['body']['functionId']);
@@ -735,10 +747,21 @@ class FunctionsCustomServerTest extends Scope
             'activate' => true,
         ]);
 
+        $deploymentId = $deployment['body']['$id'] ?? '';
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
         // Allow build step to run
-        sleep(20);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
@@ -751,7 +774,14 @@ class FunctionsCustomServerTest extends Scope
 
         $this->assertEquals(202, $execution['headers']['status-code']);
 
-        sleep(10);
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'failed');
 
         $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
@@ -823,7 +853,17 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
         // Allow build step to run
-        sleep(10);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $deployment = $this->client->call(Client::METHOD_PATCH, '/functions/' . $functionId . '/deployments/' . $deploymentId, array_merge([
             'content-type' => 'application/json',
@@ -845,7 +885,14 @@ class FunctionsCustomServerTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(10);
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'completed');
 
         $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
             'content-type' => 'application/json',
@@ -936,7 +983,17 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
         // Allow build step to run
-        sleep(10);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
@@ -951,12 +1008,14 @@ class FunctionsCustomServerTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(10);
-
-        $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()));
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'completed');
 
         $output = json_decode($executions['body']['response'], true);
 
@@ -1041,7 +1100,17 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
         // Allow build step to run
-        sleep(30);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
@@ -1056,12 +1125,14 @@ class FunctionsCustomServerTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(30);
-
-        $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()));
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'completed');
 
         $output = json_decode($executions['body']['response'], true);
 
@@ -1146,7 +1217,17 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
         // Allow build step to run
-        sleep(40);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
@@ -1161,12 +1242,14 @@ class FunctionsCustomServerTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(10);
-
-        $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()));
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'completed');
 
         $output = json_decode($executions['body']['response'], true);
 
@@ -1251,7 +1334,17 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
         // Allow build step to run
-        sleep(30);
+        $i = 0;
+        do {
+            $response = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => ['equal("$id", "' . $deploymentId . '")'],
+            ]);
+            $deployment = $response['body']['deployments'][0];
+            $i++;
+        } while ($i < 100 && $deployment['status'] !== 'ready');
 
         $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
@@ -1266,12 +1359,14 @@ class FunctionsCustomServerTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(10);
-
-        $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()));
+        $i = 0;
+        do {
+            $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+            $i++;
+        } while ($i < 100 && $executions['body']['status'] !== 'completed');
 
         $output = json_decode($executions['body']['response'], true);
 


### PR DESCRIPTION
## What does this PR do?

Some of our tests use `sleep()` to wait for the processing to complete before testing. This can add up and really slow down tests. The top 20 slowest tests (totaling 10 minutes) are:

| Test | Seconds | Updated |
|---|---|---|
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomPythonExecution | 60.04985222 | x |
| .Tests\E2E\General\UsageTest::testFunctionsStats | 55.94212304 |  |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomDartExecution | 50.05910621 | x |
| .Tests\E2E\General\UsageTest::testDatabaseStats | 46.1355685 |  |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomRubyExecution | 40.07402614 | x |
| .Tests\E2E\General\UsageTest::testUsersStats | 38.6285679 |  |
| .Tests\E2E\General\UsageTest::testStorageStats | 38.08447305 |  |
| .Tests\E2E\Services\Databases\DatabasesCustomServerTest::testAttributeResponseModels | 30.4451232 | x |
| .Tests\E2E\Services\Databases\DatabasesCustomClientTest::testAttributeResponseModels | 30.29817802 | x |
| .Tests\E2E\Services\Databases\DatabasesCustomServerTest::testIndexLimitException | 30.24824969 | x |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateDeployment | 30.09531624 | x |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testTimeout | 30.08769147 | x |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomNodeExecution | 20.1747699 | x |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateCustomPHPExecution | 20.11832878 | x |
| .Tests\E2E\Services\Functions\FunctionsCustomClientTest::testCreateCustomExecution | 20.07975648 | x |
| .Tests\E2E\Services\Functions\FunctionsCustomServerTest::testCreateExecution | 15.02911269 | x |
| .Tests\E2E\Services\Webhooks\WebhooksCustomClientTest::testCreateAttributes | 14.12158606 |  |
| .Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testExecutions | 14.07051633 |  |
| .Tests\E2E\Services\Webhooks\WebhooksCustomServerTest::testCreateAttributes | 14.05452849 |  |
| .Tests\E2E\General\HTTPTest::testSpecOpenAPI3 | 12.8995192 |  |

## Test Plan

Ensure all tests still pass

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
