### PR TITLE
feat: database update attribute endpoints

### DIFF
--- a/docs/references/databases/update-email-attribute.md
+++ b/docs/references/databases/update-email-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/docs/references/databases/update-enum-attribute.md
+++ b/docs/references/databases/update-enum-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/docs/references/databases/update-float-attribute.md
+++ b/docs/references/databases/update-float-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/docs/references/databases/update-integer-attribute.md
+++ b/docs/references/databases/update-integer-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/docs/references/databases/update-ip-attribute.md
+++ b/docs/references/databases/update-ip-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/docs/references/databases/update-string-attribute.md
+++ b/docs/references/databases/update-string-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/docs/references/databases/update-url-attribute.md
+++ b/docs/references/databases/update-url-attribute.md
@@ -1,0 +1,1 @@
+Update an email attribute.

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -145,6 +145,8 @@ class Exception extends \Exception
     public const ATTRIBUTE_ALREADY_EXISTS          = 'attribute_already_exists';
     public const ATTRIBUTE_LIMIT_EXCEEDED          = 'attribute_limit_exceeded';
     public const ATTRIBUTE_VALUE_INVALID           = 'attribute_value_invalid';
+    public const ATTRIBUTE_TYPE_INVALID            = 'attribute_type_invalid';
+    public const ATTRIBUTE_FILTER_INVALID          = 'attribute_filter_invalid';
 
     /** Indexes */
     public const INDEX_NOT_FOUND                   = 'index_not_found';


### PR DESCRIPTION
## What does this PR do?

- [x] adds `PATCH` endpoints for each attribute 
- [x] adds references to each endpoint for documentation
- [x] adds 2 more exceptions
  - `ATTRIBUTE_TYPE_INVALID`
  - `ATTRIBUTE_FILTER_INVALID`
- [] add tests
- [] update documentation
- [] update contribution guide

## Test Plan

- [] test against success
- [] test against failures

## Related PRs and Issues

- #2720 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
