### PR TITLE
Fix create execution request filter from previous SDK version

### DIFF
--- a/src/Appwrite/Utopia/Request/Filters/V16.php
+++ b/src/Appwrite/Utopia/Request/Filters/V16.php
@@ -17,7 +17,7 @@ class V16 extends Filter
                 $content['commands'] = $this->getCommands($content['runtime'] ?? '');
                 break;
             case 'functions.createExecution':
-                $content['body'] = $content['data'];
+                $content['body'] = $content['data'] ?? '';
                 unset($content['data']);
                 break;
         }

--- a/tests/unit/Utopia/Request/Filters/V16Test.php
+++ b/tests/unit/Utopia/Request/Filters/V16Test.php
@@ -34,6 +34,12 @@ class V16Test extends TestCase
                     'body' => 'Lorem ipsum'
                 ],
             ],
+            'no data' => [
+                [],
+                [
+                    'body' => ''
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When an older SDK executes a function without passing any data, the data param is unset/null so we need to make sure to handle that case.

## Test Plan

Unit test added.

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
