### PR TITLE
Fix: Certificate -> Mail worker communication

### DIFF
--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -109,6 +109,8 @@ class BuildsV1 extends Worker
 
         /** Trigger Webhook */
         $deploymentModel = new Deployment();
+
+        // TODO: Use Webhook() event here. If doesnt exist, create class for it
         $deploymentUpdate = new Event(Event::WEBHOOK_QUEUE_NAME, Event::WEBHOOK_CLASS_NAME);
         $deploymentUpdate
             ->setProject($project)

--- a/app/workers/builds.php
+++ b/app/workers/builds.php
@@ -110,7 +110,6 @@ class BuildsV1 extends Worker
         /** Trigger Webhook */
         $deploymentModel = new Deployment();
 
-        // TODO: Use Webhook() event here. If doesnt exist, create class for it
         $deploymentUpdate = new Event(Event::WEBHOOK_QUEUE_NAME, Event::WEBHOOK_CLASS_NAME);
         $deploymentUpdate
             ->setProject($project)


### PR DESCRIPTION
## What does this PR do?

We forgot to refactor the certificate worker regarding new Event classes, so he was not providing a proper structure of the data.

Also, the mails worker had an edge case for certificates email when he was expecting data that was not properly documented on the event.

This PR addresses that, as well as all the other places where new Event classes are not being utilized.

## Test Plan

- [x] Manual QA

![CleanShot 2022-09-20 at 10 19 37](https://user-images.githubusercontent.com/19310830/191205960-37a2eefc-d8cf-419a-803c-1dd8d7fc790c.png)


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes 😇
