### PR TITLE
Fix deletes worker not deleting project database tables

### DIFF
--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -253,8 +253,10 @@ class DeletesV1 extends Worker
      */
     protected function deleteProject(Document $document): void
     {
+        $projectId = $document->getId();
+
         // Delete project tables
-        $dbForProject = $this->getProjectDB($document->getId(), $document);
+        $dbForProject = $this->getProjectDB($projectId, $document);
 
         $limit = 50;
         $offset = 0;
@@ -282,10 +284,14 @@ class DeletesV1 extends Worker
         }
 
         // Delete all storage directories
-        $uploads = $this->getFilesDevice($document->getId());
-        $cache = new Local(APP_STORAGE_CACHE . '/app-' . $document->getId());
+        $uploads = $this->getFilesDevice($projectId);
+        $functions = $this->getFunctionsDevice($projectId);
+        $builds = $this->getBuildsDevice($projectId);
+        $cache = $this->getCacheDevice($projectId);
 
         $uploads->delete($uploads->getRoot(), true);
+        $functions->delete($functions->getRoot(), true);
+        $builds->delete($builds->getRoot(), true);
         $cache->delete($cache->getRoot(), true);
     }
 

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -172,6 +172,7 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document database document
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteDatabase(Document $document, string $projectId): void
     {
@@ -191,6 +192,7 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document teams document
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteCollection(Document $document, string $projectId): void
     {
@@ -217,6 +219,7 @@ class DeletesV1 extends Worker
 
     /**
      * @param string $hourlyUsageRetentionDatetime
+     * @throws Exception
      */
     protected function deleteUsageStats(string $hourlyUsageRetentionDatetime)
     {
@@ -232,6 +235,7 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document teams document
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteMemberships(Document $document, string $projectId): void
     {
@@ -245,13 +249,37 @@ class DeletesV1 extends Worker
 
     /**
      * @param Document $document project document
+     * @throws Exception
      */
     protected function deleteProject(Document $document): void
     {
-        $projectId = $document->getId();
+        // Delete project tables
+        $dbForProject = $this->getProjectDBFromDocument($document);
 
-        // Delete all DBs
-        $this->getProjectDB($projectId)->delete($projectId);
+        $limit = 50;
+        $offset = 0;
+
+        while (true) {
+            $collections = $dbForProject->listCollections($limit, $offset);
+
+            if (empty($collections)) {
+                break;
+            }
+
+            foreach ($collections as $collection) {
+                $dbForProject->deleteCollection($collection->getId());
+            }
+
+            $offset += $limit;
+        }
+
+        // Delete metadata tables
+        try {
+            $dbForProject->deleteCollection('_metadata');
+        } catch (Exception) {
+            // Ignore: deleteCollection tries to delete a metadata entry after the collection is deleted,
+            // which will throw an exception here because the metadata collection is already deleted.
+        }
 
         // Delete all storage directories
         $uploads = $this->getFilesDevice($document->getId());
@@ -264,6 +292,7 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document user document
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteUser(Document $document, string $projectId): void
     {
@@ -305,6 +334,7 @@ class DeletesV1 extends Worker
 
     /**
      * @param string $datetime
+     * @throws Exception
      */
     protected function deleteExecutionLogs(string $datetime): void
     {
@@ -337,6 +367,7 @@ class DeletesV1 extends Worker
 
     /**
      * @param string $datetime
+     * @throws Exception
      */
     protected function deleteRealtimeUsage(string $datetime): void
     {
@@ -393,6 +424,7 @@ class DeletesV1 extends Worker
     /**
      * @param string $resource
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteAuditLogsByResource(string $resource, string $projectId): void
     {
@@ -406,6 +438,7 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document function document
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteFunction(Document $document, string $projectId): void
     {
@@ -479,6 +512,7 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document deployment document
      * @param string $projectId
+     * @throws Exception
      */
     protected function deleteDeployment(Document $document, string $projectId): void
     {
@@ -528,9 +562,10 @@ class DeletesV1 extends Worker
     /**
      * @param Document $document to be deleted
      * @param Database $database to delete it from
-     * @param callable $callback to perform after document is deleted
+     * @param callable|null $callback to perform after document is deleted
      *
      * @return bool
+     * @throws \Utopia\Database\Exception\Authorization
      */
     protected function deleteById(Document $document, Database $database, callable $callback = null): bool
     {
@@ -550,6 +585,7 @@ class DeletesV1 extends Worker
 
     /**
      * @param callable $callback
+     * @throws Exception
      */
     protected function deleteForProjectIds(callable $callback): void
     {
@@ -584,9 +620,10 @@ class DeletesV1 extends Worker
 
     /**
      * @param string $collection collectionID
-     * @param Query[] $queries
+     * @param array $queries
      * @param Database $database
-     * @param callable $callback
+     * @param callable|null $callback
+     * @throws Exception
      */
     protected function deleteByGroup(string $collection, array $queries, Database $database, callable $callback = null): void
     {
@@ -620,6 +657,7 @@ class DeletesV1 extends Worker
 
     /**
      * @param Document $document certificates document
+     * @throws \Utopia\Database\Exception\Authorization
      */
     protected function deleteCertificates(Document $document): void
     {

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -254,7 +254,7 @@ class DeletesV1 extends Worker
     protected function deleteProject(Document $document): void
     {
         // Delete project tables
-        $dbForProject = $this->getProjectDBFromDocument($document);
+        $dbForProject = $this->getProjectDB($document->getId(), $document);
 
         $limit = 50;
         $offset = 0;

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -258,11 +258,8 @@ class DeletesV1 extends Worker
         // Delete project tables
         $dbForProject = $this->getProjectDB($projectId, $document);
 
-        $limit = 50;
-        $offset = 0;
-
         while (true) {
-            $collections = $dbForProject->listCollections($limit, $offset);
+            $collections = $dbForProject->listCollections();
 
             if (empty($collections)) {
                 break;
@@ -271,8 +268,6 @@ class DeletesV1 extends Worker
             foreach ($collections as $collection) {
                 $dbForProject->deleteCollection($collection->getId());
             }
-
-            $offset += $limit;
         }
 
         // Delete metadata tables

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -255,6 +255,17 @@ class DeletesV1 extends Worker
     {
         $projectId = $document->getId();
 
+        // Delete project domains and certificates
+        $dbForConsole = $this->getConsoleDB();
+
+        $domains = $dbForConsole->find('domains', [
+            Query::equal('projectInternalId', [$document->getInternalId()])
+        ]);
+
+        foreach ($domains as $domain) {
+            $this->deleteCertificates($domain);
+        }
+
         // Delete project tables
         $dbForProject = $this->getProjectDB($projectId, $document);
 

--- a/src/Appwrite/Resque/Worker.php
+++ b/src/Appwrite/Resque/Worker.php
@@ -296,6 +296,11 @@ abstract class Worker
         return $this->getDevice(APP_STORAGE_BUILDS . '/app-' . $projectId);
     }
 
+    protected function getCacheDevice(string $projectId): Device
+    {
+        return $this->getDevice(APP_STORAGE_CACHE . '/app-' . $projectId);
+    }
+
     /**
      * Get Device based on selected storage environment
      * @param string $root path of the device

--- a/src/Appwrite/Resque/Worker.php
+++ b/src/Appwrite/Resque/Worker.php
@@ -165,31 +165,20 @@ abstract class Worker
      * @return Database
      * @throws Exception
      */
-    protected function getProjectDB(string $projectId): Database
+    protected function getProjectDB(string $projectId, ?Document $project = null): Database
     {
-        $consoleDB = $this->getConsoleDB();
+        if ($project === null) {
+            $consoleDB = $this->getConsoleDB();
 
-        if ($projectId === 'console') {
-            return $consoleDB;
+            if ($projectId === 'console') {
+                return $consoleDB;
+            }
+
+            /** @var Document $project */
+            $project = Authorization::skip(fn() => $consoleDB->getDocument('projects', $projectId));
         }
 
-        /** @var Document $project */
-        $project = Authorization::skip(fn() => $consoleDB->getDocument('projects', $projectId));
-
-        return $this->getDB(self::DATABASE_PROJECT, $projectId, $project->getInternalId());
-    }
-
-    /**
-     * Get internal project database given the project document
-     *
-     * Allows avoiding race conditions when modifying the projects collection
-     * @param Document $project
-     * @return Database
-     * @throws Exception
-     */
-    protected function getProjectDBFromDocument(Document $project): Database
-    {
-        return $this->getDB(self::DATABASE_PROJECT, project: $project);
+        return $this->getDB(self::DATABASE_PROJECT, $projectId, $project->getInternalId(), $project);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The delete project endpoint would delete the project from the `_console_projects` table, then the deletes worker tried to delete the entire `appwrite` database when a project was deleted, which would fail, but because the project was deleted from the projects table, the project was no longer accessible.

This meant all the project-specific tables were present in the database with no way to remove them except manually deleting them via SQL.

Project certificates, domains, functions, builds and cache were also not deleted with a project

This PR fixes the deletes worker by:

- Deleting all project domains and certificates
- Getting a project-specific database
- Listing all the project collection tables
- Deleting them all page by page
- Deleting the project metadata tables
- Deleting function, builds and cache

It also updates the existing `getProjectDB` function in the worker base to accept a project document to allow getting a project-specific database with a project document instead of a project ID. This avoids a race condition where the delete project endpoint could delete a project document before the worker can fetch it.

## Test Plan

Manual test

## Related PRs and Issues

Fixes https://github.com/appwrite/appwrite/issues/4930

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

Yes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
