### PR TITLE
Function default timeout example fix

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Func.php
+++ b/src/Appwrite/Utopia/Response/Model/Func.php
@@ -97,7 +97,7 @@ class Func extends Model
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Function execution timeout in seconds.',
                 'default' => 15,
-                'example' => 1592981237,
+                'example' => 15,
             ])
         ;
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The example provided for function timeout is massive and looks like a timestamp. Changed so it matches default and looks more sensible.

## Test Plan

Manual

<img width="815" alt="Screenshot 2023-01-11 at 5 18 07 PM" src="https://user-images.githubusercontent.com/29069505/211929976-dc008b54-ef10-49e2-9213-20ba6125e99f.png">


