### PR TITLE
fix: deletes worker deleting projects with console team

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 ## Bugs
 - Fix not storing function's response on response codes 5xx [#4610](https://github.com/appwrite/appwrite/pull/4610)
 - Fix expire to formatTz in create account session [#4985](https://github.com/appwrite/appwrite/pull/4985)
+- Fix deleting projects when organization is deleted [#5335](https://github.com/appwrite/appwrite/pull/5335)
 
 # Version 1.2.1
 ## Changes

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -58,6 +58,9 @@ class DeletesV1 extends Worker
                         break;
                     case DELETE_TYPE_TEAMS:
                         $this->deleteMemberships($document, $project->getId());
+                        if ($project->getId() === 'console') {
+                            $this->deleteProjectsByTeam($document);
+                        }
                         break;
                     case DELETE_TYPE_BUCKETS:
                         $this->deleteBucket($document, $project->getId());
@@ -261,6 +264,24 @@ class DeletesV1 extends Worker
         $this->deleteByGroup('memberships', [
             Query::equal('teamId', [$teamId])
         ], $this->getProjectDB($projectId));
+    }
+
+    /**
+     * @param \Utopia\Database\Document $document
+     * @return void
+     * @throws \Exception
+     */
+    protected function deleteProjectsByTeam(Document $document): void
+    {
+        $dbForConsole = $this->getConsoleDB();
+
+        $projects = $dbForConsole->find('projects', [
+            Query::equal('teamInternalId', [$document->getInternalId()])
+        ]);
+
+        foreach ($projects as $project) {
+            $this->deleteProject($project);
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

- delete projects when a team on the `console` project is deleted

## Test Plan

- manual

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
