### PR TITLE
Fix yasd so that the debugger works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,8 +346,7 @@ If you are in PHP Storm you don't need any plugin. Below are the settings requir
 
 1. Create an init file. 
 2. Duplicate **dev/yasd_init.php.stub** file and name it **dev/yasd_init.php**.
-3. Change the IP address to your development machine's IP. Without the proper IP address, the debugger won't connect. 
-4. Set **DEBUG** build arg in **appwrite** service in **docker-compose.yml** file.
+3. Set **DEBUG** build arg in **appwrite** service in **docker-compose.yml** file.
 
 ### VS Code Launch Configuration
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN chmod +x /usr/local/bin/doctor && \
 RUN mkdir -p /etc/letsencrypt/live/ && chmod -Rf 755 /etc/letsencrypt/live/
 
 # Enable Extensions
-RUN if [ "$DEBUG" == "true" ]; then printf "zend_extension=yasd \nyasd.debug_mode=remote \nyasd.init_file=/usr/local/dev/yasd_init.php \nyasd.remote_port=9005 \nyasd.log_level=-1" >> /usr/local/etc/php/conf.d/yasd.ini; fi
+RUN if [ "$DEBUG" == "true" ]; then printf "zend_extension=yasd \nyasd.debug_mode=remote \nyasd.init_file=/usr/src/code/dev/yasd_init.php \nyasd.remote_port=9005 \nyasd.log_level=-1" >> /usr/local/etc/php/conf.d/yasd.ini; fi
 
 RUN if [ "$DEBUG" == "true" ]; then echo "opcache.enable=0" >> /usr/local/etc/php/conf.d/appwrite.ini; fi
 RUN echo "opcache.preload_user=www-data" >> /usr/local/etc/php/conf.d/appwrite.ini

--- a/dev/yasd_init.php.stub
+++ b/dev/yasd_init.php.stub
@@ -1,4 +1,4 @@
 <?php
 
 echo 'execute init_file success' . PHP_EOL;
-Yasd\Api\setRemoteHost('127.0.0.1'); //Set your development machine's IP
+Yasd\Api\setRemoteHost('host.docker.internal'); //Set your development machine's IP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - ./docs:/usr/src/code/docs
       - ./public:/usr/src/code/public
       - ./src:/usr/src/code/src
+      - ./dev:/usr/src/code/dev
     depends_on:
       - mariadb
       - redis
@@ -473,6 +474,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
+      - ./dev:/usr/src/code/dev
       - appwrite-functions:/storage/functions:rw
       - appwrite-builds:/storage/builds:rw
       - /tmp:/tmp:rw


### PR DESCRIPTION
## What does this PR do?

* Update the base image since the yasd extension wasn't installed correctly
* Fix the path to the yasd_init.php file
* Use `host.docker.internal` as the remote host because that should always work inside docker
* Mount the dev folder into the appwrite container so the yasd_init.php file is picked up.

## Test Plan

Manual

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
