### PR TITLE
fix: project deletion leftovers

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -1237,7 +1237,7 @@ App::get('/v1/projects/:projectId/platforms')
         }
 
         $platforms = $dbForConsole->find('platforms', [
-            Query::equal('projectId', [$project->getId()]),
+            Query::equal('projectInternalId', [$project->getInternalId()]),
             Query::limit(5000),
         ]);
 

--- a/app/workers/deletes.php
+++ b/app/workers/deletes.php
@@ -9,7 +9,6 @@ use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Appwrite\Resque\Worker;
 use Executor\Executor;
-use Utopia\Storage\Device\Local;
 use Utopia\Abuse\Abuse;
 use Utopia\Abuse\Adapters\TimeLimit;
 use Utopia\CLI\Console;
@@ -291,12 +290,13 @@ class DeletesV1 extends Worker
     protected function deleteProject(Document $document): void
     {
         $projectId = $document->getId();
+        $projectInternalId = $document->getInternalId();
 
-        // Delete project domains and certificates
+        // Delete project certificates
         $dbForConsole = $this->getConsoleDB();
 
         $domains = $dbForConsole->find('domains', [
-            Query::equal('projectInternalId', [$document->getInternalId()])
+            Query::equal('projectInternalId', [$projectInternalId])
         ]);
 
         foreach ($domains as $domain) {
@@ -317,6 +317,21 @@ class DeletesV1 extends Worker
                 $dbForProject->deleteCollection($collection->getId());
             }
         }
+
+        // Delete Platforms
+        $this->deleteByGroup('platforms', [
+            Query::equal('projectInternalId', [$projectInternalId])
+        ], $dbForConsole);
+
+        // Delete Domains
+        $this->deleteByGroup('domains', [
+            Query::equal('projectInternalId', [$projectInternalId])
+        ], $dbForConsole);
+
+        // Delete Keys
+        $this->deleteByGroup('keys', [
+            Query::equal('projectInternalId', [$projectInternalId])
+        ], $dbForConsole);
 
         // Delete metadata tables
         try {


### PR DESCRIPTION
## What does this PR do?

- uses the `projectInternalId` to fetch platforms
- removes domains, keys and platforms with the deletes worker if project is deleted

## Test Plan

- manual

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
