### PR TITLE
Assign member role for all of a users confirmed team memberships

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "utopia-php/cache": "0.6.*",
         "utopia-php/cli": "0.13.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "0.25.*",
+        "utopia-php/database": "dev-feat-member-helper as 0.25.0",
         "utopia-php/locale": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "utopia-php/cache": "0.6.*",
         "utopia-php/cli": "0.13.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "dev-feat-member-helper as 0.25.0",
+        "utopia-php/database": "0.25.*",
         "utopia-php/locale": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d537356d18e9d5735f6f08e7f361a2f5",
+    "content-hash": "aca68a1c1c7d762cabd02ce02cf40df4",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2060,16 +2060,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "dev-feat-member-helper",
+            "version": "0.25.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "214fd7ebdec7bdf4fb2714dc885e7291e6ae3c4f"
+                "reference": "140bbedf1c4d622990fb94d26681fcca235cd5b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/214fd7ebdec7bdf4fb2714dc885e7291e6ae3c4f",
-                "reference": "214fd7ebdec7bdf4fb2714dc885e7291e6ae3c4f",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/140bbedf1c4d622990fb94d26681fcca235cd5b9",
+                "reference": "140bbedf1c4d622990fb94d26681fcca235cd5b9",
                 "shasum": ""
             },
             "require": {
@@ -2118,9 +2118,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/feat-member-helper"
+                "source": "https://github.com/utopia-php/database/tree/0.25.2"
             },
-            "time": "2022-09-08T22:49:17+00:00"
+            "time": "2022-09-09T03:58:01+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -5358,18 +5358,9 @@
             "time": "2022-08-12T06:47:24+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "utopia-php/database",
-            "version": "dev-feat-member-helper",
-            "alias": "0.25.0",
-            "alias_normalized": "0.25.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "utopia-php/database": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aca68a1c1c7d762cabd02ce02cf40df4",
+    "content-hash": "d537356d18e9d5735f6f08e7f361a2f5",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2060,16 +2060,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.25.1",
+            "version": "dev-feat-member-helper",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "9d013ce3c111d1477d7986483f1003dcab2b9d14"
+                "reference": "214fd7ebdec7bdf4fb2714dc885e7291e6ae3c4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/9d013ce3c111d1477d7986483f1003dcab2b9d14",
-                "reference": "9d013ce3c111d1477d7986483f1003dcab2b9d14",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/214fd7ebdec7bdf4fb2714dc885e7291e6ae3c4f",
+                "reference": "214fd7ebdec7bdf4fb2714dc885e7291e6ae3c4f",
                 "shasum": ""
             },
             "require": {
@@ -2118,9 +2118,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.25.1"
+                "source": "https://github.com/utopia-php/database/tree/feat-member-helper"
             },
-            "time": "2022-09-07T14:47:52+00:00"
+            "time": "2022-09-08T22:49:17+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -5358,9 +5358,18 @@
             "time": "2022-08-12T06:47:24+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/database",
+            "version": "dev-feat-member-helper",
+            "alias": "0.25.0",
+            "alias_normalized": "0.25.0.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "utopia-php/database": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5384,5 +5393,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Appwrite/Auth/Auth.php
+++ b/src/Appwrite/Auth/Auth.php
@@ -431,11 +431,14 @@ class Auth
                 continue;
             }
 
-            if (isset($node['teamId']) && isset($node['roles'])) {
+            if (isset($node['$id']) && isset($node['teamId'])) {
                 $roles[] = Role::team($node['teamId'])->toString();
+                $roles[] = Role::member($node['$id'])->toString();
 
-                foreach ($node['roles'] as $nodeRole) { // Set all team roles
-                    $roles[] = Role::team($node['teamId'], $nodeRole)->toString();
+                if (isset($node['roles'])) {
+                    foreach ($node['roles'] as $nodeRole) { // Set all team roles
+                        $roles[] = Role::team($node['teamId'], $nodeRole)->toString();
+                    }
                 }
             }
         }

--- a/tests/unit/Auth/AuthTest.php
+++ b/tests/unit/Auth/AuthTest.php
@@ -353,16 +353,58 @@ class AuthTest extends TestCase
             '$id' => ID::custom('123'),
             'memberships' => [
                 [
-                    'confirm' => true,
+                    '$id' => ID::custom('456'),
                     'teamId' => ID::custom('abc'),
+                    'confirm' => true,
                     'roles' => [
                         'administrator',
                         'moderator'
                     ]
                 ],
                 [
-                    'confirm' => true,
+                    '$id' => ID::custom('abc'),
                     'teamId' => ID::custom('def'),
+                    'confirm' => true,
+                    'roles' => [
+                        'guest'
+                    ]
+                ]
+            ]
+        ]);
+
+        $roles = Auth::getRoles($user);
+
+        $this->assertCount(9, $roles);
+        $this->assertContains(Role::users()->toString(), $roles);
+        $this->assertContains(Role::user(ID::custom('123'))->toString(), $roles);
+        $this->assertContains(Role::team(ID::custom('abc'))->toString(), $roles);
+        $this->assertContains(Role::team(ID::custom('abc'), 'administrator')->toString(), $roles);
+        $this->assertContains(Role::team(ID::custom('abc'), 'moderator')->toString(), $roles);
+        $this->assertContains(Role::team(ID::custom('def'))->toString(), $roles);
+        $this->assertContains(Role::team(ID::custom('def'), 'guest')->toString(), $roles);
+        $this->assertContains(Role::member(ID::custom('456'))->toString(), $roles);
+        $this->assertContains(Role::member(ID::custom('abc'))->toString(), $roles);
+    }
+
+    public function testPrivilegedUserRoles(): void
+    {
+        Authorization::setRole(Auth::USER_ROLE_OWNER);
+        $user  = new Document([
+            '$id' => ID::custom('123'),
+            'memberships' => [
+                [
+                    '$id' => ID::custom('def'),
+                    'teamId' => ID::custom('abc'),
+                    'confirm' => true,
+                    'roles' => [
+                        'administrator',
+                        'moderator'
+                    ]
+                ],
+                [
+                    '$id' => ID::custom('abc'),
+                    'teamId' => ID::custom('def'),
+                    'confirm' => true,
                     'roles' => [
                         'guest'
                     ]
@@ -373,42 +415,6 @@ class AuthTest extends TestCase
         $roles = Auth::getRoles($user);
 
         $this->assertCount(7, $roles);
-        $this->assertContains(Role::users()->toString(), $roles);
-        $this->assertContains(Role::user(ID::custom('123'))->toString(), $roles);
-        $this->assertContains(Role::team(ID::custom('abc'))->toString(), $roles);
-        $this->assertContains(Role::team(ID::custom('abc'), 'administrator')->toString(), $roles);
-        $this->assertContains(Role::team(ID::custom('abc'), 'moderator')->toString(), $roles);
-        $this->assertContains(Role::team(ID::custom('def'))->toString(), $roles);
-        $this->assertContains(Role::team(ID::custom('def'), 'guest')->toString(), $roles);
-    }
-
-    public function testPrivilegedUserRoles(): void
-    {
-        Authorization::setRole(Auth::USER_ROLE_OWNER);
-        $user  = new Document([
-            '$id' => ID::custom('123'),
-            'memberships' => [
-                [
-                    'confirm' => true,
-                    'teamId' => ID::custom('abc'),
-                    'roles' => [
-                        'administrator',
-                        'moderator'
-                    ]
-                ],
-                [
-                    'confirm' => true,
-                    'teamId' => ID::custom('def'),
-                    'roles' => [
-                        'guest'
-                    ]
-                ]
-            ]
-        ]);
-
-        $roles = Auth::getRoles($user);
-
-        $this->assertCount(5, $roles);
         $this->assertNotContains(Role::users()->toString(), $roles);
         $this->assertNotContains(Role::user(ID::custom('123'))->toString(), $roles);
         $this->assertContains(Role::team(ID::custom('abc'))->toString(), $roles);
@@ -416,6 +422,8 @@ class AuthTest extends TestCase
         $this->assertContains(Role::team(ID::custom('abc'), 'moderator')->toString(), $roles);
         $this->assertContains(Role::team(ID::custom('def'))->toString(), $roles);
         $this->assertContains(Role::team(ID::custom('def'), 'guest')->toString(), $roles);
+        $this->assertContains(Role::member(ID::custom('def'))->toString(), $roles);
+        $this->assertContains(Role::member(ID::custom('abc'))->toString(), $roles);
     }
 
     public function testAppUserRoles(): void
@@ -425,16 +433,18 @@ class AuthTest extends TestCase
             '$id' => ID::custom('123'),
             'memberships' => [
                 [
-                    'confirm' => true,
+                    '$id' => ID::custom('def'),
                     'teamId' => ID::custom('abc'),
+                    'confirm' => true,
                     'roles' => [
                         'administrator',
                         'moderator'
                     ]
                 ],
                 [
-                    'confirm' => true,
+                    '$id' => ID::custom('abc'),
                     'teamId' => ID::custom('def'),
+                    'confirm' => true,
                     'roles' => [
                         'guest'
                     ]
@@ -444,7 +454,7 @@ class AuthTest extends TestCase
 
         $roles = Auth::getRoles($user);
 
-        $this->assertCount(5, $roles);
+        $this->assertCount(7, $roles);
         $this->assertNotContains(Role::users()->toString(), $roles);
         $this->assertNotContains(Role::user(ID::custom('123'))->toString(), $roles);
         $this->assertContains(Role::team(ID::custom('abc'))->toString(), $roles);
@@ -452,5 +462,7 @@ class AuthTest extends TestCase
         $this->assertContains(Role::team(ID::custom('abc'), 'moderator')->toString(), $roles);
         $this->assertContains(Role::team(ID::custom('def'))->toString(), $roles);
         $this->assertContains(Role::team(ID::custom('def'), 'guest')->toString(), $roles);
+        $this->assertContains(Role::member(ID::custom('def'))->toString(), $roles);
+        $this->assertContains(Role::member(ID::custom('abc'))->toString(), $roles);
     }
 }

--- a/tests/unit/Messaging/MessagingChannelsTest.php
+++ b/tests/unit/Messaging/MessagingChannelsTest.php
@@ -54,8 +54,9 @@ class MessagingChannelsTest extends TestCase
                     '$id' => ID::custom('user' . $this->connectionsCount),
                     'memberships' => [
                         [
-                            'confirm' => true,
+                            '$id' => ID::custom('member' . $i),
                             'teamId' => ID::custom('team' . $i),
+                            'confirm' => true,
                             'roles' => [
                                 empty($index % 2)
                                     ? Auth::USER_ROLE_ADMIN
@@ -122,11 +123,11 @@ class MessagingChannelsTest extends TestCase
          * Check for correct amount of subscriptions:
          *  - XXX users
          *  - XXX teams
-         *  - XXX team roles (2 roles per team)
+         *  - XXX team roles (3 roles per team)
          *  - 1 guests
          *  - 1 users
          */
-        $this->assertCount(($this->connectionsAuthenticated + (3 * $this->connectionsPerChannel) + 2), $this->realtime->subscriptions['1']);
+        $this->assertCount(($this->connectionsAuthenticated + (4 * $this->connectionsPerChannel) + 2), $this->realtime->subscriptions['1']);
 
         /**
          * Check for connections
@@ -138,7 +139,7 @@ class MessagingChannelsTest extends TestCase
         $this->realtime->unsubscribe(-1);
 
         $this->assertCount($this->connectionsTotal, $this->realtime->connections);
-        $this->assertCount(($this->connectionsAuthenticated + (3 * $this->connectionsPerChannel) + 2), $this->realtime->subscriptions['1']);
+        $this->assertCount(($this->connectionsAuthenticated + (4 * $this->connectionsPerChannel) + 2), $this->realtime->subscriptions['1']);
 
         for ($i = 0; $i < $this->connectionsCount; $i++) {
             $this->realtime->unsubscribe($i);
@@ -259,6 +260,7 @@ class MessagingChannelsTest extends TestCase
 
             for ($i = 0; $i < $this->connectionsPerChannel; $i++) {
                 $permissions[] = Role::team(ID::custom('team' . $i))->toString();
+                $permissions[] = Role::member(ID::custom('member' . $i))->toString();
             }
             $event = [
                 'project' => '1',
@@ -284,13 +286,13 @@ class MessagingChannelsTest extends TestCase
                 $this->assertStringEndsWith($index, $receiver);
             }
 
+            $role = empty($index % 2)
+                ? Auth::USER_ROLE_ADMIN
+                : 'member';
+
             $permissions = [
-                Role::team(
-                    ID::custom('team' . $index),
-                    (empty($index % 2)
-                        ? Auth::USER_ROLE_ADMIN
-                        : 'member')
-                )->toString()
+                Role::team(ID::custom('team' . $index), $role)->toString(),
+                Role::member(ID::custom('member' . $index))->toString()
             ];
 
             $event = [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Assign `member` role to a user for all confirmed team memberships

## Test Plan

Updated existing `Auth` and `MessagingChannel` tests

## Related PRs and Issues

https://github.com/appwrite/sdk-generator/pull/546
https://github.com/utopia-php/database/pull/183

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
