### PR TITLE
fix : Linode file upload failure

### DIFF
--- a/app/executor.php
+++ b/app/executor.php
@@ -137,7 +137,7 @@ function getStorageDevice($root): Device
             $doSpacesAcl = 'private';
             return new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
         case Storage::DEVICE_BACKBLAZE:
-            $root = trim ($root,"/");
+            $root = trim($root, "/");
             $backblazeAccessKey = App::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
             $backblazeSecretKey = App::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
             $backblazeRegion = App::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
@@ -145,7 +145,7 @@ function getStorageDevice($root): Device
             $backblazeAcl = 'private';
             return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
         case Storage::DEVICE_LINODE:
-            $root = trim ($root,"/");
+            $root = trim($root, "/");
             $linodeAccessKey = App::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
             $linodeSecretKey = App::getEnv('_APP_STORAGE_LINODE_SECRET', '');
             $linodeRegion = App::getEnv('_APP_STORAGE_LINODE_REGION', '');
@@ -153,7 +153,7 @@ function getStorageDevice($root): Device
             $linodeAcl = 'private';
             return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
         case Storage::DEVICE_WASABI:
-            $root = trim ($root,"/");
+            $root = trim($root, "/");
             $wasabiAccessKey = App::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
             $wasabiSecretKey = App::getEnv('_APP_STORAGE_WASABI_SECRET', '');
             $wasabiRegion = App::getEnv('_APP_STORAGE_WASABI_REGION', '');

--- a/app/executor.php
+++ b/app/executor.php
@@ -137,6 +137,7 @@ function getStorageDevice($root): Device
             $doSpacesAcl = 'private';
             return new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
         case Storage::DEVICE_BACKBLAZE:
+            $root = trim ($root,"/");
             $backblazeAccessKey = App::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
             $backblazeSecretKey = App::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
             $backblazeRegion = App::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
@@ -144,6 +145,7 @@ function getStorageDevice($root): Device
             $backblazeAcl = 'private';
             return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
         case Storage::DEVICE_LINODE:
+            $root = trim ($root,"/");
             $linodeAccessKey = App::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
             $linodeSecretKey = App::getEnv('_APP_STORAGE_LINODE_SECRET', '');
             $linodeRegion = App::getEnv('_APP_STORAGE_LINODE_REGION', '');
@@ -151,6 +153,7 @@ function getStorageDevice($root): Device
             $linodeAcl = 'private';
             return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
         case Storage::DEVICE_WASABI:
+            $root = trim ($root,"/");
             $wasabiAccessKey = App::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
             $wasabiSecretKey = App::getEnv('_APP_STORAGE_WASABI_SECRET', '');
             $wasabiRegion = App::getEnv('_APP_STORAGE_WASABI_REGION', '');

--- a/app/init.php
+++ b/app/init.php
@@ -943,6 +943,7 @@ function getDevice($root): Device
             $doSpacesAcl = 'private';
             return new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
         case Storage::DEVICE_BACKBLAZE:
+            $root = trim($root,"/");
             $backblazeAccessKey = App::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
             $backblazeSecretKey = App::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
             $backblazeRegion = App::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
@@ -950,6 +951,7 @@ function getDevice($root): Device
             $backblazeAcl = 'private';
             return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
         case Storage::DEVICE_LINODE:
+            $root = trim($root,"/");
             $linodeAccessKey = App::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
             $linodeSecretKey = App::getEnv('_APP_STORAGE_LINODE_SECRET', '');
             $linodeRegion = App::getEnv('_APP_STORAGE_LINODE_REGION', '');
@@ -957,6 +959,7 @@ function getDevice($root): Device
             $linodeAcl = 'private';
             return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
         case Storage::DEVICE_WASABI:
+            $root = trim($root,"/");
             $wasabiAccessKey = App::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
             $wasabiSecretKey = App::getEnv('_APP_STORAGE_WASABI_SECRET', '');
             $wasabiRegion = App::getEnv('_APP_STORAGE_WASABI_REGION', '');

--- a/app/init.php
+++ b/app/init.php
@@ -943,7 +943,7 @@ function getDevice($root): Device
             $doSpacesAcl = 'private';
             return new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
         case Storage::DEVICE_BACKBLAZE:
-            $root = trim($root,"/");
+            $root = trim($root, "/");
             $backblazeAccessKey = App::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
             $backblazeSecretKey = App::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
             $backblazeRegion = App::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
@@ -951,7 +951,7 @@ function getDevice($root): Device
             $backblazeAcl = 'private';
             return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
         case Storage::DEVICE_LINODE:
-            $root = trim($root,"/");
+            $root = trim($root, "/");
             $linodeAccessKey = App::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
             $linodeSecretKey = App::getEnv('_APP_STORAGE_LINODE_SECRET', '');
             $linodeRegion = App::getEnv('_APP_STORAGE_LINODE_REGION', '');
@@ -959,7 +959,7 @@ function getDevice($root): Device
             $linodeAcl = 'private';
             return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
         case Storage::DEVICE_WASABI:
-            $root = trim($root,"/");
+            $root = trim($root, "/");
             $wasabiAccessKey = App::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
             $wasabiSecretKey = App::getEnv('_APP_STORAGE_WASABI_SECRET', '');
             $wasabiRegion = App::getEnv('_APP_STORAGE_WASABI_REGION', '');

--- a/src/Appwrite/Resque/Worker.php
+++ b/src/Appwrite/Resque/Worker.php
@@ -303,7 +303,7 @@ abstract class Worker
                 $doSpacesAcl = 'private';
                 return new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
             case Storage::DEVICE_BACKBLAZE:
-                $root = trim ($root,"/");
+                $root = trim($root, "/");
                 $backblazeAccessKey = App::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
                 $backblazeSecretKey = App::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
                 $backblazeRegion = App::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
@@ -311,7 +311,7 @@ abstract class Worker
                 $backblazeAcl = 'private';
                 return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
             case Storage::DEVICE_LINODE:
-                $root = trim ($root,"/");
+                $root = trim($root, "/");
                 $linodeAccessKey = App::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
                 $linodeSecretKey = App::getEnv('_APP_STORAGE_LINODE_SECRET', '');
                 $linodeRegion = App::getEnv('_APP_STORAGE_LINODE_REGION', '');
@@ -319,7 +319,7 @@ abstract class Worker
                 $linodeAcl = 'private';
                 return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
             case Storage::DEVICE_WASABI:
-                $root = trim ($root,"/");
+                $root = trim($root, "/");
                 $wasabiAccessKey = App::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
                 $wasabiSecretKey = App::getEnv('_APP_STORAGE_WASABI_SECRET', '');
                 $wasabiRegion = App::getEnv('_APP_STORAGE_WASABI_REGION', '');

--- a/src/Appwrite/Resque/Worker.php
+++ b/src/Appwrite/Resque/Worker.php
@@ -303,6 +303,7 @@ abstract class Worker
                 $doSpacesAcl = 'private';
                 return new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
             case Storage::DEVICE_BACKBLAZE:
+                $root = trim ($root,"/");
                 $backblazeAccessKey = App::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
                 $backblazeSecretKey = App::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
                 $backblazeRegion = App::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
@@ -310,6 +311,7 @@ abstract class Worker
                 $backblazeAcl = 'private';
                 return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
             case Storage::DEVICE_LINODE:
+                $root = trim ($root,"/");
                 $linodeAccessKey = App::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
                 $linodeSecretKey = App::getEnv('_APP_STORAGE_LINODE_SECRET', '');
                 $linodeRegion = App::getEnv('_APP_STORAGE_LINODE_REGION', '');
@@ -317,6 +319,7 @@ abstract class Worker
                 $linodeAcl = 'private';
                 return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
             case Storage::DEVICE_WASABI:
+                $root = trim ($root,"/");
                 $wasabiAccessKey = App::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
                 $wasabiSecretKey = App::getEnv('_APP_STORAGE_WASABI_SECRET', '');
                 $wasabiRegion = App::getEnv('_APP_STORAGE_WASABI_REGION', '');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes Linode File upload. It initially was failing because of the extra `/` in the request url.
It was making a request to a URL as below, which is invalid because of the consecutive `//`
```
https://<bucket-name>.eu-central-1.linodeobjects.com**//**storage/uploads/app-630cd8d7a106aa302d27/630cd8e90d3b33e8ff5c/6/3/0/c/630cdc2875416374d993.jpg
```
and hence failing.

Now, we trim the path string before uploading to remove the leading extra slash for providers such as Backblaze, Linode and Wasabi as they all require the removal.

## Test Plan

- [x] Manual   <br><br>
![](https://user-images.githubusercontent.com/77877486/187242868-7fa806fd-bb70-4cd2-bb81-51795d001d0f.jpeg)



## Related PRs and Issues

 #3433 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes