### PR TITLE
Extracting function event validator to its own class.

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -7,7 +7,7 @@ use Appwrite\Event\Delete;
 use Appwrite\Event\Event;
 use Appwrite\Event\Func;
 use Appwrite\Event\Usage;
-use Appwrite\Event\Validator\Event as ValidatorEvent;
+use Appwrite\Event\Validator\FunctionEvent;
 use Appwrite\Utopia\Response\Model\Rule;
 use Appwrite\Extend\Exception;
 use Appwrite\Utopia\Database\Validator\CustomId;
@@ -136,7 +136,7 @@ App::post('/v1/functions')
     ->param('name', '', new Text(128), 'Function name. Max length: 128 chars.')
     ->param('runtime', '', new WhiteList(array_keys(Config::getParam('runtimes')), true), 'Execution runtime.')
     ->param('execute', [], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with execution permissions. By default no user is granted with any execute permissions. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
-    ->param('events', [], new ArrayList(new ValidatorEvent(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Events list. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' events are allowed.', true)
+    ->param('events', [], new ArrayList(new FunctionEvent(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Events list. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' events are allowed.', true)
     ->param('schedule', '', new Cron(), 'Schedule CRON syntax.', true)
     ->param('timeout', 15, new Range(1, (int) App::getEnv('_APP_FUNCTIONS_TIMEOUT', 900)), 'Function maximum execution time in seconds.', true)
     ->param('enabled', true, new Boolean(), 'Is function enabled? When set to \'disabled\', users cannot access the function but Server SDKs with and API key can still access the function. No data is lost when this is toggled.', true)
@@ -662,7 +662,7 @@ App::put('/v1/functions/:functionId')
     ->param('name', '', new Text(128), 'Function name. Max length: 128 chars.')
     ->param('runtime', '', new WhiteList(array_keys(Config::getParam('runtimes')), true), 'Execution runtime.', true)
     ->param('execute', [], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with execution permissions. By default no user is granted with any execute permissions. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
-    ->param('events', [], new ArrayList(new ValidatorEvent(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Events list. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' events are allowed.', true)
+    ->param('events', [], new ArrayList(new FunctionEvent(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Events list. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' events are allowed.', true)
     ->param('schedule', '', new Cron(), 'Schedule CRON syntax.', true)
     ->param('timeout', 15, new Range(1, (int) App::getEnv('_APP_FUNCTIONS_TIMEOUT', 900)), 'Maximum execution time in seconds.', true)
     ->param('enabled', true, new Boolean(), 'Is function enabled? When set to \'disabled\', users cannot access the function but Server SDKs with and API key can still access the function. No data is lost when this is toggled.', true)

--- a/src/Appwrite/Event/Validator/Event.php
+++ b/src/Appwrite/Event/Validator/Event.php
@@ -45,12 +45,6 @@ class Event extends Validator
          * Identify all sections of the pattern.
          */
         $type = $parts[0] ?? false;
-
-        if ($type == 'functions') {
-            $this->message = 'Triggering a function on a function event is not allowed.';
-            return false;
-        }
-
         $resource = $parts[1] ?? false;
         $hasSubResource = $count > 3 && ($events[$type]['$resource'] ?? false) && ($events[$type][$parts[2]]['$resource'] ?? false);
         $hasSubSubResource = $count > 5 && $hasSubResource && ($events[$type][$parts[2]][$parts[4]]['$resource'] ?? false);

--- a/src/Appwrite/Event/Validator/FunctionEvent.php
+++ b/src/Appwrite/Event/Validator/FunctionEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Event\Validator;
+
+use Utopia\Config\Config;
+
+class FunctionEvent extends Event
+{
+    /**
+     * Is valid.
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isValid($value): bool
+    {
+        if (str_starts_with($value, 'functions.')) {
+            $this->message = 'Triggering a function on a function event is not allowed.';
+            return false;
+        }
+
+        return parent::isValid($value);
+    }
+}

--- a/src/Appwrite/GraphQL/Types/Mapper.php
+++ b/src/Appwrite/GraphQL/Types/Mapper.php
@@ -235,6 +235,7 @@ class Mapper
             case 'Utopia\Validator\Domain':
             case 'Appwrite\Network\Validator\Email':
             case 'Appwrite\Event\Validator\Event':
+            case 'Appwrite\Event\Validator\FunctionEvent':
             case 'Utopia\Validator\HexColor':
             case 'Utopia\Validator\Host':
             case 'Utopia\Validator\IP':

--- a/tests/unit/Event/Validator/EventValidatorTest.php
+++ b/tests/unit/Event/Validator/EventValidatorTest.php
@@ -50,7 +50,7 @@ class EventValidatorTest extends TestCase
         $this->assertTrue($this->object->isValid('databases.books'));
         $this->assertTrue($this->object->isValid('databases.books.collections.chapters'));
         $this->assertTrue($this->object->isValid('databases.books.collections.*'));
-        // $this->assertTrue($this->object->isValid('functions.*')); TODO @christyjacob4 : enable test once we allow functions.* events
+        $this->assertTrue($this->object->isValid('functions.*'));
         $this->assertTrue($this->object->isValid('buckets.*'));
         $this->assertTrue($this->object->isValid('teams.*'));
         $this->assertTrue($this->object->isValid('users.*'));

--- a/tests/unit/Event/Validator/FunctionEventValidatorTest.php
+++ b/tests/unit/Event/Validator/FunctionEventValidatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Event\Validator;
+
+use Appwrite\Event\Validator\FunctionEvent;
+use PHPUnit\Framework\TestCase;
+
+class FunctionEventValidatorTest extends TestCase
+{
+    protected ?FunctionEvent $object = null;
+
+    public function setUp(): void
+    {
+        $this->object = new FunctionEvent();
+    }
+
+    public function tearDown(): void
+    {
+    }
+
+    public function testValues(): void
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $this->assertTrue($this->object->isValid('users.*.create'));
+        $this->assertTrue($this->object->isValid('users.torsten.update'));
+        $this->assertTrue($this->object->isValid('users.torsten'));
+        $this->assertTrue($this->object->isValid('users.*.update.email'));
+        $this->assertTrue($this->object->isValid('users.*.update'));
+        $this->assertTrue($this->object->isValid('users.*'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.chapters.documents.prolog.create'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.chapters.documents.prolog'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.chapters.documents.*.create'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.chapters.documents.*'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.*.documents.prolog.create'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.*.documents.prolog'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.*.documents.*.create'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.*.documents.*'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.chapters.documents.prolog.create'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.chapters.documents.prolog'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.chapters.documents.*.create'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.chapters.documents.*'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.*.documents.prolog.create'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.*.documents.prolog'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.*.documents.*.create'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.*.documents.*'));
+        $this->assertTrue($this->object->isValid('databases.*.collections.*'));
+        $this->assertTrue($this->object->isValid('databases.*'));
+        $this->assertTrue($this->object->isValid('databases.books'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.chapters'));
+        $this->assertTrue($this->object->isValid('databases.books.collections.*'));
+        $this->assertTrue($this->object->isValid('buckets.*'));
+        $this->assertTrue($this->object->isValid('teams.*'));
+        $this->assertTrue($this->object->isValid('users.*'));
+        $this->assertTrue($this->object->isValid('teams.*.memberships.*.update.status'));
+
+        /**
+         * Test for FAILURE
+         */
+        $this->assertFalse($this->object->isValid(false));
+        $this->assertFalse($this->object->isValid(null));
+        $this->assertFalse($this->object->isValid(''));
+        $this->assertFalse($this->object->isValid('unknown.*'));
+        $this->assertFalse($this->object->isValid('collections'));
+        $this->assertFalse($this->object->isValid('collections.*.unknown'));
+        $this->assertFalse($this->object->isValid('collections.*.documents.*.unknown'));
+        $this->assertFalse($this->object->isValid('users.torsten.unknown'));
+        $this->assertFalse($this->object->isValid('users.torsten.delete.email'));
+        $this->assertFalse($this->object->isValid('teams.*.memberships.*.update.unknown'));
+        $this->assertFalse($this->object->isValid('functions.*'));
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Closes #6218 

## Test Plan
1. Added `FunctionEventValidatorTest.php` which is the same as `EventValidatorTest.php` except that any event that starts with `functions.` will return false.
2. Tested it on a temporary local Appwrite instance, and I was able to add the `functions.*` events to a webhook but not to a function.

## Related PRs and Issues

#6218

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
