### PR TITLE
Improve OAuth2 error handling

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -195,6 +195,21 @@ return [
         'description' => 'Missing ID from OAuth2 provider.',
         'code' => 400,
     ],
+    Exception::USER_OAUTH2_BAD_REQUEST => [
+        'name' => Exception::USER_OAUTH2_BAD_REQUEST,
+        'description' => 'OAuth2 provider rejected the bad request.',
+        'code' => 400,
+    ],
+    Exception::USER_OAUTH2_UNAUTHORIZED => [
+        'name' => Exception::USER_OAUTH2_UNAUTHORIZED,
+        'description' => 'OAuth2 provider rejected the unauthorized request.',
+        'code' => 401,
+    ],
+    Exception::USER_OAUTH2_PROVIDER_ERROR => [
+        'name' => Exception::USER_OAUTH2_PROVIDER_ERROR,
+        'description' => 'OAuth2 provider returned some error.',
+        'code' => 424,
+    ],
 
     /** Teams */
     Exception::TEAM_NOT_FOUND => [

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -2,6 +2,7 @@
 
 use Ahc\Jwt\JWT;
 use Appwrite\Auth\Auth;
+use Appwrite\Auth\OAuth2\Exception as OAuth2Exception;
 use Appwrite\Auth\Validator\Password;
 use Appwrite\Auth\Validator\Phone;
 use Appwrite\Detector\Detector;
@@ -413,27 +414,22 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
         $appSecret = $project->getAttribute('authProviders', [])[$provider . 'Secret'] ?? '{}';
         $providerEnabled = $project->getAttribute('authProviders', [])[$provider . 'Enabled'] ?? false;
 
-        if (!$providerEnabled) {
-            throw new Exception(Exception::PROJECT_PROVIDER_DISABLED, 'This provider is disabled. Please enable the provider from your ' . APP_NAME . ' console to continue.');
-        }
-
-        if (!empty($appSecret) && isset($appSecret['version'])) {
-            $key = App::getEnv('_APP_OPENSSL_KEY_V' . $appSecret['version']);
-            $appSecret = OpenSSL::decrypt($appSecret['data'], $appSecret['method'], $key, 0, \hex2bin($appSecret['iv']), \hex2bin($appSecret['tag']));
-        }
-
         $className = 'Appwrite\\Auth\\OAuth2\\' . \ucfirst($provider);
 
         if (!\class_exists($className)) {
             throw new Exception(Exception::PROJECT_PROVIDER_UNSUPPORTED);
         }
 
+        $providers = Config::getParam('providers');
+        $providerName = $providers[$provider]['name'] ?? '';
+
+        /** @var Appwrite\Auth\OAuth2 $oauth2 */
         $oauth2 = new $className($appId, $appSecret, $callback);
 
         if (!empty($state)) {
             try {
                 $state = \array_merge($defaultState, $oauth2->parseState($state));
-            } catch (\Exception$exception) {
+            } catch (\Exception $exception) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to parse login state params as passed from OAuth2 provider');
             }
         } else {
@@ -447,27 +443,54 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
         if (!empty($state['failure']) && !$validateURL->isValid($state['failure'])) {
             throw new Exception(Exception::PROJECT_INVALID_FAILURE_URL);
         }
-
-        $accessToken = $oauth2->getAccessToken($code);
-        $refreshToken = $oauth2->getRefreshToken($code);
-        $accessTokenExpiry = $oauth2->getAccessTokenExpiry($code);
-
-        if (empty($accessToken)) {
-            if (!empty($state['failure'])) {
-                $response->redirect($state['failure'], 301, 0);
+        $failure = [];
+        if (!empty($state['failure'])) {
+            $failure = URLParser::parse($state['failure']);
+        }
+        $failureRedirect = (function (string $type, ?string $message = null, ?int $code = null) use ($failure, $response) {
+            $exception = new Exception($type, $message, $code);
+            if (!empty($failure)) {
+                $query = URLParser::parseQuery($failure['query']);
+                $query['error'] = json_encode([
+                    'message' => $exception->getMessage(),
+                    'type' => $exception->getType(),
+                    'code' => !\is_null($code) ? $code : $exception->getCode(),
+                ]);
+                $failure['query'] = URLParser::unparseQuery($query);
+                $response->redirect(URLParser::unparse($failure), 301);
             }
 
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to obtain access token');
+            throw $exception;
+        });
+
+        if (!$providerEnabled) {
+            $failureRedirect(Exception::PROJECT_PROVIDER_DISABLED, 'This provider is disabled. Please enable the provider from your ' . APP_NAME . ' console to continue.');
+        }
+
+        if (!empty($appSecret) && isset($appSecret['version'])) {
+            $key = App::getEnv('_APP_OPENSSL_KEY_V' . $appSecret['version']);
+            $appSecret = OpenSSL::decrypt($appSecret['data'], $appSecret['method'], $key, 0, \hex2bin($appSecret['iv']), \hex2bin($appSecret['tag']));
+        }
+
+        $accessToken = '';
+        $refreshToken = '';
+        $accessTokenExpiry = 0;
+
+        try {
+            $accessToken = $oauth2->getAccessToken($code);
+            $refreshToken = $oauth2->getRefreshToken($code);
+            $accessTokenExpiry = $oauth2->getAccessTokenExpiry($code);
+        } catch (OAuth2Exception $ex) {
+            $failureRedirect(
+                $ex->getType(),
+                'Failed to obtain access token. The ' . $providerName . ' OAuth2 provider returned an error: ' . $ex->getMessage(),
+                $ex->getCode(),
+            );
         }
 
         $oauth2ID = $oauth2->getUserID($accessToken);
-
         if (empty($oauth2ID)) {
-            if (!empty($state['failure'])) {
-                $response->redirect($state['failure'], 301, 0);
-            }
-
-            throw new Exception(Exception::USER_MISSING_ID);
+            $failureRedirect(Exception::USER_MISSING_ID);
         }
 
         $sessions = $user->getAttribute('sessions', []);
@@ -515,7 +538,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                     $total = $dbForProject->count('users', max: APP_LIMIT_USERS);
 
                     if ($total >= $limit) {
-                        throw new Exception(Exception::USER_COUNT_EXCEEDED);
+                        $failureRedirect(Exception::USER_COUNT_EXCEEDED);
                     }
                 }
 
@@ -550,13 +573,13 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                     ]);
                     Authorization::skip(fn() => $dbForProject->createDocument('users', $user));
                 } catch (Duplicate $th) {
-                    throw new Exception(Exception::USER_ALREADY_EXISTS);
+                    $failureRedirect(Exception::USER_ALREADY_EXISTS);
                 }
             }
         }
 
         if (false === $user->getAttribute('status')) { // Account is blocked
-            throw new Exception(Exception::USER_BLOCKED); // User is in status blocked
+            $failureRedirect(Exception::USER_BLOCKED); // User is in status blocked
         }
 
         // Create session token, verify user account and update OAuth2 ID and Access Token

--- a/src/Appwrite/Auth/OAuth2.php
+++ b/src/Appwrite/Auth/OAuth2.php
@@ -75,6 +75,13 @@ abstract class OAuth2
 
     /**
      * @param string $accessToken
+     * 
+     * @return string
+     */
+    abstract public function getUserID(string $accessToken): string;
+
+    /**
+     * @param string $accessToken
      *
      * @return string
      */
@@ -148,11 +155,11 @@ abstract class OAuth2
      *
      * @return string
      */
-    public function getAccessTokenExpiry(string $code): string
+    public function getAccessTokenExpiry(string $code): int
     {
         $tokens = $this->getTokens($code);
 
-        return $tokens['expires_in'] ?? '';
+        return $tokens['expires_in'] ?? 0;
     }
 
     // The parseState function was designed specifically for Amazon OAuth2 Adapter to override.

--- a/src/Appwrite/Auth/OAuth2.php
+++ b/src/Appwrite/Auth/OAuth2.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\Auth;
 
+use Appwrite\Auth\OAuth2\Exception;
+
 abstract class OAuth2
 {
     /**
@@ -75,7 +77,7 @@ abstract class OAuth2
 
     /**
      * @param string $accessToken
-     * 
+     *
      * @return string
      */
     abstract public function getUserID(string $accessToken): string;
@@ -202,7 +204,13 @@ abstract class OAuth2
         // Send the request & save response to $response
         $response = \curl_exec($ch);
 
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
         \curl_close($ch);
+
+        if ($code != 200) {
+            throw new Exception($response, $code);
+        }
 
         return (string)$response;
     }

--- a/src/Appwrite/Auth/OAuth2/Exception.php
+++ b/src/Appwrite/Auth/OAuth2/Exception.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Appwrite\Auth\OAuth2;
+
+use Appwrite\Extend\Exception as AppwriteException;
+
+class Exception extends AppwriteException
+{
+    protected string $response = '';
+    protected string $error = '';
+    protected string $errorDescription = '';
+
+    public function __construct(string $response = '', int $code = 0, \Throwable $previous = null)
+    {
+        $this->response = $response;
+        $this->message = $response;
+        $decoded = json_decode($response, true);
+        if (\is_array($decoded)) {
+            $this->error = $decoded['error'];
+            $this->errorDescription = $decoded['error_description'];
+            $this->message =  $this->error . ': ' . $this->errorDescription;
+        }
+        $type = match ($code) {
+            400 => AppwriteException::USER_OAUTH2_BAD_REQUEST,
+            401 => AppwriteException::USER_OAUTH2_UNAUTHORIZED,
+            default => AppwriteException::USER_OAUTH2_PROVIDER_ERROR
+        };
+
+        parent::__construct($type, $this->message, $code, $previous);
+    }
+
+    /**
+     * Get the error parameter from the response.
+     *
+     * See https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 for more information.
+     */
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    /**
+     * Get the error_description parameter from the response.
+     *
+     * See https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 for more information.
+     */
+    public function getErrorDescription(): string
+    {
+        return $this->errorDescription;
+    }
+}

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -75,6 +75,9 @@ class Exception extends \Exception
     public const USER_PHONE_ALREADY_EXISTS         = 'user_phone_already_exists';
     public const USER_PHONE_NOT_FOUND              = 'user_phone_not_found';
     public const USER_MISSING_ID                   = 'user_missing_id';
+    public const USER_OAUTH2_BAD_REQUEST           = 'user_oauth2_bad_request';
+    public const USER_OAUTH2_UNAUTHORIZED          = 'user_oauth2_unauthorized';
+    public const USER_OAUTH2_PROVIDER_ERROR        = 'user_oauth2_provider_error';
 
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There are two problems when the OAuth2 flow fails.

First, if there is a problem during authentication, the user will be redirected back to Appwrite without the authorization code, and Appwrite will throw an error like this:

<img width="367" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/333f7c02-5b52-4dda-bed9-9b7c3eb2a2fa">

The other problem occurs if Appwrite receives an authorization code but fails to exchange it for an access token. In that case, an error like this occurs:

<img width="342" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/f602e8d6-63c9-4c6a-a9df-242d83a6c451">

This PR improves both scenarios to show more detailed info or send the data to the failure URL for the developer.

Without a failure URL, the user will see a more detailed error:

<img width="757" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/fad049c4-54b7-43af-8c62-4bef9af0d73b">

With a failure URL, the user will be redirected to it like:

```
https://localhost/auth/oauth2/failure?error=%7B%22message%22%3A%22Failed+to+obtain+access+token.+The+Google+OAuth2+provider+returned+an+error%3A+invalid_grant%3A+Malformed+auth+code.%22%2C%22type%22%3A%22user_oauth2_bad_request%22%2C%22code%22%3A400%7D#
```

The developer can then pull the `error` from the query string with something like:

```javascript
u = new URL(window.location);
e = JSON.parse(u.searchParams.get('error'));
```

which would yield:

```json
{
    "message": "Failed to obtain access token. The Google OAuth2 provider returned an error: invalid_grant: Malformed auth code.",
    "type": "user_oauth2_bad_request",
    "code": 400
}
```

## Test Plan

Manual

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/2591
- https://github.com/appwrite/appwrite/issues/4753

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
