### PR TITLE
Fix fileSecurity check

### DIFF
--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -1316,7 +1316,7 @@ App::put('/v1/storage/buckets/:bucketId/files/:fileId')
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
 
-        $fileSecurity = $bucket->getAttributes('fileSecurity', false);
+        $fileSecurity = $bucket->getAttribute('fileSecurity', false);
         $validator = new Authorization(Database::PERMISSION_UPDATE);
         $valid = $validator->isValid($bucket->getUpdate());
         if (!$fileSecurity && !$valid) {
@@ -1423,7 +1423,7 @@ App::delete('/v1/storage/buckets/:bucketId/files/:fileId')
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
 
-        $fileSecurity = $bucket->getAttributes('fileSecurity', false);
+        $fileSecurity = $bucket->getAttribute('fileSecurity', false);
         $validator = new Authorization(Database::PERMISSION_DELETE);
         $valid = $validator->isValid($bucket->getDelete());
         if (!$fileSecurity && !$valid) {


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because of the `getAttributes()` call, `$fileSecurity` was always true which lead to invalid permission check. This resulted in files being deleted when a user had delete permissions on the file even though they didn't on the bucket.

Closes #6042

## Test Plan

<img width="710" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/60dbcc17-793c-45a1-8cbb-f10cabb38906">

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/6042

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
