### PR TITLE
Small fix to make variable keys wrap in UI

### DIFF
--- a/app/views/console/functions/function.phtml
+++ b/app/views/console/functions/function.phtml
@@ -596,7 +596,7 @@ sort($patterns);
                         </form>
 
                         <div>
-                            <span class="text-one-liner" data-ls-bind="{{variable.key}}"></span>
+                            <span data-ls-bind="{{variable.key}}"></span>
                         </div>
 
                         <div data-ui-modal class="modal box close" data-button-text="Show Value" data-button-class="link pull-start margin-end-small margin-top-tiny">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes a small UI bug with variable names not wrapping

Before:
![image](https://user-images.githubusercontent.com/26739219/188421154-4193e11c-41f4-471a-bc3c-5bfa15adb67a.png)

After:
![image](https://user-images.githubusercontent.com/26739219/188421139-440294d7-26d7-4fb8-8c39-2949dfa32810.png)


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes, I have
