### PR TITLE
Fix bucket permission migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Version 1.0.4
 
 - Fix project pagination in DB usage collector [#4517](https://github.com/appwrite/appwrite/pull/4517)
+- Fix migration of bucket permission [#4554](https://github.com/appwrite/appwrite/pull/4554)
 
 # Version 1.0.3
 ## Bugs

--- a/src/Appwrite/Migration/Version/V15.php
+++ b/src/Appwrite/Migration/Version/V15.php
@@ -114,7 +114,7 @@ class V15 extends Migration
             );
 
             if (!is_null($bucket->getAttribute('permission'))) {
-                $bucket->setAttribute('fileSecurity', $bucket->getAttribute('permissions') === 'document');
+                $bucket->setAttribute('fileSecurity', $bucket->getAttribute('permission') === 'file');
             }
 
             if (is_null($bucket->getAttribute('compression'))) {

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -124,56 +124,33 @@ class HTTPTest extends Scope
         $this->client->setEndpoint($previousEndpoint);
     }
 
-    // public function testSpecSwagger2()
-    // {
-    //     $response = $this->client->call(Client::METHOD_GET, '/specs/swagger2?platform=client', [
-    //         'content-type' => 'application/json',
-    //     ], []);
-
-    //     if(!file_put_contents(__DIR__ . '/../../resources/swagger2.json', json_encode($response['body']))) {
-    //         throw new Exception('Failed to save spec file');
-    //     }
-
-    //     $client = new Client();
-    //     $client->setEndpoint('https://validator.swagger.io');
-
-    //     /**
-    //      * Test for SUCCESS
-    //      */
-    //     $response = $client->call(Client::METHOD_POST, '/validator/debug', [
-    //         'content-type' => 'application/json',
-    //     ], json_decode(file_get_contents(realpath(__DIR__ . '/../../resources/swagger2.json')), true));
-
-    //     $response['body'] = json_decode($response['body'], true);
-
-    //     $this->assertEquals(200, $response['headers']['status-code']);
-    //     $this->assertTrue(empty($response['body']));
-
-    //     unlink(realpath(__DIR__ . '/../../resources/swagger2.json'));
-    // }
-
-    public function testSpecOpenAPI3()
+    public function testSpecs()
     {
-        $response = $this->client->call(Client::METHOD_GET, '/specs/open-api3?platform=console', [
-            'content-type' => 'application/json',
-        ], []);
-
         $directory = __DIR__ . '/../../../app/config/specs/';
 
         $files = scandir($directory);
         $client = new Client();
         $client->setEndpoint('https://validator.swagger.io');
 
+        $versions = [
+            'latest',
+            '0.15.x',
+            '0.14.x',
+        ];
+
         foreach ($files as $file) {
             if (in_array($file, ['.', '..'])) {
                 continue;
             }
 
-            if (
-                (strpos($file, 'latest') === false) &&
-                (strpos($file, '0.12.x') === false) &&
-                (strpos($file, '0.13.x') === false)
-            ) {
+            $allowed = false;
+            foreach ($versions as $version) {
+                if (\str_contains($file, $version)) {
+                    $allowed = true;
+                    break;
+                }
+            }
+            if (!$allowed) {
                 continue;
             }
 
@@ -186,7 +163,13 @@ class HTTPTest extends Scope
 
             $response['body'] = json_decode($response['body'], true);
             $this->assertEquals(200, $response['headers']['status-code']);
-            $this->assertTrue(empty($response['body']));
+
+            if (!empty($response['body']['schemaValidationMessages'])) {
+                \var_dump($file);
+                \var_dump($response['body']);
+            }
+
+            $this->assertEmpty($response['body']['schemaValidationMessages']);
         }
     }
 

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -163,12 +163,6 @@ class HTTPTest extends Scope
 
             $response['body'] = json_decode($response['body'], true);
             $this->assertEquals(200, $response['headers']['status-code']);
-
-            if (!empty($response['body']['schemaValidationMessages'])) {
-                \var_dump($file);
-                \var_dump($response['body']);
-            }
-
             $this->assertEmpty($response['body']['schemaValidationMessages']);
         }
     }


### PR DESCRIPTION
## What does this PR do?

Ensure bucket permission is migrated correctly

## Test Plan

0.15.x shows `permission` as `file`:

<img width="1147" alt="Screen Shot 2022-10-21 at 10 56 29 AM" src="https://user-images.githubusercontent.com/1477010/197273396-ca29538c-47b0-48c0-9ff3-399a28620d1b.png">

migrating to 1.0.x without the fix sets `fileSecurity` to `false`:

<img width="1101" alt="Screen Shot 2022-10-21 at 11 36 05 AM" src="https://user-images.githubusercontent.com/1477010/197273444-b0305363-4897-4f4f-a103-aea463965b0c.png">

migrating to 1.0.x with the fix sets `fileSecurity` to `true`:

<img width="1079" alt="Screen Shot 2022-10-21 at 12 16 28 PM" src="https://user-images.githubusercontent.com/1477010/197273482-bd8b4ecd-de29-4551-b179-e4f5c6b89d7e.png">

## Related PRs and Issues

* #4549

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Done

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
