### PR TITLE
feat: rename time attribute to duration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Queries have been improved to allow even more flexibility, and introduced to new endpoints. See the Queries V2 section in the document for more information [#3702](https://github.com/appwrite/appwrite/pull/3702)
 - Compound indexes are now more flexible [#151](https://github.com/utopia-php/database/pull/151)
 - `createExecution` parameter `async` default value was changed from `true` to `false` [#3781](https://github.com/appwrite/appwrite/pull/3781)
+- `time` attribute in Execution response model has been reanamed to `duration` to be more consistent with other response models. [#3801]() 
 
 ## Features
 - Added the UI to see the Parent ID of all resources within the UI. [#3653](https://github.com/appwrite/appwrite/pull/3653)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 - Queries have been improved to allow even more flexibility, and introduced to new endpoints. See the Queries V2 section in the document for more information [#3702](https://github.com/appwrite/appwrite/pull/3702)
 - Compound indexes are now more flexible [#151](https://github.com/utopia-php/database/pull/151)
 - `createExecution` parameter `async` default value was changed from `true` to `false` [#3781](https://github.com/appwrite/appwrite/pull/3781)
-- `time` attribute in Execution response model has been reanamed to `duration` to be more consistent with other response models. [#3801]() 
+- `time` attribute in Execution response model has been reanamed to `duration` to be more consistent with other response models. [#3801](https://github.com/appwrite/appwrite/pull/3801) 
 
 ## Features
 - Added the UI to see the Parent ID of all resources within the UI. [#3653](https://github.com/appwrite/appwrite/pull/3653)

--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -2673,7 +2673,7 @@ $collections = [
                 'filters' => [],
             ],
             [
-                '$id' => ID::custom('time'),
+                '$id' => ID::custom('duration'),
                 'type' => Database::VAR_FLOAT,
                 'format' => '',
                 'size' => 0,
@@ -2732,9 +2732,9 @@ $collections = [
                 'orders' => [Database::ORDER_ASC],
             ],
             [
-                '$id' => ID::custom('_key_time'),
+                '$id' => ID::custom('_key_duration'),
                 'type' => Database::INDEX_KEY,
-                'attributes' => ['time'],
+                'attributes' => ['duration'],
                 'lengths' => [],
                 'orders' => [Database::ORDER_ASC],
             ],

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -1000,7 +1000,7 @@ App::post('/v1/functions/:functionId/executions')
             'statusCode' => 0,
             'response' => '',
             'stderr' => '',
-            'time' => 0.0,
+            'duration' => 0.0,
             'search' => implode(' ', [$functionId, $executionId]),
         ])));
 
@@ -1087,11 +1087,11 @@ App::post('/v1/functions/:functionId/executions')
             $execution->setAttribute('response', $executionResponse['response']);
             $execution->setAttribute('stdout', $executionResponse['stdout']);
             $execution->setAttribute('stderr', $executionResponse['stderr']);
-            $execution->setAttribute('time', $executionResponse['time']);
+            $execution->setAttribute('duration', $executionResponse['duration']);
         } catch (\Throwable $th) {
             $interval = (new \DateTime())->diff(new \DateTime($execution->getCreatedAt()));
             $execution
-                ->setAttribute('time', (float)$interval->format('%s.%f'))
+                ->setAttribute('duration', (float)$interval->format('%s.%f'))
                 ->setAttribute('status', 'failed')
                 ->setAttribute('statusCode', $th->getCode())
                 ->setAttribute('stderr', $th->getMessage());
@@ -1105,7 +1105,7 @@ App::post('/v1/functions/:functionId/executions')
         ->setParam('functionId', $function->getId())
         ->setParam('executions.{scope}.compute', 1)
         ->setParam('executionStatus', $execution->getAttribute('status', ''))
-        ->setParam('executionTime', $execution->getAttribute('time')); // ms
+        ->setParam('executionTime', $execution->getAttribute('duration')); // ms
 
         $roles = Authorization::getRoles();
         $isPrivilegedUser = Auth::isPrivilegedUser($roles);

--- a/app/executor.php
+++ b/app/executor.php
@@ -574,7 +574,7 @@ App::post('/v1/execution')
                 'response' => \mb_strcut($res, 0, 1000000), // Limit to 1MB
                 'stdout' => \mb_strcut($stdout, 0, 1000000), // Limit to 1MB
                 'stderr' => \mb_strcut($stderr, 0, 1000000), // Limit to 1MB
-                'time' => $executionTime,
+                'duration' => $executionTime,
             ];
 
             /** Update swoole table */

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -248,7 +248,7 @@ class FunctionsV1 extends Worker
                 'statusCode' => 0,
                 'response' => '',
                 'stderr' => '',
-                'time' => 0.0,
+                'duration' => 0.0,
                 'search' => implode(' ', [$functionId, $executionId]),
             ]));
 
@@ -301,11 +301,11 @@ class FunctionsV1 extends Worker
                 ->setAttribute('response', $executionResponse['response'])
                 ->setAttribute('stdout', $executionResponse['stdout'])
                 ->setAttribute('stderr', $executionResponse['stderr'])
-                ->setAttribute('time', $executionResponse['time']);
+                ->setAttribute('duration', $executionResponse['duration']);
         } catch (\Throwable $th) {
             $interval = (new \DateTime())->diff(new \DateTime($execution->getCreatedAt()));
             $execution
-                ->setAttribute('time', (float)$interval->format('%s.%f'))
+                ->setAttribute('duration', (float)$interval->format('%s.%f'))
                 ->setAttribute('status', 'failed')
                 ->setAttribute('statusCode', $th->getCode())
                 ->setAttribute('stderr', $th->getMessage());
@@ -367,7 +367,7 @@ class FunctionsV1 extends Worker
                 ->setParam('functionId', $function->getId())
                 ->setParam('executions.{scope}.compute', 1)
                 ->setParam('executionStatus', $execution->getAttribute('status', ''))
-                ->setParam('executionTime', $execution->getAttribute('time'))
+                ->setParam('executionTime', $execution->getAttribute('duration'))
                 ->setParam('networkRequestSize', 0)
                 ->setParam('networkResponseSize', 0)
                 ->submit();

--- a/src/Appwrite/Utopia/Database/Validator/Queries/Executions.php
+++ b/src/Appwrite/Utopia/Database/Validator/Queries/Executions.php
@@ -8,7 +8,7 @@ class Executions extends Base
         'trigger',
         'status',
         'statusCode',
-        'time'
+        'duration'
     ];
 
     /**

--- a/src/Appwrite/Utopia/Response/Model/Build.php
+++ b/src/Appwrite/Utopia/Response/Model/Build.php
@@ -59,7 +59,7 @@ class Build extends Model
             ])
             ->addRule('duration', [
                 'type' => self::TYPE_INTEGER,
-                'description' => 'The build time in seconds.',
+                'description' => 'The build duration in seconds.',
                 'default' => 0,
                 'example' => 0,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -78,9 +78,9 @@ class Execution extends Model
                 'default' => '',
                 'example' => '',
             ])
-            ->addRule('time', [
+            ->addRule('duration', [
                 'type' => self::TYPE_FLOAT,
-                'description' => 'The script execution time in seconds.',
+                'description' => 'The script execution duration in seconds.',
                 'default' => 0,
                 'example' => 0.400,
             ])

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -524,7 +524,7 @@ class UsageTest extends Scope
         } elseif ($execution['body']['status'] == 'completed') {
             $executions++;
         }
-        $executionTime += (int) ($execution['body']['time'] * 1000);
+        $executionTime += (int) ($execution['body']['duration'] * 1000);
 
         sleep(25);
 

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -505,7 +505,7 @@ class UsageTest extends Scope
         $this->assertEquals(201, $execution['headers']['status-code']);
         $this->assertNotEmpty($execution['body']['$id']);
         $this->assertEquals($functionId, $execution['body']['functionId']);
-        $executionTime += (int) ($execution['body']['time'] * 1000);
+        $executionTime += (int) ($execution['body']['duration'] * 1000);
         if ($execution['body']['status'] == 'failed') {
             $failures++;
         } elseif ($execution['body']['status'] == 'completed') {

--- a/tests/e2e/Services/Account/AccountBase.php
+++ b/tests/e2e/Services/Account/AccountBase.php
@@ -365,7 +365,7 @@ trait AccountBase
 
         $this->assertContains($response['body']['logs'][2]['event'], ["users.{$userId}.create", "users.{$userId}.sessions.{$sessionId}.create"]);
         $this->assertEquals($response['body']['logs'][2]['ip'], filter_var($response['body']['logs'][2]['ip'], FILTER_VALIDATE_IP));
-        $this->assertEquals(true, DateTime::isValid($response['body']['logs'][2]['time']));
+        $this->assertEquals(true, DateTime::isValid($response['body']['logs'][2]['duration']));
 
         $this->assertEquals('Windows', $response['body']['logs'][2]['osName']);
         $this->assertEquals('WIN', $response['body']['logs'][2]['osCode']);

--- a/tests/e2e/Services/Account/AccountBase.php
+++ b/tests/e2e/Services/Account/AccountBase.php
@@ -365,7 +365,7 @@ trait AccountBase
 
         $this->assertContains($response['body']['logs'][2]['event'], ["users.{$userId}.create", "users.{$userId}.sessions.{$sessionId}.create"]);
         $this->assertEquals($response['body']['logs'][2]['ip'], filter_var($response['body']['logs'][2]['ip'], FILTER_VALIDATE_IP));
-        $this->assertEquals(true, DateTime::isValid($response['body']['logs'][2]['duration']));
+        $this->assertEquals(true, DateTime::isValid($response['body']['logs'][2]['time']));
 
         $this->assertEquals('Windows', $response['body']['logs'][2]['osName']);
         $this->assertEquals('WIN', $response['body']['logs'][2]['osCode']);

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -608,7 +608,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(0, $execution['body']['statusCode']);
         $this->assertEquals('', $execution['body']['response']);
         $this->assertEquals('', $execution['body']['stderr']);
-        $this->assertEquals(0, $execution['body']['time']);
+        $this->assertEquals(0, $execution['body']['duration']);
 
         sleep(5);
 
@@ -631,7 +631,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertStringContainsString('8.0', $execution['body']['response']);
         $this->assertStringContainsString('êä', $execution['body']['response']); // tests unknown utf-8 chars
         $this->assertEquals('', $execution['body']['stderr']);
-        $this->assertLessThan(0.500, $execution['body']['time']);
+        $this->assertLessThan(0.500, $execution['body']['duration']);
 
         /**
          * Test for FAILURE
@@ -750,7 +750,7 @@ class FunctionsCustomServerTest extends Scope
         $this->assertStringContainsString('PHP', $execution['body']['response']);
         $this->assertStringContainsString('8.0', $execution['body']['response']);
         $this->assertStringContainsString('êä', $execution['body']['response']); // tests unknown utf-8 chars
-        $this->assertLessThan(0.500, $execution['body']['time']);
+        $this->assertLessThan(0.500, $execution['body']['duration']);
 
         return $data;
     }
@@ -909,9 +909,9 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals($executions['body']['executions'][0]['trigger'], 'http');
         $this->assertEquals($executions['body']['executions'][0]['status'], 'failed');
         $this->assertEquals($executions['body']['executions'][0]['statusCode'], 500);
-        $this->assertGreaterThan(2, $executions['body']['executions'][0]['time']);
-        $this->assertLessThan(6, $executions['body']['executions'][0]['time']);
-        $this->assertGreaterThan(4, $executions['body']['executions'][0]['time']);
+        $this->assertGreaterThan(2, $executions['body']['executions'][0]['duration']);
+        $this->assertLessThan(6, $executions['body']['executions'][0]['duration']);
+        $this->assertGreaterThan(4, $executions['body']['executions'][0]['duration']);
         $this->assertEquals($executions['body']['executions'][0]['response'], '');
         $this->assertEquals($executions['body']['executions'][0]['stderr'], 'An internal curl error has occurred within the executor! Error Msg: Operation timed out');
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Rename the `time` attribute of Execution response model to `duration` to be more consistent with other Response Models

## Test Plan
Existing Tests


## Related PRs and Issues
NA

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES