### PR TITLE
fix: empty payload returned as list

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1004,7 +1004,8 @@ App::delete('/v1/users/:userId/sessions/:sessionId')
 
         $events
             ->setParam('userId', $user->getId())
-            ->setParam('sessionId', $sessionId);
+            ->setParam('sessionId', $sessionId)
+            ->setPayload($response->output($session, Response::MODEL_SESSION));
 
         $response->noContent();
     });

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -458,21 +458,29 @@ class RealtimeCustomClientTest extends Scope
         $this->assertContains("users.*", $response['data']['events']);
         $this->assertNotEmpty($response['data']['payload']);
 
+        $createSession = function () use ($projectId): array {
+            $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
+                'origin' => 'http://localhost',
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $projectId,
+            ]), [
+                'email' => 'torsten@appwrite.io',
+                'password' => 'new-password',
+            ]);
+
+            $sessionNew = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_' . $projectId];
+            $sessionNewId = $response['body']['$id'];
+
+            return array("session" => $sessionNew, "sessionId" => $sessionNewId);
+        };
+
         /**
          * Test Account Session Create
          */
-        $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
-            'origin' => 'http://localhost',
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $projectId,
-        ]), [
-            'email' => 'torsten@appwrite.io',
-            'password' => 'new-password',
-        ]);
+        $sessionData = $createSession();
 
-        $sessionNew = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_' . $projectId];
-        $sessionNewId = $response['body']['$id'];
-
+        $sessionNew = $sessionData['session'];
+        $sessionNewId = $sessionData['sessionId'];
         $response = json_decode($client->receive(), true);
 
         $this->assertArrayHasKey('type', $response);
@@ -507,6 +515,43 @@ class RealtimeCustomClientTest extends Scope
 
         $response = json_decode($client->receive(), true);
 
+        $this->assertArrayHasKey('type', $response);
+        $this->assertArrayHasKey('data', $response);
+        $this->assertEquals('event', $response['type']);
+        $this->assertNotEmpty($response['data']);
+        $this->assertCount(2, $response['data']['channels']);
+        $this->assertArrayHasKey('timestamp', $response['data']);
+        $this->assertContains('account', $response['data']['channels']);
+        $this->assertContains('account.' . $userId, $response['data']['channels']);
+        $this->assertContains("users.{$userId}.sessions.{$sessionNewId}.delete", $response['data']['events']);
+        $this->assertContains("users.{$userId}.sessions.{$sessionNewId}", $response['data']['events']);
+        $this->assertContains("users.{$userId}.sessions.*.delete", $response['data']['events']);
+        $this->assertContains("users.{$userId}.sessions.*", $response['data']['events']);
+        $this->assertContains("users.{$userId}", $response['data']['events']);
+        $this->assertContains("users.*.sessions.{$sessionNewId}.delete", $response['data']['events']);
+        $this->assertContains("users.*.sessions.{$sessionNewId}", $response['data']['events']);
+        $this->assertContains("users.*.sessions.*.delete", $response['data']['events']);
+        $this->assertContains("users.*.sessions.*", $response['data']['events']);
+        $this->assertContains("users.*", $response['data']['events']);
+        $this->assertNotEmpty($response['data']['payload']);
+
+        /**
+         * Test User Account Session Delete
+         */
+
+        $sessionData = $createSession();
+        $sessionNew = $sessionData['session'];
+        $sessionNewId = $sessionData['sessionId'];
+        $client->receive(); // Receive the creation message and drop; this was tested earlier already
+
+        $this->client->call(Client::METHOD_DELETE, '/users/' . $userId . '/sessions/' . $sessionNewId, array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]));
+
+        $response = json_decode($client->receive(), true);
         $this->assertArrayHasKey('type', $response);
         $this->assertArrayHasKey('data', $response);
         $this->assertEquals('event', $response['type']);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds a `setPayload` call to the `DELETE /user/:userId/sessions/:sessionId` endpoint which was previously missing causing the error described in #3916.

## Test Plan

An e2e test was written for the case to prevent regressions.

## Related PRs and Issues

#3916 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
