### PR TITLE
feat: fix swoole warning

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -893,7 +893,6 @@ App::get('/v1/functions/:functionId/deployments/:deploymentId/download')
         }
 
         if ($size > APP_STORAGE_READ_BUFFER) {
-            $response->addHeader('Content-Length', $deviceFunctions->getFileSize($path));
             for ($i = 0; $i < ceil($size / MAX_OUTPUT_CHUNK_SIZE); $i++) {
                 $response->chunk(
                     $deviceFunctions->read(

--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -1108,7 +1108,6 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/download')
         }
 
         if ($size > APP_STORAGE_READ_BUFFER) {
-            $response->addHeader('Content-Length', $deviceFiles->getFileSize($path));
             for ($i = 0; $i < ceil($size / MAX_OUTPUT_CHUNK_SIZE); $i++) {
                 $response->chunk(
                     $deviceFiles->read(
@@ -1261,7 +1260,6 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/view')
 
         $size = $deviceFiles->getFileSize($path);
         if ($size > APP_STORAGE_READ_BUFFER) {
-            $response->addHeader('Content-Length', $deviceFiles->getFileSize($path));
             for ($i = 0; $i < ceil($size / MAX_OUTPUT_CHUNK_SIZE); $i++) {
                 $response->chunk(
                     $deviceFiles->read(


### PR DESCRIPTION
## What does this PR do?
Prevents the following warning
![Screenshot 2023-11-02 at 11 19 14 PM](https://github.com/appwrite/appwrite/assets/22452787/3aeea696-a1c0-4775-a09a-eebeb36a128e)

Stops setting `Content-Length` for chunked responses

## Test Plan

Download a file larger than 20MB from storage (so it uses chunked download) and verify the warning is not shown.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
