### PR TITLE
Update Project providers to also include the provider key

### DIFF
--- a/app/config/providers.php
+++ b/app/config/providers.php
@@ -232,7 +232,7 @@ return [ // Ordered by ABC.
         'mock' => false
     ],
     'paypalSandbox' => [
-        'name' => 'PayPal',
+        'name' => 'PayPal Sandbox',
         'developers' => 'https://developer.paypal.com/docs/api/overview/',
         'icon' => 'icon-paypal',
         'enabled' => true,
@@ -302,7 +302,7 @@ return [ // Ordered by ABC.
         'mock' => false,
     ],
     'tradeshiftBox' => [
-        'name' => 'Tradeshift',
+        'name' => 'Tradeshift Sandbox',
         'developers' => 'https://developers.tradeshift.com/docs/api',
         'icon' => 'icon-tradeshiftbox',
         'enabled' => true,

--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -136,7 +136,7 @@ class Project extends Model
                 'type' => Response::MODEL_PROVIDER,
                 'description' => 'List of Providers.',
                 'default' => [],
-                'example' => new \stdClass(),
+                'example' => [new \stdClass()],
                 'array' => true,
             ])
             ->addRule('platforms', [
@@ -273,7 +273,8 @@ class Project extends Model
             }
 
             $projectProviders[] = new Document([
-                'name' => ucfirst($key),
+                'key' => $key,
+                'name' => $provider['name'] ?? '',
                 'appId' => $providerValues[$key . 'Appid'] ?? '',
                 'secret' => $providerValues[$key . 'Secret'] ?? '',
                 'enabled' => $providerValues[$key . 'Enabled'] ?? false,

--- a/src/Appwrite/Utopia/Response/Model/Provider.php
+++ b/src/Appwrite/Utopia/Response/Model/Provider.php
@@ -15,6 +15,12 @@ class Provider extends Model
     public function __construct()
     {
         $this
+            ->addRule('key', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Provider.',
+                'default' => '',
+                'example' => 'github',
+            ])
             ->addRule('name', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Provider name.',

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -618,7 +618,7 @@ class ProjectsConsoleClientTest extends Scope
         foreach ($providers as $key => $provider) {
             $asserted = false;
             foreach ($response['body']['providers'] as $responseProvider) {
-                if ($responseProvider['name'] === ucfirst($key)) {
+                if ($responseProvider['key'] === $key) {
                     $this->assertEquals('AppId-' . ucfirst($key), $responseProvider['appId']);
                     $this->assertEquals('Secret-' . ucfirst($key), $responseProvider['secret']);
                     $this->assertFalse($responseProvider['enabled']);
@@ -660,7 +660,7 @@ class ProjectsConsoleClientTest extends Scope
         foreach ($providers as $key => $provider) {
             $asserted = false;
             foreach ($response['body']['providers'] as $responseProvider) {
-                if ($responseProvider['name'] === ucfirst($key)) {
+                if ($responseProvider['key'] === $key) {
                     // On first provider, test enabled=false
                     $this->assertEquals($i !== 0, $responseProvider['enabled']);
                     $asserted = true;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Pass the provider key and name back so that a nicely formatted name can be shown in the Appwrite Console.

## Test Plan

<img width="1057" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/8552218b-d96b-4390-b674-9672ea643172">

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/5449
- https://github.com/appwrite/console/pull/420

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
