### PR TITLE
Docs: Create document and unknown attribute error messages.

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2399,7 +2399,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/indexes')
             $attributeIndex = \array_search($attribute, array_column($oldAttributes, 'key'));
 
             if ($attributeIndex === false) {
-                throw new Exception(Exception::ATTRIBUTE_UNKNOWN, 'Unknown attribute: ' . $attribute);
+                throw new Exception(Exception::ATTRIBUTE_UNKNOWN, 'Unknown attribute: ' . $attribute . '. Verify the attribute name or create the attribute.");
             }
 
             $attributeStatus = $oldAttributes[$attributeIndex]['status'];

--- a/docs/references/databases/create-document.md
+++ b/docs/references/databases/create-document.md
@@ -1,1 +1,1 @@
-Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](/docs/server/databases#databasesCreateCollection) API or directly from your database console.
+Create a new document. Before using this route, you should create a new collection and at least one attribute using either a [server integration](/docs/server/databases#databasesCreateCollection) API or directly from the Appwrite Console.


### PR DESCRIPTION
…own attribute.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Create document description doesn't warn users to create an attribute first
- Improve the error message with some suggested next steps.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- https://github.com/appwrite/website/issues/677

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
