### PR TITLE
Restrict characters for project ID

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -9,7 +9,7 @@ use Appwrite\Network\Validator\CNAME;
 use Utopia\Validator\Domain as DomainValidator;
 use Appwrite\Network\Validator\Origin;
 use Utopia\Validator\URL;
-use Appwrite\Utopia\Database\Validator\CustomId;
+use Appwrite\Utopia\Database\Validator\ProjectId;
 use Appwrite\Utopia\Response;
 use Utopia\Abuse\Adapters\TimeLimit;
 use Utopia\App;
@@ -56,7 +56,7 @@ App::post('/v1/projects')
     ->label('sdk.response.code', Response::STATUS_CODE_CREATED)
     ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
     ->label('sdk.response.model', Response::MODEL_PROJECT)
-    ->param('projectId', '', new CustomId(), 'Unique Id. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.')
+    ->param('projectId', '', new ProjectId(), 'Unique Id. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, and hyphen. Can\'t start with a special char. Max length is 36 chars.')
     ->param('name', null, new Text(128), 'Project name. Max length: 128 chars.')
     ->param('teamId', '', new UID(), 'Team unique ID.')
     ->param('region', App::getEnv('_APP_REGION', 'default'), new Whitelist(array_keys(array_filter(Config::getParam('regions'), fn($config) => !$config['disabled']))), 'Project Region.', true)

--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Appwrite\Utopia\Database\Validator;
+
+use Utopia\Validator;
+
+class ProjectId extends Validator
+{
+    /**
+     * Is valid.
+     *
+     * Returns true if valid or false if not.
+     *
+     * @param $value
+     *
+     * @return bool
+     */
+    public function isValid($value): bool
+    {
+        return $value == 'unique()' || preg_match('/^[a-z0-9][a-z0-9-]{1,35}$/', $value);
+    }
+
+    /**
+     * Get description.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and hyphen. Can\'t start with a special char.';
+    }
+
+    /**
+     * Is array
+     *
+     * Function will return true if object is array.
+     *
+     * @return bool
+     */
+    public function isArray(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get Type
+     *
+     * Returns validator type.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return self::TYPE_STRING;
+    }
+}

--- a/tests/unit/Utopia/Database/Validator/ProjectIdTest.php
+++ b/tests/unit/Utopia/Database/Validator/ProjectIdTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Utopia\Database\Validator;
+
+use Appwrite\Utopia\Database\Validator\ProjectId;
+use PHPUnit\Framework\TestCase;
+
+class ProjectIdTest extends TestCase
+{
+    /**
+     * @var Key
+     */
+    protected $object = null;
+
+    public function setUp(): void
+    {
+        $this->object = new ProjectId();
+    }
+
+    public function tearDown(): void
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function provideTest(): array
+    {
+        return [
+            'unique()' => ['unique()', true],
+            'dashes' => ['as12-df34', true],
+            '36 chars' => [\str_repeat('a', 36), true],
+            'uppercase' => ['ABC', false],
+            'underscore' => ['under_score', false],
+            'leading dash' => ['-dash', false],
+            'too long' => [\str_repeat('a', 37), false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTest
+     */
+    public function testValues(string $input, bool $expected): void
+    {
+        $this->assertEquals($this->object->isValid($input), $expected);
+    }
+}


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Only allow lowercase alphanumeric chars and hyphens because the project ID is used as part of url
schemes to redirect users back to mobile apps
and certain characters are not allowed.

Closes: https://github.com/appwrite/appwrite/issues/5670

## Test Plan

Automated tests should pass.

I also confirmed i was able to create a new project while still accessing the project i created with the weird project ID.

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/5670

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
