### PR TITLE
Fix the Health service's get X queue endpoints

### DIFF
--- a/app/controllers/api/health.php
+++ b/app/controllers/api/health.php
@@ -352,7 +352,7 @@ App::get('/v1/health/queue/webhooks')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::WEBHOOK_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/logs')
@@ -370,7 +370,7 @@ App::get('/v1/health/queue/logs')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::AUDITS_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/certificates')
@@ -388,7 +388,7 @@ App::get('/v1/health/queue/certificates')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::CERTIFICATES_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/builds')
@@ -406,7 +406,7 @@ App::get('/v1/health/queue/builds')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::BUILDS_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/databases')
@@ -425,7 +425,7 @@ App::get('/v1/health/queue/databases')
     ->inject('response')
     ->action(function (string $name, Connection $queue, Response $response) {
         $client = new Client($name, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/deletes')
@@ -443,7 +443,7 @@ App::get('/v1/health/queue/deletes')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::DELETE_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/mails')
@@ -461,7 +461,7 @@ App::get('/v1/health/queue/mails')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::MAILS_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/messaging')
@@ -479,7 +479,7 @@ App::get('/v1/health/queue/messaging')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::MESSAGING_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/migrations')
@@ -497,7 +497,7 @@ App::get('/v1/health/queue/migrations')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::MIGRATIONS_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/queue/functions')
@@ -515,7 +515,7 @@ App::get('/v1/health/queue/functions')
     ->inject('response')
     ->action(function (Connection $queue, Response $response) {
         $client = new Client(Event::FUNCTIONS_QUEUE_NAME, $queue);
-        $response->dynamic(new Document([ 'size' => $client->sumProcessingJobs() ]), Response::MODEL_HEALTH_QUEUE);
+        $response->dynamic(new Document([ 'size' => $client->getQueueSize() ]), Response::MODEL_HEALTH_QUEUE);
     }, ['response']);
 
 App::get('/v1/health/storage/local')


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Before this, the endpoints called $client->sumProcessingJobs() which only gets the currently processing jobs, but this endpoint should return what's currently in queue, pending to be processed. This should be retrieved using $client->getQueueSize().

## Test Plan

Steps I took to test:

1. Stop the deletes worker
2. Delete a team
3. Test the endpoint before and after the change

Before change:

<img width="403" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/595ea02b-9743-41cb-a2cd-a5b7860f19a4">

After change:

<img width="395" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/eb7258e6-75e4-4224-be08-b23e8f962f94">

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
