### PR TITLE
[WIP]: Add storage uploaded event to fix #4507

### DIFF
--- a/app/config/events.php
+++ b/app/config/events.php
@@ -144,6 +144,9 @@ return [
             'create' => [
                 '$description' => 'This event triggers when a file is created.',
             ],
+            'uploaded' => [
+                '$description' => 'This event triggers when a file is created and all chunks are uploaded.',
+            ],
             'delete' => [
                 '$description' => 'This event triggers when a file is deleted.'
             ],


### PR DESCRIPTION
## What does this PR do?

Introduce a new event: `buckets.*.files.*.upload` that is only triggered if all chunks are uploaded.


I didn't want to introduce a new event action, but I also didn't find a way to solve this problem with the current implementation without breaking API compatibility.
Please suggest a better action name than upload.
My preferred action name would be `created` but that might confuse users since `create` already exists.

## Test Plan

I only tested if functions execute correctly and they do.
I did not check Webhook and Realtime yet because i need to get some sleep now. 😴 
This is why i marked it as a draft.

## Related PRs and Issues

#4507

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [X] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
