### PR TITLE
Fix 4952 read doctor email receiver from console

### DIFF
--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -10,12 +10,14 @@ use Utopia\App;
 use Utopia\CLI\Console;
 use Utopia\Domains\Domain;
 use Utopia\Validator\Text;
+use Utopia\Validator\Wildcard;
 
 $cli
     ->task('doctor')
     ->desc('Validate server health')
     ->param('interactive', 'n', new Text(1), 'Run an interactive session', true)
-    ->action(function ($interactive) use ($register) {
+    ->param('receiver', '', new Wildcard(), 'Send an email to this address to test SMTP', true)
+    ->action(function ($interactive, $receiver) use ($register) {
         Console::log("  __   ____  ____  _  _  ____  __  ____  ____     __  __  
  / _\ (  _ \(  _ \/ )( \(  _ \(  )(_  _)(  __)   (  )/  \ 
 /    \ ) __/ ) __/\ /\ / )   / )(   )(   ) _)  _  )((  O )
@@ -139,7 +141,10 @@ $cli
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
            
-            if ($interactive == "Y" || $interactive == "y") {
+            if ($receiver != '') {
+                $mail->addAddress($receiver);
+            }
+            else if ($interactive == "Y" || $interactive == "y") {
                 $receiver = Console::confirm('Enter your email address to test SMTP connection: ');
                 $mail->addAddress($receiver);
             } else {

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -141,7 +141,7 @@ $cli
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
             if (empty($receiver)) {
                 $mail->addAddress($receiver);
-            } elseif ($interactive == "Y" || $interactive == "y") {
+            } elseif (strtolower($interactive === "y")) {
                 $receiver = Console::confirm('Enter your email address to test SMTP connection: ');
                 $mail->addAddress($receiver);
             } else {

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -9,11 +9,13 @@ use Utopia\Storage\Storage;
 use Utopia\App;
 use Utopia\CLI\Console;
 use Utopia\Domains\Domain;
+use Utopia\Validator\Text;
 
 $cli
     ->task('doctor')
     ->desc('Validate server health')
-    ->action(function () use ($register) {
+    ->param('interactive', 'n', new Text(1), 'Run an interactive session', true)
+    ->action(function ($interactive) use ($register) {
         Console::log("  __   ____  ____  _  _  ____  __  ____  ____     __  __  
  / _\ (  _ \(  _ \/ )( \(  _ \(  )(_  _)(  __)   (  )/  \ 
 /    \ ) __/ ) __/\ /\ / )   / )(   )(   ) _)  _  )((  O )
@@ -133,10 +135,17 @@ $cli
             }
         }
 
+
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
+           
+            if ($interactive == "Y" || $interactive == "y") {
+                $receiver = Console::confirm('Enter your email address to test SMTP connection: ');
+                $mail->addAddress($receiver);
+            } else {
+                $mail->addAddress('demo@example.com', 'Example.com');
+            }
 
-            $mail->addAddress('demo@example.com', 'Example.com');
             $mail->Subject = 'Test SMTP Connection';
             $mail->Body = 'Hello World';
             $mail->AltBody = 'Hello World';
@@ -144,7 +153,7 @@ $cli
             $mail->send();
             Console::success('SMTP................connected 👍');
         } catch (\Throwable $th) {
-            Console::error('SMTP.............disconnected 👎');
+            Console::error('SMTP.............disconnected '.$th.'👎');
         }
 
         $host = App::getEnv('_APP_STATSD_HOST', 'telegraf');

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -137,7 +137,6 @@ $cli
             }
         }
 
-
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
             if ($receiver != '') {

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -153,7 +153,7 @@ $cli
             $mail->send();
             Console::success('SMTP................connected 👍');
         } catch (\Throwable $th) {
-            Console::error('SMTP.............disconnected '.$th.'👎');
+            Console::error('SMTP.............disconnected 👎');
         }
 
         $host = App::getEnv('_APP_STATSD_HOST', 'telegraf');

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -140,11 +140,9 @@ $cli
 
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
-           
             if ($receiver != '') {
                 $mail->addAddress($receiver);
-            }
-            else if ($interactive == "Y" || $interactive == "y") {
+            } elseif ($interactive == "Y" || $interactive == "y") {
                 $receiver = Console::confirm('Enter your email address to test SMTP connection: ');
                 $mail->addAddress($receiver);
             } else {

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -139,7 +139,7 @@ $cli
 
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
-            if (empty($receiver)) {
+            if (!empty($receiver)) {
                 $mail->addAddress($receiver);
             } elseif (strtolower($interactive === "y")) {
                 $receiver = Console::confirm('Enter your email address to test SMTP connection: ');

--- a/app/tasks/doctor.php
+++ b/app/tasks/doctor.php
@@ -139,7 +139,7 @@ $cli
 
         try {
             $mail = $register->get('smtp'); /* @var $mail \PHPMailer\PHPMailer\PHPMailer */
-            if ($receiver != '') {
+            if (empty($receiver)) {
                 $mail->addAddress($receiver);
             } elseif ($interactive == "Y" || $interactive == "y") {
                 $receiver = Console::confirm('Enter your email address to test SMTP connection: ');


### PR DESCRIPTION
## What is the issue? Where did it come from?
This issue arised because RFC 2606, does not allow sending emails to restricted domains such as example.com. This is why, even with a valid SMTP configuration, PHP Mailer will mark SMTP as disconnected.
A different fix, such as changing the default receiver to perhaps smtp-test[@]appwrite.io could also fix this issue. But perhaps this is a better fix? 

## What does this PR do?

This PR addresses the issue #4952, as @stnguyen90 mentions exposing the receiver email to the CLI would be the best approach I've implemented the same, with also added a interactive param. 

The interactive param is defaulted to 'n', which allows our e2e tests to stay the same. But requires updating our documentation to recommend the user to run doctor in the following way-
```bash
docker exec appwrite sh -c 'doctor --interactive=y'
```

## Test Plan

I've not made much changes, that would require adding extra tests. Since this is my first pull request, I'm not fully aware of what to fill in here.

## Related PRs and Issues

- Issue #4952 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
