### PR TITLE
add fusionauth provider

### DIFF
--- a/app/config/providers.php
+++ b/app/config/providers.php
@@ -142,6 +142,16 @@ return [
         'beta' => false,
         'mock' => false,
     ],
+    'fusionauth' => [
+        'name' => 'FusionAuth',
+        'developers' => 'https://fusionauth.io/docs',
+        'icon' => 'icon-fusionauth',
+        'enabled' => true,
+        'sandbox' => false,
+        'form' => false,
+        'beta' => false,
+        'mock' => false,
+    ],
     'github' => [
         'name' => 'GitHub',
         'developers' => 'https://developer.github.com/',

--- a/src/Appwrite/Auth/OAuth2/FusionAuth.php
+++ b/src/Appwrite/Auth/OAuth2/FusionAuth.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Appwrite\Auth\OAuth2;
+
+use Appwrite\Auth\OAuth2;
+
+// Reference Material
+// https://fusionauth.io/docs/v1/tech/oauth/
+
+class FusionAuth extends OAuth2
+{
+    /**
+     * @var array
+     */
+    protected array $scopes = [
+        'openid',
+        'offline_access'
+    ];
+
+    /**
+     * @var array
+     */
+    protected array $user = [];
+
+    /**
+     * @var array
+     */
+    protected array $tokens = [];
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'fusionauth';
+    }
+
+    /**
+     * @return string
+     */
+     
+    public function getLoginURL(): string
+    {
+        return 'https://' . $this->getFusionAuthDomain() . '/oauth2/authorize?' . \http_build_query([
+            'client_id' => $this->appID,
+            'redirect_uri' => $this->callback,
+            'state' => \json_encode($this->state),
+            'scope' => \implode(' ', $this->getScopes()),
+            'response_type' => 'code'
+        ]);
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return array
+     */
+    protected function getTokens(string $code): array
+    {
+        if (empty($this->tokens)) {
+            $headers = ['Content-Type: application/x-www-form-urlencoded'];
+            $this->tokens = \json_decode($this->request(
+                'POST',
+                'https://' . $this->getFusionAuthDomain() . '/oauth2/token',
+                $headers,
+                \http_build_query([
+                    'code' => $code,
+                    'client_id' => $this->appID,
+                    'client_secret' => $this->getClientSecret(),
+                    'redirect_uri' => $this->callback,
+                    'scope' => \implode(' ', $this->getScopes()),
+                    'grant_type' => 'authorization_code'
+                ])
+            ), true);
+        }
+
+        return $this->tokens;
+    }
+
+
+    /**
+     * @param string $refreshToken
+     *
+     * @return array
+     */
+    public function refreshTokens(string $refreshToken): array
+    {
+        $headers = ['Content-Type: application/x-www-form-urlencoded'];
+        $this->tokens = \json_decode($this->request(
+            'POST',
+            'https://' . $this->getFusionAuthDomain() . '/oauth2/token',
+            $headers,
+            \http_build_query([
+                'refresh_token' => $refreshToken,
+                'client_id' => $this->appID,
+                'client_secret' => $this->getClientSecret(),
+                'grant_type' => 'refresh_token'
+            ])
+        ), true);
+
+        if (empty($this->tokens['refresh_token'])) {
+            $this->tokens['refresh_token'] = $refreshToken;
+        }
+
+        return $this->tokens;
+    }
+
+    /**
+     * @param string $accessToken
+     *
+     * @return string
+     */
+    public function getUserID(string $accessToken): string
+    {
+        $user = $this->getUser($accessToken);
+
+        return $user['sub'] ?? '';
+    }
+
+    /**
+     * @param string $accessToken
+     *
+     * @return string
+     */
+    public function getUserEmail(string $accessToken): string
+    {
+        $user = $this->getUser($accessToken);
+
+        return $user['email'] ?? '';
+    }
+
+    /**
+     * Check if the OAuth email is verified
+     *
+     * @link https://fusionauth.io/docs/v1/tech/oauth/endpoints#userinfo
+     *
+     * @param string $accessToken
+     *
+     * @return bool
+     */
+    public function isEmailVerified(string $accessToken): bool
+    {
+        $user = $this->getUser($accessToken);
+
+        if ($user['email_verified'] ?? false) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $accessToken
+     *
+     * @return string
+     */
+    public function getUserName(string $accessToken): string
+    {
+        $user = $this->getUser($accessToken);
+
+        return $user['name'] ?? '';
+    }
+
+    /**
+     * @param string $accessToken
+     *
+     * @return array
+     */
+    protected function getUser(string $accessToken): array
+    {
+        if (empty($this->user)) {
+            $headers = ['Authorization: Bearer ' . \urlencode($accessToken)];
+            $user = $this->request('GET', 'https://' . $this->getFusionAuthDomain() . '/oauth2/userinfo', $headers);
+            $this->user = \json_decode($user, true);
+        }
+
+        return $this->user;
+    }
+
+    /**
+     * Extracts the Client Secret from the JSON stored in appSecret
+     *
+     * @return string
+     */
+    protected function getClientSecret(): string
+    {
+        $secret = $this->getAppSecret();
+
+        return $secret['clientSecret'] ?? '';
+    }
+
+    /**
+     * Extracts the FusionAuth Domain from the JSON stored in appSecret
+     *
+     * @return string
+     */
+    protected function getFusionAuthDomain(): string
+    {
+        $secret = $this->getAppSecret();
+
+        return $secret['FusionAuthDomain'] ?? '';
+    }
+
+    /**
+     * Decode the JSON stored in appSecret
+     *
+     * @return array
+     */
+    protected function getAppSecret(): array
+    {
+        try {
+            $secret = \json_decode($this->appSecret, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $th) {
+            throw new \Exception('Invalid secret');
+        }
+        return $secret;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Allows for FusionAuth to be a OAuth2 provider, similar to Auth0. 

## Test Plan

Tested using this SvelteKit repo
https://github.com/codercatdev/appwrite-fusionauth.git

Create a new Application then enable OAuth2 Provider FusionAuth. 
For testing public access use https://sandbox.fusionauth.io/


## Related PRs and Issues


## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
