### PR TITLE
Fix: usage executions

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -368,6 +368,7 @@ class FunctionsV1 extends Worker
             $usage = new Stats($statsd);
             $usage
                 ->setParam('projectId', $project->getId())
+                ->setParam('projectInternalId', $project->getInternalId())
                 ->setParam('functionId', $function->getId())
                 ->setParam('executions.{scope}.compute', 1)
                 ->setParam('executionStatus', $execution->getAttribute('status', ''))

--- a/src/Appwrite/Usage/Calculators/TimeSeries.php
+++ b/src/Appwrite/Usage/Calculators/TimeSeries.php
@@ -492,7 +492,7 @@ class TimeSeries extends Calculator
 
                     $value = (!empty($point['value'])) ? $point['value'] : 0;
                     if (empty($point['projectInternalId'] ?? null)) {
-                        return;
+                        continue;
                     }
                     $this->createOrUpdateMetric(
                         $point['projectInternalId'],

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -684,6 +684,25 @@ class UsageTest extends Scope
         }
         $executionTime += (int) ($execution['body']['duration'] * 1000);
 
+        $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', $headers, [
+            'async' => true,
+        ]);
+
+        $this->assertEquals(201, $execution['headers']['status-code']);
+        $this->assertNotEmpty($execution['body']['$id']);
+        $this->assertEquals($functionId, $execution['body']['functionId']);
+
+        sleep(10);
+
+        $execution = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $execution['body']['$id'], $headers);
+
+        if ($execution['body']['status'] == 'failed') {
+            $failures++;
+        } elseif ($execution['body']['status'] == 'completed') {
+            $executions++;
+        }
+        $executionTime += (int) ($execution['body']['duration'] * 1000);
+
         $data = array_merge($data, [
             'functionId' => $functionId,
             'executionTime' => $executionTime,

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -688,7 +688,7 @@ class UsageTest extends Scope
             'async' => true,
         ]);
 
-        $this->assertEquals(201, $execution['headers']['status-code']);
+        $this->assertEquals(202, $execution['headers']['status-code']);
         $this->assertNotEmpty($execution['body']['$id']);
         $this->assertEquals($functionId, $execution['body']['functionId']);
 


### PR DESCRIPTION
## What does this PR do?

- Add internal ID for async=true executions usage stats
- Stop only current aggregation when internal project id is missing

## Test Plan

- [x] Implemented new tests

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

No changes from 1.0. Its just fixing bug we introducing in between versions.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes