### PR TITLE
Fix deletes worker not deleting database collections

### DIFF
--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -44,9 +44,6 @@ class DeletesV1 extends Worker
                     case DELETE_TYPE_DATABASES:
                         $this->deleteDatabase($document, $project->getId());
                         break;
-                    case DELETE_TYPE_COLLECTIONS:
-                        $this->deleteCollection($document, $project->getId());
-                        break;
                     case DELETE_TYPE_PROJECTS:
                         $this->deleteProject($document);
                         break;
@@ -66,6 +63,10 @@ class DeletesV1 extends Worker
                         $this->deleteBucket($document, $project->getId());
                         break;
                     default:
+                        if (\str_starts_with($document->getCollection(), 'database_')) {
+                            $this->deleteCollection($document, $project->getId());
+                            break;
+                        }
                         Console::error('No lazy delete operation available for document of type: ' . $document->getCollection());
                         break;
                 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The delete collection endpoint would remove a collection from the projects `databases` tables, but collection tables themselves (e.g. `_1_database_1_collection_1`) were not being deleted from the database because the deletes worker was checking if the document `$collection` attribute was `collections` which is no longer true.

This PR changes the worker to check if the `$collection` attribute starts with `database_` instead.

## Test Plan

Manual tests

<img width="1107" alt="Screenshot 2023-01-11 at 5 25 06 PM" src="https://user-images.githubusercontent.com/5857008/211717472-6caef655-96d8-4055-9fb8-2f961afd6d22.png">

## Related PRs and Issues

Fixes https://github.com/appwrite/appwrite/issues/4428

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
