### PR TITLE
fix : Improper filter in Create user

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -190,6 +190,11 @@ return [
         'description' => 'Missing ID from OAuth2 provider.',
         'code' => 400,
     ],
+    Exception::INVALID_USERNAME => [
+        'name' => Exception::INVALID_USERNAME,
+        'description' => 'Username must be a valid string and not contain any links.',
+        'code' => 409,
+    ],
 
     /** Teams */
     Exception::TEAM_NOT_FOUND => [

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -97,6 +97,11 @@ App::post('/v1/account')
                 throw new Exception(Exception::USER_COUNT_EXCEEDED);
             }
         }
+        
+        $regex = '(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])';
+        if (!preg_match($regex, $name)) {
+            throw new Exception(Exception::INVALID_USERNAME);
+        }
 
         $passwordHistory = $project->getAttribute('auths', [])['passwordHistory'] ?? 0;
         $password = Auth::passwordHash($password, Auth::DEFAULT_ALGO, Auth::DEFAULT_ALGO_OPTIONS);

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -74,6 +74,7 @@ class Exception extends \Exception
     public const USER_PHONE_ALREADY_EXISTS         = 'user_phone_already_exists';
     public const USER_PHONE_NOT_FOUND              = 'user_phone_not_found';
     public const USER_MISSING_ID                   = 'user_missing_id';
+    public const INVALID_USERNAME                  = 'invalid_username';
 
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';


### PR DESCRIPTION

## What does this PR do?

This PR fixes #5466 with the filter in the create user feature. The filter was improperly implemented, which could allow users to create accounts with links/URLs in their usernames without blocking them.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- #5466 #5468 

## Checklist

- [ ] I have read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)

