### PR TITLE
fix-6212-Issue-With-Linkedin-OAuth

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Linkedin.php
+++ b/src/Appwrite/Auth/OAuth2/Linkedin.php
@@ -20,8 +20,9 @@ class Linkedin extends OAuth2
      * @var array
      */
     protected array $scopes = [
-        'r_liteprofile',
-        'r_emailaddress',
+        'openid',
+        'profile',
+        'email'
     ];
 
     /**
@@ -118,7 +119,7 @@ class Linkedin extends OAuth2
     {
         $user = $this->getUser($accessToken);
 
-        return $user['id'] ?? '';
+        return $user['sub'] ?? '';
     }
 
     /**
@@ -128,9 +129,8 @@ class Linkedin extends OAuth2
      */
     public function getUserEmail(string $accessToken): string
     {
-        $email = \json_decode($this->request('GET', 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))', ['Authorization: Bearer ' . \urlencode($accessToken)]), true);
-
-        return $email['elements'][0]['handle~']['emailAddress'] ?? '';
+        $user = $this->getUser($accessToken);
+        return $user['email'] ?? '';
     }
 
     /**
@@ -144,9 +144,8 @@ class Linkedin extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        $user = $this->getUser($accessToken);
+        return $user['email_verified'] ?? '';
     }
 
     /**
@@ -159,12 +158,12 @@ class Linkedin extends OAuth2
         $user = $this->getUser($accessToken);
         $name = '';
 
-        if (isset($user['localizedFirstName'])) {
-            $name = $user['localizedFirstName'];
+        if (isset($user['given_name'])) {
+            $name = $user['given_name'];
         }
 
-        if (isset($user['localizedLastName'])) {
-            $name = (empty($name)) ? $user['localizedLastName'] : $name . ' ' . $user['localizedLastName'];
+        if (isset($user['family_name'])) {
+            $name = (empty($name)) ? $user['family_name'] : $name . ' ' . $user['family_name'];
         }
 
         return $name;
@@ -178,7 +177,7 @@ class Linkedin extends OAuth2
     protected function getUser(string $accessToken)
     {
         if (empty($this->user)) {
-            $this->user = \json_decode($this->request('GET', 'https://api.linkedin.com/v2/me', ['Authorization: Bearer ' . \urlencode($accessToken)]), true);
+            $this->user = \json_decode($this->request('GET', 'https://api.linkedin.com/v2/userinfo', ['Authorization: Bearer ' . \urlencode($accessToken)]), true);
         }
 
         return $this->user;

--- a/src/Appwrite/Auth/OAuth2/Linkedin.php
+++ b/src/Appwrite/Auth/OAuth2/Linkedin.php
@@ -118,7 +118,6 @@ class Linkedin extends OAuth2
     public function getUserID(string $accessToken): string
     {
         $user = $this->getUser($accessToken);
-
         return $user['sub'] ?? '';
     }
 
@@ -145,7 +144,7 @@ class Linkedin extends OAuth2
     public function isEmailVerified(string $accessToken): bool
     {
         $user = $this->getUser($accessToken);
-        return $user['email_verified'] ?? '';
+        return $user['email_verified'] ?? false;
     }
 
     /**
@@ -157,6 +156,10 @@ class Linkedin extends OAuth2
     {
         $user = $this->getUser($accessToken);
         $name = '';
+
+        if (isset($user['name'])) {
+            return $user['name'];
+        }
 
         if (isset($user['given_name'])) {
             $name = $user['given_name'];


### PR DESCRIPTION
## What does this PR do?
Fix related to the issue - #6212 

Reference document - https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2?context=linkedin%2Fconsumer%2Fcontext

LinkedIn has transitioned to using OpenID for authentication and authorization, necessitating updates to the existing codebase to accommodate these changes.
![Screenshot 2023-09-13 at 9 42 03 PM](https://github.com/appwrite/appwrite/assets/71667635/5617bb05-ddad-41fd-be1c-751634431a5f)


## Test Plan

![Screenshot 2023-09-14 at 1 18 31 AM](https://github.com/appwrite/appwrite/assets/71667635/a52b7af9-0412-463b-ab0f-d1845066a103)

## Related PRs and Issues

- #6212 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

