### PR TITLE
Rename execution time to duration

### DIFF
--- a/app/views/console/functions/function.phtml
+++ b/app/views/console/functions/function.phtml
@@ -416,7 +416,7 @@ sort($patterns);
                                             <span data-ls-bind="{{execution.trigger}}"></span>
                                         </td>
                                         <td data-title="Time: ">
-                                            <span data-ls-if="{{execution.status}} === 'completed' || {{execution.status}} === 'failed'" data-ls-bind="{{execution.time|seconds2hum}}"></span>
+                                            <span data-ls-if="{{execution.status}} === 'completed' || {{execution.status}} === 'failed'" data-ls-bind="{{execution.duration|seconds2hum}}"></span>
                                             <span data-ls-if="{{execution.status}} === 'waiting' || {{execution.status}} === 'processing'">-</span>
                                         </td>
                                         <td data-title="">


### PR DESCRIPTION
## What does this PR do?

Fix UI after execution.time was renamed to execution.duration.

## Test Plan

Manual Before:

![image](https://user-images.githubusercontent.com/1477010/189771750-c2330f6f-a80b-463b-bc60-0140dadd26ba.png)

Manual After

![image](https://user-images.githubusercontent.com/1477010/189771898-ded03c46-9edd-46c5-8cfb-273bebc5133d.png)

## Related PRs and Issues

Previous PR:

* https://github.com/appwrite/appwrite/pull/3801

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
