### PR TITLE
Update migration script to not remove schedule from functions

### DIFF
--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -10,7 +10,6 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception;
-use Utopia\Database\Query;
 
 class V19 extends Migration
 {
@@ -343,6 +342,7 @@ class V19 extends Migration
                         'providerSilentMode',
                         'logging',
                         'deploymentInternalId',
+                        'schedule',
                         'scheduleInternalId',
                         'scheduleId',
                         'version',
@@ -661,14 +661,6 @@ class V19 extends Migration
         }
 
         $this->projectDB->deleteCachedCollection('projects');
-
-        try {
-            $this->projectDB->deleteAttribute('functions', 'schedule');
-        } catch (\Throwable $th) {
-            Console::warning("'schedule' from functions: {$th->getMessage()}");
-        }
-
-        $this->projectDB->deleteCachedCollection('functions');
 
         try {
             $this->projectDB->deleteAttribute('builds', 'stderr');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The `schedule` attribute was not removed from the `functions` collection so we shouldn't delete it.

## Test Plan

Running migration after upgrading from 1.3.8:

<img width="549" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/8e05968b-0286-4b4a-81fd-f4f147b98219">

functions table:

<img width="620" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/02330ce9-752b-4da5-877b-0622fd885d2b">

Migrating after running 1.4.0 migration:

<img width="656" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/d24362e4-153f-4190-b7bc-6dbe837a0e13">

functions table:

<img width="627" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/2af6981a-a57a-4f65-8e03-8a9ab3415f09">

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
