### PR TITLE
Fix _APP_EXECUTOR_HOST for upgrades

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -750,6 +750,7 @@ return [
                 'introduction' => '0.13.0',
                 'default' => 'http://appwrite-executor/v1',
                 'required' => false,
+                'overwrite' => true,
                 'question' => '',
                 'filter' => ''
             ],

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -40,6 +40,7 @@ class Install extends Action
         $config = Config::getParam('variables');
         $defaultHTTPPort = '80';
         $defaultHTTPSPort = '443';
+        /** @var array<string, array<string, string>> $vars array whre key is variable name and value is variable */
         $vars = [];
 
         /**
@@ -50,7 +51,7 @@ class Install extends Action
 
         foreach ($config as $category) {
             foreach ($category['variables'] ?? [] as $var) {
-                $vars[] = $var;
+                $vars[$var['name']] = $var;
             }
         }
 
@@ -104,10 +105,10 @@ class Install extends Action
                         if (is_null($value)) {
                             continue;
                         }
-                        foreach ($vars as $i => $var) {
-                            if ($var['name'] === $key) {
-                                $vars[$i]['default'] = $value;
-                            }
+
+                        $configVar = $vars[$key] ?? [];
+                        if (!empty($configVar) && !($configVar['overwrite'] ?? false)) {
+                            $vars[$key]['default'] = $value;
                         }
                     }
                 }
@@ -123,10 +124,10 @@ class Install extends Action
                         if (is_null($value)) {
                             continue;
                         }
-                        foreach ($vars as $i => $var) {
-                            if ($var['name'] === $key) {
-                                $vars[$i]['default'] = $value;
-                            }
+
+                        $configVar = $vars[$key] ?? [];
+                        if (!empty($configVar) && !($configVar['overwrite'] ?? false)) {
+                            $vars[$key]['default'] = $value;
                         }
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

As of 1.4.0, the hostname of the executor should be executor rather than appwrite-executor. The problem is our install command always uses the existing installation's variable values as the default for the upgrade. This means the _APP_EXECUTOR_HOST will retain it's old value.

This PR Adds an overwrite key to variables.php to allow overwriting the variable value regardless of whatever was in the previous installation.

## Test Plan

Manually installed 1.3.8, ran the upgrade command, checked .env after:

<img width="829" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/a3f30b83-ccab-4811-8bb6-6c700f1fd58c">

## Related PRs and Issues

- #6137
- https://github.com/appwrite/appwrite/pull/6098

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
