### PR TITLE
Fixed the broken link

### DIFF
--- a/docs/tutorials/add-translations.md
+++ b/docs/tutorials/add-translations.md
@@ -62,7 +62,7 @@ We maintain a [`locale branch`](https://github.com/appwrite/appwrite/tree/locale
 
 2. **en.json**
 
-    [en.json]((https://github.com/appwrite/appwrite/blob/locale/app/config/locale/translations/en.json)) contains the English translation for all the terms that are present in **terms.json**. You can use this file as a reference when making a contribution for your language.
+    [en.json](https://github.com/appwrite/appwrite/blob/locale/app/config/locale/translations/en.json) contains the English translation for all the terms that are present in **terms.json**. You can use this file as a reference when making a contribution for your language.
 
     ```json
     {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixed the broken link

On line 65 Found there was additional brackets due to which the 'en.json' was not an hyperlink, so removed those brackets and now 'en.json' is an hyperlink leading to https://github.com/appwrite/appwrite/blob/locale/app/config/locale/translations/en.json