### PR TITLE
Update docker-compose.yml to version 3.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-logging: &x-logging
       max-file: '5'
       max-size: '10m'
 
-version: '3'
+version: '3.8'
 
 services:
   traefik:


### PR DESCRIPTION
Upgrading `docker-compose` to version 3.8 will remove the errors around the x-logging and the use of extension fields.

Although, version `3.4` can be used on that matter, version 3.8 requires docker 19+ which is anyhow the best practice

https://docs.docker.com/compose/compose-file/compose-file-v3/#compose-and-docker-compatibility-matrix

## What does this PR do?

Update docker-compose.yml to version 3.8

## Test Plan

Run the docker compose file.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
