### PR TITLE
Update unsupported auth error code

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -208,7 +208,7 @@ return [
     Exception::USER_AUTH_METHOD_UNSUPPORTED => [
         'name' => Exception::USER_AUTH_METHOD_UNSUPPORTED,
         'description' => 'The requested authentication method is either disabled or unsupported. Please check the supported authentication methods in the Appwrite console.',
-        'code' => 501,
+        'code' => 403,
     ],
     Exception::USER_PHONE_ALREADY_EXISTS => [
         'name' => Exception::USER_PHONE_ALREADY_EXISTS,

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -975,7 +975,7 @@ class ProjectsConsoleClientTest extends Scope
             'name' => $name,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals($response['headers']['status-code'], 403);
 
         $response = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
             'content-type' => 'application/json',
@@ -1095,7 +1095,7 @@ class ProjectsConsoleClientTest extends Scope
             'name' => $name,
         ]);
 
-        $this->assertEquals($response['headers']['status-code'], 501);
+        $this->assertEquals($response['headers']['status-code'], 403);
 
         /**
          * Test for FAILURE
@@ -1525,8 +1525,8 @@ class ProjectsConsoleClientTest extends Scope
             'userId' => $userId
         ]);
 
-        $this->assertEquals(400, $response['headers']['status-code']);
-        $this->assertEquals(400, $response['body']['code']);
+        $this->assertEquals(403, $response['headers']['status-code']);
+        $this->assertEquals(403, $response['body']['code']);
         $this->assertEquals(Exception::USER_PASSWORD_PERSONAL_DATA, $response['body']['type']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account', array_merge([


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR updates the error code for `USER_AUTH_METHOD_UNSUPPORTED` from 501 to 403 as I believe this more accurately reflects the status we are returning which is ultimately that the user cannot authenticate with that method.

## Test Plan

Expected test status codes have been updated to reflect these changes

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
