### PR TITLE
fixed team creation response if teamId already exists

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -227,6 +227,11 @@ return [
         'description' => 'The invite does not belong to the current user.',
         'code' => 401,
     ],
+    Exception::TEAM_ID_CONFLICT => [
+        'name' => Exception::TEAM_ID_CONFLICT,
+        'description' => 'Team ID already existed.',
+        'code' => 409,
+    ],
 
     /** Membership */
     Exception::MEMBERSHIP_NOT_FOUND => [

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -227,9 +227,9 @@ return [
         'description' => 'The invite does not belong to the current user.',
         'code' => 401,
     ],
-    Exception::TEAM_ID_CONFLICT => [
-        'name' => Exception::TEAM_ID_CONFLICT,
-        'description' => 'Team ID already existed.',
+    Exception::TEAM_ALREADY_EXISTS => [
+        'name' => Exception::TEAM_ALREADY_EXISTS,
+        'description' => 'Team with requested ID already exists.',
         'code' => 409,
     ],
 

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -67,18 +67,23 @@ App::post('/v1/teams')
         $isAppUser = Auth::isAppUser(Authorization::getRoles());
 
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
-        $team = Authorization::skip(fn() => $dbForProject->createDocument('teams', new Document([
-            '$id' => $teamId,
-            '$permissions' => [
-                Permission::read(Role::team($teamId)),
-                Permission::update(Role::team($teamId, 'owner')),
-                Permission::delete(Role::team($teamId, 'owner')),
-            ],
-            'name' => $name,
-            'total' => ($isPrivilegedUser || $isAppUser) ? 0 : 1,
-            'prefs' => new \stdClass(),
-            'search' => implode(' ', [$teamId, $name]),
-        ])));
+        
+        try {
+            $team = Authorization::skip(fn() => $dbForProject->createDocument('teams', new Document([
+                '$id' => $teamId,
+                '$permissions' => [
+                    Permission::read(Role::team($teamId)),
+                    Permission::update(Role::team($teamId, 'owner')),
+                    Permission::delete(Role::team($teamId, 'owner')),
+                ],
+                'name' => $name,
+                'total' => ($isPrivilegedUser || $isAppUser) ? 0 : 1,
+                'prefs' => new \stdClass(),
+                'search' => implode(' ', [$teamId, $name]),
+            ])));
+        } catch (Duplicate $th) {
+            throw new Exception(Exception::TEAM_ID_CONFLICT);
+        }
 
         if (!$isPrivilegedUser && !$isAppUser) { // Don't add user on server mode
             if (!\in_array('owner', $roles)) {

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -67,7 +67,7 @@ App::post('/v1/teams')
         $isAppUser = Auth::isAppUser(Authorization::getRoles());
 
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
-        
+
         try {
             $team = Authorization::skip(fn() => $dbForProject->createDocument('teams', new Document([
                 '$id' => $teamId,
@@ -82,7 +82,7 @@ App::post('/v1/teams')
                 'search' => implode(' ', [$teamId, $name]),
             ])));
         } catch (Duplicate $th) {
-            throw new Exception(Exception::TEAM_ID_CONFLICT);
+            throw new Exception(Exception::TEAM_ALREADY_EXISTS);
         }
 
         if (!$isPrivilegedUser && !$isAppUser) { // Don't add user on server mode

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -83,6 +83,7 @@ class Exception extends \Exception
     public const TEAM_INVALID_SECRET               = 'team_invalid_secret';
     public const TEAM_MEMBERSHIP_MISMATCH          = 'team_membership_mismatch';
     public const TEAM_INVITE_MISMATCH              = 'team_invite_mismatch';
+    public const TEAM_ID_CONFLICT                  = 'team_id_conflict';
 
     /** Membership */
     public const MEMBERSHIP_NOT_FOUND              = 'membership_not_found';

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -83,7 +83,7 @@ class Exception extends \Exception
     public const TEAM_INVALID_SECRET               = 'team_invalid_secret';
     public const TEAM_MEMBERSHIP_MISMATCH          = 'team_membership_mismatch';
     public const TEAM_INVITE_MISMATCH              = 'team_invite_mismatch';
-    public const TEAM_ID_CONFLICT                  = 'team_id_conflict';
+    public const TEAM_ALREADY_EXISTS               = 'team_already_exists';
 
     /** Membership */
     public const MEMBERSHIP_NOT_FOUND              = 'membership_not_found';

--- a/tests/e2e/Services/Teams/TeamsBase.php
+++ b/tests/e2e/Services/Teams/TeamsBase.php
@@ -79,6 +79,17 @@ trait TeamsBase
 
         $this->assertEquals(400, $response['headers']['status-code']);
 
+        $response = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'teamId' => $teamId,
+            'name' => 'John'
+        ]);
+
+        $this->assertEquals(409, $response['headers']['status-code']);
+        $this->assertEquals('team_id_conflict', $response['body']['type']);
+
         return ['teamUid' => $teamUid, 'teamName' => $teamName];
     }
 

--- a/tests/e2e/Services/Teams/TeamsBase.php
+++ b/tests/e2e/Services/Teams/TeamsBase.php
@@ -88,7 +88,7 @@ trait TeamsBase
         ]);
 
         $this->assertEquals(409, $response['headers']['status-code']);
-        $this->assertEquals('team_id_conflict', $response['body']['type']);
+        $this->assertEquals('team_already_exists', $response['body']['type']);
 
         return ['teamUid' => $teamUid, 'teamName' => $teamName];
     }


### PR DESCRIPTION
## What does this PR do?

Fixes the linked issue 

## Test Plan
- Created a simple web project, tried to create team with same teamId - 
<img width="729" alt="image" src="https://github.com/appwrite/appwrite/assets/124567525/e288879f-8bfd-42ff-abbf-48e2db4bcfea">

- Wrote test case for this - 
<img width="829" alt="image" src="https://github.com/appwrite/appwrite/assets/124567525/9faa1f03-febb-41c0-9d8c-e3acc9d9f0ae">


## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/5768

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
