### PR TITLE
Update install.php to not specify docker-compose.yml file

### DIFF
--- a/app/tasks/install.php
+++ b/app/tasks/install.php
@@ -224,9 +224,9 @@ $cli
             }
         }
 
-        Console::log("Running \"docker compose -f {$path}/docker-compose.yml up -d --remove-orphans --renew-anon-volumes\"");
+        Console::log("Running \"docker compose up -d --remove-orphans --renew-anon-volumes\"");
 
-        $exit = Console::execute("${env} docker compose -f {$path}/docker-compose.yml up -d --remove-orphans --renew-anon-volumes", '', $stdout, $stderr);
+        $exit = Console::execute("${env} docker compose --project-directory {$path} up -d --remove-orphans --renew-anon-volumes", '', $stdout, $stderr);
 
         if ($exit !== 0) {
             $message = 'Failed to install Appwrite dockers';


### PR DESCRIPTION
## What does this PR do?

By not specifying a docker-compose.yml file, docker compose automatically uses the docker-compose.yml file in the project directory and a docker-compose.override.yml file if one is present.

## Test Plan

Manual:

<img width="996" alt="image" src="https://user-images.githubusercontent.com/1477010/235373081-7982b75d-42ac-4218-acf0-ab9f29524098.png">


## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/4700

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
