### PR TITLE
Fix: db pool sharing

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,8 @@ _APP_DB_SCHEMA=appwrite
 _APP_DB_USER=user
 _APP_DB_PASS=password
 _APP_DB_ROOT_PASS=rootsecretpassword
-_APP_CONNECTIONS_MAX=251
+_APP_CONNECTIONS_MAX=151
+_APP_POOL_CLIENTS=14
 _APP_CONNECTIONS_DB_PROJECT=db_fra1_02=mariadb://user:password@mariadb:3306/appwrite
 _APP_CONNECTIONS_DB_CONSOLE=db_fra1_01=mariadb://user:password@mariadb:3306/appwrite
 _APP_CONNECTIONS_CACHE=redis_fra1_01=redis://redis:6379

--- a/app/init.php
+++ b/app/init.php
@@ -557,7 +557,7 @@ $register->set('pools', function () {
 
     $multiprocessing = App::getenv('_APP_SERVER_MULTIPROCESS', 'disabled') === 'enabled';
 
-    if($multiprocessing) {
+    if ($multiprocessing) {
         $workerCount = swoole_cpu_num() * intval(App::getEnv('_APP_WORKER_PER_CORE', 6));
     } else {
         $workerCount = 1;

--- a/app/init.php
+++ b/app/init.php
@@ -552,10 +552,16 @@ $register->set('pools', function () {
         ],
     ];
 
-    $instances = 3; // REST, Realtime, CLI
-    $workerCount = swoole_cpu_num() * intval(App::getEnv('_APP_WORKER_PER_CORE', 6));
-    $maxConnections = App::getenv('_APP_CONNECTIONS_MAX', 251);
-    $instanceConnections = $maxConnections / $instances;
+    $maxConnections = App::getenv('_APP_CONNECTIONS_MAX', 151);
+    $instanceConnections = $maxConnections / App::getenv('_APP_POOL_CLIENTS', 14);
+
+    $multiprocessing = App::getenv('_APP_SERVER_MULTIPROCESS', 'disabled') === 'enabled';
+
+    if($multiprocessing) {
+        $workerCount = swoole_cpu_num() * intval(App::getEnv('_APP_WORKER_PER_CORE', 6));
+    } else {
+        $workerCount = 1;
+    }
 
     if ($workerCount > $instanceConnections) {
         throw new \Exception('Pool size is too small. Increase the number of allowed database connections or decrease the number of workers.', 500);

--- a/composer.lock
+++ b/composer.lock
@@ -2356,16 +2356,16 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "c8f96a33e7fbf58c1145eb6cf0f2c00cbe319979"
+                "reference": "d2870ab74b31b7f4027799f082e85122154f8bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/c8f96a33e7fbf58c1145eb6cf0f2c00cbe319979",
-                "reference": "c8f96a33e7fbf58c1145eb6cf0f2c00cbe319979",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/d2870ab74b31b7f4027799f082e85122154f8bed",
+                "reference": "d2870ab74b31b7f4027799f082e85122154f8bed",
                 "shasum": ""
             },
             "require": {
@@ -2401,9 +2401,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/0.4.1"
+                "source": "https://github.com/utopia-php/pools/tree/0.4.2"
             },
-            "time": "2022-11-15T08:55:16+00:00"
+            "time": "2022-11-22T07:55:45+00:00"
         },
         {
             "name": "utopia-php/preloader",
@@ -5403,5 +5403,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
     environment:
       - _APP_ENV
       - _APP_WORKER_PER_CORE
+      - _APP_SERVER_MULTIPROCESS=enabled
       - _APP_LOCALE
       - _APP_CONSOLE_WHITELIST_ROOT
       - _APP_CONSOLE_WHITELIST_EMAILS
@@ -204,6 +205,7 @@ services:
     environment:
       - _APP_ENV
       - _APP_WORKER_PER_CORE
+      - _APP_SERVER_MULTIPROCESS=enabled
       - _APP_OPTIONS_ABUSE
       - _APP_OPENSSL_KEY_V1
       - _APP_DB_HOST


### PR DESCRIPTION


## What does this PR do?

Improves connection sharing logic in pools using following vars:

- _APP_CONNECTIONS_MAX - Maximum amount of connections to a resource  (in our case MySQL max connections)
- _APP_POOL_CLIENTS - Amount of containers to share max connections between
- _APP_SERVER_MULTIPROCESS - enabled/disabled. Must be enabled if process is using swoole async-style - spawning new process for every worker

## Test Plan

No

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

No

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
