### PR TITLE
Docs: Fix Max Size of Function Response

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -62,19 +62,19 @@ class Execution extends Model
             ])
             ->addRule('response', [
                 'type' => self::TYPE_STRING,
-                'description' => 'The script response output string. Logs the last 4,000 characters of the execution response output.',
+                'description' => 'The script response output string. Logs the last 1MB of the execution response output.',
                 'default' => '',
                 'example' => '',
             ])
             ->addRule('stdout', [
                 'type' => self::TYPE_STRING,
-                'description' => 'The script stdout output string. Logs the last 4,000 characters of the execution stdout output. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'description' => 'The script stdout output string. Logs the last 1MB characters of the execution stdout output. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
                 'default' => '',
                 'example' => '',
             ])
             ->addRule('stderr', [
                 'type' => self::TYPE_STRING,
-                'description' => 'The script stderr output string. Logs the last 4,000 characters of the execution stderr output. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'description' => 'The script stderr output string. Logs the last 1MB characters of the execution stderr output. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
                 'default' => '',
                 'example' => '',
             ])


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The response size has been 1MB for a while instead of 4,000 bytes.

## Test Plan
