### PR TITLE
Fix create deployment realtime not triggering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Bugs
 - Fix license detection for Flutter and Dart SDKs [#4435](https://github.com/appwrite/appwrite/pull/4435)
+- Fix missing realtime event for create function deployment [#4574](https://github.com/appwrite/appwrite/pull/4574)
 
 # Version 1.0.3
 ## Bugs

--- a/src/Appwrite/Messaging/Adapter/Realtime.php
+++ b/src/Appwrite/Messaging/Adapter/Realtime.php
@@ -321,7 +321,7 @@ class Realtime extends Adapter
                     }
                 } elseif ($parts[2] === 'deployments') {
                     $channels[] = 'console';
-
+                    $projectId = 'console';
                     $roles = [Role::team($project->getAttribute('teamId'))->toString()];
                 }
 


### PR DESCRIPTION
## What does this PR do?

Because the deployment event was missing the project ID, the realtime event never fired.

## Test Plan

Debug logs before change:

```
appwrite  | triggering realtime: array (
appwrite  |   'channels' => 
appwrite  |   array (
appwrite  |     0 => 'console',
appwrite  |   ),
appwrite  |   'roles' => 
appwrite  |   array (
appwrite  |     0 => 'team:635308a7ad8f2093fb40',
appwrite  |   ),
appwrite  |   'permissionsChanged' => false,
appwrite  |   'projectId' => NULL,
appwrite  | )
```

debug logs after change:

```
appwrite  | triggering realtime: array (
appwrite  |   'channels' => 
appwrite  |   array (
appwrite  |     0 => 'console',
appwrite  |   ),
appwrite  |   'roles' => 
appwrite  |   array (
appwrite  |     0 => 'team:635308a7ad8f2093fb40',
appwrite  |   ),
appwrite  |   'permissionsChanged' => false,
appwrite  |   'projectId' => 'console',
appwrite  | )
```

Manual test:

<img width="939" alt="image" src="https://user-images.githubusercontent.com/1477010/197883410-336d25ef-73ae-4e34-9ac4-049495cd8c92.png">

E2E test

## Related PRs and Issues

None

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
