### PR TITLE
fix: correctly handle `=` in .env

### DIFF
--- a/src/Appwrite/Docker/Env.php
+++ b/src/Appwrite/Docker/Env.php
@@ -19,7 +19,7 @@ class Env
         $data = explode("\n", $data);
 
         foreach ($data as &$row) {
-            $row = explode('=', $row);
+            $row = explode('=', $row, 2);
             $key = (isset($row[0])) ? trim($row[0]) : null;
             $value = (isset($row[1])) ? trim($row[1]) : null;
 

--- a/tests/resources/docker/.env
+++ b/tests/resources/docker/.env
@@ -1,3 +1,4 @@
 _APP_X=value1
 _APP_Y=value2
 _APP_Z = value3
+_APP_W = value5=

--- a/tests/unit/Docker/EnvTest.php
+++ b/tests/unit/Docker/EnvTest.php
@@ -28,6 +28,7 @@ class EnvTest extends TestCase
         $this->assertEquals('value1', $this->object->getVar('_APP_X'));
         $this->assertEquals('value2', $this->object->getVar('_APP_Y'));
         $this->assertEquals('value3', $this->object->getVar('_APP_Z'));
+        $this->assertEquals('value5=', $this->object->getVar('_APP_W'));
         $this->assertEquals('value4', $this->object->getVar('_APP_TEST'));
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds the limit argument to explode method to correctly handle `=` in .env files

## Test Plan

The code has been manually ran and tested against test case.

## Related PRs and Issues

Closes #4294 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
