### PR TITLE
Fix: V2 functions env vars

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -1658,6 +1658,16 @@ App::post('/v1/functions/:functionId/executions')
 
         $vars = [];
 
+        // V2 vars
+        if ($version === 'v2') {
+            $vars = \array_merge($vars, [
+                'APPWRITE_FUNCTION_TRIGGER' => $headers['x-appwrite-trigger'] ?? '',
+                'APPWRITE_FUNCTION_DATA' => $body ?? '',
+                'APPWRITE_FUNCTION_USER_ID' => $headers['x-appwrite-user-id'] ?? '',
+                'APPWRITE_FUNCTION_JWT' => $headers['x-appwrite-user-jwt'] ?? ''
+            ]);
+        }
+
         // Shared vars
         foreach ($function->getAttribute('varsProject', []) as $var) {
             $vars[$var->getAttribute('key')] = $var->getAttribute('value', '');

--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -140,7 +140,24 @@ Server::setResource('execute', function () {
 
         $durationStart = \microtime(true);
 
+        $body = $eventData ?? '';
+        if (empty($body)) {
+            $body = $data ?? '';
+        }
+
         $vars = [];
+
+        // V2 vars
+        if ($version === 'v2') {
+            $vars = \array_merge($vars, [
+                'APPWRITE_FUNCTION_TRIGGER' => $headers['x-appwrite-trigger'] ?? '',
+                'APPWRITE_FUNCTION_DATA' => $body ?? '',
+                'APPWRITE_FUNCTION_EVENT_DATA' => $body ?? '',
+                'APPWRITE_FUNCTION_EVENT' => $headers['x-appwrite-event'] ?? '',
+                'APPWRITE_FUNCTION_USER_ID' => $headers['x-appwrite-user-id'] ?? '',
+                'APPWRITE_FUNCTION_JWT' => $headers['x-appwrite-user-jwt'] ?? ''
+            ]);
+        }
 
         // Shared vars
         foreach ($function->getAttribute('varsProject', []) as $var) {
@@ -161,11 +178,6 @@ Server::setResource('execute', function () {
             'APPWRITE_FUNCTION_RUNTIME_NAME' => $runtime['name'] ?? '',
             'APPWRITE_FUNCTION_RUNTIME_VERSION' => $runtime['version'] ?? '',
         ]);
-
-        $body = $eventData ?? '';
-        if (empty($body)) {
-            $body = $data ?? '';
-        }
 
         /** Execute function */
         try {


### PR DESCRIPTION
## What does this PR do?

In V3, we moved dynamic env vars into headers.

For proper backwards compatibility, we need to re-add those dynamic vars back into variables array for V2 functions.

## Test Plan

- [x] Manually, locally


<img width="474" alt="CleanShot 2023-09-11 at 13 36 15@2x" src="https://github.com/appwrite/appwrite/assets/19310830/3905e66a-8593-476d-b037-d18434b9547b">
<img width="624" alt="CleanShot 2023-09-11 at 13 36 01@2x" src="https://github.com/appwrite/appwrite/assets/19310830/dc3241c0-00f3-47bd-8e71-2fd5f2f2d15d">

![CleanShot 2023-09-11 at 13 35 57@2x](https://github.com/appwrite/appwrite/assets/19310830/11760af4-d645-4629-a864-9b24d71e9cc8)

## Related PRs and Issues

 https://github.com/appwrite/appwrite/issues/6209

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
