### PR TITLE
fix: default file permission in admin mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Bugs
 - Fix license detection for Flutter and Dart SDKs [#4435](https://github.com/appwrite/appwrite/pull/4435)
 - Fix missing status, buildStderr and buildStderr from get deployment response [#4611](https://github.com/appwrite/appwrite/pull/4611)
+- Fix default file permissions when creating file with console [#4624](https://github.com/appwrite/appwrite/pull/4624)
 
 # Version 1.0.4
 

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -382,7 +382,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
         $permissions = Permission::aggregate($permissions, $allowedPermissions);
 
         // Add permissions for current the user if none were provided.
-        if (\is_null($permissions)) {
+        if ($mode !== APP_MODE_ADMIN && \is_null($permissions)) {
             $permissions = [];
             if (!empty($user->getId())) {
                 foreach ($allowedPermissions as $permission) {

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -380,10 +380,10 @@ App::post('/v1/storage/buckets/:bucketId/files')
 
         // Map aggregate permissions to into the set of individual permissions they represent.
         $permissions = Permission::aggregate($permissions, $allowedPermissions);
+        $roles = Authorization::getRoles();
 
-        // Add permissions for current the user if none were provided.
-        if ($mode !== APP_MODE_ADMIN && \is_null($permissions)) {
-            $permissions = [];
+        // Add permissions for current the user if none were provided. Skip for API Keys and Admin Mode.
+        if ($mode !== APP_MODE_ADMIN && !Auth::isAppUser($roles) && \is_null($permissions)) {
             if (!empty($user->getId())) {
                 foreach ($allowedPermissions as $permission) {
                     $permissions[] = (new Permission($permission, 'user', $user->getId()))->toString();
@@ -392,7 +392,6 @@ App::post('/v1/storage/buckets/:bucketId/files')
         }
 
         // Users can only manage their own roles, API keys and Admin users can manage any
-        $roles = Authorization::getRoles();
         if (!Auth::isAppUser($roles) && !Auth::isPrivilegedUser($roles)) {
             foreach (Database::PERMISSIONS as $type) {
                 foreach ($permissions as $permission) {

--- a/tests/e2e/Services/Storage/StorageConsoleClientTest.php
+++ b/tests/e2e/Services/Storage/StorageConsoleClientTest.php
@@ -2,11 +2,15 @@
 
 namespace Tests\E2E\Services\Storage;
 
+use CURLFile;
 use Tests\E2E\Client;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SideConsole;
+use Utopia\Database\DateTime;
 use Utopia\Database\ID;
+use Utopia\Database\Permission;
+use Utopia\Database\Role;
 
 class StorageConsoleClientTest extends Scope
 {
@@ -102,5 +106,49 @@ class StorageConsoleClientTest extends Scope
         $this->assertIsArray($response['body']['filesUpdate']);
         $this->assertIsArray($response['body']['filesDelete']);
         $this->assertIsArray($response['body']['filesStorage']);
+    }
+
+    public function testCreateBucketFileWithoutDefaultPermissions(): void
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'bucketId' => ID::unique(),
+            'name' => 'Test Bucket',
+            'fileSecurity' => true,
+            'maximumFileSize' => 2000000, //2MB
+            'allowedFileExtensions' => ["jpg", "png"],
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+        ]);
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+        $this->assertNotEmpty($bucket['body']['$id']);
+
+        $bucketId = $bucket['body']['$id'];
+
+        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+            'content-type' => 'multipart/form-data',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'fileId' => ID::unique(),
+            'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/logo.png'), 'image/png', 'logo.png')
+        ]);
+        $this->assertEquals(201, $file['headers']['status-code']);
+
+        $file1 = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $file['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $file1['headers']['status-code']);
+        $this->assertCount(0, $file1['body']['$permissions']);
     }
 }


### PR DESCRIPTION
## What does this PR do?

- prevent default permission when file is created in admin mode

## Test Plan

- added tests

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

✅ 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 
