### PR TITLE
Same two way key

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1642,7 +1642,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/relati
         /** @var Document[] $attributes */
         foreach ($attributes as $attribute) {
             if (\strtolower($attribute->getId()) === \strtolower($key)) {
-                throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS);
+                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS);
             }
 
             if (
@@ -1650,11 +1650,17 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/relati
                 \strtolower($attribute->getAttribute('options')['twoWayKey']) === \strtolower($twoWayKey) &&
                 $attribute->getAttribute('options')['relatedCollection'] === $relatedCollection->getId()
             ) {
-                if ($twoWayKeyNull) {
-                    $twoWayKey .= '_' . uniqid();
-                } else {
-                    throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS);
-                }
+                // Currently, we always throw an Exception even when, We do not want to change $twoWayKsy on $twoWayKeyNull
+                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS);
+            }
+
+            if (
+                $type === Database::RELATION_MANY_TO_MANY &&
+                $attribute->getAttribute('type') === Database::VAR_RELATIONSHIP &&
+                $attribute->getAttribute('options')['relationType'] === Database::RELATION_MANY_TO_MANY &&
+                $attribute->getAttribute('options')['relatedCollection'] === $relatedCollection->getId()
+            ) {
+                throw new Exception('Cannot create more than one ManyToMany relation.');
             }
         }
 

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1650,8 +1650,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/relati
                 \strtolower($attribute->getAttribute('options')['twoWayKey']) === \strtolower($twoWayKey) &&
                 $attribute->getAttribute('options')['relatedCollection'] === $relatedCollection->getId()
             ) {
-                // Currently, we always throw an Exception even when, We do not want to change $twoWayKsy on $twoWayKeyNull
-                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS);
+                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS, 'Creating more than one "manyToMany" relationship on the same collection is currently not permitted.');
             }
 
             if (

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1650,7 +1650,8 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/relati
                 \strtolower($attribute->getAttribute('options')['twoWayKey']) === \strtolower($twoWayKey) &&
                 $attribute->getAttribute('options')['relatedCollection'] === $relatedCollection->getId()
             ) {
-                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS, 'Creating more than one "manyToMany" relationship on the same collection is currently not permitted.');
+                // Currently, we always throw an Exception even when, We do not want to change $twoWayKsy on $twoWayKeyNull
+                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS);
             }
 
             if (
@@ -1659,7 +1660,7 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/relati
                 $attribute->getAttribute('options')['relationType'] === Database::RELATION_MANY_TO_MANY &&
                 $attribute->getAttribute('options')['relatedCollection'] === $relatedCollection->getId()
             ) {
-                throw new Exception('Cannot create more than one ManyToMany relation.');
+                throw new Exception(Exception::ATTRIBUTE_ALREADY_EXISTS, 'Creating more than one "manyToMany" relationship on the same collection is currently not permitted.');
             }
         }
 

--- a/composer.lock
+++ b/composer.lock
@@ -1050,16 +1050,16 @@
         },
         {
             "name": "matomo/device-detector",
-            "version": "6.1.5",
+            "version": "6.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/device-detector.git",
-                "reference": "40ca2990dba2c1719e5c62168e822e0b86c167d4"
+                "reference": "5cbea85106e561c7138d03603eb6e05128480409"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/40ca2990dba2c1719e5c62168e822e0b86c167d4",
-                "reference": "40ca2990dba2c1719e5c62168e822e0b86c167d4",
+                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/5cbea85106e561c7138d03603eb6e05128480409",
+                "reference": "5cbea85106e561c7138d03603eb6e05128480409",
                 "shasum": ""
             },
             "require": {
@@ -1115,7 +1115,7 @@
                 "source": "https://github.com/matomo-org/matomo",
                 "wiki": "https://dev.matomo.org/"
             },
-            "time": "2023-08-17T16:17:41+00:00"
+            "time": "2023-10-02T10:01:54+00:00"
         },
         {
             "name": "mongodb/mongodb",
@@ -6017,5 +6017,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -156,11 +156,11 @@
         },
         {
             "name": "appwrite/php-runtimes",
-            "version": "0.13.0",
+            "version": "0.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/runtimes.git",
-                "reference": "5ab496b3908992b39275994a23783701c4b3de84"
+                "reference": "b584d19cdcd82737d0ee5c34d23de791f5ed3610"
             },
             "require": {
                 "php": ">=8.0",
@@ -195,7 +195,7 @@
                 "php",
                 "runtimes"
             ],
-            "time": "2023-09-12T19:38:43+00:00"
+            "time": "2023-10-16T15:39:53+00:00"
         },
         {
             "name": "chillerlan/php-qrcode",
@@ -341,16 +341,16 @@
         },
         {
             "name": "colinmollenhour/credis",
-            "version": "v1.15.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "28810439de1d9597b7ba11794ed9479fb6f3de7c"
+                "reference": "5641140e14a9679f5a6f66c97268727f9558b881"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/28810439de1d9597b7ba11794ed9479fb6f3de7c",
-                "reference": "28810439de1d9597b7ba11794ed9479fb6f3de7c",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/5641140e14a9679f5a6f66c97268727f9558b881",
+                "reference": "5641140e14a9679f5a6f66c97268727f9558b881",
                 "shasum": ""
             },
             "require": {
@@ -382,9 +382,9 @@
             "homepage": "https://github.com/colinmollenhour/credis",
             "support": {
                 "issues": "https://github.com/colinmollenhour/credis/issues",
-                "source": "https://github.com/colinmollenhour/credis/tree/v1.15.0"
+                "source": "https://github.com/colinmollenhour/credis/tree/v1.16.0"
             },
-            "time": "2023-04-18T15:34:23+00:00"
+            "time": "2023-10-26T17:02:51+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -897,72 +897,6 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.5"
             },
             "time": "2021-10-08T21:21:46+00:00"
-        },
-        {
-            "name": "laravel/pint",
-            "version": "v1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/pint.git",
-                "reference": "e60e2112ee779ce60f253695b273d1646a17d6f1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/e60e2112ee779ce60f253695b273d1646a17d6f1",
-                "reference": "e60e2112ee779ce60f253695b273d1646a17d6f1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "ext-tokenizer": "*",
-                "ext-xml": "*",
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.11.0",
-                "illuminate/view": "^9.32.0",
-                "laravel-zero/framework": "^9.2.0",
-                "mockery/mockery": "^1.5.1",
-                "nunomaduro/larastan": "^2.2.0",
-                "nunomaduro/termwind": "^1.14.0",
-                "pestphp/pest": "^1.22.1"
-            },
-            "bin": [
-                "builds/pint"
-            ],
-            "type": "project",
-            "autoload": {
-                "psr-4": {
-                    "App\\": "app/",
-                    "Database\\Seeders\\": "database/seeders/",
-                    "Database\\Factories\\": "database/factories/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "An opinionated code formatter for PHP.",
-            "homepage": "https://laravel.com",
-            "keywords": [
-                "format",
-                "formatter",
-                "lint",
-                "linter",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/pint/issues",
-                "source": "https://github.com/laravel/pint"
-            },
-            "time": "2022-11-29T16:25:20+00:00"
         },
         {
             "name": "league/csv",
@@ -1711,7 +1645,7 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -1758,7 +1692,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -2152,16 +2086,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.43.4",
+            "version": "0.43.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "cabdd02e8dc1732eb0b22007c511e7bb3caa5c8c"
+                "reference": "5f7b05189cfbcc0506090498c580c5765375a00a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/cabdd02e8dc1732eb0b22007c511e7bb3caa5c8c",
-                "reference": "cabdd02e8dc1732eb0b22007c511e7bb3caa5c8c",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/5f7b05189cfbcc0506090498c580c5765375a00a",
+                "reference": "5f7b05189cfbcc0506090498c580c5765375a00a",
                 "shasum": ""
             },
             "require": {
@@ -2202,9 +2136,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.43.4"
+                "source": "https://github.com/utopia-php/database/tree/0.43.5"
             },
-            "time": "2023-09-28T09:00:05+00:00"
+            "time": "2023-10-06T06:49:47+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -2564,16 +2498,16 @@
         },
         {
             "name": "utopia-php/migration",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "b2fd3a8310296f4e44ff0e85b0eb0230ad9a2f83"
+                "reference": "f78273b38bade23db5866e5c7cb5f55427ba82af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/b2fd3a8310296f4e44ff0e85b0eb0230ad9a2f83",
-                "reference": "b2fd3a8310296f4e44ff0e85b0eb0230ad9a2f83",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/f78273b38bade23db5866e5c7cb5f55427ba82af",
+                "reference": "f78273b38bade23db5866e5c7cb5f55427ba82af",
                 "shasum": ""
             },
             "require": {
@@ -2606,9 +2540,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/0.3.5"
+                "source": "https://github.com/utopia-php/migration/tree/0.3.6"
             },
-            "time": "2023-09-25T16:51:47+00:00"
+            "time": "2023-11-02T15:13:03+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -3092,26 +3026,25 @@
         },
         {
             "name": "utopia-php/system",
-            "version": "0.7.1",
+            "version": "0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/system.git",
-                "reference": "01bf0d283aded0ee0a7a6e5ff540acf64270ab27"
+                "reference": "4593d4d334b0c15879c4744a826e0362924c5d66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/system/zipball/01bf0d283aded0ee0a7a6e5ff540acf64270ab27",
-                "reference": "01bf0d283aded0ee0a7a6e5ff540acf64270ab27",
+                "url": "https://api.github.com/repos/utopia-php/system/zipball/4593d4d334b0c15879c4744a826e0362924c5d66",
+                "reference": "4593d4d334b0c15879c4744a826e0362924c5d66",
                 "shasum": ""
             },
             "require": {
-                "laravel/pint": "1.2.*",
                 "php": ">=8.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "squizlabs/php_codesniffer": "^3.6",
-                "vimeo/psalm": "4.0.1"
+                "laravel/pint": "1.13.*",
+                "phpstan/phpstan": "1.10.*",
+                "phpunit/phpunit": "9.6.*"
             },
             "type": "library",
             "autoload": {
@@ -3143,9 +3076,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/system/issues",
-                "source": "https://github.com/utopia-php/system/tree/0.7.1"
+                "source": "https://github.com/utopia-php/system/tree/0.7.2"
             },
-            "time": "2023-08-30T09:14:37+00:00"
+            "time": "2023-10-20T01:39:17+00:00"
         },
         {
             "name": "utopia-php/vcs",
@@ -3381,16 +3314,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "0.35.2",
+            "version": "0.35.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "2dfe0430a64ffd2a07078d83b20144b871acac3b"
+                "reference": "4c431d5324a8f8cd2cab9a5515c170a5b427d44c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/2dfe0430a64ffd2a07078d83b20144b871acac3b",
-                "reference": "2dfe0430a64ffd2a07078d83b20144b871acac3b",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/4c431d5324a8f8cd2cab9a5515c170a5b427d44c",
+                "reference": "4c431d5324a8f8cd2cab9a5515c170a5b427d44c",
                 "shasum": ""
             },
             "require": {
@@ -3426,9 +3359,9 @@
             "description": "Appwrite PHP library for generating API SDKs for multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/0.35.2"
+                "source": "https://github.com/appwrite/sdk-generator/tree/0.35.3"
             },
-            "time": "2023-09-14T14:59:50+00:00"
+            "time": "2023-11-12T05:56:27+00:00"
         },
         {
             "name": "doctrine/deprecations",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
+         stopOnFailure="true"
 >
     <extensions>
         <extension class="Appwrite\Tests\TestHook" />

--- a/tests/e2e/Services/Databases/DatabasesCustomClientTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomClientTest.php
@@ -6,6 +6,7 @@ use Tests\E2E\Client;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SideClient;
+use Utopia\Database\Database;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
@@ -224,6 +225,126 @@ class DatabasesCustomClientTest extends Scope
         $this->assertEquals(404, $response['headers']['status-code']);
 
         return [];
+    }
+
+    public function testRelationshipSameTwoWayKey(): void
+    {
+        $database = $this->client->call(Client::METHOD_POST, '/databases', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ], [
+            'databaseId' => ID::unique(),
+            'name' => 'Same two way key'
+        ]);
+
+        $databaseId = $database['body']['$id'];
+
+        $collection1 = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'collectionId' => ID::unique(),
+            'name' => 'c1',
+            'documentSecurity' => false,
+            'permissions' => [
+                Permission::create(Role::user($this->getUser()['$id'])),
+                Permission::read(Role::user($this->getUser()['$id'])),
+                Permission::update(Role::user($this->getUser()['$id'])),
+                Permission::delete(Role::user($this->getUser()['$id'])),
+            ]
+        ]);
+
+        $collection2 = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'collectionId' => ID::unique(),
+            'name' => 'c2',
+            'documentSecurity' => false,
+            'permissions' => [
+                Permission::create(Role::user($this->getUser()['$id'])),
+                Permission::read(Role::user($this->getUser()['$id'])),
+                Permission::update(Role::user($this->getUser()['$id'])),
+                Permission::delete(Role::user($this->getUser()['$id'])),
+            ]
+        ]);
+
+        \sleep(2);
+
+        $relation = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $collection1['body']['$id'] . '/attributes/relationship', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'relatedCollectionId' => $collection2['body']['$id'],
+            'type' => Database::RELATION_ONE_TO_ONE,
+            'twoWay' => false,
+            'onDelete' => 'cascade',
+            'key' => 'attr1',
+            'twoWayKey' => 'same_key'
+        ]);
+
+        \sleep(2);
+
+        $this->assertEquals(202, $relation['headers']['status-code']);
+        $this->assertEquals('same_key', $relation['body']['twoWayKey']);
+
+        $relation = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $collection1['body']['$id'] . '/attributes/relationship', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'relatedCollectionId' => $collection2['body']['$id'],
+            'type' => Database::RELATION_ONE_TO_MANY,
+            'twoWay' => false,
+            'onDelete' => 'cascade',
+            'key' => 'attr2',
+            'twoWayKey' => 'same_key'
+        ]);
+
+        \sleep(2);
+
+        $this->assertEquals('Document with the requested ID already exists. Try again with a different ID or use "unique()" to generate a unique ID.', $relation['body']['message']);
+        $this->assertEquals(409, $relation['body']['code']);
+
+
+        // twoWayKey is null
+        $relation = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $collection1['body']['$id'] . '/attributes/relationship', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'relatedCollectionId' => $collection2['body']['$id'],
+            'type' => Database::RELATION_ONE_TO_MANY,
+            'twoWay' => false,
+            'onDelete' => 'cascade',
+            'key' => 'attr3',
+        ]);
+
+        \sleep(2);
+
+        $this->assertEquals(202, $relation['headers']['status-code']);
+        $this->assertArrayHasKey('twoWayKey', $relation['body']);
+
+        $relation = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $collection1['body']['$id'] . '/attributes/relationship', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'relatedCollectionId' => $collection2['body']['$id'],
+            'type' => Database::RELATION_ONE_TO_MANY,
+            'twoWay' => false,
+            'onDelete' => 'cascade',
+            'key' => 'attr4',
+        ]);
+
+        \sleep(2);
+
+        $this->assertEquals(202, $relation['headers']['status-code']);
+        $this->assertArrayHasKey('twoWayKey', $relation['body']);
     }
 
     public function testUpdateTwoWayRelationship(): void

--- a/tests/e2e/Services/Databases/DatabasesCustomClientTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomClientTest.php
@@ -381,8 +381,8 @@ class DatabasesCustomClientTest extends Scope
 
         \sleep(2);
 
-        $this->assertEquals(500, $relation['body']['code']);
-        $this->assertEquals('Server Error', $relation['body']['message']);
+        $this->assertEquals(409, $relation['body']['code']);
+        $this->assertEquals('Creating more than one "manyToMany" relationship on the same collection is currently not permitted.', $relation['body']['message']);
     }
 
     public function testUpdateWithoutRelationPermission(): void


### PR DESCRIPTION
Fix for relations attributes when twoWayKey variable is not passed in API,
We do not want the worker to throw the Error
Until now, it was checked only for twoWay = true

Added a validation to prevent the creation of 2 manyToMany relations between same collections


Fixes: https://github.com/appwrite/appwrite/issues/6281
