### PR TITLE
add restart policy for worker-messaging container

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -509,6 +509,7 @@ services:
     entrypoint: worker-messaging
     <<: *x-logging
     container_name: appwrite-worker-messaging
+    restart: unless-stopped
     networks:
       - appwrite
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -554,6 +554,7 @@ services:
     entrypoint: worker-messaging
     <<: *x-logging
     container_name: appwrite-worker-messaging
+    restart: unless-stopped
     image: appwrite-dev
     networks:
       - appwrite


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It adds a restart policy in `appwrite-worker-messaging` service in `docker-compose.yml`

## Test Plan

This can be tested by restarting the machine where appwrite is deployed and checking the status of `appwrite-worker-messaging` container, the status should be running.

## Related PRs and Issues

#4986 

### Have you added your change to the [Changelog](https://github.com/appwrite/appwrite/blob/master/CHANGES.md)?

No

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
