### PR TITLE
Fix: realtime logs

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -113,7 +113,7 @@ class Executor
     ) {
         $timeout  = (int) App::getEnv('_APP_FUNCTIONS_BUILD_TIMEOUT', 900);
 
-        $runtimeId = "$projectId-$deploymentId";
+        $runtimeId = "$projectId-$deploymentId-build";
         $route = "/runtimes/{$runtimeId}/logs";
         $params = [
             'timeout' => $timeout


### PR DESCRIPTION
## What does this PR do?

In previous patch we added `-build` suffix to deployment containers, to separate them from execution containers. This patch was supposed to prevent executor saying that same runtime already exists (possible race condition).

We forgot to rename logs container name. Realtime logs were watching logs of executor container, which didn't exit.

This PR fixes it, and realtime logs now look at proper build container.

_This patch is only necessary urgent for Cloud, as the previous patch PR was not yet released in 1.4.x._

## Test Plan

- [x] manual QA

Before:
<img width="943" alt="CleanShot 2023-10-04 at 10 17 44@2x" src="https://github.com/appwrite/appwrite/assets/19310830/c9d3a874-add3-4a45-9036-9f1c5b22707f">

After:

![CleanShot 2023-10-04 at 10 19 44@2x](https://github.com/appwrite/appwrite/assets/19310830/34a39851-2887-4aeb-952d-363d196eb031)

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/6270

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
