### PR TITLE
Feat: Add appwriteException with constants for error types in specs

### DIFF
--- a/src/Appwrite/Utopia/Response.php
+++ b/src/Appwrite/Utopia/Response.php
@@ -85,6 +85,7 @@ use Appwrite\Utopia\Response\Model\UsageProject;
 use Appwrite\Utopia\Response\Model\UsageStorage;
 use Appwrite\Utopia\Response\Model\UsageUsers;
 use Appwrite\Utopia\Response\Model\Variable;
+use Appwrite\Utopia\Response\Model\AppwriteException;
 
 /**
  * @method int getStatusCode()
@@ -111,6 +112,7 @@ class Response extends SwooleResponse
     public const MODEL_USAGE_FUNCTIONS = 'usageFunctions';
     public const MODEL_USAGE_FUNCTION = 'usageFunction';
     public const MODEL_USAGE_PROJECT = 'usageProject';
+    public const MODEL_APPWRITE_EXCEPTION = 'appwriteException';
 
     // Database
     public const MODEL_DATABASE = 'database';
@@ -250,6 +252,7 @@ class Response extends SwooleResponse
             ->setModel(new Any())
             ->setModel(new Error())
             ->setModel(new ErrorDev())
+            ->setModel(new AppwriteException())
             // Lists
             ->setModel(new BaseList('Documents List', self::MODEL_DOCUMENT_LIST, 'documents', self::MODEL_DOCUMENT))
             ->setModel(new BaseList('Collections List', self::MODEL_COLLECTION_LIST, 'collections', self::MODEL_COLLECTION))

--- a/src/Appwrite/Utopia/Response/Model/AppwriteException.php
+++ b/src/Appwrite/Utopia/Response/Model/AppwriteException.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Appwrite\Utopia\Response\Model;
+
+use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Response\Model;
+use Utopia\Config\Config;
+
+class AppwriteException extends Model
+{
+    public function __construct()
+    {
+        $enum = [];
+        foreach (Config::getParam('errors', []) as $key => $value) {
+            $enum[] = $key;
+        }
+        $this
+            ->addRule('message', [
+              'type' => self::TYPE_STRING,
+                'description' => 'Error message.',
+                'example' => 'Invalid id: Parameter must be a valid number',
+            ])
+            ->addRule('type', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Error type.',
+                'enum' => $enum,
+                'example' => "argument_invalid"
+            ])
+            ->addRule("code", [
+              "type" => self::TYPE_INTEGER,
+              "description" => "Error code.",
+              "example" => 400,
+              "format" => "int32"
+            ])
+        ;
+    }
+
+    /**
+     * Get Name
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Appwrite Exception';
+    }
+
+    /**
+     * Get Type
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Response::MODEL_APPWRITE_EXCEPTION;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add appwriteException with constants for error types in generated specs for Swagger2 and OpenAPI3.

<!-- ## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.) -->

## Related PRs and Issues
- appwrite/sdk-generator#698

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
<!-- - [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?-->
