### PR TITLE
Update graphql examples to recursively show nested fields

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2720,16 +2720,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "0.29.1",
+            "version": "0.29.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "a13ad2a5a62b1662f58596bfdd45e1fb0b6d5fb8"
+                "reference": "d5352e09ffe9442eb1bf7a5ddbaf2618df8ade6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/a13ad2a5a62b1662f58596bfdd45e1fb0b6d5fb8",
-                "reference": "a13ad2a5a62b1662f58596bfdd45e1fb0b6d5fb8",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/d5352e09ffe9442eb1bf7a5ddbaf2618df8ade6a",
+                "reference": "d5352e09ffe9442eb1bf7a5ddbaf2618df8ade6a",
                 "shasum": ""
             },
             "require": {
@@ -2765,9 +2765,9 @@
             "description": "Appwrite PHP library for generating API SDKs for multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/0.29.1"
+                "source": "https://github.com/appwrite/sdk-generator/tree/0.29.2"
             },
-            "time": "2022-12-27T20:50:20+00:00"
+            "time": "2022-12-28T06:52:51+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -3423,16 +3423,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.22",
+            "version": "9.2.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "e4bf60d2220b4baaa0572986b5d69870226b06df"
+                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e4bf60d2220b4baaa0572986b5d69870226b06df",
-                "reference": "e4bf60d2220b4baaa0572986b5d69870226b06df",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
                 "shasum": ""
             },
             "require": {
@@ -3488,7 +3488,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.22"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
             },
             "funding": [
                 {
@@ -3496,7 +3496,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-18T16:40:55+00:00"
+            "time": "2022-12-28T12:41:10+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/docs/examples/1.2.x/client-graphql/examples/account/create.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/create.md
@@ -15,6 +15,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/get.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/get.md
@@ -11,6 +11,8 @@ query {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/list-logs.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/list-logs.md
@@ -1,6 +1,28 @@
 query {
     accountListLogs {
         total
-        logs
+        logs {
+            event
+            userId
+            userEmail
+            userName
+            mode
+            ip
+            time
+            osCode
+            osName
+            osVersion
+            clientType
+            clientCode
+            clientName
+            clientVersion
+            clientEngine
+            clientEngineVersion
+            deviceName
+            deviceBrand
+            deviceModel
+            countryCode
+            countryName
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/list-sessions.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/list-sessions.md
@@ -1,6 +1,32 @@
 query {
     accountListSessions {
         total
-        sessions
+        sessions {
+            _id
+            _createdAt
+            userId
+            expire
+            provider
+            providerUid
+            providerAccessToken
+            providerAccessTokenExpiry
+            providerRefreshToken
+            ip
+            osCode
+            osName
+            osVersion
+            clientType
+            clientCode
+            clientName
+            clientVersion
+            clientEngine
+            clientEngineVersion
+            deviceName
+            deviceBrand
+            deviceModel
+            countryCode
+            countryName
+            current
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-email.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-email.md
@@ -14,6 +14,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-name.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-name.md
@@ -13,6 +13,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-password.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-password.md
@@ -13,6 +13,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-phone.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-phone.md
@@ -14,6 +14,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-prefs.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-prefs.md
@@ -13,6 +13,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/account/update-status.md
+++ b/docs/examples/1.2.x/client-graphql/examples/account/update-status.md
@@ -11,6 +11,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/databases/list-documents.md
+++ b/docs/examples/1.2.x/client-graphql/examples/databases/list-documents.md
@@ -4,6 +4,14 @@ query {
         collectionId: "[COLLECTION_ID]"
     ) {
         total
-        documents
+        documents {
+            _id
+            _collectionId
+            _databaseId
+            _createdAt
+            _updatedAt
+            _permissions
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/functions/list-executions.md
+++ b/docs/examples/1.2.x/client-graphql/examples/functions/list-executions.md
@@ -3,6 +3,19 @@ query {
         functionId: "[FUNCTION_ID]"
     ) {
         total
-        executions
+        executions {
+            _id
+            _createdAt
+            _updatedAt
+            _permissions
+            functionId
+            trigger
+            status
+            statusCode
+            response
+            stdout
+            stderr
+            duration
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/locale/list-continents.md
+++ b/docs/examples/1.2.x/client-graphql/examples/locale/list-continents.md
@@ -1,6 +1,9 @@
 query {
     localeListContinents {
         total
-        continents
+        continents {
+            name
+            code
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/locale/list-countries-e-u.md
+++ b/docs/examples/1.2.x/client-graphql/examples/locale/list-countries-e-u.md
@@ -1,6 +1,9 @@
 query {
     localeListCountriesEU {
         total
-        countries
+        countries {
+            name
+            code
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/locale/list-countries-phones.md
+++ b/docs/examples/1.2.x/client-graphql/examples/locale/list-countries-phones.md
@@ -1,6 +1,10 @@
 query {
     localeListCountriesPhones {
         total
-        phones
+        phones {
+            code
+            countryCode
+            countryName
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/locale/list-countries.md
+++ b/docs/examples/1.2.x/client-graphql/examples/locale/list-countries.md
@@ -1,6 +1,9 @@
 query {
     localeListCountries {
         total
-        countries
+        countries {
+            name
+            code
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/locale/list-currencies.md
+++ b/docs/examples/1.2.x/client-graphql/examples/locale/list-currencies.md
@@ -1,6 +1,14 @@
 query {
     localeListCurrencies {
         total
-        currencies
+        currencies {
+            symbol
+            name
+            symbolNative
+            decimalDigits
+            rounding
+            code
+            namePlural
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/locale/list-languages.md
+++ b/docs/examples/1.2.x/client-graphql/examples/locale/list-languages.md
@@ -1,6 +1,10 @@
 query {
     localeListLanguages {
         total
-        languages
+        languages {
+            name
+            code
+            nativeName
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/storage/list-files.md
+++ b/docs/examples/1.2.x/client-graphql/examples/storage/list-files.md
@@ -3,6 +3,18 @@ query {
         bucketId: "[BUCKET_ID]"
     ) {
         total
-        files
+        files {
+            _id
+            bucketId
+            _createdAt
+            _updatedAt
+            _permissions
+            name
+            signature
+            mimeType
+            sizeOriginal
+            chunksTotal
+            chunksUploaded
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/teams/list-memberships.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/list-memberships.md
@@ -3,6 +3,19 @@ query {
         teamId: "[TEAM_ID]"
     ) {
         total
-        memberships
+        memberships {
+            _id
+            _createdAt
+            _updatedAt
+            userId
+            userName
+            userEmail
+            teamId
+            teamName
+            invited
+            joined
+            confirm
+            roles
+        }
     }
 }

--- a/docs/examples/1.2.x/client-graphql/examples/teams/list.md
+++ b/docs/examples/1.2.x/client-graphql/examples/teams/list.md
@@ -1,6 +1,12 @@
 query {
     teamsList {
         total
-        teams
+        teams {
+            _id
+            _createdAt
+            _updatedAt
+            name
+            total
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/get.md
@@ -11,6 +11,8 @@ query {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/list-logs.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/list-logs.md
@@ -1,6 +1,28 @@
 query {
     accountListLogs {
         total
-        logs
+        logs {
+            event
+            userId
+            userEmail
+            userName
+            mode
+            ip
+            time
+            osCode
+            osName
+            osVersion
+            clientType
+            clientCode
+            clientName
+            clientVersion
+            clientEngine
+            clientEngineVersion
+            deviceName
+            deviceBrand
+            deviceModel
+            countryCode
+            countryName
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/list-sessions.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/list-sessions.md
@@ -1,6 +1,32 @@
 query {
     accountListSessions {
         total
-        sessions
+        sessions {
+            _id
+            _createdAt
+            userId
+            expire
+            provider
+            providerUid
+            providerAccessToken
+            providerAccessTokenExpiry
+            providerRefreshToken
+            ip
+            osCode
+            osName
+            osVersion
+            clientType
+            clientCode
+            clientName
+            clientVersion
+            clientEngine
+            clientEngineVersion
+            deviceName
+            deviceBrand
+            deviceModel
+            countryCode
+            countryName
+            current
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-email.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-email.md
@@ -14,6 +14,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-name.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-name.md
@@ -13,6 +13,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-password.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-password.md
@@ -13,6 +13,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-phone.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-phone.md
@@ -14,6 +14,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-prefs.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-prefs.md
@@ -13,6 +13,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/account/update-status.md
+++ b/docs/examples/1.2.x/server-graphql/examples/account/update-status.md
@@ -11,6 +11,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/create-collection.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/create-collection.md
@@ -13,6 +13,11 @@ mutation {
         enabled
         documentSecurity
         attributes
-        indexes
+        indexes {
+            key
+            type
+            status
+            attributes
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/get-collection.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/get-collection.md
@@ -12,6 +12,11 @@ query {
         enabled
         documentSecurity
         attributes
-        indexes
+        indexes {
+            key
+            type
+            status
+            attributes
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/list-collections.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/list-collections.md
@@ -3,6 +3,22 @@ query {
         databaseId: "[DATABASE_ID]"
     ) {
         total
-        collections
+        collections {
+            _id
+            _createdAt
+            _updatedAt
+            _permissions
+            databaseId
+            name
+            enabled
+            documentSecurity
+            attributes
+            indexes {
+                key
+                type
+                status
+                attributes
+            }
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/list-documents.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/list-documents.md
@@ -4,6 +4,14 @@ query {
         collectionId: "[COLLECTION_ID]"
     ) {
         total
-        documents
+        documents {
+            _id
+            _collectionId
+            _databaseId
+            _createdAt
+            _updatedAt
+            _permissions
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/list-indexes.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/list-indexes.md
@@ -4,6 +4,11 @@ query {
         collectionId: "[COLLECTION_ID]"
     ) {
         total
-        indexes
+        indexes {
+            key
+            type
+            status
+            attributes
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/list.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/list.md
@@ -1,6 +1,11 @@
 query {
     databasesList {
         total
-        databases
+        databases {
+            _id
+            name
+            _createdAt
+            _updatedAt
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/databases/update-collection.md
+++ b/docs/examples/1.2.x/server-graphql/examples/databases/update-collection.md
@@ -13,6 +13,11 @@ mutation {
         enabled
         documentSecurity
         attributes
-        indexes
+        indexes {
+            key
+            type
+            status
+            attributes
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/create.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/create.md
@@ -13,7 +13,14 @@ mutation {
         enabled
         runtime
         deployment
-        vars
+        vars {
+            _id
+            _createdAt
+            _updatedAt
+            key
+            value
+            functionId
+        }
         events
         schedule
         scheduleNext

--- a/docs/examples/1.2.x/server-graphql/examples/functions/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/get.md
@@ -10,7 +10,14 @@ query {
         enabled
         runtime
         deployment
-        vars
+        vars {
+            _id
+            _createdAt
+            _updatedAt
+            key
+            value
+            functionId
+        }
         events
         schedule
         scheduleNext

--- a/docs/examples/1.2.x/server-graphql/examples/functions/list-deployments.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/list-deployments.md
@@ -3,6 +3,20 @@ query {
         functionId: "[FUNCTION_ID]"
     ) {
         total
-        deployments
+        deployments {
+            _id
+            _createdAt
+            _updatedAt
+            resourceId
+            resourceType
+            entrypoint
+            size
+            buildId
+            activate
+            status
+            buildStdout
+            buildStderr
+            buildTime
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/list-executions.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/list-executions.md
@@ -3,6 +3,19 @@ query {
         functionId: "[FUNCTION_ID]"
     ) {
         total
-        executions
+        executions {
+            _id
+            _createdAt
+            _updatedAt
+            _permissions
+            functionId
+            trigger
+            status
+            statusCode
+            response
+            stdout
+            stderr
+            duration
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/list-runtimes.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/list-runtimes.md
@@ -1,6 +1,14 @@
 query {
     functionsListRuntimes {
         total
-        runtimes
+        runtimes {
+            _id
+            name
+            version
+            base
+            image
+            logo
+            supports
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/list-variables.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/list-variables.md
@@ -3,6 +3,13 @@ query {
         functionId: "[FUNCTION_ID]"
     ) {
         total
-        variables
+        variables {
+            _id
+            _createdAt
+            _updatedAt
+            key
+            value
+            functionId
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/list.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/list.md
@@ -1,6 +1,28 @@
 query {
     functionsList {
         total
-        functions
+        functions {
+            _id
+            _createdAt
+            _updatedAt
+            execute
+            name
+            enabled
+            runtime
+            deployment
+            vars {
+                _id
+                _createdAt
+                _updatedAt
+                key
+                value
+                functionId
+            }
+            events
+            schedule
+            scheduleNext
+            schedulePrevious
+            timeout
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/functions/update-deployment.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/update-deployment.md
@@ -11,7 +11,14 @@ mutation {
         enabled
         runtime
         deployment
-        vars
+        vars {
+            _id
+            _createdAt
+            _updatedAt
+            key
+            value
+            functionId
+        }
         events
         schedule
         scheduleNext

--- a/docs/examples/1.2.x/server-graphql/examples/functions/update.md
+++ b/docs/examples/1.2.x/server-graphql/examples/functions/update.md
@@ -12,7 +12,14 @@ mutation {
         enabled
         runtime
         deployment
-        vars
+        vars {
+            _id
+            _createdAt
+            _updatedAt
+            key
+            value
+            functionId
+        }
         events
         schedule
         scheduleNext

--- a/docs/examples/1.2.x/server-graphql/examples/locale/list-continents.md
+++ b/docs/examples/1.2.x/server-graphql/examples/locale/list-continents.md
@@ -1,6 +1,9 @@
 query {
     localeListContinents {
         total
-        continents
+        continents {
+            name
+            code
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/locale/list-countries-e-u.md
+++ b/docs/examples/1.2.x/server-graphql/examples/locale/list-countries-e-u.md
@@ -1,6 +1,9 @@
 query {
     localeListCountriesEU {
         total
-        countries
+        countries {
+            name
+            code
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/locale/list-countries-phones.md
+++ b/docs/examples/1.2.x/server-graphql/examples/locale/list-countries-phones.md
@@ -1,6 +1,10 @@
 query {
     localeListCountriesPhones {
         total
-        phones
+        phones {
+            code
+            countryCode
+            countryName
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/locale/list-countries.md
+++ b/docs/examples/1.2.x/server-graphql/examples/locale/list-countries.md
@@ -1,6 +1,9 @@
 query {
     localeListCountries {
         total
-        countries
+        countries {
+            name
+            code
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/locale/list-currencies.md
+++ b/docs/examples/1.2.x/server-graphql/examples/locale/list-currencies.md
@@ -1,6 +1,14 @@
 query {
     localeListCurrencies {
         total
-        currencies
+        currencies {
+            symbol
+            name
+            symbolNative
+            decimalDigits
+            rounding
+            code
+            namePlural
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/locale/list-languages.md
+++ b/docs/examples/1.2.x/server-graphql/examples/locale/list-languages.md
@@ -1,6 +1,10 @@
 query {
     localeListLanguages {
         total
-        languages
+        languages {
+            name
+            code
+            nativeName
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/storage/list-buckets.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/list-buckets.md
@@ -1,6 +1,19 @@
 query {
     storageListBuckets {
         total
-        buckets
+        buckets {
+            _id
+            _createdAt
+            _updatedAt
+            _permissions
+            fileSecurity
+            name
+            enabled
+            maximumFileSize
+            allowedFileExtensions
+            compression
+            encryption
+            antivirus
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/storage/list-files.md
+++ b/docs/examples/1.2.x/server-graphql/examples/storage/list-files.md
@@ -3,6 +3,18 @@ query {
         bucketId: "[BUCKET_ID]"
     ) {
         total
-        files
+        files {
+            _id
+            bucketId
+            _createdAt
+            _updatedAt
+            _permissions
+            name
+            signature
+            mimeType
+            sizeOriginal
+            chunksTotal
+            chunksUploaded
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/teams/list-memberships.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/list-memberships.md
@@ -3,6 +3,19 @@ query {
         teamId: "[TEAM_ID]"
     ) {
         total
-        memberships
+        memberships {
+            _id
+            _createdAt
+            _updatedAt
+            userId
+            userName
+            userEmail
+            teamId
+            teamName
+            invited
+            joined
+            confirm
+            roles
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/teams/list.md
+++ b/docs/examples/1.2.x/server-graphql/examples/teams/list.md
@@ -1,6 +1,12 @@
 query {
     teamsList {
         total
-        teams
+        teams {
+            _id
+            _createdAt
+            _updatedAt
+            name
+            total
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-argon2user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-argon2user.md
@@ -18,6 +18,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-bcrypt-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-bcrypt-user.md
@@ -18,6 +18,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-m-d5user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-m-d5user.md
@@ -18,6 +18,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-p-h-pass-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-p-h-pass-user.md
@@ -18,6 +18,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-s-h-a-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-s-h-a-user.md
@@ -18,6 +18,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-modified-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-modified-user.md
@@ -21,6 +21,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-user.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create-scrypt-user.md
@@ -23,6 +23,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/create.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/create.md
@@ -16,6 +16,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/get.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/get.md
@@ -16,6 +16,8 @@ query {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/list-logs.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/list-logs.md
@@ -3,6 +3,28 @@ query {
         userId: "[USER_ID]"
     ) {
         total
-        logs
+        logs {
+            event
+            userId
+            userEmail
+            userName
+            mode
+            ip
+            time
+            osCode
+            osName
+            osVersion
+            clientType
+            clientCode
+            clientName
+            clientVersion
+            clientEngine
+            clientEngineVersion
+            deviceName
+            deviceBrand
+            deviceModel
+            countryCode
+            countryName
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/list-memberships.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/list-memberships.md
@@ -3,6 +3,19 @@ query {
         userId: "[USER_ID]"
     ) {
         total
-        memberships
+        memberships {
+            _id
+            _createdAt
+            _updatedAt
+            userId
+            userName
+            userEmail
+            teamId
+            teamName
+            invited
+            joined
+            confirm
+            roles
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/list-sessions.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/list-sessions.md
@@ -3,6 +3,32 @@ query {
         userId: "[USER_ID]"
     ) {
         total
-        sessions
+        sessions {
+            _id
+            _createdAt
+            userId
+            expire
+            provider
+            providerUid
+            providerAccessToken
+            providerAccessTokenExpiry
+            providerRefreshToken
+            ip
+            osCode
+            osName
+            osVersion
+            clientType
+            clientCode
+            clientName
+            clientVersion
+            clientEngine
+            clientEngineVersion
+            deviceName
+            deviceBrand
+            deviceModel
+            countryCode
+            countryName
+            current
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/list.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/list.md
@@ -1,6 +1,24 @@
 query {
     usersList {
         total
-        users
+        users {
+            _id
+            _createdAt
+            _updatedAt
+            name
+            password
+            hash
+            hashOptions
+            registration
+            status
+            passwordUpdate
+            email
+            phone
+            emailVerification
+            phoneVerification
+            prefs {
+                data
+            }
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-email-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-email-verification.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-email.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-email.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-name.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-name.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-password.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-password.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-phone-verification.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-phone-verification.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-phone.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-phone.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }

--- a/docs/examples/1.2.x/server-graphql/examples/users/update-status.md
+++ b/docs/examples/1.2.x/server-graphql/examples/users/update-status.md
@@ -17,6 +17,8 @@ mutation {
         phone
         emailVerification
         phoneVerification
-        prefs
+        prefs {
+            data
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

GraphQL requests must always specify the attributes to be returned in the request. This PR ensures response models are processed recursively so that all examples display all attributes for nested models.

## Test Plan

Manually generated.

databases/list-documents.md:

```graphql
query {
    databasesListDocuments(
        databaseId: "[DATABASE_ID]",
        collectionId: "[COLLECTION_ID]"
    ) {
        total
        documents {
            _id
            _collectionId
            _databaseId
            _createdAt
            _updatedAt
            _permissions
            data
        }
    }
}
```

teams/get.md:

```graphql
query {
    teamsGet(
        teamId: "[TEAM_ID]"
    ) {
        _id
        _createdAt
        _updatedAt
        name
        total
    }
}
```

users/list.md:

```graphql
query {
    usersList {
        total
        users {
            _id
            _createdAt
            _updatedAt
            name
            password
            hash
            hashOptions
            registration
            status
            passwordUpdate
            email
            phone
            emailVerification
            phoneVerification
            prefs {
                data
            }
        }
    }
}
```

## Related PRs and Issues

* https://github.com/appwrite/sdk-generator/pull/598

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes