### PR TITLE
Fixed Image Links in README.md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Appwrite's current structure is a combination of both [Monolithic](https://en.wi
 
 ---
 
-## ![Appwrite](docs/specs/overview.drawio.svg)
+## ![Appwrite](https://ipfs.io/ipfs/bafybeickjqc4i4eil6thlzsx4dujvdjtctucz52n4pkptbgufo2jesmrla/overview.drawio.svg)
 
 ### File Structure
 
@@ -463,7 +463,7 @@ Pull requests are great, but there are many other ways you can help Appwrite.
 
 ### Blogging & Speaking
 
-Blogging, speaking about, or creating tutorials about one of Appwrite’s many features are great ways to get the word out about Appwrite. Mention [@appwrite](https://twitter.com/appwrite) on Twitter and/or [email team@appwrite.io](mailto:team@appwrite.io) so we can give pointers and tips and help you spread the word by promoting your content on the different Appwrite communication channels. Please add your blog posts and videos of talks to our [Awesome Appwrite](https://github.com/appwrite/awesome-appwrite) repo on GitHub.
+Blogging, speaking about, or creating tutorials about one of Appwrite’s many features are great ways to get the word out about Appwrite. Mention [@appwrite](https://twitter.com/appwrite) on X and/or [email team@appwrite.io](mailto:team@appwrite.io) so we can give pointers and tips and help you spread the word by promoting your content on the different Appwrite communication channels. Please add your blog posts and videos of talks to our [Awesome Appwrite](https://github.com/appwrite/awesome-appwrite) repo on GitHub.
 
 ### Presenting at Meetups
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -2,7 +2,7 @@
 
 <br />
 <p align="center">
-    <a href="https://appwrite.io" target="_blank"><img src="./public/images/banner.png" alt="Appwrite Logo"></a>
+    <a href="https://appwrite.io" target="_blank"><img src="https://ipfs.io/ipfs/bafybeihsb6oxzouskiennltqlnkgrhspppu4uqhcrj2kpv7rw7nb2pa3ri/banner.png" alt="Appwrite Logo"></a>
     <br />
     <br />
     <b>适用于[Flutter/Vue/Angular/React/iOS/Android/* 等等平台 *]的完整后端服务</b>
@@ -29,7 +29,14 @@ Appwrite是一个基于Docker的端到端开发者平台，其容器化的微服
 
 Appwrite 可以提供给开发者用户验证，外部授权，用户数据读写检索，文件储存，图像处理，云函数计算，[等多种服务](https://appwrite.io/docs).
 
-![Appwrite](public/images/github.png)
+<p align="center">
+    <br />
+    <a href="https://www.producthunt.com/posts/appwrite-2?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-appwrite-2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=360315&theme=light&period=daily" alt="Appwrite - 100&#0037;&#0032;open&#0032;source&#0032;alternative&#0032;for&#0032;Firebase | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+    <br />
+    <br />
+</p>
+
+![Appwrite](https://ipfs.io/ipfs/bafybeicfrjeacfkl7wuos25dvn5fruf4xezcq7ee64c4k4iqhxknazgthe/github.png)
 
 更多信息请到 Appwrite 官网查看： [https://appwrite.io](https://appwrite.io)
 
@@ -153,7 +160,7 @@ docker run -it --rm `
 
 ## 软件架构
 
-![Appwrite 软件架构](docs/specs/overview.drawio.svg)
+![Appwrite 软件架构](https://ipfs.io/ipfs/bafybeickjqc4i4eil6thlzsx4dujvdjtctucz52n4pkptbgufo2jesmrla/overview.drawio.svg)
 
 Appwrite 使用高拓展性的微服务架构。此外，Appwrite 支持多种 API（REST、WebSocket 和 即将推出的 GraphQL），来迎合您的个性化开发习惯。
 
@@ -171,7 +178,7 @@ Appwrite API 界面层利用后台缓存和任务委派来提供极速的响应�
 
 ## 订阅我们
 
-加入我们在世界各地不断发展的社区！请参阅我们的官方 [博客](https://medium.com/appwrite-io)。在 [Twitter](https://twitter.com/appwrite)、[Facebook 页面](https://www.facebook.com/appwrite.io)、[Facebook 群组](https://www.facebook.com/appwrite.io/groups/)、[开发者社区](https://dev.to/appwrite) 等平台订阅我们或加入我们的 [Discord 社区](https://discord.gg/GSeTUeA) 以获得更多帮助，想法和讨论。
+加入我们在世界各地不断发展的社区！请参阅我们的官方 [博客](https://medium.com/appwrite-io)。在 [X](https://twitter.com/appwrite)、[Facebook 页面](https://www.facebook.com/appwrite.io)、[Facebook 群组](https://www.facebook.com/appwrite.io/groups/)、[开发者社区](https://dev.to/appwrite) 等平台订阅我们或加入我们的 [Discord 社区](https://discord.gg/GSeTUeA) 以获得更多帮助，想法和讨论。
 
 ## 版权说明
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Using Appwrite, you can easily integrate your app with user authentication and m
     <br />
     <a href="https://www.producthunt.com/posts/appwrite-2?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-appwrite-2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=360315&theme=light&period=daily" alt="Appwrite - 100&#0037;&#0032;open&#0032;source&#0032;alternative&#0032;for&#0032;Firebase | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
     <br />
+    <br />
 </p>
 
-![Appwrite](public/images/github.png)
+![Appwrite](https://ipfs.io/ipfs/bafybeicfrjeacfkl7wuos25dvn5fruf4xezcq7ee64c4k4iqhxknazgthe/github.png)
 
 Find out more at: [https://appwrite.io](https://appwrite.io)
 
@@ -212,7 +213,7 @@ For security issues, kindly email us at [security@appwrite.io](mailto:security@a
 
 ## Follow Us
 
-Join our growing community around the world! Check out our official [Blog](https://medium.com/appwrite-io). Follow us on [Twitter](https://twitter.com/appwrite), [Facebook Page](https://www.facebook.com/appwrite.io), [Facebook Group](https://www.facebook.com/groups/appwrite.developers/), [Dev Community](https://dev.to/appwrite) or join our live [Discord server](https://discord.gg/GSeTUeA) for more help, ideas, and discussions.
+Join our growing community around the world! Check out our official [Blog](https://medium.com/appwrite-io). Follow us on [X](https://twitter.com/appwrite), [Facebook Page](https://www.facebook.com/appwrite.io), [Facebook Group](https://www.facebook.com/groups/appwrite.developers/), [Dev Community](https://dev.to/appwrite) or join our live [Discord server](https://discord.gg/GSeTUeA) for more help, ideas, and discussions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <br />
 <p align="center">
-    <a href="https://appwrite.io" target="_blank"><img src="./public/images/banner.png" alt="Appwrite Logo"></a>
+    <a href="https://appwrite.io" target="_blank"><img src="https://ipfs.io/ipfs/bafybeihsb6oxzouskiennltqlnkgrhspppu4uqhcrj2kpv7rw7nb2pa3ri/banner.png" alt="Appwrite Logo"></a>
     <br />
     <br />
     <b>Appwrite is a backend platform for developing Web, Mobile, and Flutter applications. Built with the open source community and optimized for developer experience in the coding languages you love.</b>
@@ -34,7 +34,6 @@ Using Appwrite, you can easily integrate your app with user authentication and m
 <p align="center">
     <br />
     <a href="https://www.producthunt.com/posts/appwrite-2?utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-appwrite-2" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=360315&theme=light&period=daily" alt="Appwrite - 100&#0037;&#0032;open&#0032;source&#0032;alternative&#0032;for&#0032;Firebase | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
-    <br />
     <br />
 </p>
 
@@ -119,19 +118,19 @@ Choose from one of the providers below:
   <tr>
     <td align="center" width="100" height="100">
       <a href="https://marketplace.digitalocean.com/apps/appwrite">
-        <img width="50" height="39" src="public/images/integrations/digitalocean-logo.svg" alt="DigitalOcean Logo" />
+        <img width="50" height="39" src="https://ipfs.io/ipfs/bafybeihvfqbxzovytxgwgi2lftew4sgcij6mb7272x2qe4oix63x5t6bo4/digitalocean-logo.svg" alt="DigitalOcean Logo" />
           <br /><sub><b>DigitalOcean</b></sub></a>
         </a>
     </td>
     <td align="center" width="100" height="100">
       <a href="https://gitpod.io/#https://github.com/appwrite/integration-for-gitpod">
-        <img width="50" height="39" src="public/images/integrations/gitpod-logo.svg" alt="Gitpod Logo" />
+        <img width="50" height="39" src="https://ipfs.io/ipfs/bafybeihg7vede7mij3dfa5ptnv7woqzunnwmeindhol3vatwa5jzlsq5ei/gitpod-logo.svg" alt="Gitpod Logo" />
           <br /><sub><b>Gitpod</b></sub></a>    
       </a>
     </td>
     <td align="center" width="100" height="100">
       <a href="https://www.linode.com/marketplace/apps/appwrite/appwrite/">
-        <img width="50" height="39" src="public/images/integrations/akamai-logo.svg" alt="Akamai Logo" />
+        <img width="50" height="39" src="https://ipfs.io/ipfs/bafybeig6btok4xffvkaigd3hybb4kbpcoje2oio47cveosaqcf6tuzmxli/akamai-logo.svg" alt="Akamai Logo" />
           <br /><sub><b>Akamai Compute</b></sub></a>    
       </a>
     </td>
@@ -195,7 +194,7 @@ Looking for more SDKs? - Help us by contributing a pull request to our [SDK Gene
 
 ## Architecture
 
-![Appwrite Architecture](docs/specs/overview.drawio.svg)
+![Appwrite Architecture](https://ipfs.io/ipfs/bafybeickjqc4i4eil6thlzsx4dujvdjtctucz52n4pkptbgufo2jesmrla/overview.drawio.svg)
 
 Appwrite uses a microservices architecture that was designed for easy scaling and delegation of responsibilities. In addition, Appwrite supports multiple APIs, such as REST, WebSocket, and GraphQL to allow you to interact with your resources by leveraging your existing knowledge and protocols of choice.
 


### PR DESCRIPTION
## What does this PR do?
In the latest PR, I've replaced GitHub relative links with IPFS storage links in the README.md file to enhance image reliability. This change addresses image loading issues on GitHub, as demonstrated by the examples below, and ensures a consistent experience, particularly for contributors and developers with slower internet connections. Your feedback on this update is highly valuable.

#### Example: 
![Screenshot (1083)](https://github.com/appwrite/appwrite/assets/62978274/12015120-1a71-45cc-a885-b82e4a11feee)
![Screenshot (1084)](https://github.com/appwrite/appwrite/assets/62978274/55b985f2-7be1-4378-a49e-fcfa75d7b60e)
![Screenshot (1085)](https://github.com/appwrite/appwrite/assets/62978274/93790cb8-dbed-489c-9ffd-056a941a0158)


## Test Plan
You can view the README files now with the images rendering every time someone loads the file. 

## Related PRs and Issues
I found this issue while going through the repository and thought of fixing it.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

Could you please look into it and suggest to me if any improvements or changes are required? Would be more than happy to learn and grow. 
Alos, if possible could you please add the hacktoberfest label if you find it worth it? 
Thank you