### PR TITLE
set correct value for logging drivers

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -152,7 +152,7 @@ return [
             ],
             [
                 'name' => '_APP_LOGGING_PROVIDER',
-                'description' => 'This variable allows you to enable logging errors to 3rd party providers. This value is empty by default, to enable the logger set the value to one of \'sentry\', \'raygun\', \'appsignal\', \'logowl\'',
+                'description' => 'This variable allows you to enable logging errors to 3rd party providers. This value is empty by default, to enable the logger set the value to one of \'sentry\', \'raygun\', \'appSignal\', \'logOwl\'',
                 'introduction' => '0.12.0',
                 'default' => '',
                 'required' => false,


### PR DESCRIPTION
**What does this PR do?**
It sets the correct values for the logowl and appsignal logging drivers according to:


https://github.com/utopia-php/logger/blob/main/src/Logger/Logger.php at line 15

**Related PRs and Issues**
https://github.com/utopia-php/logger/pull/8 / https://github.com/appwrite/appwrite/pull/2729

**Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?**
Yes