### PR TITLE
Fix 6279 wrong validation of projectid

### DIFF
--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -17,7 +17,7 @@ class ProjectId extends Validator
      */
     public function isValid($value): bool
     {
-        return $value == 'unique()' || preg_match('/^[a-z0-9][a-z0-9-]{1,35}$/', $value);
+        return $value == 'unique()' || preg_match('/^[a-zA-Z0-9][a-zA-Z0-9\-_.]{1,35}$/', $value);
     }
 
     /**
@@ -27,7 +27,7 @@ class ProjectId extends Validator
      */
     public function getDescription(): string
     {
-        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and hyphen. Can\'t start with a special char.';
+        return 'Project IDs must contain at most 36 chars. Valid chars are A-Z, a-z, 0-9, and hyphen. Can\'t start with a special char.';
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It correct the validation for a project id . Project id cannot include capital letters, hyphens, or periods

## Test Plan

i modified the regex to include all necessary characters

## Before
![Before](https://github.com/appwrite/appwrite/assets/77477551/ae49324d-bebb-46d2-8c85-3d1175ac12fb)



## After
![After](https://github.com/appwrite/appwrite/assets/77477551/9c3ee586-650c-48f6-ad1f-21ff1507ef10)

## Before
![bf](https://github.com/appwrite/appwrite/assets/77477551/c31ab17e-dd70-4d70-ac4b-cde0e4e73eed)

## After
![af](https://github.com/appwrite/appwrite/assets/77477551/96378e49-e624-4423-8383-7e7941004a46)


## Related PRs and Issues

- (Bug Report: Not able to Create Project with Project id not equal to (Contain at most 36 chars. Valid chars are a-z, 0-9, and hyphen. Can't start with a special char.) #6279)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
