### PR TITLE
fix: add try catch block in the schedules task

### DIFF
--- a/src/Appwrite/Platform/Tasks/Schedule.php
+++ b/src/Appwrite/Platform/Tasks/Schedule.php
@@ -89,7 +89,12 @@ class Schedule extends Action
             $sum = count($results);
             $total = $total + $sum;
             foreach ($results as $document) {
-                $schedules[$document['resourceId']] = $getSchedule($document);
+                try {
+                    $schedules[$document['resourceId']] = $getSchedule($document);
+                } catch (\Throwable $th) {
+                    Console::error("Failed to load schedule for project {$document['projectId']} and function {$document['resourceId']}");
+                    Console::error($th->getMessage());
+                }
             }
 
             $latestDocument = !empty(array_key_last($results)) ? $results[array_key_last($results)] : null;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If there was any issue fetching schedules for a particular function, the schedules container would crash resulting is schedule failures for all the other functions across projects.

Here we add a try catch block to this code, to safely skip any problematic projects and ensure the container stays operational for other schedules. 

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
