### PR TITLE
Fix team memberships secret exposure

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -449,7 +449,18 @@ App::post('/v1/teams/:teamId/memberships')
         $events
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId())
+            ->setPayload($response->output(
+                $membership
+                ->setAttribute('teamName', $team->getAttribute('name'))
+                ->setAttribute('userName', $invitee->getAttribute('name'))
+                ->setAttribute('userEmail', $invitee->getAttribute('email'))
+                ->setAttribute('secret', $secret),
+                Response::MODEL_MEMBERSHIP
+            ))
         ;
+
+        // Hide secret for clients
+        $membership->setAttribute('secret', ($isPrivilegedUser || $isAppUser) ? $secret : '');
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
@@ -485,6 +496,9 @@ App::get('/v1/teams/:teamId/memberships')
         if ($team->isEmpty()) {
             throw new Exception(Exception::TEAM_NOT_FOUND);
         }
+
+        $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
+        $isAppUser = Auth::isAppUser(Authorization::getRoles());
 
         $queries = Query::parseQueries($queries);
 
@@ -525,7 +539,11 @@ App::get('/v1/teams/:teamId/memberships')
 
         $memberships = array_filter($memberships, fn(Document $membership) => !empty($membership->getAttribute('userId')));
 
-        $memberships = array_map(function ($membership) use ($dbForProject, $team) {
+        $memberships = array_map(function ($membership) use ($dbForProject, $team, $isPrivilegedUser, $isAppUser) {
+
+            // Hide secret for clients
+            $membership->setAttribute('secret', ($isPrivilegedUser || $isAppUser) ? $membership->getAttribute('secret') : '');
+
             $user = $dbForProject->getDocument('users', $membership->getAttribute('userId'));
 
             $membership
@@ -572,7 +590,13 @@ App::get('/v1/teams/:teamId/memberships/:membershipId')
             throw new Exception(Exception::MEMBERSHIP_NOT_FOUND);
         }
 
+        $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
+        $isAppUser = Auth::isAppUser(Authorization::getRoles());
+
         $user = $dbForProject->getDocument('users', $membership->getAttribute('userId'));
+
+        // Hide secret for clients
+        $membership->setAttribute('secret', ($isPrivilegedUser || $isAppUser) ? $membership->getAttribute('secret') : '');
 
         $membership
             ->setAttribute('teamName', $team->getAttribute('name'))
@@ -644,6 +668,9 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
         $events
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId());
+
+        // Hide secret for clients
+        $membership->setAttribute('secret', ($isPrivilegedUser || $isAppUser) ? $membership->getAttribute('secret') : '');
 
         $response->dynamic(
             $membership
@@ -718,6 +745,9 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId/status')
             throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
         }
 
+        $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
+        $isAppUser = Auth::isAppUser(Authorization::getRoles());
+
         $membership // Attach user to team
             ->setAttribute('joined', DateTime::now())
             ->setAttribute('confirm', true)
@@ -778,6 +808,9 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId/status')
             ->addCookie(Auth::$cookieName . '_legacy', Auth::encodeSession($user->getId(), $secret), (new \DateTime($expire))->getTimestamp(), '/', Config::getParam('cookieDomain'), ('https' == $protocol), true, null)
             ->addCookie(Auth::$cookieName, Auth::encodeSession($user->getId(), $secret), (new \DateTime($expire))->getTimestamp(), '/', Config::getParam('cookieDomain'), ('https' == $protocol), true, Config::getParam('cookieSamesite'))
         ;
+
+        // Hide secret for clients
+        $membership->setAttribute('secret', ($isPrivilegedUser || $isAppUser) ? $membership->getAttribute('secret') : '');
 
         $response->dynamic(
             $membership

--- a/src/Appwrite/Utopia/Response/Model/Membership.php
+++ b/src/Appwrite/Utopia/Response/Model/Membership.php
@@ -83,6 +83,12 @@ class Membership extends Model
                 'example' => 'admin',
                 'array' => true,
             ])
+            ->addRule('secret', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Token secret key. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'default' => '',
+                'example' => '',
+            ])
         ;
     }
 

--- a/tests/e2e/Services/Teams/TeamsBaseClient.php
+++ b/tests/e2e/Services/Teams/TeamsBaseClient.php
@@ -32,6 +32,7 @@ trait TeamsBaseClient
         $this->assertEquals($teamName, $response['body']['memberships'][0]['teamName']);
         $this->assertContains('owner', $response['body']['memberships'][0]['roles']);
         $this->assertContains('player', $response['body']['memberships'][0]['roles']);
+        $this->assertEmpty($response['body']['memberships'][0]['secret']);
 
         $membershipId = $response['body']['memberships'][0]['$id'];
 
@@ -205,6 +206,7 @@ trait TeamsBaseClient
         $this->assertCount(2, $response['body']['roles']);
         $this->assertEquals(false, DateTime::isValid($response['body']['joined'])); // is null in DB
         $this->assertEquals(false, $response['body']['confirm']);
+        $this->assertEmpty($response['body']['secret']);
 
         $lastEmail = $this->getLastEmail();
 

--- a/tests/e2e/Services/Teams/TeamsBaseServer.php
+++ b/tests/e2e/Services/Teams/TeamsBaseServer.php
@@ -59,6 +59,7 @@ trait TeamsBaseServer
         $this->assertCount(2, $response['body']['roles']);
         $this->assertEquals(true, DateTime::isValid($response['body']['joined'])); // is null in DB
         $this->assertEquals(true, $response['body']['confirm']);
+        $this->assertNotEmpty(true, $response['body']['secret']);
 
         /**
          * Test for FAILURE
@@ -110,6 +111,7 @@ trait TeamsBaseServer
         $this->assertCount(2, $response['body']['roles']);
         $this->assertEquals(true, DateTime::isValid($response['body']['joined']));
         $this->assertEquals(true, $response['body']['confirm']);
+        $this->assertNotEmpty(true, $response['body']['secret']);
 
         $userUid = $response['body']['userId'];
         $membershipUid = $response['body']['$id'];
@@ -211,7 +213,7 @@ trait TeamsBaseServer
         $this->assertEquals($roles[0], $response['body']['roles'][0]);
         $this->assertEquals($roles[1], $response['body']['roles'][1]);
         $this->assertEquals($roles[2], $response['body']['roles'][2]);
-
+        $this->assertNotEmpty(true, $response['body']['secret']);
 
         /**
          * Test for FAILURE

--- a/tests/e2e/Services/Teams/TeamsBaseServer.php
+++ b/tests/e2e/Services/Teams/TeamsBaseServer.php
@@ -2,6 +2,7 @@
 
 namespace Tests\E2E\Services\Teams;
 
+use Appwrite\Auth\Auth;
 use Tests\E2E\Client;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -115,6 +116,18 @@ trait TeamsBaseServer
 
         $userUid = $response['body']['userId'];
         $membershipUid = $response['body']['$id'];
+        $membershipSecret = $response['body']['secret'];
+
+        // Ensure secret is present on GET too, but hashed
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships/' . $membershipUid, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals($membershipUid, $response['body']['$id']);
+        $this->assertNotEmpty(true, $response['body']['secret']);
+        $this->assertEquals(Auth::hash($membershipSecret), $response['body']['secret']);
 
         // $response = $this->client->call(Client::METHOD_GET, '/users/'.$userUid, array_merge([
         //     'content-type' => 'application/json',

--- a/tests/e2e/Services/Teams/TeamsConsoleClientTest.php
+++ b/tests/e2e/Services/Teams/TeamsConsoleClientTest.php
@@ -101,6 +101,7 @@ class TeamsConsoleClientTest extends Scope
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEmpty($response['body']['secret']);
 
         $response = $this->client->call(Client::METHOD_GET, '/users', array_merge([
             'content-type' => 'application/json',


### PR DESCRIPTION
## What does this PR do?

When team membership is created by an API key or console user, a plain secret should be returned so developers can share the secret over custom channels, or implement re-invitation logic.

## Test Plan

- [x] Update existing tests
- [x] Add new tests to ensure the secret is not exposed
- [x] Add tests to ensure secret persistency

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/4441

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
