### PR TITLE
Added new testcase and modified duplicate domain error

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -571,7 +571,7 @@ return [
     ],
     Exception::DOMAIN_ALREADY_EXISTS => [
         'name' => Exception::DOMAIN_ALREADY_EXISTS,
-        'description' => 'A Domain with the requested NAME already exists.',
+        'description' => 'A Domain with the requested name already exists.',
         'code' => 409,
     ],
     Exception::VARIABLE_NOT_FOUND => [

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -571,7 +571,7 @@ return [
     ],
     Exception::DOMAIN_ALREADY_EXISTS => [
         'name' => Exception::DOMAIN_ALREADY_EXISTS,
-        'description' => 'A Domain with the requested ID already exists.',
+        'description' => 'A Domain with the requested NAME already exists.',
         'code' => 409,
     ],
     Exception::VARIABLE_NOT_FOUND => [

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -2848,10 +2848,10 @@ class ProjectsConsoleClientTest extends Scope
         return $data;
     }
 
-    /** 
+    /**
      * @depends testCreateDuplicateProjectDomain
      */
-    public function testCreateDuplicateProjectDomain($data): array 
+    public function testCreateDuplicateProjectDomain($data): array
     {
         $id = $data['projectId'] ?? '';
 

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -2843,6 +2843,28 @@ class ProjectsConsoleClientTest extends Scope
             'hostname' => \str_repeat("bestdomain", 25) . '.com' // 250 + 4 chars total (exactly above limit)
         ]);
 
+        $this->assertEquals(400, $response['headers']['status-code']);
+
+        return $data;
+    }
+
+    /** 
+     * @depends testCreateDuplicateProjectDomain
+     */
+    public function testCreateDuplicateProjectDomain($data): array 
+    {
+        $id = $data['projectId'] ?? '';
+
+        $response = $this->client->call(Client::METHOD_POST, '/projects/' . $id . '/domains', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['key'],
+        ], $this->getHeaders()), [
+            'domain' => 'sub.example.com',
+        ]);
+
+        $this->assertEquals(409, $response['headers']['status-code']);
+
         return $data;
     }
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses issue #4519, it performs two things.
1. Creates a new test case, for testing out duplicate domain for the same project and checks the error code. 
2. Modifies the previous error, to clearly state that the domain is the duplicate and not the id.
3. It fixes a previous test which lacked an assert statement

## Test Plan

I attempt to create a new project, with the same name as the one created in the previous test.

## Related PRs and Issues

- #4519 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
