### PR TITLE
Fix deployment delete

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -84,6 +84,7 @@ $redeployVcs = function (Request $request, Document $function, Document $project
             Permission::delete(Role::any()),
         ],
         'resourceId' => $function->getId(),
+        'resourceInternalId' => $function->getInternalId(),
         'resourceType' => 'functions',
         'entrypoint' => $entrypoint,
         'commands' => $function->getAttribute('commands', ''),

--- a/app/controllers/api/vcs.php
+++ b/app/controllers/api/vcs.php
@@ -50,6 +50,7 @@ $createGitDeployments = function (GitHub $github, string $providerInstallationId
 
             $functionId = $resource->getAttribute('resourceId');
             $function = Authorization::skip(fn () => $dbForProject->getDocument('functions', $functionId));
+            $functionInternalId = $function->getInternalId();
 
             $deploymentId = ID::unique();
             $repositoryId = $resource->getId();
@@ -173,6 +174,7 @@ $createGitDeployments = function (GitHub $github, string $providerInstallationId
                     Permission::delete(Role::any()),
                 ],
                 'resourceId' => $functionId,
+                'resourceInternalId' => $functionInternalId,
                 'resourceType' => 'functions',
                 'entrypoint' => $function->getAttribute('entrypoint'),
                 'commands' => $function->getAttribute('commands'),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Prior to this, deleting a VCS deployment would fail because the deployment path for VCS deployments are empty. Because an error gets thrown, the delete function would stop and not delete the build files.

This change updates the worker to only delete the storage files if the path is set.

Fixes #6289

## Test Plan

Manually deleted a deployment:

<img width="805" alt="Screen Shot 2023-09-20 at 7 29 53 PM" src="https://github.com/appwrite/appwrite/assets/1477010/17476e6f-038f-42d5-9d4a-49ba4fac4601">

Manually deleted a function

<img width="839" alt="Screen Shot 2023-09-20 at 7 30 14 PM" src="https://github.com/appwrite/appwrite/assets/1477010/7d40e584-2cd3-4df5-a9b4-0abeff3324b4">

## Related PRs and Issues

- #6289

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
