### PR TITLE
Fix the routing for the default OAuth2 pages

### DIFF
--- a/app/controllers/web/console.php
+++ b/app/controllers/web/console.php
@@ -5,10 +5,11 @@ use Utopia\App;
 
 App::get('/console/*')
     ->alias('/')
+    ->alias('auth/*')
     ->alias('/invite')
     ->alias('/login')
     ->alias('/recover')
-    ->alias('/register')
+    ->alias('/register/*')
     ->groups(['web'])
     ->label('permission', 'public')
     ->label('scope', 'home')

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -160,4 +160,15 @@ class HTTPTest extends Scope
         $this->assertIsString($body['server-ruby']);
         $this->assertIsString($body['console-cli']);
     }
+
+    public function testDefaultOAuth2()
+    {
+        $response = $this->client->call(Client::METHOD_GET, '/auth/oauth2/success', $this->getHeaders());
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/auth/oauth2/failure', $this->getHeaders());
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Without this, you would get a 404 trying to browse to the default OAuth2 pages.

## Test Plan

Added a new e2e test

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/5623

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
