### PR TITLE
Fix 6467 correct projectid error message

### DIFF
--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -27,7 +27,7 @@ class ProjectId extends Validator
      */
     public function getDescription(): string
     {
-        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and non-leading hyphens. Can\'t start with a special char.';
+        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and non-leading hyphens. Can\'t start with a special char';
     }
 
     /**

--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -27,7 +27,7 @@ class ProjectId extends Validator
      */
     public function getDescription(): string
     {
-        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and non-leading hyphens. Can\'t start with a special char';
+        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9 and non-leading hyphens. Can\'t start with a special char';
     }
 
     /**

--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -27,7 +27,7 @@ class ProjectId extends Validator
      */
     public function getDescription(): string
     {
-        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9 and non-leading hyphens. Can\'t start with a special char';
+        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9 and non-leading hyphens. Can\'t start with a special char.';
     }
 
     /**

--- a/src/Appwrite/Utopia/Database/Validator/ProjectId.php
+++ b/src/Appwrite/Utopia/Database/Validator/ProjectId.php
@@ -27,7 +27,7 @@ class ProjectId extends Validator
      */
     public function getDescription(): string
     {
-        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and hyphen. Can\'t start with a special char.';
+        return 'Project IDs must contain at most 36 chars. Valid chars are a-z, 0-9, and non-leading hyphens. Can\'t start with a special char.';
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR updates the description for Project IDs to clarify that they are limited to 36 characters, with valid characters being a-z, 0-9, and non-leading hyphens. It ensures accuracy and clarity in the documentation.


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

- [x] Verified that the Project IDs validation matches the updated description.
- [x] Checked for any rendering issues in the documentation.

![2023-10-04 05_46_23-Organizations - Appwrite](https://github.com/appwrite/appwrite/assets/64472685/a4d3f547-d8ab-4c32-a222-a82fc3c025ab)



## Related PRs and Issues

Related issue: #6467 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
