### PR TITLE
Feat: Parse event body

### DIFF
--- a/app/workers/functions.php
+++ b/app/workers/functions.php
@@ -363,7 +363,8 @@ $server->job()
                         path: '/',
                         method: 'POST',
                         headers: [
-                            'user-agent' => 'Appwrite/' . APP_VERSION_STABLE
+                            'user-agent' => 'Appwrite/' . APP_VERSION_STABLE,
+                            'content-type' => 'application/json'
                         ],
                     );
                     Console::success('Triggered function: ' . $events[0]);

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1294,6 +1294,9 @@ class FunctionsCustomServerTest extends Scope
 
         $this->assertEquals(200, $deployment['headers']['status-code']);
 
+        // Wait a little for activation to finish
+        sleep(5);
+
         // Create user to trigger event
         $user = $this->client->call(Client::METHOD_POST, '/users', array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1313,9 +1313,7 @@ class FunctionsCustomServerTest extends Scope
         $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()), [
-            'async' => false
-        ]);
+        ], $this->getHeaders()));
 
         $execution = $executions['body']['executions'][0];
 

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -32,8 +32,8 @@ class FunctionsCustomServerTest extends Scope
             'runtime' => 'php-8.0',
             'entrypoint' => 'index.php',
             'events' => [
-                'users.*.create',
-                'users.*.delete',
+                'buckets.*.create',
+                'buckets.*.delete',
             ],
             'schedule' => '0 0 1 1 *',
             'timeout' => 10,
@@ -50,8 +50,8 @@ class FunctionsCustomServerTest extends Scope
         $this->assertEquals(true, $dateValidator->isValid($response1['body']['$updatedAt']));
         $this->assertEquals('', $response1['body']['deployment']);
         $this->assertEquals([
-            'users.*.create',
-            'users.*.delete',
+            'buckets.*.create',
+            'buckets.*.delete',
         ], $response1['body']['events']);
         $this->assertEquals('0 0 1 1 *', $response1['body']['schedule']);
         $this->assertEquals(10, $response1['body']['timeout']);
@@ -191,8 +191,8 @@ class FunctionsCustomServerTest extends Scope
             'runtime' => 'php-8.0',
             'entrypoint' => 'index.php',
             'events' => [
-                'users.*.create',
-                'users.*.delete',
+                'buckets.*.create',
+                'buckets.*.delete',
             ],
             'schedule' => '0 0 1 1 *',
             'timeout' => 10,

--- a/tests/resources/functions/php-event/index.php
+++ b/tests/resources/functions/php-event/index.php
@@ -1,0 +1,8 @@
+<?php
+
+return function ($context) {
+    $context->log($context->req->body['$id']);
+    $context->log($context->req->body['name']);
+
+    return $context->res->empty();
+};


### PR DESCRIPTION
## What does this PR do?

Allows you to easily get data from event-triggered execution without having to parse it. Thanks to header, Open RUntimes will parse it.

## Test Plan

- [x] Add new test

## Related PRs and Issues

Reported during Office Hours on Discord

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
