### PR TITLE
Feat: Implement 'locales' command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -343,6 +343,7 @@ RUN chmod +x /usr/local/bin/doctor && \
     chmod +x /usr/local/bin/ssl && \
     chmod +x /usr/local/bin/test && \
     chmod +x /usr/local/bin/vars && \
+    chmod +x /usr/local/bin/locales && \
     chmod +x /usr/local/bin/worker-audits && \
     chmod +x /usr/local/bin/worker-certificates && \
     chmod +x /usr/local/bin/worker-databases && \

--- a/app/cli.php
+++ b/app/cli.php
@@ -12,15 +12,19 @@ Authorization::disable();
 
 $cli = new CLI();
 
+// Administartive commands
 include 'tasks/doctor.php';
 include 'tasks/maintenance.php';
 include 'tasks/install.php';
 include 'tasks/migrate.php';
-include 'tasks/sdks.php';
-include 'tasks/specs.php';
 include 'tasks/ssl.php';
 include 'tasks/vars.php';
 include 'tasks/usage.php';
+
+// Tooling commands
+include 'tasks/sdks.php';
+include 'tasks/specs.php';
+include 'tasks/locales.php';
 
 $cli
     ->task('version')

--- a/app/tasks/locales.php
+++ b/app/tasks/locales.php
@@ -1,0 +1,63 @@
+<?php
+
+global $cli;
+
+use Utopia\CLI\Console;
+use Utopia\Locale\Locale;
+use Utopia\Validator\WhiteList;
+
+$cli
+    ->task('locales')
+    ->desc('Find missing locales configuration')
+    ->param('type', 'verbose', new WhiteList(['verbose', 'debug', 'json']), 'Style of result logging.', true)
+    ->action(function ($type) {
+        $languages = Locale::getLanguages();
+
+        $mainLanguage = 'en';
+        $mainTranslations = [];
+
+        $mainLocale = new Locale($mainLanguage);
+        foreach ($mainLocale->getTranslations() as $key => $value) {
+            if(!empty($value)) {
+                $mainTranslations[] = $key;
+            }
+        }
+
+        $results = [];
+
+        foreach ($languages as $language) {
+            $locale = new Locale($language);
+            $translations = $locale->getTranslations();
+            $missing = [];
+            foreach ($mainTranslations as $translation) {
+                if(empty($translations[$translation])) {
+                    $missing[] = $translation;
+                }
+            }
+
+            if(\count($missing) <= 0) {
+                $type !== 'json' && Console::success('Locale "' . $language . '" is fully translated.');
+            } else {
+                $type !== 'json' && Console::error('Locale "' . $language . '" is missing ' . \count($missing) . ' translations.');
+
+                if($type === 'debug') {
+                    foreach ($missing as $key) {
+                        Console::log('"' . $key . '" missing in "' . $language . '".');
+                    }
+                } else if ($type === 'json') {
+                    if(!(\array_key_exists($language, $results))) {
+                        $results[$language] = [];
+                    }
+
+                    $results[$language] = $key;
+                }
+            }
+        }
+
+        $type !== 'json'  && Console::info('To get detailed information about missing translations, run the command with --type=debug parameter. Use --type=json to get JSON formatted results.');
+        
+        if($type === 'json') {
+            Console::log(\json_encode($results));
+        }
+    
+    });

--- a/bin/locales
+++ b/bin/locales
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+php /usr/src/code/app/cli.php locales $@

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "utopia-php/cli": "0.13.*",
         "utopia-php/config": "0.2.*",
         "utopia-php/database": "0.25.*",
-        "utopia-php/locale": "0.4.*",
+        "utopia-php/locale": "dev-feat-get-languages as 0.4.0",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",
         "utopia-php/domains": "1.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "568151395a8877f87d9bdce048adc2dc",
+    "content-hash": "ed42f5767ed3c24ad5bddccb4c164270",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2279,16 +2279,16 @@
         },
         {
             "name": "utopia-php/locale",
-            "version": "0.4.0",
+            "version": "dev-feat-get-languages",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/locale.git",
-                "reference": "c2d9358d0fe2f6b6ed5448369f9d1e430c615447"
+                "reference": "88f855c56445452a916f60282529f8c3d96a66b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/locale/zipball/c2d9358d0fe2f6b6ed5448369f9d1e430c615447",
-                "reference": "c2d9358d0fe2f6b6ed5448369f9d1e430c615447",
+                "url": "https://api.github.com/repos/utopia-php/locale/zipball/88f855c56445452a916f60282529f8c3d96a66b8",
+                "reference": "88f855c56445452a916f60282529f8c3d96a66b8",
                 "shasum": ""
             },
             "require": {
@@ -2324,9 +2324,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/locale/issues",
-                "source": "https://github.com/utopia-php/locale/tree/0.4.0"
+                "source": "https://github.com/utopia-php/locale/tree/feat-get-languages"
             },
-            "time": "2021-07-24T11:35:55+00:00"
+            "time": "2022-10-07T07:22:14+00:00"
         },
         {
             "name": "utopia-php/logger",
@@ -5358,9 +5358,18 @@
             "time": "2022-09-28T08:42:51+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/locale",
+            "version": "dev-feat-get-languages",
+            "alias": "0.4.0",
+            "alias_normalized": "0.4.0.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "utopia-php/locale": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5384,5 +5393,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## What does this PR do?

`locales` command helps us identify missing translations for our messages. These are mainly used in email templates.

## Test Plan

- [x] Manual QA:

![CleanShot 2022-10-07 at 09 48 31](https://user-images.githubusercontent.com/19310830/194501689-9581e4b0-21fe-4551-869a-2e56353ac1a9.png)

![CleanShot 2022-10-07 at 09 48 16](https://user-images.githubusercontent.com/19310830/194501696-178fa068-386e-46da-a1ea-849fe750a9d7.png)

![CleanShot 2022-10-07 at 09 51 11](https://user-images.githubusercontent.com/19310830/194501702-920402b5-8f62-4409-b270-d5ac39c8d57b.png)

## Related PRs and Issues

- Must be merged and released: https://github.com/utopia-php/locale/pull/12

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Sure! 😎
