### PR TITLE
Fix Session API Defaults and convert from minutes to seconds

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -522,7 +522,7 @@ App::patch('/v1/projects/:projectId/auth/duration')
     ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
     ->label('sdk.response.model', Response::MODEL_PROJECT)
     ->param('projectId', '', new UID(), 'Project unique ID.')
-    ->param('duration', 525600, new Range(0, 525600), 'Project session length in minutes. Max length: 525600 minutes.')
+    ->param('duration', 31536000, new Range(0, 31536000), 'Project session length in seconds. Max length: 31536000 seconds.')
     ->inject('response')
     ->inject('dbForConsole')
     ->action(function (string $projectId, int $duration, Response $response, Database $dbForConsole) {
@@ -534,7 +534,7 @@ App::patch('/v1/projects/:projectId/auth/duration')
         }
 
         $auths = $project->getAttribute('auths', []);
-        $auths['duration'] = $duration * 60;
+        $auths['duration'] = $duration;
 
         $dbForConsole->updateDocument('projects', $project->getId(), $project
             ->setAttribute('auths', $auths));

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -81,7 +81,7 @@ App::post('/v1/projects')
         }
 
         $auth = Config::getParam('auth', []);
-        $auths = ['limit' => 0];
+        $auths = ['limit' => 0, 'duration' => Auth::TOKEN_EXPIRATION_LOGIN_LONG];
         foreach ($auth as $index => $method) {
             $auths[$method['key'] ?? ''] = true;
         }

--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Utopia\Response\Model;
 
+use Appwrite\Auth\Auth;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
 use Utopia\Config\Config;
@@ -102,10 +103,10 @@ class Project extends Model
                 'example' => '131102020',
             ])
             ->addRule('authDuration', [
-                'type' => self::TYPE_STRING,
+                'type' => self::TYPE_INTEGER,
                 'description' => 'Session duration in seconds.',
-                'default' => '',
-                'example' => '30',
+                'default' => Auth::TOKEN_EXPIRATION_LOGIN_LONG,
+                'example' => 60,
             ])
             ->addRule('authLimit', [
                 'type' => self::TYPE_INTEGER,
@@ -231,7 +232,7 @@ class Project extends Model
         $auth = Config::getParam('auth', []);
 
         $document->setAttribute('authLimit', $authValues['limit'] ?? 0);
-        $document->setAttribute('authDuration', $authValues['duration'] ?? 0);
+        $document->setAttribute('authDuration', $authValues['duration'] ?? Auth::TOKEN_EXPIRATION_LOGIN_LONG);
 
         foreach ($auth as $index => $method) {
             $key = $method['key'];

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -494,7 +494,7 @@ class ProjectsConsoleClientTest extends Scope
             'x-appwrite-project' => $projectId,
             'Cookie' => $sessionCookie,
         ]));
-    
+
         $this->assertEquals(200, $response['headers']['status-code']);
 
         // Wait just over a minute

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -434,7 +434,7 @@ class ProjectsConsoleClientTest extends Scope
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
-            'duration' => '1', // Set session duration to 2 minutes
+            'duration' => 60, // Set session duration to 2 minutes
         ]);
 
         $this->assertEquals(200, $response['headers']['status-code']);
@@ -484,8 +484,21 @@ class ProjectsConsoleClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
 
+        // Check session doesn't expire too soon.
+
+        sleep(30);
+
+        // Get User
+        $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'Cookie' => $sessionCookie,
+        ]));
+    
+        $this->assertEquals(200, $response['headers']['status-code']);
+
         // Wait just over a minute
-        sleep(65);
+        sleep(35);
 
         // Get User
         $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
@@ -501,7 +514,7 @@ class ProjectsConsoleClientTest extends Scope
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
-            'duration' => 525600,
+            'duration' => Auth::TOKEN_EXPIRATION_LOGIN_LONG,
         ]);
 
         $this->assertEquals(200, $response['headers']['status-code']);
@@ -514,7 +527,7 @@ class ProjectsConsoleClientTest extends Scope
         ], $this->getHeaders()));
 
         $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals(31536000, $response['body']['authDuration']); // 1 Year
+        $this->assertEquals(Auth::TOKEN_EXPIRATION_LOGIN_LONG, $response['body']['authDuration']); // 1 Year
 
         return ['projectId' => $projectId];
     }

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -417,6 +417,15 @@ class ProjectsConsoleClientTest extends Scope
     {
         $id = $data['projectId'];
 
+        // Check defaults
+        $response = $this->client->call(Client::METHOD_GET, '/projects/' . $id, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => 'console',
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(Auth::TOKEN_EXPIRATION_LOGIN_LONG, $response['body']['authDuration']); // 1 Year
+
         /**
          * Test for SUCCESS
          */


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes the defaults of the session API to make it not 0, it also implements new tests to ensure the default is set correctly.

This PR additionally converts the endpoint to handle seconds instead of minutes.

## Test Plan

Tests have been updated to check defaults.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
