### PR TITLE
updated account.php to not include set cookies for default Oauth route

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -613,15 +613,22 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
             $query['secret'] = Auth::encodeSession($user->getId(), $secret);
             $state['success']['query'] = URLParser::unparseQuery($query);
             $state['success'] = URLParser::unparse($state['success']);
+            $response
+                ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+                ->addHeader('Pragma', 'no-cache')
+                ->redirect($state['success'])
+        ;
+        }
+        else{
+            $response
+                ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+                ->addHeader('Pragma', 'no-cache')
+                ->addCookie(Auth::$cookieName . '_legacy', Auth::encodeSession($user->getId(), $secret), (new \DateTime($expire))->getTimestamp(), '/', Config::getParam('cookieDomain'), ('https' == $protocol), true, null)
+                ->addCookie(Auth::$cookieName, Auth::encodeSession($user->getId(), $secret), (new \DateTime($expire))->getTimestamp(), '/', Config::getParam('cookieDomain'), ('https' == $protocol), true, Config::getParam('cookieSamesite'))
+                ->redirect($state['success'])
+            ;
         }
 
-        $response
-            ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
-            ->addHeader('Pragma', 'no-cache')
-            ->addCookie(Auth::$cookieName . '_legacy', Auth::encodeSession($user->getId(), $secret), (new \DateTime($expire))->getTimestamp(), '/', Config::getParam('cookieDomain'), ('https' == $protocol), true, null)
-            ->addCookie(Auth::$cookieName, Auth::encodeSession($user->getId(), $secret), (new \DateTime($expire))->getTimestamp(), '/', Config::getParam('cookieDomain'), ('https' == $protocol), true, Config::getParam('cookieSamesite'))
-            ->redirect($state['success'])
-        ;
     });
 
 App::post('/v1/account/sessions/magic-url')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The default OAuth URL is primarily utilized as a deep link on mobile applications to establish sessions. However, the current approach has a flaw as it sets the cookies on the appwrite domain. This presents an issue, particularly when two mobile apps are concurrently running on the same project, as one app's session might overwrite another's.

To rectify this, it is advisable not to include the cookies in the default success link. By doing so, a session will not be created on the browser end, enabling two apps for the same project to function independently without any session conflicts.

## Test Plan

I have manually tested it with two different apps running on react native for the same project.

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [yes] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [no] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
