### PR TITLE
Update function execution from console to be async

### DIFF
--- a/app/views/console/functions/function.phtml
+++ b/app/views/console/functions/function.phtml
@@ -841,6 +841,8 @@ sort($patterns);
         data-failure-param-alert-text="Failed to execute function"
         data-failure-param-alert-classname="error">
 
+        <input name="async" data-cast-to="bool" value="true" type="hidden" />
+
         <label for="execution-data">Custom Data</label>
         <textarea id="execution-data" name="data" autocomplete="off" class="margin-bottom" placeholder="Data string (optional)"></textarea>
 


### PR DESCRIPTION
## What does this PR do?

Before 1.0.x, function executions were async by default. This ensures executions starting 1.0.x are still async.

## Test Plan

Manual:

![image](https://user-images.githubusercontent.com/1477010/192628179-92ab45e5-b192-478f-8912-eda05532a117.png)

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/3927

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
