### PR TITLE
[FIX] #5506 fixed by increasing the offset from 5000 to 1000000 for li…

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2926,7 +2926,7 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/documents')
         $filterQueries = Query::groupByType($queries)['filters'];
 
         $documents = $dbForProject->find('database_' . $database->getInternalId() . '_collection_' . $collection->getInternalId(), $queries);
-        $total = $dbForProject->count('database_' . $database->getInternalId() . '_collection_' . $collection->getInternalId(), $filterQueries, APP_LIMIT_COUNT);
+        $total = $dbForProject->count('database_' . $database->getInternalId() . '_collection_' . $collection->getInternalId(), $filterQueries, APP_LIMIT_DOCUMENT_COUNT);
 
         // Add $collectionId and $databaseId for all documents
         $processDocument = function (Document $collection, Document $document) use (&$processDocument, $dbForProject, $database): bool {

--- a/app/init.php
+++ b/app/init.php
@@ -98,6 +98,7 @@ const APP_LIMIT_SUBQUERY = 1000;
 const APP_LIMIT_WRITE_RATE_DEFAULT = 60; // Default maximum write rate per rate period
 const APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT = 60; // Default maximum write rate period in seconds
 const APP_LIMIT_LIST_DEFAULT = 25; // Default maximum number of items to return in list API calls
+const APP_LIMIT_DOCUMENT_COUNT = 1000000;  // Maximum offset for documents
 const APP_KEY_ACCCESS = 24 * 60 * 60; // 24 hours
 const APP_CACHE_UPDATE = 24 * 60 * 60; // 24 hours
 const APP_CACHE_BUSTER = 503;


### PR DESCRIPTION
…st documents pagination

#5006 fixed with adding APP_LIMIT_DOCUMENT_COUNT new variable added in init.php with value as 1000000

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Increases the pagination offset for list documents from 5000 to 1000000. Increased for this - https://appwrite.io/docs/pagination

## Test Plan

Not needed

## Related PRs and Issues

- #5506 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
