### PR TITLE
fixed: wrong error message show on adding duplicate number to a user

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -888,7 +888,7 @@ App::patch('/v1/users/:userId/phone')
         try {
             $user = $dbForProject->updateDocument('users', $user->getId(), $user);
         } catch (Duplicate $th) {
-            throw new Exception(Exception::USER_EMAIL_ALREADY_EXISTS);
+            throw new Exception(Exception::USER_PHONE_ALREADY_EXISTS);
         }
 
         $events->setParam('userId', $user->getId());

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -953,6 +953,25 @@ trait UsersBase
         $this->assertEquals($user['headers']['status-code'], 200);
         $this->assertEquals($user['body']['phone'], $updatedNumber);
 
+         /**
+         * Test for FAILURE
+         */
+
+        $errorType = "user_phone_already_exists";
+        $user1Id = "user1";
+        $statusCodeForUserPhoneAlredyExists = 409;
+
+        // adding same number ($updatedNumber) to different user i.e user1
+        $response = $this->client->call(Client::METHOD_PATCH, '/users/' . $user1Id . '/phone', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'number' => $updatedNumber,
+        ]);
+        $this->assertEquals($response['headers']['status-code'], $statusCodeForUserPhoneAlredyExists);
+        $this->assertNotEmpty($response['body']);
+        $this->assertEquals($response['body']['type'], $errorType);
+
         return $data;
     }
 

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -926,6 +926,62 @@ trait UsersBase
         return $data;
     }
 
+    /**
+     * @depends testGetUser
+     */
+    public function testUpdateUserNumber(array $data): array
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $updatedNumber = "+910000000000"; //dummy number
+        $user = $this->client->call(Client::METHOD_PATCH, '/users/' . $data['userId'] . '/phone', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'number' => $updatedNumber,
+        ]);
+
+        $this->assertEquals($user['headers']['status-code'], 200);
+        $this->assertEquals($user['body']['phone'], $updatedNumber);
+
+        $user = $this->client->call(Client::METHOD_GET, '/users/' . $data['userId'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals($user['headers']['status-code'], 200);
+        $this->assertEquals($user['body']['phone'], $updatedNumber);
+
+        return $data;
+    }
+
+    /**
+     * @depends testUpdateUserNumber
+     */
+    public function testUpdateUserNumberSearch($data): void
+    {
+        $id = $data['userId'] ?? '';
+        $newNumber = "+910000000000"; //dummy number
+
+        /**
+         * Test for SUCCESS
+         */
+        $response = $this->client->call(Client::METHOD_GET, '/users', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'search' => $newNumber,
+        ]);
+
+        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertNotEmpty($response['body']);
+        $this->assertNotEmpty($response['body']['users']);
+        $this->assertCount(1, $response['body']['users']);
+        $this->assertEquals($response['body']['users'][0]['$id'], $id);
+        $this->assertEquals($response['body']['users'][0]['phone'], $newNumber);
+    }
+
 
     /**
      * @depends testGetUser


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Show correct toast or message when adding a duplicate phone number to a user.

## Test Plan

Try to add duplicate phone number to different user to see the correct message.

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/3810

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
