### PR TITLE
Fix the default oauth paths to match the route

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # Version 1.1.2
 ## Changes
 - Make `region` parameter optional with default for project create [#4763](https://github.com/appwrite/appwrite/pull/4763)
+
 ## Bugs
+- Fix default oauth paths [#4725](https://github.com/appwrite/appwrite/pull/4725)
 - Fix session expiration, and expired session deletion [#4739](https://github.com/appwrite/appwrite/pull/4739)
 - Fix processing status on sync executions [#4737](https://github.com/appwrite/appwrite/pull/4737)
 - Fix Locale API returning Unknown continent [#4761](https://github.com/appwrite/appwrite/pull/4761)

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -41,8 +41,8 @@ use Utopia\Validator\Assoc;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
-$oauthDefaultSuccess = '/v1/auth/oauth2/success';
-$oauthDefaultFailure = '/v1/auth/oauth2/failure';
+$oauthDefaultSuccess = '/auth/oauth2/success';
+$oauthDefaultFailure = '/auth/oauth2/failure';
 
 App::post('/v1/account')
     ->desc('Create Account')


### PR DESCRIPTION
## What does this PR do?

Previously, Utopia handled `/auth/oauth2/success` and `/v1/auth/oauth2/success` exactly the same (with the same handler). So on mobile, when users were redirected `$oauthDefaultSuccess` (`/v1/auth/oauth2/success`), it was still handled. After we deleted that route and [moved the code to the new console](https://github.com/appwrite/console/commit/2171d7f22d27b3a9ee99693e6b71b4a445a4eda3), the default `/v1/auth/oauth2/success` resulted in a 404. This changes the default path to remove the `/v1/` prefix so that the console can handle the redirect.

## Test Plan

Manual

## Related PRs and Issues

- #4714 

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

(The CHANGES.md file tracks all the changes that make it to the `main` branch. Add your change to this file in the following format)
- One line description of your PR [#pr_number](Link to your PR)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
