### PR TITLE
Fix of Broken "Installation" Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For advanced production and custom installation, check out our Docker [environme
 
 ### Upgrade from an Older Version
 
-If you are upgrading your Appwrite server from an older version, you should use the Appwrite migration tool once your setup is completed. For more information regarding this, check out the [Installation Docs](https://appwrite.io/docs/installation).
+If you are upgrading your Appwrite server from an older version, you should use the Appwrite migration tool once your setup is completed. For more information regarding this, check out the [Installation Docs](https://appwrite.io/docs/advanced/self-hosting/).
 
 ## One-Click Setups
 


### PR DESCRIPTION


## What does this PR do?

This PR will fix the Broken "Installation" link at "[Upgrade from an Older Version]"

###Description

In the README.md file, under the Installation Section there is a link (please see the screenshot below)
![image](https://github.com/appwrite/appwrite/assets/114372455/a8ad3692-290c-476d-a1c0-8391ac177eac)

When you click on the Installation Docs, It redirects you to an url "https://appwrite.io/docs/installation" . But this URL shows 404 error. The valid URL is "https://appwrite.io/docs/advanced/self-hosting" . Which i have attached in my Commit.

BEFORE THE FIX:
![image](https://github.com/appwrite/appwrite/assets/114372455/30bacbf5-8d67-4b91-a37b-b626b0f80945)

AFTER THE FIX:
![image](https://github.com/appwrite/appwrite/assets/114372455/da97efc3-e8e4-4dfb-9b48-e6960016db20)


## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
