### PR TITLE
Update contributing guide to include submodule update command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ git clone git@github.com:[YOUR_FORK_HERE]/appwrite.git
 
 cd appwrite
 
+git submodule update --init
+
 docker compose build
 docker compose up -d
 ```


### PR DESCRIPTION
## What does this PR do?

Since the Appwrite Console is a submodule now, the submodule must be initialized with:

```
git submodule update --init
```

before building Appwrite.

## Test Plan

Manual

## Related PRs and Issues

None
### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Not applicable

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
