### PR TITLE
Fix: nested escaping

### DIFF
--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -300,8 +300,9 @@ class Resolvers
         $resolve($payload);
     }
 
-    private static function escapePayload(array $payload, int $depth) {
-        if($depth > App::getEnv('_APP_GRAPHQL_MAX_DEPTH', 3)) {
+    private static function escapePayload(array $payload, int $depth)
+    {
+        if ($depth > App::getEnv('_APP_GRAPHQL_MAX_DEPTH', 3)) {
             return;
         }
 
@@ -312,7 +313,7 @@ class Resolvers
                 unset($payload[$key]);
             }
 
-            if(\is_array($value)) {
+            if (\is_array($value)) {
                 $payload[$key] = self::escapePayload($value, $depth + 1);
             }
         }

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -291,18 +291,32 @@ class Resolvers
             return;
         }
 
-        foreach ($payload as $key => $value) {
-            if (\str_starts_with($key, '$')) {
-                $escapedKey = \str_replace('$', '_', $key);
-                $payload[$escapedKey] = $value;
-                unset($payload[$key]);
-            }
-        }
+        $payload = self::escapePayload($payload, 1);
 
         if ($beforeResolve) {
             $payload = $beforeResolve($payload);
         }
 
         $resolve($payload);
+    }
+
+    private static function escapePayload(array $payload, int $depth) {
+        if($depth > App::getEnv('_APP_GRAPHQL_MAX_DEPTH', 3)) {
+            return;
+        }
+
+        foreach ($payload as $key => $value) {
+            if (\str_starts_with($key, '$')) {
+                $escapedKey = \str_replace('$', '_', $key);
+                $payload[$escapedKey] = $value;
+                unset($payload[$key]);
+            }
+
+            if(\is_array($value)) {
+                $payload[$key] = self::escapePayload($value, $depth + 1);
+            }
+        }
+
+        return $payload;
     }
 }


### PR DESCRIPTION
## What does this PR do?

This query didnt work:

```
query {
    databasesListDocuments(
        databaseId: "63ab3cb73e378bd801e1",
        collectionId: "63ab3cb92b52aefc4a9b"
    ) {
        total
        documents {
	     _id
	}
    }
}
```

Not it does

## Test Plan

- [x] Manual QA

## Related PRs and Issues

x

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

No.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
