### PR TITLE
Disallow creating user with no email, phone or password

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -240,6 +240,11 @@ return [
         'description' => 'OAuth2 provider returned some error.',
         'code' => 424,
     ],
+    Exception::USER_MISSING_IDENTIFIER => [
+        'name' => Exception::USER_MISSING_IDENTIFIER,
+        'description' => 'The user phone and email are missing. You must provide either a phone or an email.',
+        'code' => 400,
+    ],
 
     /** Teams */
     Exception::TEAM_NOT_FOUND => [

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -125,13 +125,16 @@ App::post('/v1/users')
     ->param('userId', '', new CustomId(), 'User ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.')
     ->param('email', null, new Email(), 'User email.', true)
     ->param('phone', null, new Phone(), 'Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
-    ->param('password', '', fn ($project, $passwordsDictionary) => new PasswordDictionary($passwordsDictionary, $project->getAttribute('auths', [])['passwordDictionary'] ?? false), 'Plain text user password. Must be at least 8 chars.', true, ['project', 'passwordsDictionary'])
+    ->param('password', '', fn ($project, $passwordsDictionary) => new PasswordDictionary($passwordsDictionary, $project->getAttribute('auths', [])['passwordDictionary'] ?? false), 'Plain text user password. Must be at least 8 chars.', injections: ['project', 'passwordsDictionary'])
     ->param('name', '', new Text(128), 'User name. Max length: 128 chars.', true)
     ->inject('response')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('events')
     ->action(function (string $userId, ?string $email, ?string $phone, ?string $password, string $name, Response $response, Document $project, Database $dbForProject, Event $events) {
+        if (empty($email) && empty($phone)) {
+            throw new Exception(Exception::USER_MISSING_IDENTIFIER);
+        }
 
         $user = createUser('plaintext', '{}', $userId, $email, $password, $phone, $name, $project, $dbForProject, $events);
 

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -85,6 +85,8 @@ class Exception extends \Exception
     public const USER_OAUTH2_UNAUTHORIZED          = 'user_oauth2_unauthorized';
     public const USER_OAUTH2_PROVIDER_ERROR        = 'user_oauth2_provider_error';
 
+    public const USER_MISSING_IDENTIFIER           = 'user_missing_identifier';
+
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';
     public const TEAM_INVITE_ALREADY_EXISTS        = 'team_invite_already_exists';

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -172,6 +172,18 @@ trait UsersBase
         $this->assertEquals($res['body']['hashOptions']['signerKey'], 'XyEKE9RcTDeLEsL/RjwPDBv/RqDl8fb3gpYEOQaPihbxf1ZAtSOHCjuAAa7Q3oHpCYhXSN9tizHgVOwn6krflQ==');
         $this->assertEquals($res['body']['hashOptions']['saltSeparator'], 'Bw==');
 
+        /**
+         * Test for failure
+         */
+        $user = $this->client->call(Client::METHOD_POST, '/users', array_merge([
+            'content-type' => 'application/json',
+        ], $this->getHeaders()), [
+            'userId' => ID::unique(),
+            'password' => 'AxbbHBlhjbdxnrnKLJsde',
+        ]);
+
+        $this->assertEquals($user['headers']['status-code'], 400);
+
         return ['userId' => $body['$id']];
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Require either email or phone, and password, when creating a user

## Test Plan

Added test to assert 400 if no identifiers are passed

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/6117

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
