### PR TITLE
Fix bug where Query parser ignored 0 strings

### DIFF
--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -1441,6 +1441,15 @@ trait DatabasesBase
 
         $this->assertCount(0, $documents['body']['documents']);
 
+        $documents = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $data['moviesId'] . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => ['equal("releaseYear", [0])'],
+        ]);
+
+        $this->assertEquals(200, $documents['headers']['status-code']);
+
         /**
          * Test for Failure
          */


### PR DESCRIPTION
## What does this PR do?

Dependent on:

* https://github.com/utopia-php/database/pull/194

When `Query::parse()` parsed a string like `equal("attr", [0])` it ignored the 0 string so the values was an empty array. This caused a 500 error in Appwrite.

```
appwrite  | array(1) {
appwrite  |   [0]=>
appwrite  |   object(Utopia\Database\Query)#1556 (3) {
appwrite  |     ["method":protected]=>
appwrite  |     string(5) "equal"
appwrite  |     ["attribute":protected]=>
appwrite  |     string(7) "intAttr"
appwrite  |     ["values":protected]=>
appwrite  |     array(0) {
appwrite  |     }
appwrite  |   }
appwrite  | }
appwrite  | [Error] Type: Utopia\Exception
appwrite  | [Error] Message: Error handler had an error
appwrite  | [Error] File: /usr/src/code/vendor/utopia-php/framework/src/App.php
```

Related issue:

* https://github.com/appwrite/appwrite/issues/3926

## Test Plan

Added e2e test.

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/3926

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
