### PR TITLE
Updated the error to 501 error code for custom domain when _APP_DOMAIN and _APP_DOMAIN_TARGET is setup incorrectly

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -474,6 +474,11 @@ return [
         'description' => 'Project with the requested ID could not be found. Please check the value of the X-Appwrite-Project header to ensure the correct project ID is being used.',
         'code' => 404,
     ],
+    Exception::ENV_VARIABLE_INCORRECT_SETUP => [
+        'name' => Exception::ENV_VARIABLE_INCORRECT_SETUP,
+        'description' => 'For Custom Domain ENV Variable is not setup correctly',
+        'code' => 501,
+    ],
     Exception::PROJECT_UNKNOWN => [
         'name' => Exception::PROJECT_UNKNOWN,
         'description' => 'The project ID is either missing or not valid. Please check the value of the X-Appwrite-Project header to ensure the correct project ID is being used.',

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -1340,7 +1340,7 @@ App::post('/v1/projects/:projectId/domains')
         $target = new Domain(App::getEnv('_APP_DOMAIN_TARGET', ''));
 
         if (!$target->isKnown() || $target->isTest()) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Unreachable CNAME target (' . $target->get() . '), please use a domain with a public suffix.');
+            throw new Exception(Exception::ENV_VARIABLE_INCORRECT_SETUP, 'Unreachable CNAME target (' . $target->get() . '), please use a domain with a public suffix.');
         }
 
         $domain = new Domain($domain);

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -177,6 +177,7 @@ class Exception extends \Exception
     public const DOMAIN_NOT_FOUND                  = 'domain_not_found';
     public const DOMAIN_ALREADY_EXISTS             = 'domain_already_exists';
     public const DOMAIN_VERIFICATION_FAILED        = 'domain_verification_failed';
+    public const ENV_VARIABLE_INCORRECT_SETUP      = 'env_variable_setup_incorrectly';
 
     /** GraphqQL */
     public const GRAPHQL_NO_QUERY                  = 'graphql_no_query';


### PR DESCRIPTION

## What does this PR do?

For API POST - /v1/projects/:projectId/domains  -> The error code is changed to 501 when the environment variable (`_APP_DOMAIN` and `_APP_DOMAIN_TARGET`) is not setup correctly. Doing this change now the error is visible to user while creating custom domain if the environment variable is not setup correctly. Attaching a screenshot.
<img width="1417" alt="Screenshot 2023-03-05 at 2 39 21 PM" src="https://user-images.githubusercontent.com/20492520/222951958-4a6e7962-58f0-4f82-9816-fd396054de87.png">

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

* I have ran the unit test case and lint.
* I have manually tested issue by creating the docker image by unsetting the environment variables `_APP_DOMAIN` and `_APP_DOMAIN_TARGET` to replicate the issue. After that I was able to view the error on the UI.

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/5159

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


