### PR TITLE
Only delete collection data for correct db

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Version 1.0.3
+## Bugs
+- Fix document audit deletion [#4429](https://github.com/appwrite/appwrite/pull/4429)
+- Fix attribute, index, and audit deletion [#4429](https://github.com/appwrite/appwrite/pull/4429)
+
 # Version 1.0.2
 ## Bugs
 - Fixed nullable values in functions variables [#3885](https://github.com/appwrite/appwrite/pull/3885)

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -193,21 +193,24 @@ class DeletesV1 extends Worker
     protected function deleteCollection(Document $document, string $projectId): void
     {
         $collectionId = $document->getId();
-        $databaseId = str_replace('database_', '', $document->getCollection());
+        $databaseId = $document->getAttribute('databaseId');
+        $databaseInternalId = $document->getAttribute('databaseInternalId');
 
         $dbForProject = $this->getProjectDB($projectId);
 
-        $dbForProject->deleteCollection('database_' . $databaseId . '_collection_' . $document->getInternalId());
+        $dbForProject->deleteCollection('database_' . $databaseInternalId . '_collection_' . $document->getInternalId());
 
         $this->deleteByGroup('attributes', [
+            Query::equal('databaseId', [$databaseId]),
             Query::equal('collectionId', [$collectionId])
         ], $dbForProject);
 
         $this->deleteByGroup('indexes', [
+            Query::equal('databaseId', [$databaseId]),
             Query::equal('collectionId', [$collectionId])
         ], $dbForProject);
 
-        $this->deleteAuditLogsByResource('collection/' . $collectionId, $projectId);
+        $this->deleteAuditLogsByResource('database/' . $databaseId . '/collection/' . $collectionId, $projectId);
     }
 
     /**


### PR DESCRIPTION
Ensure attributes, indexes, and audit for correct database is deleted.

## What does this PR do?

Closes #4427

## Test Plan

Attributes and Indexes before and after database deletion shows attributes and indexes in database test1 are not deleted:

<img width="1906" alt="Screen Shot 2022-10-11 at 3 42 34 PM" src="https://user-images.githubusercontent.com/1477010/195212788-eaeca39f-ce92-499d-8d2a-1632e06bfc86.png">

Audit during document deletion show documents are deleted as expected rather than no documents:

<img width="2141" alt="Screen Shot 2022-10-11 at 3 38 00 PM" src="https://user-images.githubusercontent.com/1477010/195212790-66944ffe-c0a3-4ea4-86d2-ff038640f112.png">


## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/4427

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
