### PR TITLE
Fix the release github action job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests:
-    name: Unit & E2E
+    name: Release
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What does this PR do?

Fix the name so that it doesn't show up as "Unit & E2E" on GitHub:

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/1477010/235239777-3c6614e4-5faf-40e9-b76a-a6ade498d582.png">

## Test Plan

None

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
