### PR TITLE
Ensure openruntimes-executor restarts after a server reboot

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -666,6 +666,7 @@ services:
     container_name: openruntimes-executor
     hostname: appwrite-executor
     <<: *x-logging
+    restart: unless-stopped
     stop_signal: SIGINT
     image: openruntimes/executor:0.4.3
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -722,6 +722,7 @@ services:
     <<: *x-logging
     stop_signal: SIGINT
     image: openruntimes/executor:0.4.3
+    restart: unless-stopped
     networks:
       - appwrite
       - runtimes


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Every other service restarts automatically after a server reboot so the openruntimes-executor should too. Otherwise, function executions will fail as the executor is unavailable.

## Test Plan

None

## Related PRs and Issues

- #6442 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
