### PR TITLE
Fix:Changing command collections to collection

### DIFF
--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -73,7 +73,7 @@ Your function has now been deployed on your Appwrite server! As soon as the buil
 Similarly, you can deploy all your collections to your Appwrite server using 
 
 ```sh
-appwrite deploy collections
+appwrite deploy collection
 ```
 
 > ### Note


### PR DESCRIPTION
## What does this PR do?

The documentation for the CLI command is wrong.
When checking the [deploy.js](https://github.com/appwrite/sdk-for-cli/blob/master/lib/commands/deploy.js) file.
the command is deploy "collection" and not "collections" as described in the documentation.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
