### PR TITLE
Fix: Function deletes worker

### DIFF
--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -411,6 +411,14 @@ class DeletesV1 extends Worker
         $functionId = $document->getId();
 
         /**
+         * Delete Variables
+         */
+        Console::info("Deleting variables for function " . $functionId);
+        $this->deleteByGroup('variables', [
+            Query::equal('functionId', [$functionId])
+        ], $dbForProject);
+
+        /**
          * Delete Deployments
          */
         Console::info("Deleting deployments for function " . $functionId);


### PR DESCRIPTION
## What does this PR do?

Delete worker does not delete function variables when function is deleted. It does now.

## Test Plan

It is internal cleanup. No endpoint exposed it anyway. Not sure if we can have a test for it.

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
