### PR TITLE
Add support for multiple events per endpoint

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -79,11 +79,15 @@ function createAttribute(string $databaseId, string $collectionId, Document $att
         throw new Exception(Exception::DATABASE_NOT_FOUND);
     }
 
+    $events->setContext('database', $db);
+
     $collection = $dbForProject->getDocument('database_' . $db->getInternalId(), $collectionId);
 
     if ($collection->isEmpty()) {
         throw new Exception(Exception::COLLECTION_NOT_FOUND);
     }
+
+    $events->setContext('collection', $collection);
 
     if (!empty($format)) {
         if (!Structure::hasFormat($format, $type)) {
@@ -197,8 +201,6 @@ function createAttribute(string $databaseId, string $collectionId, Document $att
     ;
 
     $events
-        ->setContext('collection', $collection)
-        ->setContext('database', $db)
         ->setParam('databaseId', $databaseId)
         ->setParam('collectionId', $collection->getId())
         ->setParam('attributeId', $attribute->getId())
@@ -230,11 +232,15 @@ function updateAttribute(
         throw new Exception(Exception::DATABASE_NOT_FOUND);
     }
 
+    $events->setContext('database', $db);
+
     $collection = $dbForProject->getDocument('database_' . $db->getInternalId(), $collectionId);
 
     if ($collection->isEmpty()) {
         throw new Exception(Exception::COLLECTION_NOT_FOUND);
     }
+
+    $events->setContext('collection', $collection);
 
     $attribute = $dbForProject->getDocument('attributes', $db->getInternalId() . '_' . $collection->getInternalId() . '_' . $key);
 
@@ -359,8 +365,6 @@ function updateAttribute(
     $dbForProject->deleteCachedDocument('database_' . $db->getInternalId(), $collection->getId());
 
     $events
-        ->setContext('collection', $collection)
-        ->setContext('database', $db)
         ->setParam('databaseId', $databaseId)
         ->setParam('collectionId', $collection->getId())
         ->setParam('attributeId', $attribute->getId());
@@ -731,6 +735,8 @@ App::post('/v1/databases/:databaseId/collections')
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 
+        $events->setContext('database', $database);
+
         $collectionId = $collectionId == 'unique()' ? ID::unique() : $collectionId;
 
         // Map aggregate permissions into the multiple permissions they represent.
@@ -757,7 +763,6 @@ App::post('/v1/databases/:databaseId/collections')
         }
 
         $events
-            ->setContext('database', $database)
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId());
 
@@ -990,6 +995,8 @@ App::put('/v1/databases/:databaseId/collections/:collectionId')
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 
+        $events->setContext('database', $database);
+
         $collection = $dbForProject->getDocument('database_' . $database->getInternalId(), $collectionId);
 
         if ($collection->isEmpty()) {
@@ -1018,7 +1025,6 @@ App::put('/v1/databases/:databaseId/collections/:collectionId')
         }
 
         $events
-            ->setContext('database', $database)
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId());
 
@@ -1056,6 +1062,8 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId')
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 
+        $events->setContext('database', $database);
+
         $collection = $dbForProject->getDocument('database_' . $database->getInternalId(), $collectionId);
 
         if ($collection->isEmpty()) {
@@ -1073,7 +1081,6 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId')
             ->setDocument($collection);
 
         $events
-            ->setContext('database', $database)
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId())
             ->setPayload($response->output($collection, Response::MODEL_COLLECTION));
@@ -2231,11 +2238,16 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId/attributes/:key
         if ($db->isEmpty()) {
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
+
+        $events->setContext('database', $db);
+
         $collection = $dbForProject->getDocument('database_' . $db->getInternalId(), $collectionId);
 
         if ($collection->isEmpty()) {
             throw new Exception(Exception::COLLECTION_NOT_FOUND);
         }
+
+        $events->setContext('collection', $collection);
 
         $attribute = $dbForProject->getDocument('attributes', $db->getInternalId() . '_' . $collection->getInternalId() . '_' . $key);
 
@@ -2346,11 +2358,16 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/indexes')
         if ($db->isEmpty()) {
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
+
+        $events->setContext('database', $db);
+
         $collection = $dbForProject->getDocument('database_' . $db->getInternalId(), $collectionId);
 
         if ($collection->isEmpty()) {
             throw new Exception(Exception::COLLECTION_NOT_FOUND);
         }
+
+        $events->setContext('collection', $collection);
 
         $count = $dbForProject->count('indexes', [
             Query::equal('collectionInternalId', [$collection->getInternalId()]),
@@ -2455,9 +2472,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/indexes')
         $events
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId())
-            ->setParam('indexId', $index->getId())
-            ->setContext('collection', $collection)
-            ->setContext('database', $db);
+            ->setParam('indexId', $index->getId());
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -2580,11 +2595,16 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId/indexes/:key')
         if ($db->isEmpty()) {
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
+
+        $events->setContext('database', $db);
+
         $collection = $dbForProject->getDocument('database_' . $db->getInternalId(), $collectionId);
 
         if ($collection->isEmpty()) {
             throw new Exception(Exception::COLLECTION_NOT_FOUND);
         }
+
+        $events->setContext('collection', $collection);
 
         $index = $dbForProject->getDocument('indexes', $db->getInternalId() . '_' . $collection->getInternalId() . '_' . $key);
 
@@ -2609,8 +2629,6 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId/indexes/:key')
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId())
             ->setParam('indexId', $index->getId())
-            ->setContext('collection', $collection)
-            ->setContext('database', $db)
             ->setPayload($response->output($index, Response::MODEL_INDEX));
 
         $response->noContent();
@@ -2666,6 +2684,8 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/documents')
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 
+        $events->setContext('database', $database);
+
         $collection = Authorization::skip(fn() => $dbForProject->getDocument('database_' . $database->getInternalId(), $collectionId));
 
         if ($collection->isEmpty() || !$collection->getAttribute('enabled')) {
@@ -2673,6 +2693,8 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/documents')
                 throw new Exception(Exception::COLLECTION_NOT_FOUND);
             }
         }
+
+        $events->setContext('collection', $collection);
 
         $allowedPermissions = [
             Database::PERMISSION_READ,
@@ -2847,9 +2869,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/documents')
         $events
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId())
-            ->setParam('documentId', $document->getId())
-            ->setContext('collection', $collection)
-            ->setContext('database', $database);
+            ->setParam('documentId', $document->getId());
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
@@ -3231,6 +3251,8 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 
+        $events->setContext('database', $database);
+
         $collection = Authorization::skip(fn() => $dbForProject->getDocument('database_' . $database->getInternalId(), $collectionId));
 
         if ($collection->isEmpty() || !$collection->getAttribute('enabled')) {
@@ -3238,6 +3260,8 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
                 throw new Exception(Exception::COLLECTION_NOT_FOUND);
             }
         }
+
+        $events->setContext('collection', $collection);
 
         // Read permission should not be required for update
         /** @var Document $document */
@@ -3424,9 +3448,7 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
         $events
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId())
-            ->setParam('documentId', $document->getId())
-            ->setContext('collection', $collection)
-            ->setContext('database', $database);
+            ->setParam('documentId', $document->getId());
 
         $response->dynamic($document, Response::MODEL_DOCUMENT);
     });
@@ -3469,6 +3491,8 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId/documents/:docu
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 
+        $events->setContext('database', $database);
+
         $collection = Authorization::skip(fn() => $dbForProject->getDocument('database_' . $database->getInternalId(), $collectionId));
 
         if ($collection->isEmpty() || !$collection->getAttribute('enabled')) {
@@ -3476,6 +3500,8 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId/documents/:docu
                 throw new Exception(Exception::COLLECTION_NOT_FOUND);
             }
         }
+
+        $events->setContext('collection', $collection);
 
         // Read permission should not be required for delete
         $document = Authorization::skip(fn() => $dbForProject->getDocument('database_' . $database->getInternalId() . '_collection_' . $collection->getInternalId(), $documentId));
@@ -3590,8 +3616,6 @@ App::delete('/v1/databases/:databaseId/collections/:collectionId/documents/:docu
             ->setParam('databaseId', $databaseId)
             ->setParam('collectionId', $collection->getId())
             ->setParam('documentId', $document->getId())
-            ->setContext('collection', $collection)
-            ->setContext('database', $database)
             ->setPayload($response->output($document, Response::MODEL_DOCUMENT));
 
         $response->noContent();

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -1041,6 +1041,8 @@ App::post('/v1/functions/:functionId/executions')
             }
         }
 
+        $events->setContext('function', $function);
+
         $runtimes = Config::getParam('runtimes', []);
 
         $runtime = (isset($runtimes[$function->getAttribute('runtime', '')])) ? $runtimes[$function->getAttribute('runtime', '')] : null;
@@ -1115,8 +1117,7 @@ App::post('/v1/functions/:functionId/executions')
 
         $events
             ->setParam('functionId', $function->getId())
-            ->setParam('executionId', $execution->getId())
-            ->setContext('function', $function);
+            ->setParam('executionId', $execution->getId());
 
         if ($async) {
             $event = new Func();

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -368,6 +368,8 @@ App::post('/v1/storage/buckets/:bucketId/files')
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
 
+        $events->setContext('bucket', $bucket);
+
         $validator = new Authorization(Database::PERMISSION_CREATE);
         if (!$validator->isValid($bucket->getCreate())) {
             throw new Exception(Exception::USER_UNAUTHORIZED);
@@ -651,7 +653,6 @@ App::post('/v1/storage/buckets/:bucketId/files')
         $events
             ->setParam('bucketId', $bucket->getId())
             ->setParam('fileId', $file->getId())
-            ->setContext('bucket', $bucket)
         ;
 
         $deletes
@@ -1284,6 +1285,8 @@ App::put('/v1/storage/buckets/:bucketId/files/:fileId')
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
 
+        $events->setContext('bucket', $bucket);
+
         $fileSecurity = $bucket->getAttributes('fileSecurity', false);
         $validator = new Authorization(Database::PERMISSION_UPDATE);
         $valid = $validator->isValid($bucket->getUpdate());
@@ -1349,7 +1352,6 @@ App::put('/v1/storage/buckets/:bucketId/files/:fileId')
         $events
             ->setParam('bucketId', $bucket->getId())
             ->setParam('fileId', $file->getId())
-            ->setContext('bucket', $bucket)
         ;
 
         $response->dynamic($file, Response::MODEL_FILE);
@@ -1388,6 +1390,8 @@ App::delete('/v1/storage/buckets/:bucketId/files/:fileId')
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && $mode !== APP_MODE_ADMIN)) {
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
+
+        $events->setContext('bucket', $bucket);
 
         $fileSecurity = $bucket->getAttributes('fileSecurity', false);
         $validator = new Authorization(Database::PERMISSION_DELETE);
@@ -1444,7 +1448,6 @@ App::delete('/v1/storage/buckets/:bucketId/files/:fileId')
         $events
             ->setParam('bucketId', $bucket->getId())
             ->setParam('fileId', $file->getId())
-            ->setContext('bucket', $bucket)
             ->setPayload($response->output($file, Response::MODEL_FILE))
         ;
 

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1114,6 +1114,8 @@ App::delete('/v1/users/:userId')
         // clone user object to send to workers
         $clone = clone $user;
 
+        $events->setContext('user', $clone);
+
         $dbForProject->deleteDocument('users', $userId);
 
         $deletes

--- a/app/init.php
+++ b/app/init.php
@@ -23,6 +23,7 @@ use Ahc\Jwt\JWTException;
 use Appwrite\Auth\Auth;
 use Appwrite\DSN\DSN;
 use Appwrite\Event\Audit;
+use Appwrite\Event\DatabaseListener;
 use Appwrite\Event\Database as EventDatabase;
 use Appwrite\Event\Delete;
 use Appwrite\Event\Event;
@@ -1180,3 +1181,10 @@ App::setResource('requestTimestamp', function ($request) {
     }
     return $requestTimestamp;
 }, ['request']);
+
+App::setResource('eventHandler', function (?Logger $logger, array $loggerBreadcrumbs, Document $project, Document $user, Event $events, Locale $locale) {
+    return function (string $databaseEvent, Document $document) use ($logger, $loggerBreadcrumbs, $project, $user, $events, $locale) {
+        $listener = new DatabaseListener($logger, $loggerBreadcrumbs, $project, $user, $events, $locale);
+        $listener->handle($databaseEvent, $document);
+    };
+}, ['logger', 'loggerBreadcrumbs', 'project', 'user', 'events', 'locale']);

--- a/src/Appwrite/Event/DatabaseListener.php
+++ b/src/Appwrite/Event/DatabaseListener.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace Appwrite\Event;
+
+use Appwrite\Auth\Auth;
+use Appwrite\Messaging\Adapter\Realtime;
+use Appwrite\Utopia\Response;
+use Swoole\Http\Response as SwooleResponse;
+use Utopia\App;
+use Utopia\Database\Database;
+use Utopia\Database\DateTime;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\Authorization;
+use Utopia\Locale\Locale;
+use Utopia\Logger\Log;
+use Utopia\Logger\Log\User;
+use Utopia\Logger\Logger;
+
+class DatabaseListener {
+    protected ?Logger $logger;
+    protected array $loggerBreadcrumbs;
+    protected Document $project;
+    protected Document $user;
+    protected Event $events;
+    protected Locale $locale;
+
+    public function __construct(?Logger $logger, array $loggerBreadcrumbs, Document $project, Document $user, Event $events, Locale $locale)
+    {
+        $this->logger = $logger;
+        $this->loggerBreadcrumbs = $loggerBreadcrumbs;
+        $this->project = $project;
+        $this->user = $user;
+        $this->events = $events;
+        $this->locale = $locale;
+    }
+
+    public function handle(string $databaseEvent, Document $document)
+    {
+        $response = new Response(new SwooleResponse());
+        $dump = function ($value) {
+            $p = var_export($value, true);
+            $b = debug_backtrace();
+            print($b[0]['file'] . ':' . $b[0]['line'] . ' - ' . $p . "\n");
+        };
+        try {
+            $event = new Event('', '');
+
+            $event
+                ->setProject($this->project)
+                ->setUser($this->user);
+
+            $eventPattern = $this->events->getEvent();
+            $collection = $document->getCollection();
+            $dump($databaseEvent);
+            $dump($collection);
+
+            $action = match ($databaseEvent) {
+                Database::EVENT_DOCUMENT_CREATE => '.create',
+                Database::EVENT_DOCUMENT_UPDATE => '.update',
+                Database::EVENT_DOCUMENT_DELETE => '.delete',
+            };
+
+            // Create a copy of the document to avoid any changes to the original
+            $document = new Document($document->getArrayCopy());
+
+            switch ($collection) {
+                case 'users':
+                    $modelType = Response::MODEL_USER;
+                    if (!\str_starts_with($eventPattern, 'users.[userId].update')) {
+                        $eventPattern = 'users.[userId]' . $action;
+                    }
+
+                    $event->setParam('userId', $document->getId());
+                    break;
+                case 'sessions':
+                    $modelType = Response::MODEL_SESSION;
+                    $eventPattern = 'users.[userId].sessions.[sessionId]' . $action;
+
+                    $current = $document->getAttribute('secret') == Auth::hash(Auth::$secret);
+                    $countryName = $this->locale->getText('countries.' . strtolower($document->getAttribute('countryCode')), $this->locale->getText('locale.country.unknown'));
+                    $expire = DateTime::addSeconds(new \DateTime($document->getCreatedAt()), Auth::TOKEN_EXPIRATION_LOGIN_LONG);
+                    $document
+                        ->setAttribute('current', $current)
+                        ->setAttribute('countryName', $countryName)
+                        ->setAttribute('expire', $expire);
+
+                    $event
+                        ->setParam('userId', $document->getAttribute('userId'))
+                        ->setParam('sessionId', $document->getId());
+                    break;
+                case 'tokens':
+                    $modelType = Response::MODEL_TOKEN;
+
+                    $tokenType = $document->getAttribute('type');
+                    $eventPattern = match($tokenType) {
+                        Auth::TOKEN_TYPE_VERIFICATION, Auth::TOKEN_TYPE_PHONE => 'users.[userId].verification.[tokenId]',
+                        Auth::TOKEN_TYPE_RECOVERY => 'users.[userId].recovery.[tokenId]',
+                        default => '',
+                    };
+
+                    if (empty($eventPattern)) {
+                        return;
+                    }
+
+                    $eventPattern .= match ($databaseEvent) {
+                        Database::EVENT_DOCUMENT_CREATE => '.create',
+                        // We act like we're updating and validating the 
+                        // token but actually we don't need it anymore.
+                        Database::EVENT_DOCUMENT_DELETE => '.update', 
+                    };
+
+                    $token = $this->events->getContext('token');
+                    $secret = $token->getAttribute('secret', null);
+
+                    $document->setAttribute('secret', $secret);
+
+                    $event
+                        ->setParam('userId', $document->getAttribute('userId'))
+                        ->setParam('tokenId', $document->getId());
+                    break;
+                case 'teams':
+                    $modelType = Response::MODEL_TEAM;
+                    if ($eventPattern !== 'teams.[teamId].update.prefs') {
+                        $eventPattern = 'teams.[teamId]' . $action;
+                    }
+
+                    $event->setParam('teamId', $document->getId());
+                    break;
+                case 'memberships':
+                    $modelType = Response::MODEL_MEMBERSHIP;
+                    $eventPattern = 'teams.[teamId].memberships.[membershipId]' . $action;
+
+                    $team = $this->events->getContext('team');
+                    $user = $this->events->getContext('user');
+
+                    $event
+                        ->setParam('teamId', $document->getAttribute('teamId'))
+                        ->setParam('membershipId', $document->getId());
+
+                    $document
+                        ->setAttribute('teamName', $team->getAttribute('name'))
+                        ->setAttribute('userName', $user->getAttribute('name'))
+                        ->setAttribute('userEmail', $user->getAttribute('email'));
+                    break;
+                case 'databases':
+                    $modelType = Response::MODEL_DATABASE;
+                    $eventPattern = 'databases.[databaseId]' . $action;
+                    $event->setParam('databaseId', $document->getId());
+                    break;
+                case 'attributes':
+                    $eventPattern = 'databases.[databaseId].collections.[collectionId].attributes.[attributeId]' . $action;
+                    $database = $this->events->getContext('database');
+                    $collection = $this->events->getContext('collection');
+                    $event
+                        ->setContext('database', $database)
+                        ->setContext('collection', $collection);
+
+                    $event
+                        ->setParam('databaseId', $database->getId())
+                        ->setParam('collectionId', $collection->getId())
+                        ->setParam('attributeId', $document->getId());
+
+                    // Select response model based on type and format
+                    $type = $document->getAttribute('type');
+                    $format = $document->getAttribute('format');
+                    $modelType = match ($type) {
+                        Database::VAR_BOOLEAN => Response::MODEL_ATTRIBUTE_BOOLEAN,
+                        Database::VAR_INTEGER => Response::MODEL_ATTRIBUTE_INTEGER,
+                        Database::VAR_FLOAT => Response::MODEL_ATTRIBUTE_FLOAT,
+                        Database::VAR_DATETIME => Response::MODEL_ATTRIBUTE_DATETIME,
+                        Database::VAR_RELATIONSHIP => Response::MODEL_ATTRIBUTE_RELATIONSHIP,
+                        Database::VAR_STRING => match ($format) {
+                            APP_DATABASE_ATTRIBUTE_EMAIL => Response::MODEL_ATTRIBUTE_EMAIL,
+                            APP_DATABASE_ATTRIBUTE_ENUM => Response::MODEL_ATTRIBUTE_ENUM,
+                            APP_DATABASE_ATTRIBUTE_IP => Response::MODEL_ATTRIBUTE_IP,
+                            APP_DATABASE_ATTRIBUTE_URL => Response::MODEL_ATTRIBUTE_URL,
+                            default => Response::MODEL_ATTRIBUTE_STRING,
+                        },
+                        default => Response::MODEL_ATTRIBUTE,
+                    };
+
+                    break;
+                case 'indexes':
+                    $modelType = Response::MODEL_INDEX;
+                    $eventPattern = 'databases.[databaseId].collections.[collectionId].indexes.[indexId]' . $action;
+                    $database = $this->events->getContext('database');
+                    $collection = $this->events->getContext('collection');
+                    $event
+                        ->setContext('database', $database)
+                        ->setContext('collection', $collection);
+
+                    $event
+                        ->setParam('databaseId', $database->getId())
+                        ->setParam('collectionId', $collection->getId())
+                        ->setParam('indexId', $document->getId());
+                    break;
+                case 'buckets':
+                    $modelType = Response::MODEL_BUCKET;
+                    $eventPattern = 'buckets.[bucketId]' . $action;
+
+                    $event->setParam('bucketId', $document->getId());
+                    break;
+                case \str_starts_with($collection, 'bucket_'):
+                    $modelType = Response::MODEL_FILE;
+                    $eventPattern = 'buckets.[bucketId].files.[fileId]' . $action;
+
+                    $bucket = $this->events->getContext('bucket');
+                    $event->setContext('bucket', $bucket);
+
+                    $event
+                        ->setParam('bucketId', $bucket->getId())
+                        ->setParam('fileId', $document->getId());
+                    break;
+                case 'functions':
+                    $modelType = Response::MODEL_FUNCTION;
+                    $eventPattern = 'functions.[functionId]' . $action;
+
+                    $event->setParam('functionId', $document->getId());
+                    break;
+                case 'deployments':
+                    $modelType = Response::MODEL_DEPLOYMENT;
+                    $eventPattern = 'functions.[functionId].deployments.[deploymentId]' . $action;
+
+                    $event
+                        ->setParam('functionId', $document->getAttribute('resourceId'))
+                        ->setParam('deploymentId', $document->getId());
+                    break;
+                case 'executions':
+                    $modelType = Response::MODEL_EXECUTION;
+                    $eventPattern = 'functions.[functionId].executions.[executionId]' . $action;
+        
+                    $function = $this->events->getContext('function');
+                    $event->setContext('function', $function);
+
+                    $event
+                        ->setParam('functionId', $function->getId())
+                        ->setParam('executionId', $document->getId());
+                    break;
+                case \str_starts_with($collection, 'database_'):
+                    if (\str_contains($collection, '_collection_')) {
+                        $modelType = Response::MODEL_DOCUMENT;
+                        $eventPattern = 'databases.[databaseId].collections.[collectionId].documents.[documentId]' . $action;
+
+                        $database = $this->events->getContext('database');
+                        $collection = $this->events->getContext('collection');
+
+                        $document->setAttribute('$databaseId', $database->getId());
+                        $document->setAttribute('$collectionId', $collection->getId());
+
+                        $event
+                            ->setContext('database', $database)
+                            ->setContext('collection', $collection);
+
+                        $event
+                            ->setParam('databaseId', $database->getId())
+                            ->setParam('collectionId', $collection->getId())
+                            ->setParam('documentId', $document->getId());
+                    } else {
+                        $modelType = Response::MODEL_COLLECTION;
+                        $eventPattern = 'databases.[databaseId].collections.[collectionId]' . $action;
+
+                        $database = $this->events->getContext('database');
+                        $event->setContext('database', $database);
+
+                        $event
+                            ->setParam('databaseId', $database->getId())
+                            ->setParam('collectionId', $document->getId());
+                    }
+                    break;
+                default:
+                    return;
+            }
+
+            $event->setEvent($eventPattern);
+
+            $payload = $response->output($document, $modelType);
+            $event->setPayload($payload);
+
+            $dump($event->getEvent());
+            $dump($event->getParams());
+            $dump($event->getPayload());
+
+            /**
+             * Trigger functions.
+             */
+            $event
+                ->setClass(Event::FUNCTIONS_CLASS_NAME)
+                ->setQueue(Event::FUNCTIONS_QUEUE_NAME)
+                ->trigger();
+
+            /**
+             * Trigger webhooks.
+             */
+            $event
+                ->setClass(Event::WEBHOOK_CLASS_NAME)
+                ->setQueue(Event::WEBHOOK_QUEUE_NAME)
+                ->trigger();
+
+            /**
+             * Trigger realtime.
+             */
+            if ($this->project->getId() !== 'console') {
+                $allEvents = Event::generateEvents($event->getEvent(), $event->getParams());
+                $payload = new Document($event->getPayload());
+
+                if ($payload->getAttribute('secret') !== null) {
+                    $payload->setAttribute('secret', '');
+                }
+
+                $db = $event->getContext('database');
+                $collection = $event->getContext('collection');
+                $bucket = $event->getContext('bucket');
+
+                $target = Realtime::fromPayload(
+                    // Pass first, most verbose event pattern
+                    event: $allEvents[0],
+                    payload: $payload,
+                    project: $this->project,
+                    database: $db,
+                    collection: $collection,
+                    bucket: $bucket,
+                );
+
+                Realtime::send(
+                    projectId: $target['projectId'] ?? $this->project->getId(),
+                    payload: $event->getPayload(),
+                    events: $allEvents,
+                    channels: $target['channels'],
+                    roles: $target['roles'],
+                    options: [
+                        'permissionsChanged' => $target['permissionsChanged'],
+                        'userId' => $event->getParam('userId')
+                    ]
+                );
+            }
+        } catch (\Throwable $th) {
+            $dump($th->getMessage());
+            if (empty($logger)) {
+                return;
+            }
+
+            $log = new Log();
+
+            if (isset($user) && !$user->isEmpty()) {
+                $log->setUser(new User($user->getId()));
+            }
+
+            $log->setNamespace("http");
+            $log->setServer(\gethostname());
+            $log->setVersion(App::getEnv('_APP_VERSION', 'UNKNOWN'));
+            $log->setType(Log::TYPE_ERROR);
+            $log->setMessage($th->getMessage());
+
+            $log->addTag('verboseType', get_class($th));
+            $log->addTag('code', $th->getCode());
+            $log->addTag('projectId', $this->project->getId());
+            $log->addTag('locale', $this->locale->default);
+
+            $log->addExtra('file', $th->getFile());
+            $log->addExtra('line', $th->getLine());
+            $log->addExtra('trace', $th->getTraceAsString());
+            $log->addExtra('detailedTrace', $th->getTrace());
+            $log->addExtra('roles', Authorization::getRoles());
+
+            $log->setAction($action);
+
+            $isProduction = App::getEnv('_APP_ENV', 'development') === 'production';
+            $log->setEnvironment($isProduction ? Log::ENVIRONMENT_PRODUCTION : Log::ENVIRONMENT_STAGING);
+
+            foreach ($this->loggerBreadcrumbs as $loggerBreadcrumb) {
+                $log->addBreadcrumb($loggerBreadcrumb);
+            }
+
+            $logger->addLog($log);
+        }
+    }
+}

--- a/src/Appwrite/Utopia/Response/Model/User.php
+++ b/src/Appwrite/Utopia/Response/Model/User.php
@@ -119,7 +119,7 @@ class User extends Model
     /**
      * Get Collection
      *
-     * @return string
+     * @return Document
      */
     public function filter(Document $document): Document
     {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Trigger events using database listeners

We initially designed events to trigger via labels on the endpoint. the problem with this approach was triggering multiple events per endpoint became very messy.

## Test Plan

TBD

## Related PRs and Issues

- #2406 
- https://github.com/appwrite/appwrite/issues/5198

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
