### PR TITLE
fix: ui missing database id from document activity

### DIFF
--- a/app/views/console/databases/document.phtml
+++ b/app/views/console/databases/document.phtml
@@ -413,7 +413,7 @@ $permissions = $this->getParam('permissions', null);
                     </div>
                 </li>
                 <?php if(!$new): ?>
-                    <li data-state="/console/databases/document/activity?id={{router.params.id}}&collection={{router.params.collection}}&project={{router.params.project}}">
+                    <li data-state="/console/databases/document/activity?id={{router.params.id}}&collection={{router.params.collection}}&project={{router.params.project}}&databaseId={{router.params.databaseId}}">
                         <h2>Activity</h2>
 
                         <?php echo $logs->render(); ?>


### PR DESCRIPTION
## What does this PR do?

- adds missing `databaseId` to the activity page of documents

## Test Plan

- manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 