### PR TITLE
Don't update User Accessed At for Users and Teams APIs

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -491,7 +491,6 @@ App::post('/v1/teams/:teamId/memberships')
                     'tokens' => null,
                     'memberships' => null,
                     'search' => implode(' ', [$userId, $email, $name]),
-                    'accessedAt' => DateTime::now(),
                 ])));
             } catch (Duplicate $th) {
                 throw new Exception(Exception::USER_ALREADY_EXISTS);

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -97,7 +97,6 @@ function createUser(string $hash, mixed $hashOptions, string $userId, ?string $e
             'tokens' => null,
             'memberships' => null,
             'search' => implode(' ', [$userId, $email, $phone, $name]),
-            'accessedAt' => DateTime::now(),
         ]));
     } catch (Duplicate $th) {
         throw new Exception(Exception::USER_ALREADY_EXISTS);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes #6177.

## Test Plan

Automated tests should pass.

I also manually tested:

<img width="1247" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/36fd5ca9-ab21-4101-a613-8d843dfed375">

new@example.com was created via create team membership. the empty user in the 2nd row was created via create user.

## Related PRs and Issues

- #6177 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
