### PR TITLE
Fix $createdAt and $updatedAt so they are datetime instead of string

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1557,7 +1557,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/indexes')
 
         $oldAttributes[] = [
             'key' => '$id',
-            'type' => 'string',
+            'type' => Database::VAR_STRING,
             'status' => 'available',
             'required' => true,
             'array' => false,
@@ -1567,7 +1567,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/indexes')
 
         $oldAttributes[] = [
             'key' => '$createdAt',
-            'type' => 'string',
+            'type' => Database::VAR_DATETIME,
             'status' => 'available',
             'signed' => false,
             'required' => false,
@@ -1578,7 +1578,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/indexes')
 
         $oldAttributes[] = [
             'key' => '$updatedAt',
-            'type' => 'string',
+            'type' => Database::VAR_DATETIME,
             'status' => 'available',
             'signed' => false,
             'required' => false,


### PR DESCRIPTION
## What does this PR do?

In the Create Index API, the type for the $createdAt and $updatedAt attributes were string instead of datetime.

## Test Plan

1. Automated Tests
2. Manually Create Index

![image](https://user-images.githubusercontent.com/1477010/189241882-055f867b-66bd-4ce9-bbf9-51509f5ccdd7.png)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
