### PR TITLE
Fix graphql examples to include _ for internal attributes

### DIFF
--- a/docs/examples/1.2.x/client-graphql/examples/account/create-anonymous-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-anonymous-session.md
@@ -1,7 +1,7 @@
 mutation {
     accountCreateAnonymousSession {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/client-graphql/examples/account/create-email-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-email-session.md
@@ -3,8 +3,8 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/client-graphql/examples/account/create-magic-u-r-l-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-magic-u-r-l-session.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         email: "email@example.com"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/create-phone-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-phone-session.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         phone: "+12065550100"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/create-phone-verification.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-phone-verification.md
@@ -1,7 +1,7 @@
 mutation {
     accountCreatePhoneVerification {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/create-recovery.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-recovery.md
@@ -3,8 +3,8 @@ mutation {
         email: "email@example.com",
         url: "https://example.com"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/create-verification.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create-verification.md
@@ -2,8 +2,8 @@ mutation {
     accountCreateVerification(
         url: "https://example.com"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/create.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create.md
@@ -4,9 +4,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/get-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/get-session.md
@@ -2,8 +2,8 @@ query {
     accountGetSession(
         sessionId: "[SESSION_ID]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/client-graphql/examples/account/get.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/get.md
@@ -1,8 +1,8 @@
 query {
     accountGet {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-email.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-email.md
@@ -3,9 +3,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-magic-u-r-l-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-magic-u-r-l-session.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-name.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-name.md
@@ -2,9 +2,9 @@ mutation {
     accountUpdateName(
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-password.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-password.md
@@ -2,9 +2,9 @@ mutation {
     accountUpdatePassword(
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-phone-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-phone-session.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-phone-verification.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-phone-verification.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-phone.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-phone.md
@@ -3,9 +3,9 @@ mutation {
         phone: "+12065550100",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-prefs.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-prefs.md
@@ -2,9 +2,9 @@ mutation {
     accountUpdatePrefs(
         prefs: "{}"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-recovery.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-recovery.md
@@ -5,8 +5,8 @@ mutation {
         password: "password",
         passwordAgain: "password"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-session.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-session.md
@@ -2,8 +2,8 @@ mutation {
     accountUpdateSession(
         sessionId: "[SESSION_ID]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-status.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-status.md
@@ -1,8 +1,8 @@
 mutation {
     accountUpdateStatus {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-verification.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-verification.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/client-graphql/examples/databases/create-document.md
+++ b/docs/examples/1.2.x/client-graphql/examples/databases/create-document.md
@@ -5,12 +5,12 @@ mutation {
         documentId: "[DOCUMENT_ID]",
         data: "{}"
     ) {
-        id
-        collectionId
-        databaseId
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _collectionId
+        _databaseId
+        _createdAt
+        _updatedAt
+        _permissions
         data
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/databases/get-document.md
+++ b/docs/examples/1.2.x/client-graphql/examples/databases/get-document.md
@@ -4,12 +4,12 @@ query {
         collectionId: "[COLLECTION_ID]",
         documentId: "[DOCUMENT_ID]"
     ) {
-        id
-        collectionId
-        databaseId
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _collectionId
+        _databaseId
+        _createdAt
+        _updatedAt
+        _permissions
         data
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/databases/update-document.md
+++ b/docs/examples/1.2.x/client-graphql/examples/databases/update-document.md
@@ -4,12 +4,12 @@ mutation {
         collectionId: "[COLLECTION_ID]",
         documentId: "[DOCUMENT_ID]"
     ) {
-        id
-        collectionId
-        databaseId
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _collectionId
+        _databaseId
+        _createdAt
+        _updatedAt
+        _permissions
         data
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/functions/create-execution.md
+++ b/docs/examples/1.2.x/client-graphql/examples/functions/create-execution.md
@@ -2,10 +2,10 @@ mutation {
     functionsCreateExecution(
         functionId: "[FUNCTION_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         functionId
         trigger
         status

--- a/docs/examples/1.2.x/client-graphql/examples/functions/get-execution.md
+++ b/docs/examples/1.2.x/client-graphql/examples/functions/get-execution.md
@@ -3,10 +3,10 @@ query {
         functionId: "[FUNCTION_ID]",
         executionId: "[EXECUTION_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         functionId
         trigger
         status

--- a/docs/examples/1.2.x/client-graphql/examples/storage/get-file.md
+++ b/docs/examples/1.2.x/client-graphql/examples/storage/get-file.md
@@ -3,11 +3,11 @@ query {
         bucketId: "[BUCKET_ID]",
         fileId: "[FILE_ID]"
     ) {
-        id
+        _id
         bucketId
-        createdAt
-        updatedAt
-        permissions
+        _createdAt
+        _updatedAt
+        _permissions
         name
         signature
         mimeType

--- a/docs/examples/1.2.x/client-graphql/examples/storage/update-file.md
+++ b/docs/examples/1.2.x/client-graphql/examples/storage/update-file.md
@@ -3,11 +3,11 @@ mutation {
         bucketId: "[BUCKET_ID]",
         fileId: "[FILE_ID]"
     ) {
-        id
+        _id
         bucketId
-        createdAt
-        updatedAt
-        permissions
+        _createdAt
+        _updatedAt
+        _permissions
         name
         signature
         mimeType

--- a/docs/examples/1.2.x/client-graphql/examples/teams/create-membership.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/create-membership.md
@@ -5,9 +5,9 @@ mutation {
         roles: [],
         url: "https://example.com"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/client-graphql/examples/teams/create.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/create.md
@@ -3,9 +3,9 @@ mutation {
         teamId: "[TEAM_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         total
     }

--- a/docs/examples/1.2.x/client-graphql/examples/teams/get-membership.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/get-membership.md
@@ -3,9 +3,9 @@ query {
         teamId: "[TEAM_ID]",
         membershipId: "[MEMBERSHIP_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/client-graphql/examples/teams/get.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/get.md
@@ -2,9 +2,9 @@ query {
     teamsGet(
         teamId: "[TEAM_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         total
     }

--- a/docs/examples/1.2.x/client-graphql/examples/teams/update-membership-roles.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/update-membership-roles.md
@@ -4,9 +4,9 @@ mutation {
         membershipId: "[MEMBERSHIP_ID]",
         roles: []
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/client-graphql/examples/teams/update-membership-status.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/update-membership-status.md
@@ -5,9 +5,9 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/client-graphql/examples/teams/update.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/update.md
@@ -3,9 +3,9 @@ mutation {
         teamId: "[TEAM_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         total
     }

--- a/docs/examples/1.2.x/server-graphql/examples/account/create-phone-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/create-phone-verification.md
@@ -1,7 +1,7 @@
 mutation {
     accountCreatePhoneVerification {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/server-graphql/examples/account/create-recovery.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/create-recovery.md
@@ -3,8 +3,8 @@ mutation {
         email: "email@example.com",
         url: "https://example.com"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/server-graphql/examples/account/create-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/create-verification.md
@@ -2,8 +2,8 @@ mutation {
     accountCreateVerification(
         url: "https://example.com"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/server-graphql/examples/account/get-session.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/get-session.md
@@ -2,8 +2,8 @@ query {
     accountGetSession(
         sessionId: "[SESSION_ID]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/server-graphql/examples/account/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/get.md
@@ -1,8 +1,8 @@
 query {
     accountGet {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-email.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-email.md
@@ -3,9 +3,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-name.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-name.md
@@ -2,9 +2,9 @@ mutation {
     accountUpdateName(
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-password.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-password.md
@@ -2,9 +2,9 @@ mutation {
     accountUpdatePassword(
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-phone-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-phone-verification.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-phone.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-phone.md
@@ -3,9 +3,9 @@ mutation {
         phone: "+12065550100",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-prefs.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-prefs.md
@@ -2,9 +2,9 @@ mutation {
     accountUpdatePrefs(
         prefs: "{}"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-recovery.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-recovery.md
@@ -5,8 +5,8 @@ mutation {
         password: "password",
         passwordAgain: "password"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-session.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-session.md
@@ -2,8 +2,8 @@ mutation {
     accountUpdateSession(
         sessionId: "[SESSION_ID]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         expire
         provider

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-status.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-status.md
@@ -1,8 +1,8 @@
 mutation {
     accountUpdateStatus {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         registration
         status

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-verification.md
@@ -3,8 +3,8 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
+        _id
+        _createdAt
         userId
         secret
         expire

--- a/docs/examples/1.2.x/server-graphql/examples/databases/create-collection.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/create-collection.md
@@ -4,10 +4,10 @@ mutation {
         collectionId: "[COLLECTION_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         databaseId
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/databases/create-document.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/create-document.md
@@ -5,12 +5,12 @@ mutation {
         documentId: "[DOCUMENT_ID]",
         data: "{}"
     ) {
-        id
-        collectionId
-        databaseId
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _collectionId
+        _databaseId
+        _createdAt
+        _updatedAt
+        _permissions
         data
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/create.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/create.md
@@ -3,9 +3,9 @@ mutation {
         databaseId: "[DATABASE_ID]",
         name: "[NAME]"
     ) {
-        id
+        _id
         name
-        createdAt
-        updatedAt
+        _createdAt
+        _updatedAt
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/get-collection.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/get-collection.md
@@ -3,10 +3,10 @@ query {
         databaseId: "[DATABASE_ID]",
         collectionId: "[COLLECTION_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         databaseId
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/databases/get-document.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/get-document.md
@@ -4,12 +4,12 @@ query {
         collectionId: "[COLLECTION_ID]",
         documentId: "[DOCUMENT_ID]"
     ) {
-        id
-        collectionId
-        databaseId
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _collectionId
+        _databaseId
+        _createdAt
+        _updatedAt
+        _permissions
         data
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/get.md
@@ -2,9 +2,9 @@ query {
     databasesGet(
         databaseId: "[DATABASE_ID]"
     ) {
-        id
+        _id
         name
-        createdAt
-        updatedAt
+        _createdAt
+        _updatedAt
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/update-collection.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/update-collection.md
@@ -4,10 +4,10 @@ mutation {
         collectionId: "[COLLECTION_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         databaseId
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/databases/update-document.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/update-document.md
@@ -4,12 +4,12 @@ mutation {
         collectionId: "[COLLECTION_ID]",
         documentId: "[DOCUMENT_ID]"
     ) {
-        id
-        collectionId
-        databaseId
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _collectionId
+        _databaseId
+        _createdAt
+        _updatedAt
+        _permissions
         data
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/update.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/update.md
@@ -3,9 +3,9 @@ mutation {
         databaseId: "[DATABASE_ID]",
         name: "[NAME]"
     ) {
-        id
+        _id
         name
-        createdAt
-        updatedAt
+        _createdAt
+        _updatedAt
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/create-execution.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/create-execution.md
@@ -2,10 +2,10 @@ mutation {
     functionsCreateExecution(
         functionId: "[FUNCTION_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         functionId
         trigger
         status

--- a/docs/examples/1.2.x/server-graphql/examples/functions/create-variable.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/create-variable.md
@@ -4,9 +4,9 @@ mutation {
         key: "[KEY]",
         value: "[VALUE]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         key
         value
         functionId

--- a/docs/examples/1.2.x/server-graphql/examples/functions/create.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/create.md
@@ -5,9 +5,9 @@ mutation {
         execute: ["any"],
         runtime: "node-14.5"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         execute
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/functions/get-deployment.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/get-deployment.md
@@ -3,9 +3,9 @@ query {
         functionId: "[FUNCTION_ID]",
         deploymentId: "[DEPLOYMENT_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         resourceId
         resourceType
         entrypoint

--- a/docs/examples/1.2.x/server-graphql/examples/functions/get-execution.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/get-execution.md
@@ -3,10 +3,10 @@ query {
         functionId: "[FUNCTION_ID]",
         executionId: "[EXECUTION_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         functionId
         trigger
         status

--- a/docs/examples/1.2.x/server-graphql/examples/functions/get-variable.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/get-variable.md
@@ -3,9 +3,9 @@ query {
         functionId: "[FUNCTION_ID]",
         variableId: "[VARIABLE_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         key
         value
         functionId

--- a/docs/examples/1.2.x/server-graphql/examples/functions/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/get.md
@@ -2,9 +2,9 @@ query {
     functionsGet(
         functionId: "[FUNCTION_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         execute
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/functions/update-deployment.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/update-deployment.md
@@ -3,9 +3,9 @@ mutation {
         functionId: "[FUNCTION_ID]",
         deploymentId: "[DEPLOYMENT_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         execute
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/functions/update-variable.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/update-variable.md
@@ -4,9 +4,9 @@ mutation {
         variableId: "[VARIABLE_ID]",
         key: "[KEY]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         key
         value
         functionId

--- a/docs/examples/1.2.x/server-graphql/examples/functions/update.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/update.md
@@ -4,9 +4,9 @@ mutation {
         name: "[NAME]",
         execute: ["any"]
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         execute
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/storage/create-bucket.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/create-bucket.md
@@ -3,10 +3,10 @@ mutation {
         bucketId: "[BUCKET_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         fileSecurity
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/storage/get-bucket.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/get-bucket.md
@@ -2,10 +2,10 @@ query {
     storageGetBucket(
         bucketId: "[BUCKET_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         fileSecurity
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/storage/get-file.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/get-file.md
@@ -3,11 +3,11 @@ query {
         bucketId: "[BUCKET_ID]",
         fileId: "[FILE_ID]"
     ) {
-        id
+        _id
         bucketId
-        createdAt
-        updatedAt
-        permissions
+        _createdAt
+        _updatedAt
+        _permissions
         name
         signature
         mimeType

--- a/docs/examples/1.2.x/server-graphql/examples/storage/update-bucket.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/update-bucket.md
@@ -3,10 +3,10 @@ mutation {
         bucketId: "[BUCKET_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
-        permissions
+        _id
+        _createdAt
+        _updatedAt
+        _permissions
         fileSecurity
         name
         enabled

--- a/docs/examples/1.2.x/server-graphql/examples/storage/update-file.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/update-file.md
@@ -3,11 +3,11 @@ mutation {
         bucketId: "[BUCKET_ID]",
         fileId: "[FILE_ID]"
     ) {
-        id
+        _id
         bucketId
-        createdAt
-        updatedAt
-        permissions
+        _createdAt
+        _updatedAt
+        _permissions
         name
         signature
         mimeType

--- a/docs/examples/1.2.x/server-graphql/examples/teams/create-membership.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/create-membership.md
@@ -5,9 +5,9 @@ mutation {
         roles: [],
         url: "https://example.com"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/server-graphql/examples/teams/create.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/create.md
@@ -3,9 +3,9 @@ mutation {
         teamId: "[TEAM_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         total
     }

--- a/docs/examples/1.2.x/server-graphql/examples/teams/get-membership.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/get-membership.md
@@ -3,9 +3,9 @@ query {
         teamId: "[TEAM_ID]",
         membershipId: "[MEMBERSHIP_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/server-graphql/examples/teams/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/get.md
@@ -2,9 +2,9 @@ query {
     teamsGet(
         teamId: "[TEAM_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         total
     }

--- a/docs/examples/1.2.x/server-graphql/examples/teams/update-membership-roles.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/update-membership-roles.md
@@ -4,9 +4,9 @@ mutation {
         membershipId: "[MEMBERSHIP_ID]",
         roles: []
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/server-graphql/examples/teams/update-membership-status.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/update-membership-status.md
@@ -5,9 +5,9 @@ mutation {
         userId: "[USER_ID]",
         secret: "[SECRET]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         userId
         userName
         userEmail

--- a/docs/examples/1.2.x/server-graphql/examples/teams/update.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/update.md
@@ -3,9 +3,9 @@ mutation {
         teamId: "[TEAM_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         total
     }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-argon2user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-argon2user.md
@@ -4,9 +4,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-bcrypt-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-bcrypt-user.md
@@ -4,9 +4,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-m-d5user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-m-d5user.md
@@ -4,9 +4,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-p-h-pass-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-p-h-pass-user.md
@@ -4,9 +4,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-s-h-a-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-s-h-a-user.md
@@ -4,9 +4,9 @@ mutation {
         email: "email@example.com",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-modified-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-modified-user.md
@@ -7,9 +7,9 @@ mutation {
         passwordSaltSeparator: "[PASSWORD_SALT_SEPARATOR]",
         passwordSignerKey: "[PASSWORD_SIGNER_KEY]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-user.md
@@ -9,9 +9,9 @@ mutation {
         passwordParallel: 0,
         passwordLength: 0
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/create.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create.md
@@ -2,9 +2,9 @@ mutation {
     usersCreate(
         userId: "[USER_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/get.md
@@ -2,9 +2,9 @@ query {
     usersGet(
         userId: "[USER_ID]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-email-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-email-verification.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         emailVerification: false
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-email.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-email.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         email: "email@example.com"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-name.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-name.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         name: "[NAME]"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-password.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-password.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         password: "password"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-phone-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-phone-verification.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         phoneVerification: false
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-phone.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-phone.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         number: "+12065550100"
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-status.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-status.md
@@ -3,9 +3,9 @@ mutation {
         userId: "[USER_ID]",
         status: false
     ) {
-        id
-        createdAt
-        updatedAt
+        _id
+        _createdAt
+        _updatedAt
         name
         password
         hash


### PR DESCRIPTION
## What does this PR do?

The SDK generator previously just stripped the leading `$` from the internal attributes, but this doesn't work. Instead, they should have been replaced by `_`.

## Test Plan

Manual

## Related PRs and Issues

* https://github.com/appwrite/sdk-generator/pull/597
* https://github.com/appwrite/sdk-generator/pull/598

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

(The CHANGES.md file tracks all the changes that make it to the `main` branch. Add your change to this file in the following format)
- One line description of your PR [#pr_number](Link to your PR)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
