### PR TITLE
Fix schedule loop triggering

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -71,8 +71,13 @@ App::post('/v1/functions')
     ->param('enabled', true, new Boolean(), 'Is function enabled?', true)
     ->inject('response')
     ->inject('dbForProject')
+    ->inject('project')
+    ->inject('user')
     ->inject('events')
-    ->action(function (string $functionId, string $name, array $execute, string $runtime, array $events, string $schedule, int $timeout, bool $enabled, Response $response, Database $dbForProject, Event $eventsInstance) {
+    ->action(function (string $functionId, string $name, array $execute, string $runtime, array $events, string $schedule, int $timeout, bool $enabled, Response $response, Database $dbForProject, Document $project, Document $user, Event $eventsInstance) {
+
+        $cron = !empty($schedule) ? new CronExpression($schedule) : null;
+        $next = !empty($schedule) ? DateTime::format($cron->getNextRunDate()) : null;
 
         $functionId = ($functionId == 'unique()') ? ID::unique() : $functionId;
         $function = $dbForProject->createDocument('functions', new Document([
@@ -86,10 +91,21 @@ App::post('/v1/functions')
             'schedule' => $schedule,
             'scheduleUpdatedAt' => DateTime::now(),
             'schedulePrevious' => null,
-            'scheduleNext' => null,
+            'scheduleNext' => $next,
             'timeout' => $timeout,
             'search' => implode(' ', [$functionId, $name, $runtime])
         ]));
+
+        if ($next) {
+            // Async task reschedule
+            $functionEvent = new Func();
+            $functionEvent
+                ->setFunction($function)
+                ->setType('schedule')
+                ->setUser($user)
+                ->setProject($project)
+                ->schedule(new \DateTime($next));
+        }
 
         $eventsInstance->setParam('functionId', $function->getId());
 
@@ -442,11 +458,9 @@ App::put('/v1/functions/:functionId')
             throw new Exception(Exception::FUNCTION_NOT_FOUND);
         }
 
-        $original = $function->getAttribute('schedule', '');
-        $cron = (!empty($function->getAttribute('deployment')) && !empty($schedule)) ? new CronExpression($schedule) : null;
-        $next = (!empty($function->getAttribute('deployment')) && !empty($schedule)) ? DateTime::format($cron->getNextRunDate()) : null;
+        $cron = !empty($schedule) ? new CronExpression($schedule) : null;
+        $next = !empty($schedule) ? DateTime::format($cron->getNextRunDate()) : null;
 
-        $scheduleUpdatedAt = $schedule !== $original ? DateTime::now() : $function->getAttribute('scheduleUpdatedAt');
         $enabled ??= $function->getAttribute('enabled', true);
 
         $function = $dbForProject->updateDocument('functions', $function->getId(), new Document(array_merge($function->getArrayCopy(), [
@@ -454,14 +468,14 @@ App::put('/v1/functions/:functionId')
             'name' => $name,
             'events' => $events,
             'schedule' => $schedule,
-            'scheduleUpdatedAt' => $scheduleUpdatedAt,
+            'scheduleUpdatedAt' => DateTime::now(),
             'scheduleNext' => $next,
             'timeout' => $timeout,
             'enabled' => $enabled,
             'search' => implode(' ', [$functionId, $name, $function->getAttribute('runtime')]),
         ])));
 
-        if ($next && $schedule !== $original) {
+        if ($next) {
             // Async task reschedule
             $functionEvent = new Func();
             $functionEvent
@@ -519,23 +533,9 @@ App::patch('/v1/functions/:functionId/deployments/:deploymentId')
             throw new Exception(Exception::BUILD_NOT_READY);
         }
 
-        $schedule = $function->getAttribute('schedule', '');
-        $cron = (empty($function->getAttribute('deployment')) && !empty($schedule)) ? new CronExpression($schedule) : null;
-        $next = (empty($function->getAttribute('deployment')) && !empty($schedule)) ? DateTime::format($cron->getNextRunDate()) : null;
-
         $function = $dbForProject->updateDocument('functions', $function->getId(), new Document(array_merge($function->getArrayCopy(), [
-            'deployment' => $deployment->getId(),
-            'scheduleNext' => $next,
+            'deployment' => $deployment->getId()
         ])));
-
-        if ($next) { // Init first schedule
-            $functionEvent = new Func();
-            $functionEvent
-                ->setType('schedule')
-                ->setFunction($function)
-                ->setProject($project)
-                ->schedule(new \DateTime($next));
-        }
 
         $events
             ->setParam('functionId', $function->getId())

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -150,13 +150,20 @@ class FunctionsV1 extends Worker
                     throw new Exception('Function not found (' . $function->getId() . ')');
                 }
 
+                \var_dump("Got here");
+
                 if ($functionOriginal->getAttribute('schedule') !== $function->getAttribute('schedule')) { // Schedule has changed from previous run, ignore this run.
                     return;
                 }
 
+
+                \var_dump("Got here 2");
+
                 if ($functionOriginal->getAttribute('scheduleUpdatedAt') !== $function->getAttribute('scheduleUpdatedAt')) { // Double execution due to rapid cron changes, ignore this run.
                     return;
                 }
+
+                \var_dump("Got here 3");
 
                 $cron = new CronExpression($function->getAttribute('schedule'));
                 $next = DateTime::format($cron->getNextRunDate());

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -150,20 +150,13 @@ class FunctionsV1 extends Worker
                     throw new Exception('Function not found (' . $function->getId() . ')');
                 }
 
-                \var_dump("Got here");
-
                 if ($functionOriginal->getAttribute('schedule') !== $function->getAttribute('schedule')) { // Schedule has changed from previous run, ignore this run.
                     return;
                 }
 
-
-                \var_dump("Got here 2");
-
                 if ($functionOriginal->getAttribute('scheduleUpdatedAt') !== $function->getAttribute('scheduleUpdatedAt')) { // Double execution due to rapid cron changes, ignore this run.
                     return;
                 }
-
-                \var_dump("Got here 3");
 
                 $cron = new CronExpression($function->getAttribute('schedule'));
                 $next = DateTime::format($cron->getNextRunDate());


### PR DESCRIPTION
## What does this PR do?

If you set schedule in `createFunction`, the schedule loop is never started. This occurs in Appwrite CLI. This PR solves it.

Also, this PR makes it so `updateFunction` forcefully re-triggers schedule loop. Old loop will be stopped, so no double executions. This is useful, for instance, when you clean your Redis instance and loop is gone. By clicking "Update" on function settings you can easily re-trigger the loop.

## Test Plan

Manual QA for all edge cases I can think of:

<img width="1035" alt="CleanShot 2022-09-23 at 08 12 10@2x" src="https://user-images.githubusercontent.com/19310830/191901488-019373ca-24b4-4fc3-95bd-7b32bf649887.png">

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes 😇
