### PR TITLE
Update the request filter to handle select queries

### DIFF
--- a/src/Appwrite/Utopia/Request/Filters/V16.php
+++ b/src/Appwrite/Utopia/Request/Filters/V16.php
@@ -22,6 +22,15 @@ class V16 extends Filter
                 break;
         }
 
+        if (isset($content['queries'])) {
+            $queries = $content['queries'];
+            foreach ($queries as $index => $query) {
+                if (\str_starts_with($query, 'select([')) {
+                    $content['queries'][$index] = \str_replace('select([', 'select(["$id","$createdAt","$updatedAt","$permissions",', $query);
+                }
+            }
+        }
+
         return $content;
     }
 

--- a/tests/unit/Utopia/Request/Filters/V16Test.php
+++ b/tests/unit/Utopia/Request/Filters/V16Test.php
@@ -4,7 +4,6 @@ namespace Tests\Unit\Utopia\Request\Filters;
 
 use Appwrite\Utopia\Request\Filter;
 use Appwrite\Utopia\Request\Filters\V16;
-use Appwrite\Utopia\Response\Model;
 use PHPUnit\Framework\TestCase;
 
 class V16Test extends TestCase
@@ -43,6 +42,88 @@ class V16Test extends TestCase
     public function testCreateExecution(array $content, array $expected): void
     {
         $model = 'functions.createExecution';
+
+        $result = $this->filter->parse($content, $model);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function queriesProvider(): array
+    {
+        return [
+            'no queries' => [
+                [],
+                [],
+            ],
+            'empty queries' => [
+                [
+                    'queries' => [],
+                ],
+                [
+                    'queries' => [],
+                ],
+            ],
+            'without select query' => [
+                [
+                    'queries' => [
+                        'limit(12)',
+                        'offset(0)',
+                        'orderDesc("")',
+                    ],
+                ],
+                [
+                    'queries' => [
+                        'limit(12)',
+                        'offset(0)',
+                        'orderDesc("")',
+                    ],
+                ],
+            ],
+            'with single select query' => [
+                [
+                    'queries' => [
+                        'limit(12)',
+                        'offset(0)',
+                        'orderDesc("")',
+                        'select(["attr1"])',
+                    ],
+                ],
+                [
+                    'queries' => [
+                        'limit(12)',
+                        'offset(0)',
+                        'orderDesc("")',
+                        'select(["$id","$createdAt","$updatedAt","$permissions","attr1"])',
+                    ],
+                ],
+            ],
+            'with multi select query' => [
+                [
+                    'queries' => [
+                        'limit(12)',
+                        'offset(0)',
+                        'orderDesc("")',
+                        'select(["attr1","attr2"])',
+                    ],
+                ],
+                [
+                    'queries' => [
+                        'limit(12)',
+                        'offset(0)',
+                        'orderDesc("")',
+                        'select(["$id","$createdAt","$updatedAt","$permissions","attr1","attr2"])',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider queriesProvider
+     */
+    public function testQueries(array $content, array $expected): void
+    {
+        $model = 'databases.listDocuments';
 
         $result = $this->filter->parse($content, $model);
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Previously, system attributes were returned even if they weren't included in the select query, but 1.4.0 changed this behavior. This commit updates the request filter to add the system attributes to the select query if they are not already included to retain the same behavior as before.

## Test Plan

Unit test added

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/6158

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
