### PR TITLE
Fix 6279 wrong validation of projectid

### DIFF
--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -17,7 +17,7 @@ class ProjectId extends Validator
      */
     public function isValid($value): bool
     {
-        return $value == 'unique()' || preg_match('/^[a-z0-9][a-z0-9-]{1,35}$/', $value);
+        return $value == 'unique()' || preg_match('/^[a-zA-Z0-9][a-zA-Z0-9\-_.]{1,35}$/', $value);
     }
 
     /**
@@ -27,7 +27,7 @@ class ProjectId extends Validator
      */
     public function getDescription(): string
     {
-        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and hyphen. Can\'t start with a special char.';
+        return 'Project IDs must contain at most 36 chars. Valid chars are A-Z, a-z, 0-9, and hyphen. Can\'t start with a special char.';
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It correct the validation for a project id . Project id cannot include capital letters, hyphens, or periods

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

i modified the regex to include all necessary characters

