### PR TITLE
Helm chart

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.5.5
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 17.9.0
+- name: telegraf
+  repository: https://helm.influxdata.com/
+  version: 1.8.26
+digest: sha256:3101feaa5de1854ff25673f059988104e28f2481a8c6ec0d434fb8a5e78076ad
+generated: "2023-03-24T12:30:07.256605462+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: appwrite
+description: Appwrite Helm chart
+type: application
+version: 1.0.0
+appVersion: "1.2.1"
+dependencies:
+  - name: mariadb
+    version: 11.5.5
+    repository: https://charts.bitnami.com/bitnami
+  - name: redis
+    version: 17.9.0
+    repository: https://charts.bitnami.com/bitnami
+  - name: telegraf
+    version: 1.8.26
+    repository: https://helm.influxdata.com/
+    condition: appwrite.usageStats.enabled

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,99 @@
+# appwrite
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
+
+Appwrite Helm chart
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | mariadb | 11.5.5 |
+| https://charts.bitnami.com/bitnami | redis | 17.9.0 |
+| https://helm.influxdata.com/ | telegraf | 1.8.26 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| appwrite.autoscaling.enabled | bool | `false` | Whether to enable autoscaling |
+| appwrite.console.whitelist.emails | list | `[]` | This option allows you to limit creation of new users on the Appwrite console. This option is very useful for small teams or sole developers. |
+| appwrite.console.whitelist.ips | list | `[]` | This last option allows you to limit creation of users in Appwrite console for users sharing the same set of IP addresses. This option is very useful for team working with a VPN service or a company IP. |
+| appwrite.console.whitelist.root | bool | `true` | This option allows you to disable the creation of new users on the Appwrite console. When enabled only 1 user will be able to use the registration form. New users can be added by inviting them to your project. |
+| appwrite.domain | string | `"appwrite.local"` | Domain used for ingresses |
+| appwrite.env | string | `"development"` | Server Environment |
+| appwrite.image.pullPolicy | string | `""` | Image pull policy, Always when tag is latest, IfNotPresent for any other tag You probably don't need to change it. |
+| appwrite.image.repository | string | `"appwrite/appwrite"` | The repository (and image name) where the appwrite docker image is stored |
+| appwrite.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| appwrite.ingress.annotations | object | `{"cert-manager.io/cluster-issuer":"letsencrypt-prod"}` | Core ingress annotation |
+| appwrite.ingress.enabled | bool | `true` | Core API Ingress |
+| appwrite.ingress.tls.enabled | bool | `false` | Core ingress TLS enabled |
+| appwrite.locale | string | `"en"` | Locale |
+| appwrite.options.abuse | bool | `true` | Abuse checks and API rate limiting. |
+| appwrite.options.forceHttps | bool | `false` | Force SSL |
+| appwrite.replicaCount | int | `1` | How many replicas of appwrite should be deployed, it is ignored if autoscaling is enabled |
+| appwrite.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resources for the main appwrite pods |
+| appwrite.sslKey | string | `"changeme"` | This is your server private key (as base64 string) that is used to encrypt all sensitive data on your server. Appwrite server encrypts all secret data on your server like webhooks, HTTP passwords, user sessions, and storage files. `--set-file appwrite.sslKey=key.pem` can be used to import a key file. |
+| appwrite.system.email.addr | string | `"team@appwrite.io"` | This is the sender email address that will appear on email messages sent to developers from the Appwrite console. You should choose an email address that is allowed to be used from your SMTP server to avoid the server email ending in the users' SPAM folders. |
+| appwrite.system.email.name | string | `"Appwrite"` | This is the sender name value that will appear on email messages sent to developers from the Appwrite console. You can use url encoded strings for spaces and special chars. |
+| appwrite.system.responseFormat | string | `""` | Use this environment variable to set the default Appwrite HTTP response format to support an older version of Appwrite. This option is useful to overcome breaking changes between versions. You can also use the X-Appwrite-Response-Format HTTP request header to overwrite the response for a specific request. This variable accepts any valid Appwrite version. To use the current version format, leave the value of the variable empty. |
+| appwrite.system.securityAddress | string | `"certs@appwrite.io"` | This is the email address used to issue SSL certificates for custom domains or the user agent in your webhooks payload. |
+| appwrite.usageStats.enabled | bool | `true` | This variable allows you to disable the collection and displaying of usage stats.  You will need an external InfluxDB instance in the `monitoring` namespace. When disabled, the Usage and Telegraf containers will be turned off. |
+| appwrite.usageStats.interval | int | `30` | The stats aggregation interval in seconds |
+| appwrite.volumes.cache.size | string | `"1Gi"` | Cache volume size |
+| appwrite.volumes.certificates.size | string | `"1Gi"` | Certificates volume size |
+| appwrite.volumes.config.size | string | `"1Gi"` | Configuration volume size |
+| appwrite.volumes.functions.size | string | `"1Gi"` | Functions volume size |
+| appwrite.volumes.uploads.size | string | `"1Gi"` | Upload volume size |
+| appwrite.workersPerCore | int | `6` | Internal Worker per core for the API containers. Can be configured to optimize performance. |
+| clamav.clamd.resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the ClamAV scan process |
+| clamav.enabled | bool | `true` | This variable allows you to disable the internal anti-virus (ClamAV) scans. |
+| clamav.freshclam.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resources for the ClamAV auth-update process |
+| clamav.image | object | `{"pullPolicy":"","repository":"appwrite/clamav","tag":"2.0.0"}` | Clamav image settings |
+| clamav.persistence.size | string | `"1Gi"` | ClamAV storage size |
+| commonLabels | object | `{}` | Labels to append to all manifests |
+| fullnameOverride | string | `""` | String to fully override the deployment name |
+| functions.containers | int | `10` | The maximum number of containers Appwrite is allowed to keep alive in the background for function environments.  Running containers allow faster execution time as there is no need to recreate each container every time a function gets executed. |
+| functions.cpus | int | `1` | The maximum number of CPU core a single cloud function is allowed to use.  Please note that setting a value higher than available cores will result in a function error, which might result in an error.  When empty, CPU limit will be disabled. |
+| functions.memory | string | `"256Mb"` | The maximum amount of memory a single cloud function is allowed to use in megabytes.  When empty, memory limit will be disabled. |
+| functions.runtimes | list | `["node-16.0","php-8.0","python-3.9","ruby-3.0","java-16.0","dart-2.14","dotnet-5.0"]` | This option allows you to limit the available environments for cloud functions. |
+| functions.swap | string | `"256Mb"` | The maximum amount of swap memory a single cloud function is allowed to use in megabytes.  The default value is empty. When empty, swap memory limit will be disabled. |
+| functions.timeout | int | `900` | The maximum number of seconds allowed as a timeout value when creating a new function. |
+| influxdb.host | string | `"influxdb.monitoring.svc"` | InfluxDB hostname |
+| influxdb.port | int | `8086` | InfluxDB port |
+| maintenance.replicaCount | int | `1` | Number of maintenance pods |
+| mariadb | object | `{"auth":{"database":"appwrite","existingSecret":"","password":"changeme","rootPassword":"myrootsecret","username":"appwrite"},"primary":{"persistence":{"size":"2Gi"}},"volumePermissions":{"enabled":true}}` | See https://artifacthub.io/packages/helm/bitnami/mariadb |
+| mariadb.auth.database | string | `"appwrite"` | MariaDB appwrite database |
+| mariadb.auth.existingSecret | string | `""` | Use this if you'd like to use a secret object instead. The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password` |
+| mariadb.auth.password | string | `"changeme"` | MariaDB appwrite password |
+| mariadb.auth.rootPassword | string | `"myrootsecret"` | MariaDB root password |
+| mariadb.auth.username | string | `"appwrite"` | MariaDB appwrite username |
+| mariadb.primary.persistence.size | string | `"2Gi"` | MariaDB storage size |
+| nameOverride | string | `""` | String to partially override the deployment name (will maintain the release name) |
+| namespaceOverride | string | `nil` | String to fully override the deployment namespace |
+| realtime.autoscaling.enabled | bool | `false` | Whether to enable autoscaling |
+| realtime.ingress.annotations | object | `{"cert-manager.io/cluster-issuer":"letsencrypt-prod"}` | Real-time ingress annotation |
+| realtime.ingress.enabled | bool | `true` | Real-time API ingress |
+| realtime.ingress.tls.enabled | bool | `false` | Real-time ingress TLS enabled |
+| realtime.replicaCount | int | `1` |  |
+| realtime.resources | object | `{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resources for the realtime appwrite pods |
+| realtime.workersPerCore | int | `6` | Internal Worker per core for the Realtime containers. Can be configured to optimize performance. |
+| redis | object | `{"architecture":"standalone","auth":{"enabled":false,"existingSecret":"","existingSecretPasswordKey":"","password":"","sentinel":false,"usePasswordFiles":false},"master":{"persistence":{"size":"1Gi"},"resources":{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}}}` | See https://artifacthub.io/packages/helm/bitnami/redis |
+| schedule.replicaCount | int | `1` | Number of schedule pods |
+| sms.from | string | `""` | Phone number used for sending out messages. Must start with a leading '+' and maximum of 15 digits without spaces (+123456789). |
+| sms.provider | string | `""` | Provider used for delivering SMS for Phone authentication. Use the following format: `sms://[USER]:[SECRET]@[PROVIDER]`. Available providers are twilio, text-magic, telesign, msg91, and vonage. |
+| smtp.host | string | `"maildev"` | SMTP server host name address. Use an empty string to disable all mail sending from the server.  The default value for this variable is an empty string |
+| smtp.pass | string | `""` | SMTP server user password. Empty by default. |
+| smtp.port | int | `1025` | SMTP server TCP port. Empty by default. |
+| smtp.secure | bool | `false` | SMTP secure connection protocol. Empty by default, change to 'tls' if running on a secure connection. |
+| smtp.user | string | `""` | SMTP server user name. Empty by default. |
+| storage.bucket.accessKey | string | `""` | Bucket API access key ID |
+| storage.bucket.name | string | `""` | Bucket name |
+| storage.bucket.region | string | `"eu-west-1"` | Bucket region |
+| storage.bucket.secret | string | `""` | Bucket API secret key |
+| storage.device | string | `"local"` | Select default storage device. The default value is 'local'.  List of supported adapters are 'local', 's3', 'dospaces', 'backblaze', 'linode' and 'wasabi'. |
+| storage.uploadLimit | string | `"30Mi"` | Maximum file size allowed for file upload. The default value is 30MB limitation. |
+| telegraf | object | `{"image":{"repo":"appwrite/telegraf","tag":"1.4.0"},"resources":{"limits":{"cpu":"250m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}}` | See https://artifacthub.io/packages/helm/influxdata/telegraf |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/helm/files/seed.sql
+++ b/helm/files/seed.sql
@@ -1,0 +1,90 @@
+CREATE DATABASE IF NOT EXISTS `appwrite` /*!40100 DEFAULT CHARACTER SET utf8mb4 */;
+
+USE `appwrite`;
+
+CREATE TABLE IF NOT EXISTS `template.abuse.abuse` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `_key` varchar(255) NOT NULL,
+  `_time` int(11) NOT NULL,
+  `_count` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique1` (`_key`,`_time`),
+  KEY `index1` (`_key`,`_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `template.audit.audit` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `userId` varchar(45) NOT NULL,
+  `event` varchar(45) NOT NULL,
+  `resource` varchar(45) DEFAULT NULL,
+  `userAgent` text NOT NULL,
+  `ip` varchar(45) NOT NULL,
+  `location` varchar(45) DEFAULT NULL,
+  `time` datetime NOT NULL,
+  `data` longtext DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id_UNIQUE` (`id`),
+  KEY `index_1` (`userId`),
+  KEY `index_2` (`event`),
+  KEY `index_3` (`resource`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `template.database.documents` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique ID for each node',
+  `uid` varchar(45) DEFAULT NULL,
+  `status` int(11) NOT NULL DEFAULT 0,
+  `createdAt` datetime DEFAULT NULL,
+  `updatedAt` datetime DEFAULT NULL,
+  `signature` varchar(32) NOT NULL,
+  `revision` varchar(45) NOT NULL,
+  `permissions` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id_UNIQUE` (`id`),
+  UNIQUE KEY `index2` (`uid`),
+  KEY `index3` (`signature`,`uid`,`revision`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `template.database.properties` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Primary Key',
+  `documentUid` varchar(45) NOT NULL COMMENT 'Unique UID foreign key',
+  `documentRevision` varchar(45) NOT NULL,
+  `key` varchar(32) NOT NULL COMMENT 'Property key name',
+  `value` text NOT NULL COMMENT 'Value of property',
+  `primitive` varchar(32) NOT NULL COMMENT 'Primitive type of property value',
+  `array` tinyint(4) NOT NULL DEFAULT 0,
+  `order` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index1` (`documentUid`),
+  KEY `index2` (`key`,`value`(5)),
+  FULLTEXT KEY `index3` (`value`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `template.database.relationships` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `revision` varchar(45) NOT NULL,
+  `start` varchar(45) NOT NULL COMMENT 'Unique UID foreign key',
+  `end` varchar(45) NOT NULL COMMENT 'Unique UID foreign key',
+  `key` varchar(256) NOT NULL,
+  `path` int(11) NOT NULL DEFAULT 0,
+  `array` tinyint(4) NOT NULL DEFAULT 0,
+  `order` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `relationships_start_nodes_id_idx` (`start`),
+  KEY `relationships_end_nodes_id_idx` (`end`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `template.database.unique` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `key` varchar(128) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index1` (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+/* Default App */
+
+CREATE TABLE IF NOT EXISTS `app_console.database.documents` LIKE `template.database.documents`;
+CREATE TABLE IF NOT EXISTS `app_console.database.properties` LIKE `template.database.properties`;
+CREATE TABLE IF NOT EXISTS `app_console.database.relationships` LIKE `template.database.relationships`;
+CREATE TABLE IF NOT EXISTS `app_console.database.unique` LIKE `template.database.unique`;
+CREATE TABLE IF NOT EXISTS `app_console.audit.audit` LIKE `template.audit.audit`;
+CREATE TABLE IF NOT EXISTS `app_console.abuse.abuse` LIKE `template.abuse.abuse`;

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,146 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "appwrite.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "appwrite.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "appwrite.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "appwrite.labels" -}}
+app.kubernetes.io/name: {{ include "appwrite.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- range $name, $value := .Values.commonLabels }}
+{{ $name }}: {{ $value  }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "appwrite.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "appwrite.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}
+
+{{- define "boolToStr" }}
+{{- if . -}}
+  "enabled"
+{{- else -}}
+  "disabled"
+{{- end -}}
+{{- end -}}
+
+{{- define "_arrayjoin"}}
+{{- range $i, $val := . }}
+{{- (print $val ",") -}}
+{{ end -}}
+{{- end -}}
+
+{{- define "array.join" }}
+{{- include "_arrayjoin" . | trimSuffix "," | quote -}}
+{{- end -}}
+
+{{- define "_sitoNum" }}
+{{- if hasSuffix "Gi" . -}}
+{{ mul (mul (mul (trimSuffix "Gi" . | atoi) 1024) 1024) 1024 }}
+{{- else if hasSuffix "Mi" . -}}
+{{ mul (mul (trimSuffix "Mi" . | atoi) 1024) 1024 }}
+{{- else if hasSuffix "Ki" . -}}
+{{ mul (trimSuffix "Ki" . | atoi) 1024 }}
+{{- end -}}
+{{- end -}}
+
+{{- define "si.toNum" }}
+{{- include "_sitoNum" . | quote -}}
+{{- end -}}
+
+{{- define "probeTcp" -}}
+livenessProbe:
+  tcpSocket:
+    port: {{ . }}
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+readinessProbe:
+  tcpSocket:
+    port: {{ . }}
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+startupProbe:
+  tcpSocket:
+    port: {{ . }}
+  initialDelaySeconds: 60
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+{{- end -}}
+
+{{- define "probeHttp" -}}
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /ping
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+startupProbe:
+  httpGet:
+    path: /ping
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+{{- end -}}
+
+# Place it to initContainers section
+{{- define "influxdbCheck" -}}
+
+{{- end }}
+
+{{- define "dbCheck" -}}
+
+{{- end }}
+
+{{- define "redisCheck" -}}
+
+{{- end }}

--- a/helm/templates/config/db-seed.yaml
+++ b/helm/templates/config/db-seed.yaml
@@ -1,0 +1,12 @@
+{{ if and .Values.initdbScriptsConfigMap (eq .Values.initdbScriptsConfigMap "appwrite-db-seed") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: appwrite-db-seed
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+data:
+  seed.sql: |-
+{{ .Files.Get "files/seed.sql" | indent 4 }}
+{{ end }}

--- a/helm/templates/config/env.yaml
+++ b/helm/templates/config/env.yaml
@@ -1,0 +1,48 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-env"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+data:
+  _APP_CONSOLE_WHITELIST_EMAILS: {{ include "array.join" .Values.appwrite.console.whitelist.emails }}
+  _APP_CONSOLE_WHITELIST_IPS: {{ include "array.join" .Values.appwrite.console.whitelist.ips }}
+  _APP_CONSOLE_WHITELIST_ROOT: {{ include "boolToStr" .Values.appwrite.console.whitelist.root }}
+  _APP_DOMAIN: {{ .Values.appwrite.domain | quote }}
+  _APP_DOMAIN_TARGET: {{ .Values.appwrite.domain | quote }}
+  _APP_ENV: {{ .Values.appwrite.env | quote }}
+  _APP_FUNCTIONS_CONTAINERS: {{ .Values.functions.containers | quote }}
+  _APP_FUNCTIONS_CPUS: {{ .Values.functions.cpus | quote }}
+  _APP_FUNCTIONS_MEMORY: {{ .Values.functions.memory | quote }}
+  _APP_FUNCTIONS_MEMORY_SWAP: {{ .Values.functions.swap | quote }}
+  _APP_FUNCTIONS_RUNTIMES: {{ include "array.join" .Values.functions.runtimes }}
+  _APP_FUNCTIONS_TIMEOUT: {{ .Values.functions.timeout | quote }}
+  _APP_INFLUXDB_HOST: {{ .Values.influxdb.host | quote }}
+  _APP_INFLUXDB_PORT: {{ .Values.influxdb.port | quote }}
+  _APP_LOCALE: {{ .Values.appwrite.locale | quote }}
+  _APP_OPTIONS_ABUSE: {{ include "boolToStr" .Values.appwrite.options.abuse }}
+  _APP_OPTIONS_FORCE_HTTPS: {{ include "boolToStr" .Values.appwrite.options.forceHttps }}
+  _APP_SMS_FROM: {{ .Values.sms.from | quote }}
+  _APP_SMS_PROVIDER: {{ .Values.sms.provider | quote }}
+  _APP_SMTP_HOST: {{ .Values.smtp.host | quote }}
+  _APP_SMTP_PORT: {{ .Values.smtp.port | quote }}
+  _APP_SMTP_SECURE: {{ .Values.smtp.secure | quote }}
+  _APP_STATSD_HOST: {{ include "appwrite.fullname" $ }}-telegraf
+  _APP_STATSD_PORT: "8125"
+  _APP_STORAGE_DEVICE: {{ .Values.storage.device | lower | quote }}
+  _APP_STORAGE_LIMIT: {{ include "si.toNum" .Values.storage.uploadLimit }}
+  _APP_STORAGE_ANTIVIRUS: {{ include "boolToStr" .Values.clamav.enabled }}
+  _APP_STORAGE_ANTIVIRUS_HOST: {{ include "appwrite.fullname" $ }}-clamav
+  _APP_STORAGE_ANTIVIRUS_PORT: "3310"
+  {{- if ne (lower .Values.storage.device) "local" }}
+  {{ printf "_APP_STORAGE_%s_ACCESS_KEY" .Values.storage.device | upper }}: {{ .Values.storage.bucket.accessKey | quote }}
+  {{ printf "_APP_STORAGE_%s_BUCKET"     .Values.storage.device | upper }}: {{ .Values.storage.bucket.name | quote }}
+  {{ printf "_APP_STORAGE_%s_REGION"     .Values.storage.device | upper }}: {{ .Values.storage.bucket.region | quote }}
+  {{- end }}
+  _APP_SYSTEM_EMAIL_NAME: {{ .Values.appwrite.system.email.name | quote }}
+  _APP_SYSTEM_EMAIL_ADDRESS: {{ .Values.appwrite.system.email.addr | quote }}
+  _APP_SYSTEM_RESPONSE_FORMAT: {{ .Values.appwrite.system.responseFormat | quote }}
+  _APP_SYSTEM_SECURITY_EMAIL_ADDRESS: {{ .Values.appwrite.system.securityAddress | quote }}
+  _APP_USAGE_STATS: {{ include "boolToStr" .Values.appwrite.usageStats.enabled }}
+  _APP_USAGE_AGGREGATION_INTERVAL: {{ .Values.appwrite.usageStats.interval | quote }}

--- a/helm/templates/deployments/clamav.yaml
+++ b/helm/templates/deployments/clamav.yaml
@@ -1,0 +1,56 @@
+{{ if .Values.clamav.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-clamav"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: clamav
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: clamav
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: clamav
+    spec:
+      containers:
+      - name: freshclam
+        image: "{{ .Values.clamav.image.repository }}:{{ .Values.clamav.image.tag }}"
+        {{- with .Values.clamav.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        env:
+        - name: MODE
+          value: "freshclam"
+        resources:
+{{ toYaml .Values.clamav.freshclam.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /var/lib/clamav
+          name: data
+      - name: clamd
+        image: "{{ .Values.clamav.image.repository }}:{{ .Values.clamav.image.tag }}"
+        {{- with .Values.clamav.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        ports:
+        - containerPort: 3310
+          name: clamav
+        env:
+        - name: MODE
+          value: "clamd"
+        resources:
+{{ toYaml .Values.clamav.clamd.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /var/lib/clamav
+          name: data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-clamav"
+{{ end }}

--- a/helm/templates/deployments/core.yaml
+++ b/helm/templates/deployments/core.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-core"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: core
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: core
+  {{- if not .Values.appwrite.autoscaling.enabled }}
+  replicas: {{ .Values.appwrite.replicaCount }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: core
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+        checksum/secrets-smtp: {{ include (print $.Template.BasePath "/secrets/smtp.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      {{- include "influxdbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-core
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+          - name: _APP_WORKER_PER_CORE
+            value: {{ .Values.appwrite.workerPerCore | quote }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-smtp-env
+        {{- include "probeHttp" $ | nindent 8 }}
+        resources:
+{{ toYaml .Values.appwrite.resources | indent 10 }}
+        volumeMounts:
+        {{- range $k, $v := .Values.appwrite.volumes }}
+        - mountPath: /storage/{{ $k }}
+          name: {{ $k }}
+        {{- end }}
+      volumes:
+        {{- range $k, $v := .Values.appwrite.volumes }}
+        - name: {{ $k }}
+          persistentVolumeClaim:
+            claimName: "{{ include "appwrite.fullname" $ }}-{{ $k }}"
+        {{- end }}

--- a/helm/templates/deployments/maintenance.yaml
+++ b/helm/templates/deployments/maintenance.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-maintenance"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: maintenance
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: maintenance
+  replicas: {{ .Values.maintenance.replicaCount }}
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: maintenance
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-maintenance
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "maintenance"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env

--- a/helm/templates/deployments/realtime.yaml
+++ b/helm/templates/deployments/realtime.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-realtime"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: realtime
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: realtime
+  {{- if not .Values.realtime.autoscaling.enabled }}
+  replicas: {{ .Values.realtime.replicaCount }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: realtime
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-realtime
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        command:
+          - "realtime"
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+          - name: _APP_WORKER_PER_CORE
+            value: {{ .Values.realtime.workerPerCore | quote }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+        resources:
+{{ toYaml .Values.realtime.resources | indent 10 }}

--- a/helm/templates/deployments/shedule.yaml
+++ b/helm/templates/deployments/shedule.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-schedule"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: schedule
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: schedule
+  replicas: {{ .Values.schedule.replicaCount }}
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: schedule
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-schedule
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "schedule"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env

--- a/helm/templates/deployments/usage.yaml
+++ b/helm/templates/deployments/usage.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.appwrite.usageStats.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-usage"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: usage
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: usage
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: usage
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-usage
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "usage"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+{{- end }}

--- a/helm/templates/deployments/workers/audits.yaml
+++ b/helm/templates/deployments/workers/audits.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-audits"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: audits
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: audits
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: audits
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+        checksum/secrets-smtp: {{ include (print $.Template.BasePath "/secrets/smtp.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-audits
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-audits"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env

--- a/helm/templates/deployments/workers/builds.yaml
+++ b/helm/templates/deployments/workers/builds.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-builds"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: builds
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: builds
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: builds
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-builds
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-builds"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env

--- a/helm/templates/deployments/workers/certificates.yaml
+++ b/helm/templates/deployments/workers/certificates.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-certificates"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: certificates
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: certificates
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: certificates
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-certificates
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-certificates"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+        volumeMounts:
+        - mountPath: /storage/config
+          name: data-config
+        - mountPath: /storage/certificates
+          name: data-certificates
+      volumes:
+      - name: data-config
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-config"
+      - name: data-certificates
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-certificates"

--- a/helm/templates/deployments/workers/databases.yaml
+++ b/helm/templates/deployments/workers/databases.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-databases"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: databases
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: databases
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: databases
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-databases
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-databases"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+

--- a/helm/templates/deployments/workers/deletes.yaml
+++ b/helm/templates/deployments/workers/deletes.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-deletes"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: deletes
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: deletes
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: deletes
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-deletes
+
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-deletes"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+        volumeMounts:
+        - mountPath: /storage/uploads
+          name: data-uploads
+        - mountPath: /storage/cache
+          name: data-cache
+        - mountPath: /storage/certificates
+          name: data-certificates
+      volumes:
+      - name: data-uploads
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-uploads"
+      - name: data-cache
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-cache"
+      - name: data-certificates
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-certificates"

--- a/helm/templates/deployments/workers/functions.yaml
+++ b/helm/templates/deployments/workers/functions.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-functions"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: functions
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: functions
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: functions
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-functions
+
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-functions"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+
+        volumeMounts:
+        - mountPath: /storage/functions
+          name: data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: "{{ include "appwrite.fullname" $ }}-functions"

--- a/helm/templates/deployments/workers/mails.yaml
+++ b/helm/templates/deployments/workers/mails.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-mails"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: mails
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: mails
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: mails
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+        checksum/secrets-smtp: {{ include (print $.Template.BasePath "/secrets/smtp.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-mails
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-mails"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-smtp-env

--- a/helm/templates/deployments/workers/messaging.yaml
+++ b/helm/templates/deployments/workers/messaging.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-messaging"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: messaging
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: messaging
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: messaging
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+        checksum/secrets-smtp: {{ include (print $.Template.BasePath "/secrets/smtp.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-messaging
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-messaging"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env

--- a/helm/templates/deployments/workers/webhooks.yaml
+++ b/helm/templates/deployments/workers/webhooks.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-webhooks"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: webhooks
+spec:
+  selector:
+    matchLabels:
+{{ include "appwrite.selectorLabels" $ | indent 6 }}
+      app.kubernetes.io/component: webhooks
+  replicas: 1
+  template:
+    metadata:
+      labels:
+{{ include "appwrite.labels" $ | indent 8 }}
+        app.kubernetes.io/component: webhooks
+      annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/config/env.yaml") . | sha256sum }}
+        checksum/secrets-env: {{ include (print $.Template.BasePath "/secrets/env.yaml") . | sha256sum }}
+        checksum/secrets-db: {{ include (print $.Template.BasePath "/secrets/db.yaml") . | sha256sum }}
+        checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets/redis.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      {{- include "redisCheck" $ | nindent 6 }}
+      {{- include "dbCheck" $ | nindent 6 }}
+      containers:
+      - name: appwrite-webhooks
+        image: "{{ .Values.appwrite.image.repository }}:{{ .Values.appwrite.image.tag | default .Chart.AppVersion }}"
+        command:
+          - "worker-webhooks"
+        {{- with .Values.appwrite.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-db-env
+        - secretRef:
+            name: {{ include "appwrite.fullname" $ }}-redis-env

--- a/helm/templates/hpa/core.yaml
+++ b/helm/templates/hpa/core.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.appwrite.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-core"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: core
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "appwrite.fullname" . }}-core
+  minReplicas: {{ .Values.appwrite.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.appwrite.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.appwrite.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.appwrite.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.appwrite.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.appwrite.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/hpa/realtime.yaml
+++ b/helm/templates/hpa/realtime.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.appwrite.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-realtime"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: realtime
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "appwrite.fullname" . }}-realtime
+  minReplicas: {{ .Values.realtime.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.realtime.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.appwrite.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.realtime.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.appwrite.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.realtime.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/ingress/core.yaml
+++ b/helm/templates/ingress/core.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.appwrite.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "appwrite.fullname" $ }}-core
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+{{- if .Values.appwrite.ingress.annotations }}
+  annotations:
+{{- toYaml .Values.appwrite.ingress.annotations | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ .Values.appwrite.domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "appwrite.fullname" $ }}-core
+                port:
+                  number: 80
+  {{- if .Values.appwrite.ingress.tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .Values.appwrite.domain }}
+      secretName: {{ include "appwrite.fullname" $ }}-tls
+  {{- end -}}
+{{- end -}}

--- a/helm/templates/ingress/realtime.yaml
+++ b/helm/templates/ingress/realtime.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.realtime.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "appwrite.fullname" $ }}-realtime
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+{{- if .Values.realtime.ingress.annotations }}
+  annotations:
+{{- toYaml .Values.realtime.ingress.annotations | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ .Values.appwrite.domain }}
+      http:
+        paths:
+          - path: /v1/realtime
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "appwrite.fullname" $ }}-realtime
+                port:
+                  number: 80
+  {{- if .Values.realtime.ingress.tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .Values.appwrite.domain }}
+      secretName: {{ include "appwrite.fullname" $ }}-tls
+  {{- end -}}
+{{- end -}}

--- a/helm/templates/secrets/db.yaml
+++ b/helm/templates/secrets/db.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-db-env"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+type: Opaque
+data:
+  _APP_DB_USER: {{ .Values.mariadb.auth.username | b64enc }}
+  _APP_DB_PASS: {{ .Values.mariadb.auth.password | b64enc }}
+  _APP_DB_ROOT_PASS: {{ .Values.mariadb.auth.rootPassword | b64enc }}
+  _APP_DB_PORT: {{ "3306" | b64enc }}
+  _APP_DB_SCHEMA: {{ "appwrite" | b64enc }}
+  _APP_DB_HOST: {{ include "appwrite.fullname" . | printf "%s-mariadb" | b64enc }}

--- a/helm/templates/secrets/env.yaml
+++ b/helm/templates/secrets/env.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-env"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+type: Opaque
+data:
+  _APP_OPENSSL_KEY_V1: {{ .Values.appwrite.sslKey | b64enc }}
+  {{- if ne (lower .Values.storage.device) "local" }}
+  {{ printf "_APP_STORAGE_%s_SECRET" .Values.storage.device | upper }}: {{ .Values.storage.bucket.secret | b64enc }}
+  {{- end }}

--- a/helm/templates/secrets/redis.yaml
+++ b/helm/templates/secrets/redis.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-redis-env"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+type: Opaque
+data:
+  {{ if .Values.redis.user -}}_APP_REDIS_USER: {{ .Values.redis.user | b64enc }}{{- end -}}
+  {{ if .Values.redis.pass -}}_APP_REDIS_PASS: {{ .Values.redis.pass | b64enc }}{{- end -}}
+  _APP_REDIS_HOST:  {{ include "appwrite.fullname" . | printf "%s-redis-master" | b64enc }}
+  _APP_REDIS_PORT: {{ "6379" | b64enc }}

--- a/helm/templates/secrets/smtp.yaml
+++ b/helm/templates/secrets/smtp.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-smtp-env"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+type: Opaque
+data:
+  _APP_SMTP_USERNAME: {{ .Values.smtp.user | b64enc }}
+  _APP_SMTP_PASSWORD: {{ .Values.smtp.pass | b64enc }}

--- a/helm/templates/services/clamav.yaml
+++ b/helm/templates/services/clamav.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.clamav.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-clamav"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: clamav
+spec:
+  ports:
+    - port: 3310
+      targetPort: 3310
+  selector:
+{{ include "appwrite.selectorLabels" $ | indent 4 }}
+    app.kubernetes.io/component: clamav
+{{ end }}

--- a/helm/templates/services/core.yaml
+++ b/helm/templates/services/core.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-core"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: core
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+{{ include "appwrite.selectorLabels" $ | indent 4 }}
+    app.kubernetes.io/component: core

--- a/helm/templates/services/realtime.yaml
+++ b/helm/templates/services/realtime.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-realtime"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: realtime
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+{{ include "appwrite.selectorLabels" $ | indent 4 }}
+    app.kubernetes.io/component: realtime

--- a/helm/templates/services/telegraf.yaml
+++ b/helm/templates/services/telegraf.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-telegraf"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+    app.kubernetes.io/component: telegraf
+spec:
+  ports:
+    - port: 8125
+      targetPort: 8125
+  selector:
+{{ include "appwrite.selectorLabels" $ | indent 4 }}
+    app.kubernetes.io/component: telegraf

--- a/helm/templates/volumes/appwrite.yaml
+++ b/helm/templates/volumes/appwrite.yaml
@@ -1,0 +1,18 @@
+{{- range $k, $v := .Values.appwrite.volumes }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-{{ $k }}"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ $v.size }}
+  {{- with $v.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}  
+{{- end }}

--- a/helm/templates/volumes/clamav.yaml
+++ b/helm/templates/volumes/clamav.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.clamav.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ include "appwrite.fullname" $ }}-clamav"
+  labels:
+{{ include "appwrite.labels" $ | indent 4 }}
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ .Values.clamav.persistence.size }}
+  {{- with .Values.clamav.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}  
+{{ end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,325 @@
+
+# nameOverride -- String to partially override the deployment name (will maintain the release name)
+nameOverride: ""
+# -- String to fully override the deployment name
+fullnameOverride: ""
+# -- String to fully override the deployment namespace
+namespaceOverride:
+
+# commonLabels -- Labels to append to all manifests
+commonLabels: {}
+  # foo: bar
+
+appwrite:
+  image:
+    # -- The repository (and image name) where the appwrite docker image is stored
+    repository: appwrite/appwrite
+    # -- Image pull policy, Always when tag is latest, IfNotPresent for any other tag
+    # You probably don't need to change it.
+    pullPolicy: ""
+    # -- Overrides the image tag whose default is the chart appVersion
+    tag: ""
+
+  # -- How many replicas of appwrite should be deployed, it is ignored if autoscaling is enabled
+  replicaCount: 1
+  autoscaling:
+    # -- Whether to enable autoscaling
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 5
+    # targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  # -- Server Environment
+  env: development
+  # -- Locale
+  locale: en
+  # -- This is your server private key (as base64 string) that is used to encrypt all sensitive data on your server.
+  # Appwrite server encrypts all secret data on your server like webhooks, HTTP passwords, user sessions, and storage files.
+  #`--set-file appwrite.sslKey=key.pem` can be used to import a key file.
+  sslKey: changeme
+  # -- Domain used for ingresses
+  domain: appwrite.local
+  options:
+    # -- Abuse checks and API rate limiting.
+    abuse: true
+    # -- Force SSL
+    forceHttps: false
+  console:
+    whitelist:
+      # -- This option allows you to disable the creation of new users on the Appwrite console.
+      # When enabled only 1 user will be able to use the registration form. New users can be added by inviting them to your project.
+      root: true
+      # -- This option allows you to limit creation of new users on the Appwrite console.
+      # This option is very useful for small teams or sole developers.
+      emails: []
+      # -- This last option allows you to limit creation of users in Appwrite console for users sharing the same set of IP addresses.
+      # This option is very useful for team working with a VPN service or a company IP.
+      ips: []
+  system:
+    email:
+      # -- This is the sender name value that will appear on email messages sent to developers from the Appwrite console.
+      # You can use url encoded strings for spaces and special chars.
+      name: Appwrite
+      # -- This is the sender email address that will appear on email messages sent to developers from the Appwrite console.
+      # You should choose an email address that is allowed to be used from your SMTP server to avoid the server email ending in the users' SPAM folders.
+      addr: team@appwrite.io
+    # -- Use this environment variable to set the default Appwrite HTTP response format to support an older version of Appwrite.
+    # This option is useful to overcome breaking changes between versions.
+    # You can also use the X-Appwrite-Response-Format HTTP request header to overwrite the response for a specific request.
+    # This variable accepts any valid Appwrite version. To use the current version format, leave the value of the variable empty.
+    responseFormat: ""
+    # -- This is the email address used to issue SSL certificates for custom domains or the user agent in your webhooks payload.
+    securityAddress: certs@appwrite.io
+  usageStats: 
+    # -- This variable allows you to disable the collection and displaying of usage stats. 
+    # You will need an external InfluxDB instance in the `monitoring` namespace.
+    # When disabled, the Usage and Telegraf containers will be turned off.
+    enabled: true
+    # -- The stats aggregation interval in seconds
+    interval: 30
+
+  # -- Internal Worker per core for the API containers. Can be configured to optimize performance.
+  workersPerCore: 6
+
+  ingress:
+    # -- Core API Ingress
+    enabled: true
+    # -- Core ingress annotation
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    tls:
+      # -- Core ingress TLS enabled
+      enabled: false
+
+  # -- Resources for the main appwrite pods
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 250m
+
+  volumes:
+    uploads:
+      # -- Upload volume size
+      size: 1Gi
+    cache:
+      # -- Cache volume size
+      size: 1Gi
+    config:
+      # -- Configuration volume size
+      size: 1Gi
+    certificates:
+      # -- Certificates volume size
+      size: 1Gi
+    functions:
+      # -- Functions volume size
+      size: 1Gi
+
+realtime:
+  # replicaCount -- How many replicas of realtime should be deployed, it is ignored if autoscaling is enabled
+  replicaCount: 1
+  autoscaling:
+    # -- Whether to enable autoscaling
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 5
+    # targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  # -- Internal Worker per core for the Realtime containers. Can be configured to optimize performance.
+  workersPerCore: 6
+
+  ingress:
+    # -- Real-time API ingress
+    enabled: true
+    # -- Real-time ingress annotation
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    tls:
+      # -- Real-time ingress TLS enabled
+      enabled: false
+
+  # -- Resources for the realtime appwrite pods
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 250m
+
+schedule:
+  # -- Number of schedule pods
+  replicaCount: 1
+
+maintenance:
+  # -- Number of maintenance pods
+  replicaCount: 1
+
+influxdb:
+  # -- InfluxDB hostname
+  host: influxdb.monitoring.svc
+  # -- InfluxDB port
+  port: 8086
+
+## Chart dependencies
+##
+
+# -- See https://artifacthub.io/packages/helm/influxdata/telegraf
+telegraf:
+  image: 
+    repo: appwrite/telegraf
+    tag: 1.4.0
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 250m
+
+# -- See https://artifacthub.io/packages/helm/bitnami/redis
+redis:
+  architecture: standalone
+  auth:
+    enabled: false
+    sentinel: false
+    password: ""
+    existingSecret: ""
+    existingSecretPasswordKey: ""
+    usePasswordFiles: false
+
+  master:
+    persistence:
+      size: 1Gi
+    resources:
+      requests:
+        memory: 128Mi
+        cpu: 100m
+      limits:
+        memory: 256Mi
+        cpu: 250m
+
+# -- See https://artifacthub.io/packages/helm/bitnami/mariadb
+mariadb:
+  # initdbScriptsConfigMap: appwrite-db-seed
+
+  auth:
+    # -- MariaDB root password
+    rootPassword: myrootsecret
+    # -- MariaDB appwrite database
+    database: appwrite
+    # -- MariaDB appwrite username
+    username: appwrite
+    # -- MariaDB appwrite password
+    password: changeme
+    # -- Use this if you'd like to use a secret object instead.
+    # The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`
+    existingSecret: ""
+
+  volumePermissions:
+    enabled: true
+
+  primary:
+    persistence:
+      # -- MariaDB storage size
+      size: 2Gi
+
+sms:
+  # -- Provider used for delivering SMS for Phone authentication. Use the following format: `sms://[USER]:[SECRET]@[PROVIDER]`.
+  #Available providers are twilio, text-magic, telesign, msg91, and vonage.
+  provider: ""
+  # -- Phone number used for sending out messages. Must start with a leading '+' and maximum of 15 digits without spaces (+123456789).
+  from: ""
+
+smtp:
+  # -- SMTP server host name address. Use an empty string to disable all mail sending from the server. 
+  # The default value for this variable is an empty string
+  host: maildev
+  # -- SMTP server TCP port. Empty by default.
+  port: 1025
+  # -- SMTP secure connection protocol. Empty by default, change to 'tls' if running on a secure connection.
+  secure: false
+  # -- SMTP server user name. Empty by default.
+  user: ""
+  # -- SMTP server user password. Empty by default.
+  pass: ""
+
+storage:
+  # -- Maximum file size allowed for file upload. The default value is 30MB limitation.
+  uploadLimit: 30Mi
+  # -- Select default storage device. The default value is 'local'. 
+  # List of supported adapters are 'local', 's3', 'dospaces', 'backblaze', 'linode' and 'wasabi'.
+  device: local
+  bucket:
+    # -- Bucket API access key ID
+    accessKey: ""
+    # -- Bucket API secret key
+    secret: ""
+    # -- Bucket region
+    region: eu-west-1
+    # -- Bucket name
+    name: ""
+
+clamav:
+  # -- This variable allows you to disable the internal anti-virus (ClamAV) scans.
+  enabled: true
+  # -- Clamav image settings
+  image: 
+    repository: appwrite/clamav
+    tag: "2.0.0"
+    pullPolicy: ""
+
+  persistence:
+    # -- ClamAV storage size
+    size: 1Gi
+
+  freshclam:
+    # -- Resources for the ClamAV auth-update process
+    resources:
+      requests:
+        memory: 128Mi
+        cpu: 100m
+      limits:
+        memory: 256Mi
+        cpu: 250m
+
+  clamd:
+    # -- Resources for the ClamAV scan process
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 100m
+      limits:
+        memory: 2Gi
+        cpu: 1
+
+functions:
+  # -- The maximum number of seconds allowed as a timeout value when creating a new function.
+  timeout: 900
+  # -- The maximum number of containers Appwrite is allowed to keep alive in the background for function environments. 
+  # Running containers allow faster execution time as there is no need to recreate each container every time a function gets executed.
+  containers: 10
+  # -- The maximum number of CPU core a single cloud function is allowed to use. 
+  # Please note that setting a value higher than available cores will result in a function error, which might result in an error. 
+  # When empty, CPU limit will be disabled.
+  cpus: 1
+  # -- The maximum amount of memory a single cloud function is allowed to use in megabytes. 
+  # When empty, memory limit will be disabled.
+  memory: 256Mb
+  # -- The maximum amount of swap memory a single cloud function is allowed to use in megabytes. 
+  # The default value is empty.
+  # When empty, swap memory limit will be disabled.
+  swap: 256Mb
+  # -- This option allows you to limit the available environments for cloud functions.
+  runtimes:
+    - node-16.0
+    - php-8.0
+    - python-3.9
+    - ruby-3.0
+    - java-16.0
+    - dart-2.14
+    - dotnet-5.0


### PR DESCRIPTION
## What does this PR do?

This is a Helm chart for deploying AppWrite on Kubernetes.
It's based of https://github.com/k3env/appwrite-helm.

## Test Plan

- Use Minikube to create a cluster: `minikube start --network-plugin=cni --cni=calico --addons ingress`
- Install InfluxDB: `helm -n monitoring install --create-namespace influxdb influxdata/influxdb`
- Create a key for secure storage: `openssl genrsa -out key.pem 2048`

Finally, install AppWrite: 
```bash
helm -n appwrite upgrade --install --create-namespace --set-file appwrite.sslKey=key.pem --dependency-update appwrite ./helm/
```
You can find the cluster's ip with `minikube ip`
Update your `/etc/hosts` with e.g: `192.168.49.2 appwrite.local`
Open `http://appwrite.local` with your browser, that's it.

Stuff that doesn't work:
- Usage stats
  - The usage service connects fine but I could not make it write data. (stats always at 0)
  - Doctor says everything is OK
- Executor
  - It would require interaction with the K8S API instead of using docker commands
  - Docker in Docker via Sysbox might work if installed on cluster.

Some more testing would be needed as I don't know the stack very well.
I originally used the SQL script bundled here (from `appwrite/mariadb`) but it seems like it's not needed.

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/24
- https://github.com/appwrite/appwrite/issues/364

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
