### PR TITLE
fixed svg images using links in place of local svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Using Appwrite, you can easily integrate your app with user authentication and m
     <br />
 </p>
 
-![Appwrite](public/images/github.png)
+<!-- ![Appwrite](https://appwrite.io/images/appwrite.svg) -->
+<img src="https://appwrite.io/images/appwrite.svg" alt="Appwrite" width="150" height="20"/>
+
 
 Find out more at: [https://appwrite.io](https://appwrite.io)
 
@@ -118,13 +120,13 @@ Choose from one of the providers below:
   <tr>
     <td align="center" width="100" height="100">
       <a href="https://marketplace.digitalocean.com/apps/appwrite">
-        <img width="50" height="39" src="public/images/integrations/digitalocean-logo.svg" alt="DigitalOcean Logo" />
+        <img width="50" height="39" src="https://upload.wikimedia.org/wikipedia/commons/f/ff/DigitalOcean_logo.svg" alt="DigitalOcean Logo" />
           <br /><sub><b>DigitalOcean</b></sub></a>
         </a>
     </td>
     <td align="center" width="100" height="100">
       <a href="https://gitpod.io/#https://github.com/appwrite/integration-for-gitpod">
-        <img width="50" height="39" src="public/images/integrations/gitpod-logo.svg" alt="Gitpod Logo" />
+        <img width="50" height="39" src="https://upload.wikimedia.org/wikipedia/commons/3/3f/Gitpod-ddd.svg" alt="Gitpod Logo" />
           <br /><sub><b>Gitpod</b></sub></a>    
       </a>
     </td>


### PR DESCRIPTION
in readme file the logos of appwrite , digital-ocean and gitpod were not rendering as there source were local svgs which doesn't work for src attribute in img tag

## What does this PR do?
I changes the src value with links

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- issue #5217

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
