### PR TITLE
Prevent cache from being flushed on start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,6 +434,14 @@ composer lint
 composer lint <your file path>
 ```
 
+## Clearing the Cache
+
+If you need to clear the cache, you can do so by running the following command:
+
+```bash
+docker compose exec redis redis-cli FLUSHALL
+```
+
 ## Tutorials
 
 From time to time, our team will add tutorials that will help contributors find their way in the Appwrite source code. Below is a list of currently available tutorials:

--- a/app/http.php
+++ b/app/http.php
@@ -89,8 +89,6 @@ $http->on('start', function (Server $http) use ($payloadSize, $register) {
         $collections = Config::getParam('collections', []);
 
         try {
-            $cache = $app->getResource('cache'); /** @var Utopia\Cache\Cache $cache */
-            $cache->flush();
             Console::success('[Setup] - Creating database: appwrite...');
             $dbForConsole->create();
         } catch (\Exception $e) {


### PR DESCRIPTION
## What does this PR do?

Prevent cache from being flushed on start. We shouldn't clear the cache because scheduled functions are also in the cache, and we don't want to lose them.

## Test Plan

Manual

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
