### PR TITLE
Updated error when _APP_USAGE_STATS is disabled

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -88,6 +88,11 @@ return [
         'description' => 'The request cannot be fulfilled with the current protocol. Please check the value of the _APP_OPTIONS_FORCE_HTTPS environment variable.',
         'code' => 500,
     ],
+    Exception::GENERAL_USAGE_DISABLED => [
+        'name' => Exception::GENERAL_USAGE_DISABLED,
+        'description' => 'Usage stats is not configured. Please check the value of the _APP_USAGE_STATS environment variable of your Appwrite server.',
+        'code' => 501,
+    ],
 
     /** User Errors */
     Exception::USER_COUNT_EXCEEDED => [

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2471,6 +2471,9 @@ App::get('/v1/databases/usage')
     ->action(function (string $range, Response $response, Database $dbForProject) {
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [
@@ -2590,6 +2593,9 @@ App::get('/v1/databases/:databaseId/usage')
     ->action(function (string $databaseId, string $range, Response $response, Database $dbForProject) {
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [
@@ -2710,6 +2716,9 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/usage')
         }
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -234,6 +234,9 @@ App::get('/v1/functions/:functionId/usage')
         }
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [
@@ -337,6 +340,9 @@ App::get('/v1/functions/usage')
     ->action(function (string $range, Response $response, Database $dbForProject) {
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -268,6 +268,9 @@ App::get('/v1/projects/:projectId/usage')
         }
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -1461,6 +1461,9 @@ App::get('/v1/storage/usage')
     ->action(function (string $range, Response $response, Database $dbForProject) {
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') === 'enabled') {
             $periods = [
                 '24h' => [
@@ -1578,6 +1581,9 @@ App::get('/v1/storage/:bucketId/usage')
         }
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') === 'enabled') {
             $periods = [
                 '24h' => [

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1114,6 +1114,9 @@ App::get('/v1/users/usage')
     ->action(function (string $range, string $provider, Response $response, Database $dbForProject) {
 
         $usage = [];
+        if (App::getEnv('_APP_USAGE_STATS', 'enabled') != 'enabled') {
+            throw new Exception(Exception::GENERAL_USAGE_DISABLED);
+        }
         if (App::getEnv('_APP_USAGE_STATS', 'enabled') == 'enabled') {
             $periods = [
                 '24h' => [

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -51,6 +51,7 @@ class Exception extends \Exception
     public const GENERAL_CURSOR_NOT_FOUND          = 'general_cursor_not_found';
     public const GENERAL_SERVER_ERROR              = 'general_server_error';
     public const GENERAL_PROTOCOL_UNSUPPORTED      = 'general_protocol_unsupported';
+    public const GENERAL_USAGE_DISABLED            = 'general_usage_disabled';
 
     /** Users */
     public const USER_COUNT_EXCEEDED               = 'user_count_exceeded';


### PR DESCRIPTION
for usage

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

* Updated error for <component>/usage apis to throw 501 error when _APP_USAGE_STATS is disabled.
* Captured the error on console(Front-end UI) when calling usage api so that correct error is displayed on the view.

## What does this PR do?

Issue for this PR:
https://github.com/appwrite/appwrite/issues/4960

## Test Plan

Mannual Testing

Screenshot for usage view when `_APP_USAGE_STATS` env variable is `disabled`.

<img width="1440" alt="Screenshot 2023-03-18 at 10 22 36 PM" src="https://user-images.githubusercontent.com/20492520/226121460-8811acfa-5390-4546-bcb6-5cae8dfb0c54.png">



Logs from Appwrite containers
```
[Error] Timestamp: 2023-03-18T16:52:02+00:00
[Error] Method: GET
[Error] URL: /v1/databases/usage
[Error] Type: Appwrite\Extend\Exception
[Error] Message: Usage stats is not configured. Please check the value of the _APP_USAGE_STATS environment variable of your Appwrite server.
[Error] File: /usr/src/code/app/controllers/api/databases.php
[Error] Line: 2475
```

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
