### PR TITLE
Create a GH workflow to cleanup the GH cache

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,42 @@
+name: Cleanup Cache
+
+# for testing
+on: [pull_request]
+
+# on:
+#   pull_request:
+#     types:
+#       - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          while true
+          do
+            cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+            if [ -z "$cacheKeysForPR" ]
+            then
+              break
+            fi
+
+            ## Setting this to not fail the workflow while deleting cache keys. 
+            set +e
+            for cacheKey in $cacheKeysForPR
+            do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+            done
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The GitHub actions cache is helpful to speed up CI jobs. Once a branch is closed, we don't need the cacche anymore so we should delete it so the disk space can be reclaimed.

This workflow was copied from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries.

## Test Plan

https://github.com/appwrite/appwrite/actions/runs/6031274668/job/16364664657?pr=6080

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
