### PR TITLE
Remove PDO rethrow

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -403,11 +403,6 @@ App::error()
         $version = App::getEnv('_APP_VERSION', 'UNKNOWN');
         $route = $utopia->match($request);
 
-        /** Delegate PDO exceptions to the global handler so the database connection can be returned to the pool */
-        if ($error instanceof PDOException) {
-            throw $error;
-        }
-
         if ($logger) {
             if ($error->getCode() >= 500 || $error->getCode() === 0) {
                 try {

--- a/app/http.php
+++ b/app/http.php
@@ -317,13 +317,6 @@ $http->on('request', function (SwooleRequest $swooleRequest, SwooleResponse $swo
         Console::error('[Error] File: ' . $th->getFile());
         Console::error('[Error] Line: ' . $th->getLine());
 
-        /**
-         * Reset Database connection if PDOException was thrown.
-         */
-        if ($th instanceof PDOException) {
-            $db = null;
-        }
-
         $swooleResponse->setStatusCode(500);
 
         $output = ((App::isDevelopment())) ? [


### PR DESCRIPTION
## What does this PR do?

Remove the PDO rethrow.

The PDOException was rethrown in general.php so that it could be caught in the catch block of http.php. However, [a change in utopia-php/framework](https://github.com/utopia-php/framework/commit/9d37326851f65f354344cfe2e3c1a282d5231025) caused the exception to be masked as an Exception rather than the underlying PDOException. As such, the `$th instanceof PDOException` in http.php is always false and `$db = null` is never executed. Since these snippets of code aren't doing anything or adding value, they should be removed.

In addition, the `$db = null` may have been added to ensure the connection was added back to the pool and/or reset if needed, but it seems like that's not a problem anymore.

## Test Plan

Manually tested to make sure queries to the DB were still working

## Related PRs and Issues

* #4535

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Not needed

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
