### PR TITLE
V1: Fix: DB Usage projects pagination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Version 1.0.4
 
-- Fix project pagination in DB usage collector [#X](X)
+- Fix project pagination in DB usage collector [#4517](https://github.com/appwrite/appwrite/pull/4517)
 
 # Version 1.0.3
 ## Bugs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Version 1.0.4
+
+- Fix project pagination in DB usage collector [#X](X)
+
 # Version 1.0.3
 ## Bugs
 - Fix document audit deletion [#4429](https://github.com/appwrite/appwrite/pull/4429)

--- a/src/Appwrite/Usage/Calculators/Database.php
+++ b/src/Appwrite/Usage/Calculators/Database.php
@@ -132,7 +132,6 @@ class Database extends Calculator
         $results = [];
         $sum = $limit;
         $latestDocument = null;
-        $this->database->setNamespace('_' . $projectId);
 
         while ($sum === $limit) {
             try {
@@ -140,6 +139,8 @@ class Database extends Calculator
                 if ($latestDocument !== null) {
                     $paginationQueries[] =  Query::cursorAfter($latestDocument);
                 }
+
+                $this->database->setNamespace('_' . $projectId);
                 $results = $this->database->find($collection, \array_merge($paginationQueries, $queries));
             } catch (\Exception $e) {
                 if (is_callable($this->errorHandler)) {


### PR DESCRIPTION
## What does this PR do?

Pagination of projects did not work properly because callback causes the namespace to change. This caused pagination to not work, and only the first 50 projects got their stats updated. This would become a huge problem with Appwrite Cloud.

## Test Plan

- [x] Manual QA. Set pagination limit to 2, created 4 projects, all got their stats

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
