### PR TITLE
Fix: DB Usage projects pagination

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,8 @@
 tasks:
   - name: Run Appwrite Docker Stack
     init: |
-      docker compose pull
       docker compose build
+      docker compose pull
       docker pull composer
     command: |
       docker run --rm --interactive --tty \

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Bugs
 - Fix license detection for Flutter and Dart SDKs [#4435](https://github.com/appwrite/appwrite/pull/4435)
+- Fix project pagination in DB usage collector [#4513](https://github.com/appwrite/appwrite/pull/4513)
 
 # Version 1.0.3
 ## Bugs

--- a/composer.lock
+++ b/composer.lock
@@ -3413,25 +3413,30 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
+                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
+                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
@@ -3457,9 +3462,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
             },
-            "time": "2022-03-15T21:29:03+00:00"
+            "time": "2022-10-14T12:47:21+00:00"
         },
         {
             "name": "phpspec/prophecy",

--- a/src/Appwrite/Usage/Calculators/Database.php
+++ b/src/Appwrite/Usage/Calculators/Database.php
@@ -132,7 +132,6 @@ class Database extends Calculator
         $results = [];
         $sum = $limit;
         $latestDocument = null;
-        $this->database->setNamespace('_' . $projectId);
 
         while ($sum === $limit) {
             try {
@@ -140,6 +139,7 @@ class Database extends Calculator
                 if ($latestDocument !== null) {
                     $paginationQueries[] =  Query::cursorAfter($latestDocument);
                 }
+                $this->database->setNamespace('_' . $projectId);
                 $results = $this->database->find($collection, \array_merge($paginationQueries, $queries));
             } catch (\Exception $e) {
                 if (is_callable($this->errorHandler)) {


### PR DESCRIPTION
## What does this PR do?

Pagination of projects did not work properly because callback causes the namespace to change. This caused pagination to not work, and only the first 50 projects got their stats updated. This would become a huge problem with Appwrite Cloud.

This PR also fixes order of Gitpod rebuild commands. Prebuilds were failing due to unsuccessful pull of appwrite-dev. Now it works fine, tested manually.

## Test Plan

- [x] Manual QA. Set pagination limit to 2, created 4 projects, all got their stats

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
