### PR TITLE
Hide function execution stdout from Console UI

### DIFF
--- a/app/views/console/functions/function.phtml
+++ b/app/views/console/functions/function.phtml
@@ -391,9 +391,9 @@ sort($patterns);
                                     <tr>
                                         <th width="30"></th>
                                         <th width="160">Created</th>
-                                        <th width="100">Status</th>
-                                        <th width="80">Trigger</th>
-                                        <th width="60">Runtime</th>
+                                        <th width="150">Status</th>
+                                        <th width="120">Trigger</th>
+                                        <th width="80">Runtime</th>
                                         <th width=""></th>
                                     </tr>
                                 </thead>
@@ -422,11 +422,11 @@ sort($patterns);
                                         <td data-title="">
                                             <div data-ls-if="{{execution.status}} === 'completed' || {{execution.status}} === 'failed'" data-title="" style="display: flex;">
                                                 <button class="desktops-only pull-end link margin-start text-danger" data-ls-ui-trigger="execution-stderr-{{execution.$id}}">Stderr</button>
-                                                <button class="desktops-only pull-end link margin-start" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button>
+                                                <!--button class="desktops-only pull-end link margin-start" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button-->
                                                 <button class="desktops-only pull-end link margin-start" data-ls-ui-trigger="execution-response-{{execution.$id}}">Response</button>
 
                                                 <button class="phones-only-inline tablets-only-inline link margin-end-small" data-ls-ui-trigger="execution-response-{{execution.$id}}">Response</button>
-                                                <button class="phones-only-inline tablets-only-inline link margin-end-small" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button>
+                                                <!--button class="phones-only-inline tablets-only-inline link margin-end-small" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button-->
                                                 <button class="phones-only-inline tablets-only-inline link text-danger" data-ls-ui-trigger="execution-stderr-{{execution.$id}}">Stderr</button>
 
                                                 <div data-ui-modal class="modal width-large box close" data-button-alias="none" data-open-event="execution-response-{{execution.$id}}">


### PR DESCRIPTION
## What does this PR do?

Because it's possible for execution stdout to end up in the wrong execution, we're going to hide the result from the UI to help avoid confusion for users while we work on resolving the problem.

## Test Plan

Manual Before:

<img width="974" alt="Screen Shot 2022-09-13 at 9 34 23 AM" src="https://user-images.githubusercontent.com/1477010/189964163-43d37093-f9e7-4fa5-926c-aacfda30255b.png">

Manual After:

<img width="992" alt="Screen Shot 2022-09-13 at 9 59 42 AM" src="https://user-images.githubusercontent.com/1477010/189964178-3a99634d-f13f-4a6f-ae67-1f9486a66b82.png">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
