### PR TITLE
Fix function timeout

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -846,10 +846,11 @@ return [
             ],
             [
                 'name' => '_APP_FUNCTIONS_MAINTENANCE_INTERVAL',
-                'description' => 'Interval how often executor checks for inactive runimes. The default value is 60 seconds.',
-                'introduction' => '1.2.0',
-                'default' => '60',
+                'description' => 'Interval value containing the number of seconds that the executor should wait before checking for inactive runtimes. The default value is 3600 seconds (1 hour).',
+                'introduction' => '1.4.0',
+                'default' => '3600',
                 'required' => false,
+                'overwrite' => true,
                 'question' => '',
                 'filter' => ''
             ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

    Fix the _APP_FUNCTIONS_MAINTENANCE_INTERVAL variable
    
    * Clarify the description and make it match the other maintenance
      variables.
    * Fix the introduction since it was introduced in 1.4.0 and not 1.2.0.
    * Fix the default value because it was 1 hour in the previous versions
      and a number that is too low will conflict with a function's timeout.

Fixes #6234 

## Test Plan

Manually tested.

## Related PRs and Issues

- #6234 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
