### PR TITLE
Fix 400 error on function domain execution

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -408,7 +408,7 @@ App::init()
         * @see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
         */
         if (App::getEnv('_APP_OPTIONS_FORCE_HTTPS', 'disabled') === 'enabled') { // Force HTTPS
-            if ($request->getProtocol() !== 'https' && ($requestHeaders['host'] ?? '') !== 'localhost' && ($requestHeaders['host'] ?? '') !== APP_HOSTNAME_INTERNAL) { // localhost allowed for proxy, APP_HOSTNAME_INTERNAL allowed for migrations
+            if ($request->getProtocol() !== 'https' && ($swooleRequest->header['host'] ?? '') !== 'localhost' && ($swooleRequest->header['host'] ?? '') !== APP_HOSTNAME_INTERNAL) { // localhost allowed for proxy, APP_HOSTNAME_INTERNAL allowed for migrations
                 if ($request->getMethod() !== Request::METHOD_GET) {
                     throw new AppwriteException(AppwriteException::GENERAL_PROTOCOL_UNSUPPORTED, 'Method unsupported over HTTP. Please use HTTPS instead.');
                 }

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -107,6 +107,10 @@ class Request extends UtopiaRequest
     {
         $headers = $this->generateHeaders();
 
+        if (empty($this->swoole->cookie)) {
+            return $headers;
+        }
+
         $cookieHeaders = [];
         foreach ($this->swoole->cookie as $key => $value) {
             $cookieHeaders[] = "{$key}={$value}";


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

### Fix warning when cookie is null

`$this->swoole->cookie` was being referenced when it was null causing these warnings:

![image](https://github.com/appwrite/appwrite/assets/1477010/211b9f55-a699-4ef2-b691-880e9498e65f)

This PR checks for empty value before trying to iterate it.

### Fix incorrect genera_prototocol_unsupported error

`$requestHeaders` was being referenced before it was set. This PR reverts code back to using `$swooleRequest` to extract the header.

## Test Plan

Manual

## Related PRs and Issues

Previous PR:

* https://github.com/appwrite/appwrite/pull/7024

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
