### PR TITLE
Enable HSTS for all HTTPS requests

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -223,7 +223,9 @@ App::init()
 
                 return $response->redirect('https://' . $request->getHostname() . $request->getURI());
             }
+        }
 
+        if ($request->getProtocol() === 'https') {
             $response->addHeader('Strict-Transport-Security', 'max-age=' . (60 * 60 * 24 * 126)); // 126 days
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Enable HSTS for all HTTPS requests, not just when `_APP_OPTIONS_FORCE_HTTPS` is also enabled

## Test Plan

Manual + existing tests

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
