### PR TITLE
Fix: build worker warning

### DIFF
--- a/src/Appwrite/Usage/Stats.php
+++ b/src/Appwrite/Usage/Stats.php
@@ -82,7 +82,7 @@ class Stats
     public function submit(): void
     {
         $projectId = $this->params['projectId'] ?? '';
-        $projectInternalId = $this->params['projectInternalId'];
+        $projectInternalId = $this->params['projectInternalId'] ?? '';
         $tags = ",projectInternalId={$projectInternalId},projectId={$projectId},version=" . App::getEnv('_APP_VERSION', 'UNKNOWN');
 
         // the global namespace is prepended to every key (optional)


### PR DESCRIPTION
## What does this PR do?

During QA I got warning when building Python function:

```
appwrite-worker-builds  | Creating build for deployment: 63f760351627f3cf6d16
appwrite-worker-builds  | Build id: 63f7603530751cb30c3f created
appwrite-worker-builds  | Warning: Undefined array key "projectInternalId" in /usr/src/code/src/Appwrite/Usage/Stats.php on line 85
```

Looking at line above my change, project ID defaults to empty string. My changes add same default fallback to internal project ID

## Test Plan

None.

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
