### PR TITLE
fix: worker database authorization reset

### DIFF
--- a/app/worker.php
+++ b/app/worker.php
@@ -33,7 +33,7 @@ use Utopia\Logger\Logger;
 use Utopia\Pools\Group;
 use Utopia\Queue\Connection;
 
-Authorization::disable();
+Authorization::setDefaultStatus(false);
 Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
 
 


### PR DESCRIPTION
## What does this PR do?

- `listCollections` resets the authorization state and breaks the deletes worker during runtime when a project is deleted

## Test Plan

- covered

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
