### PR TITLE
Update teamInternalId when updating project team

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -483,6 +483,7 @@ App::patch('/v1/projects/:projectId/team')
 
         $project = $dbForConsole->updateDocument('projects', $project->getId(), $project
             ->setAttribute('teamId', $teamId)
+            ->setAttribute('teamInternalId', $team->getInternalId())
             ->setAttribute('$permissions', [
                 Permission::read(Role::team(ID::custom($teamId))),
                 Permission::update(Role::team(ID::custom($teamId), 'owner')),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This is important because when an organization is deleted, projects are
fetched by the teamInternalId and if the teamInternalId is not updated
when the project team is updated, the project will be deleted if the
previous organization is deleted.

In addition, since the following collections also have permissions set to the team,
this PR updates them for consistency:

- installations
- repositories
- vcsComments

I did look into other collections but they didn't need to be updated:

- schedules
  - Always skip so don't have to update permissions
  - Team ID isn't in schedule
- platforms
  - Permissions are set to any since the data is fetched via subquery filter
- keys
  - Permissions are set to any since the data is fetched via subquery filter
- webhooks
  - Permissions are set to any since the data is fetched via subquery filter
- certificates
  - fetch calls are only done in admin mode where permissions are ignored
- realtime
  - Only fetched and updated by Appwrite internally
- rules
  - fetch calls are only done in admin mode where permissions are ignored
- vcsCommentLocks
  - Only fetched and updated by Appwrite internally.

Fixes #6879

## Test Plan

Manually moved a project, deleted the old organization, and confirmed the project still exists.

The logs show only the organization is deleted (since there aren't any other projects in the organization):

<img width="1005" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/4f95419b-ad29-4140-acca-b18692521375">

## Related PRs and Issues

- #6879

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
