### PR TITLE
feat: bump console to 2.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "app/console"]
 	path = app/console
 	url = https://github.com/appwrite/console
-	branch = 2.1.1
+	branch = 2.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Version 1.2.1
 ## Changes
+- Upgrade Console to [2.2.0](https://github.com/appwrite/console/releases/tag/2.2.0)
 - Update DBIP Database [#5049](https://github.com/appwrite/appwrite/pull/5049)
 
 ## Bugs


### PR DESCRIPTION
## What does this PR do?

- bumps `app/console` to 2.2.0

## Test Plan

- manual

## Related PRs and Issues

- https://github.com/appwrite/console/releases/tag/2.2.0

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
