### PR TITLE
Fix: loose booleans

### DIFF
--- a/app/controllers/api/avatars.php
+++ b/app/controllers/api/avatars.php
@@ -313,9 +313,9 @@ App::get('/v1/avatars/qr')
     ->param('margin', 1, new Range(0, 10), 'Margin from edge. Pass an integer between 0 to 10. Defaults to 1.', true)
     ->param('download', false, new Boolean(true), 'Return resulting image with \'Content-Disposition: attachment \' headers for the browser to start downloading it. Pass 0 for no header, or 1 for otherwise. Default value is set to 0.', true)
     ->inject('response')
-    ->action(function (string $text, int $size, int $margin, bool $download, Response $response) {
+    ->action(function (string $text, int $size, int $margin, mixed $downloadLoose, Response $response) {
+        $download = in_array($downloadLoose, ['1', 'true', 1, true], true);
 
-        $download = ($download === '1' || $download === 'true' || $download === 1 || $download === true);
         $options = new QROptions([
             'addQuietzone' => true,
             'quietzoneSize' => $margin,

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -496,7 +496,8 @@ App::post('/v1/databases/:databaseId/collections')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('events')
-    ->action(function (string $databaseId, string $collectionId, string $name, ?array $permissions, bool $documentSecurity, Response $response, Database $dbForProject, Event $events) {
+    ->action(function (string $databaseId, string $collectionId, string $name, ?array $permissions, mixed $documentSecurityLoose, Response $response, Database $dbForProject, Event $events) {
+        $documentSecurity = in_array($documentSecurityLoose, ['1', 'true', 1, true], true);
 
         $database = Authorization::skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
@@ -752,7 +753,8 @@ App::put('/v1/databases/:databaseId/collections/:collectionId')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('events')
-    ->action(function (string $databaseId, string $collectionId, string $name, ?array $permissions, bool $documentSecurity, bool $enabled, Response $response, Database $dbForProject, Event $events) {
+    ->action(function (string $databaseId, string $collectionId, string $name, ?array $permissions, mixed $documentSecurityLoose, bool $enabled, Response $response, Database $dbForProject, Event $events) {
+        $documentSecurity = in_array($documentSecurityLoose, ['1', 'true', 1, true], true);
 
         $database = Authorization::skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -610,7 +610,8 @@ App::post('/v1/functions/:functionId/deployments')
     ->inject('project')
     ->inject('deviceFunctions')
     ->inject('deviceLocal')
-    ->action(function (string $functionId, string $entrypoint, mixed $code, bool $activate, Request $request, Response $response, Database $dbForProject, Event $events, Document $project, Device $deviceFunctions, Device $deviceLocal) {
+    ->action(function (string $functionId, string $entrypoint, mixed $code, mixed $activateLoose, Request $request, Response $response, Database $dbForProject, Event $events, Document $project, Device $deviceFunctions, Device $deviceLocal) {
+        $activate = in_array($activateLoose, ['1', 'true', 1, true], true);
 
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -688,8 +689,6 @@ App::post('/v1/functions/:functionId/deployments')
         if (empty($chunksUploaded)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
         }
-
-        $activate = (bool) filter_var($activate, FILTER_VALIDATE_BOOLEAN);
 
         if ($chunksUploaded === $chunks) {
             if ($activate) {

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -510,12 +510,12 @@ App::patch('/v1/projects/:projectId/auth/:method')
     ->param('status', false, new Boolean(true), 'Set the status of this auth method.')
     ->inject('response')
     ->inject('dbForConsole')
-    ->action(function (string $projectId, string $method, bool $status, Response $response, Database $dbForConsole) {
+    ->action(function (string $projectId, string $method, mixed $statusLoose, Response $response, Database $dbForConsole) {
+        $status = in_array($statusLoose, ['1', 'true', 1, true], true);
 
         $project = $dbForConsole->getDocument('projects', $projectId);
         $auth = Config::getParam('auth')[$method] ?? [];
         $authKey = $auth['key'] ?? '';
-        $status = ($status === '1' || $status === 'true' || $status === 1 || $status === true);
 
         if ($project->isEmpty()) {
             throw new Exception(Exception::PROJECT_NOT_FOUND);
@@ -593,15 +593,14 @@ App::post('/v1/projects/:projectId/webhooks')
     ->param('httpPass', '', new Text(256), 'Webhook HTTP password. Max length: 256 chars.', true)
     ->inject('response')
     ->inject('dbForConsole')
-    ->action(function (string $projectId, string $name, array $events, string $url, bool $security, string $httpUser, string $httpPass, Response $response, Database $dbForConsole) {
+    ->action(function (string $projectId, string $name, array $events, string $url, mixed $securityLoose, string $httpUser, string $httpPass, Response $response, Database $dbForConsole) {
+        $security = in_array($securityLoose, ['1', 'true', 1, true], true);
 
         $project = $dbForConsole->getDocument('projects', $projectId);
 
         if ($project->isEmpty()) {
             throw new Exception(Exception::PROJECT_NOT_FOUND);
         }
-
-        $security = (bool) filter_var($security, FILTER_VALIDATE_BOOLEAN);
 
         $webhook = new Document([
             '$id' => ID::unique(),
@@ -716,15 +715,14 @@ App::put('/v1/projects/:projectId/webhooks/:webhookId')
     ->param('httpPass', '', new Text(256), 'Webhook HTTP password. Max length: 256 chars.', true)
     ->inject('response')
     ->inject('dbForConsole')
-    ->action(function (string $projectId, string $webhookId, string $name, array $events, string $url, bool $security, string $httpUser, string $httpPass, Response $response, Database $dbForConsole) {
+    ->action(function (string $projectId, string $webhookId, string $name, array $events, string $url, mixed $securityLoose, string $httpUser, string $httpPass, Response $response, Database $dbForConsole) {
+        $security = in_array($securityLoose, ['1', 'true', 1, true], true);
 
         $project = $dbForConsole->getDocument('projects', $projectId);
 
         if ($project->isEmpty()) {
             throw new Exception(Exception::PROJECT_NOT_FOUND);
         }
-
-        $security = ($security === '1' || $security === 'true' || $security === 1 || $security === true);
 
         $webhook = $dbForConsole->findOne('webhooks', [
             Query::equal('_uid', [$webhookId]),

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -71,7 +71,11 @@ App::post('/v1/storage/buckets')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('events')
-    ->action(function (string $bucketId, string $name, ?array $permissions, bool $fileSecurity, bool $enabled, int $maximumFileSize, array $allowedFileExtensions, string $compression, bool $encryption, bool $antivirus, Response $response, Database $dbForProject, Event $events) {
+    ->action(function (string $bucketId, string $name, ?array $permissions, mixed $fileSecurityLoose, mixed $enabledLoose, int $maximumFileSize, array $allowedFileExtensions, string $compression, mixed $encryptionLoose, mixed $antivirusLoose, Response $response, Database $dbForProject, Event $events) {
+        $fileSecurity = in_array($fileSecurityLoose, ['1', 'true', 1, true], true);
+        $enabled = in_array($enabledLoose, ['1', 'true', 1, true], true);
+        $encryption = in_array($encryptionLoose, ['1', 'true', 1, true], true);
+        $antivirus = in_array($antivirusLoose, ['1', 'true', 1, true], true);
 
         $bucketId = $bucketId === 'unique()' ? ID::unique() : $bucketId;
 
@@ -243,7 +247,12 @@ App::put('/v1/storage/buckets/:bucketId')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('events')
-    ->action(function (string $bucketId, string $name, ?array $permissions, bool $fileSecurity, bool $enabled, ?int $maximumFileSize, array $allowedFileExtensions, string $compression, bool $encryption, bool $antivirus, Response $response, Database $dbForProject, Event $events) {
+    ->action(function (string $bucketId, string $name, ?array $permissions, mixed $fileSecurityLoose, mixed $enabledLoose, ?int $maximumFileSize, array $allowedFileExtensions, string $compression, mixed $encryptionLoose, mixed $antivirusLoose, Response $response, Database $dbForProject, Event $events) {
+        $fileSecurity = in_array($fileSecurityLoose, ['1', 'true', 1, true], true);
+        $enabled = in_array($enabledLoose, ['1', 'true', 1, true], true);
+        $encryption = in_array($encryptionLoose, ['1', 'true', 1, true], true);
+        $antivirus = in_array($antivirusLoose, ['1', 'true', 1, true], true);
+
         $bucket = $dbForProject->getDocument('buckets', $bucketId);
 
         if ($bucket->isEmpty()) {

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -633,7 +633,8 @@ App::patch('/v1/users/:userId/status')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('events')
-    ->action(function (string $userId, bool $status, Response $response, Database $dbForProject, Event $events) {
+    ->action(function (string $userId, mixed $statusLoose, Response $response, Database $dbForProject, Event $events) {
+        $status = in_array($statusLoose, ['1', 'true', 1, true], true);
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -641,7 +642,7 @@ App::patch('/v1/users/:userId/status')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
-        $user = $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('status', (bool) $status));
+        $user = $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('status', $status));
 
         $events
             ->setParam('userId', $user->getId());


### PR DESCRIPTION
## What does this PR do?

In a few places we allowed loose boolean (meaning string or integer should work), but never converted it properly to boolean. That caused all deployments to be always marked as active if you provided `active: "false"` instead of `active: false`, even tho validator allowed it.

This PR:

- Fixes bugs regarding loose booleans
- Makes approach consistent everywhere

## Test Plan

- [x] Manual QA. Also tested with CLI - there we stringify body if a file is present in the request (making boolean value `activate` loose)

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Ýes
