### PR TITLE
Fix: unsaved changes in team invitation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+- Fix invited account verified status [#4776](https://github.com/appwrite/appwrite/pull/4776)
+
 # Version 1.1.2
 ## Changes
 - Make `region` parameter optional with default for project create [#4763](https://github.com/appwrite/appwrite/pull/4763)

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -724,7 +724,7 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId/status')
             ->setAttribute('confirm', true)
         ;
 
-        $user->setAttribute('emailVerification', true);
+        $user = $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('emailVerification', true));
 
         // Log user in
 

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -724,7 +724,7 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId/status')
             ->setAttribute('confirm', true)
         ;
 
-        $user = $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('emailVerification', true));
+        $user = Authorization::skip(fn() => $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('emailVerification', true)));
 
         // Log user in
 

--- a/tests/e2e/Services/Teams/TeamsBaseClient.php
+++ b/tests/e2e/Services/Teams/TeamsBaseClient.php
@@ -342,6 +342,15 @@ trait TeamsBaseClient
         $session = $this->client->parseCookie((string)$response['headers']['set-cookie'])['a_session_' . $this->getProject()['$id']];
         $data['session'] = $session;
 
+        $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+        ]));
+
+        $this->assertEquals(true, $response['body']['emailVerification']);
+
 
         /** [START] TESTS TO CHECK PASSWORD UPDATE OF NEW USER CREATED USING TEAM INVITE */
         /**


### PR DESCRIPTION
## What does this PR do?

A member can only accept invitation by getting secret from email. Accepting an invitation marks account emailVerified.

This logic is there, but due to bug it's not saved to database.

## Test Plan

- [x] New test added

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
