### PR TITLE
Stop tests on failure

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
+         stopOnFailure="true"
 >
     <extensions>
         <extension class="Appwrite\Tests\TestHook" />


### PR DESCRIPTION
## What does this PR do?

Since tests take almost 20 minute to run, stopping tests as soon as an failure occurs will allow for faster iteration locally and also free up resources in the CI pipeline.

## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes