### PR TITLE
fix: adds the missing expire attribute to ListSessions call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+- Fix added the missing 'expire' attribute to the ListSessions response [#4846](https://github.com/appwrite/appwrite/pull/4872)
 - Fix invited account verified status [#4776](https://github.com/appwrite/appwrite/pull/4776)
 - Get default region from environment on project create [#4780](https://github.com/appwrite/appwrite/pull/4780)
 - Fix max mimetype size [#4814](https://github.com/appwrite/appwrite/pull/4814)

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1342,6 +1342,7 @@ App::get('/v1/account/sessions')
 
             $session->setAttribute('countryName', $countryName);
             $session->setAttribute('current', ($current == $session->getId()) ? true : false);
+            $session->setAttribute('expire', DateTime::addSeconds(new \DateTime($session->getCreatedAt()), $authDuration))
 
             $sessions[$key] = $session;
         }

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1342,7 +1342,7 @@ App::get('/v1/account/sessions')
 
             $session->setAttribute('countryName', $countryName);
             $session->setAttribute('current', ($current == $session->getId()) ? true : false);
-            $session->setAttribute('expire', DateTime::addSeconds(new \DateTime($session->getCreatedAt()), $authDuration))
+            $session->setAttribute('expire', DateTime::addSeconds(new \DateTime($session->getCreatedAt()), $authDuration));
 
             $sessions[$key] = $session;
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds the missing `expire` attribute to the ListSessions response. Linked to issue #4846 
## Test Plan

Changes were done as suggested in the issue discussion thread by @stnguyen90. I couldn't figure out a way to test it and would appreciate any help in setting up a dummy call to the API and check for ListSessions output.

## Related PRs and Issues

Fixes #4846 
### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?
Yes

(The CHANGES.md file tracks all the changes that make it to the `main` branch. Add your change to this file in the following format)
- One line description of your PR [#pr_number](Link to your PR)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
