### PR TITLE
Fix CLI backwards compatibility

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -660,7 +660,7 @@ App::put('/v1/functions/:functionId')
     ->label('sdk.response.model', Response::MODEL_FUNCTION)
     ->param('functionId', '', new UID(), 'Function ID.')
     ->param('name', '', new Text(128), 'Function name. Max length: 128 chars.')
-    ->param('runtime', '', new WhiteList(array_keys(Config::getParam('runtimes')), true), 'Execution runtime.')
+    ->param('runtime', '', new WhiteList(array_keys(Config::getParam('runtimes')), true), 'Execution runtime.', true)
     ->param('execute', [], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with execution permissions. By default no user is granted with any execute permissions. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
     ->param('events', [], new ArrayList(new ValidatorEvent(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Events list. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' events are allowed.', true)
     ->param('schedule', '', new Cron(), 'Schedule CRON syntax.', true)
@@ -702,6 +702,10 @@ App::put('/v1/functions/:functionId')
 
         if ($function->isEmpty()) {
             throw new Exception(Exception::FUNCTION_NOT_FOUND);
+        }
+
+        if (empty($runtime)) {
+            $runtime = $function->getAttribute('runtime');
         }
 
         $enabled ??= $function->getAttribute('enabled', true);

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -1062,10 +1062,8 @@ App::post('/v1/functions/:functionId/deployments')
         }
 
         if ($commands === null) {
-            $commands = $function->getAttribute('entrypoint', '');
+            $commands = $function->getAttribute('commands', '');
         }
-
-        $commands = $function->getAttribute('commands', '');
 
         if (empty($entrypoint)) {
             throw new Exception(Exception::FUNCTION_ENTRYPOINT_MISSING);

--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -615,7 +615,7 @@ class V19 extends Migration
     {
         $runtime = $function->getAttribute('runtime');
         $language = explode('-', $runtime)[0];
-        $commands = match($language) {
+        $commands = match ($language) {
             'dart' => 'dart pub get',
             'deno' => 'deno cache ' . $function->getAttribute('entrypoint'),
             'dotnet' => 'dotnet restore',

--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -56,6 +56,14 @@ class V19 extends Migration
                 $status = 'verified';
             }
 
+            $projectId = $domain->getAttribute('projectId');
+            $projectInternalId = $domain->getAttribute('projectInternalId');
+
+            if (empty($projectId) || empty($projectInternalId)) {
+                Console::warning("Error migrating domain {$domain->getAttribute('domain')}: Missing projectId or projectInternalId");
+                continue;
+            }
+
             $ruleDocument = new Document([
                 'projectId' => $domain->getAttribute('projectId'),
                 'projectInternalId' => $domain->getAttribute('projectInternalId'),

--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -295,16 +295,31 @@ class V19 extends Migration
 
                     break;
                 case 'executions':
-                    try {
-                        $this->createAttributeFromCollection($this->projectDB, $id, 'functionInternalId');
-                    } catch (\Throwable $th) {
-                        Console::warning("'functionInternalId' from {$id}: {$th->getMessage()}");
+                    $attributesToCreate = [
+                        'functionInternalId',
+                        'deploymentInternalId',
+                        'requestMethod',
+                        'requestPath',
+                        'requestHeaders',
+                        'responseHeaders',
+                    ];
+                    foreach ($attributesToCreate as $attribute) {
+                        try {
+                            $this->createAttributeFromCollection($this->projectDB, $id, $attribute);
+                        } catch (\Throwable $th) {
+                            Console::warning("$attribute from {$id}: {$th->getMessage()}");
+                        }
                     }
 
-                    try {
-                        $this->createAttributeFromCollection($this->projectDB, $id, 'deploymentInternalId');
-                    } catch (\Throwable $th) {
-                        Console::warning("'deploymentInternalId' from {$id}: {$th->getMessage()}");
+                    $attributesToDelete = [
+                        'response'
+                    ];
+                    foreach ($attributesToDelete as $attribute) {
+                        try {
+                            $this->projectDB->deleteAttribute($id, $attribute);
+                        } catch (\Throwable $th) {
+                            Console::warning("'$attribute' from {$id}: {$th->getMessage()}");
+                        }
                     }
 
                     try {
@@ -323,6 +338,18 @@ class V19 extends Migration
                         $this->projectDB->renameAttribute($id, 'statusCode', 'responseStatusCode');
                     } catch (\Throwable $th) {
                         Console::warning("'responseStatusCode' from {$id}: {$th->getMessage()}");
+                    }
+
+                    try {
+                        $this->projectDB->deleteIndex($id, '_key_statusCode');
+                    } catch (\Throwable $th) {
+                        Console::warning("'_key_statusCode' from {$id}: {$th->getMessage()}");
+                    }
+
+                    try {
+                        $this->createIndexFromCollection($this->projectDB, $id, '_key_responseStatusCode');
+                    } catch (\Throwable $th) {
+                        Console::warning("'_key_responseStatusCode' from {$id}: {$th->getMessage()}");
                     }
 
                     $this->projectDB->deleteCachedCollection($id);

--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -696,6 +696,9 @@ class V19 extends Migration
                 $document->setAttribute('templates', []);
 
                 break;
+            case 'variables':
+                $document->setAttribute('resourceType', 'function');
+                break;
             default:
                 break;
         }

--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -190,16 +190,23 @@ class V19 extends Migration
 
                     break;
                 case 'builds':
-                    try {
-                        $this->createAttributeFromCollection($this->projectDB, $id, 'deploymentInternalId');
-                    } catch (\Throwable $th) {
-                        Console::warning("'deploymentInternalId' from {$id}: {$th->getMessage()}");
+                    $attributesToCreate = [
+                        'size',
+                        'deploymentInternalId',
+                        'logs',
+                    ];
+                    foreach ($attributesToCreate as $attribute) {
+                        try {
+                            $this->createAttributeFromCollection($this->projectDB, $id, $attribute);
+                        } catch (\Throwable $th) {
+                            Console::warning("$attribute from {$id}: {$th->getMessage()}");
+                        }
                     }
 
                     try {
-                        $this->createAttributeFromCollection($this->projectDB, $id, 'logs');
+                        $this->projectDB->renameAttribute($id, 'outputPath', 'path');
                     } catch (\Throwable $th) {
-                        Console::warning("'logs' from {$id}: {$th->getMessage()}");
+                        Console::warning("'path' from {$id}: {$th->getMessage()}");
                     }
 
                     $this->projectDB->deleteCachedCollection($id);
@@ -209,13 +216,13 @@ class V19 extends Migration
                     try {
                         $this->projectDB->renameAttribute($id, 'log', 'logs');
                     } catch (\Throwable $th) {
-                        Console::warning("'errors' from {$id}: {$th->getMessage()}");
+                        Console::warning("'logs' from {$id}: {$th->getMessage()}");
                     }
 
                     try {
                         $this->projectDB->updateAttribute($id, 'logs', size: 1000000);
                     } catch (\Throwable $th) {
-                        Console::warning("'errors' from {$id}: {$th->getMessage()}");
+                        Console::warning("'logs' from {$id}: {$th->getMessage()}");
                     }
 
                     $this->projectDB->deleteCachedCollection($id);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

After upgrading to 1.4, functions created before 1.4 should still work. This PR fixes some migration problems that:

1. prevent function variables from showing up
2. prevent executions from running

This also updates the update function API to make runtimes optional for backwards compatibility.

## Test Plan

After all of these changes I was able to deploy a pre-1.4 function using version 2.0.2 of the Appwrite CLI:

<img width="908" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/673cf43a-7081-4817-9f68-a1b029cf1abe">

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/6120

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
