### PR TITLE
Update Console to Show Function Stdout Logs

### DIFF
--- a/app/views/console/functions/function.phtml
+++ b/app/views/console/functions/function.phtml
@@ -391,9 +391,9 @@ sort($patterns);
                                     <tr>
                                         <th width="30"></th>
                                         <th width="160">Created</th>
-                                        <th width="150">Status</th>
-                                        <th width="120">Trigger</th>
-                                        <th width="80">Runtime</th>
+                                        <th width="100">Status</th>
+                                        <th width="80">Trigger</th>
+                                        <th width="60">Runtime</th>
                                         <th width=""></th>
                                     </tr>
                                 </thead>
@@ -422,11 +422,11 @@ sort($patterns);
                                         <td data-title="">
                                             <div data-ls-if="{{execution.status}} === 'completed' || {{execution.status}} === 'failed'" data-title="" style="display: flex;">
                                                 <button class="desktops-only pull-end link margin-start text-danger" data-ls-ui-trigger="execution-stderr-{{execution.$id}}">Stderr</button>
-                                                <!--button class="desktops-only pull-end link margin-start" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button-->
+                                                <button class="desktops-only pull-end link margin-start" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button>
                                                 <button class="desktops-only pull-end link margin-start" data-ls-ui-trigger="execution-response-{{execution.$id}}">Response</button>
 
                                                 <button class="phones-only-inline tablets-only-inline link margin-end-small" data-ls-ui-trigger="execution-response-{{execution.$id}}">Response</button>
-                                                <!--button class="phones-only-inline tablets-only-inline link margin-end-small" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button-->
+                                                <button class="phones-only-inline tablets-only-inline link margin-end-small" data-ls-ui-trigger="execution-stdout-{{execution.$id}}">Stdout</button>
                                                 <button class="phones-only-inline tablets-only-inline link text-danger" data-ls-ui-trigger="execution-stderr-{{execution.$id}}">Stderr</button>
 
                                                 <div data-ui-modal class="modal width-large box close" data-button-alias="none" data-open-event="execution-response-{{execution.$id}}">


### PR DESCRIPTION
## What does this PR do?

Although there is still a known issue where function stdout logs can appear in the wrong execution, not having the logs easily accessible in the console makes troubleshooting functions significantly more difficult.

## Test Plan

Manual before:

![Screen Shot 2022-09-27 at 12 45 01 PM](https://user-images.githubusercontent.com/1477010/192623409-87607380-9e3f-4323-9414-449cb892dba9.png)

Manual after:

![Screen Shot 2022-09-27 at 12 47 22 PM](https://user-images.githubusercontent.com/1477010/192623433-769432a1-e6c4-43ea-9b5b-597d2b0862a4.png)

![Screen Shot 2022-09-27 at 12 48 05 PM](https://user-images.githubusercontent.com/1477010/192623445-5441a3b5-c52e-4ffd-9062-5d1df69c241b.png)

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/3934
* https://github.com/appwrite/appwrite/issues/3295

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
