### PR TITLE
Deprecate team deletion with project

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -563,10 +563,6 @@ App::delete('/v1/projects/:projectId')
             ->setDocument($project)
         ;
 
-        if (!$dbForConsole->deleteDocument('teams', $project->getAttribute('teamId', null))) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove project team from DB');
-        }
-
         if (!$dbForConsole->deleteDocument('projects', $projectId)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove project from DB');
         }


### PR DESCRIPTION
## What does this PR do?

In the new console, one organization (team) can have multiple projects. This PR makes sure that a project can be deleted without forcefully also deleting a team.

## Test Plan

- [x] Implemented new tests

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
