### PR TITLE
Add a secrets attribute to the identities collection

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -782,6 +782,18 @@ $commonCollections = [
                 'array' => false,
                 'filters' => ['encrypt'],
             ],
+            [
+                // Used to store data from provider that may or may not be sensitive
+                '$id' => ID::custom('secrets'),
+                'type' => Database::VAR_STRING,
+                'format' => '',
+                'size' => 16384,
+                'signed' => true,
+                'required' => false,
+                'default' => [],
+                'array' => false,
+                'filters' => ['json', 'encrypt'],
+            ],
         ],
         'indexes' => [
             [


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

These secrets can be used to store data from the provider that may or may not be sensitive.

For example, this will be used by the migration API when connecting to Firebase to store the service account used for the migration.

This data will only be used internally inside Appwrite and not exposed to an end user or developer.

Data here is tied to the user identity so that it can be removed when the user or the user identity is removed.

## Test Plan

None

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/5921
- https://github.com/appwrite/appwrite/pull/5953

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
