### PR TITLE
Update tests CI to cache docker layers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,13 +51,3 @@ jobs:
 
     - name: Run Tests
       run: docker compose exec -T appwrite test --debug
-
-    # This ugly bit is necessary if you don't want your cache to grow forever
-    # until it hits GitHub's limit of 5GB.
-    # Temp fix
-    # https://github.com/docker/build-push-action/issues/252
-    # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         context: .
         push: false
         tags: appwrite-dev
+        load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,18 +21,28 @@ jobs:
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
+    # This is a separate action that sets up buildx runner
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Build Appwrite
-      # Upstream bug causes buildkit pulls to fail so prefetch base images
-      # https://github.com/moby/moby/issues/41864
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: false
+        tags: appwrite-dev
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+          DEBUG=false
+          TESTING=true
+          VERSION=dev
+
+    - name: Start Appwrite
       run:  |
-        export COMPOSE_INTERACTIVE_NO_CLI
-        export DOCKER_BUILDKIT=1
-        export COMPOSE_DOCKER_CLI_BUILD=1
-        export BUILDKIT_PROGRESS=plain
-        docker pull composer:2.0
-        docker compose build appwrite
         docker compose up -d
         sleep 30
+
     - name: Doctor
       run: docker compose exec -T appwrite doctor
 
@@ -41,3 +51,13 @@ jobs:
 
     - name: Run Tests
       run: docker compose exec -T appwrite test --debug
+
+    # This ugly bit is necessary if you don't want your cache to grow forever
+    # until it hits GitHub's limit of 5GB.
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     # This is a separate action that sets up buildx runner
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Build Appwrite
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: false


### PR DESCRIPTION
## What does this PR do?

Because each GitHub Action is a fresh environment, Docker's build cache isn't used by default. This change updates the build process to cache the docker build layers into GitHub action's cache so they can be reused, speeding up build times.

## Test Plan

Actions

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
