### PR TITLE
Fix email-base.tpl path in certificates worker

### DIFF
--- a/app/workers/certificates.php
+++ b/app/workers/certificates.php
@@ -383,7 +383,7 @@ class CertificatesV1 extends Worker
             $locale->setDefault('en');
         }
 
-        $body = Template::fromFile(__DIR__ . '/../../config/locale/templates/email-base.tpl');
+        $body = Template::fromFile(__DIR__ . '/../config/locale/templates/email-base.tpl');
 
             $subject = \sprintf($locale->getText("emails.certificate.subject"), $domain);
             $body->setParam('{{domain}}', $domain);


### PR DESCRIPTION
## What does this PR do?

The path in the worker needs to be corrected so it doesn't error out. 

![error](https://user-images.githubusercontent.com/1477010/230491745-3d6425a5-d8d3-4551-b370-8c24c4322406.jpg)

This fixes the path.

## Test Plan

None

## Related PRs and Issues

Previous PR:

* https://github.com/appwrite/appwrite/pull/4859

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
