### PR TITLE
Fix event-triggered executions syntax error

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -276,7 +276,7 @@ $server->job()
                         queueForFunctions: $queueForFunctions,
                         trigger: 'event',
                         event: $events[0],
-                        eventData: $eventData,
+                        eventData: \is_string($eventData) ? $eventData : \json_encode($eventData),
                         user: $user,
                         data: null,
                         executionId: null,


### PR DESCRIPTION
## What does this PR do?

Fixes syntax error resulting in execution not being triggered on any event.

## Test Plan

- [x] Manual QA

Before:
![CleanShot 2022-12-09 at 19 49 08@2x](https://user-images.githubusercontent.com/19310830/206773442-093e0cfb-0f4c-4941-af52-3ad8895a9efa.png)

After:
![CleanShot 2022-12-09 at 19 50 45@2x](https://user-images.githubusercontent.com/19310830/206773462-f3d6f31b-1bec-4447-bdd0-5d416dbd89a1.png)

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

No, not needed.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
