### PR TITLE
Fix patch script, make errors silent

### DIFF
--- a/src/Appwrite/Platform/Tasks/patchRecreateRepositoriesDocuments.php
+++ b/src/Appwrite/Platform/Tasks/patchRecreateRepositoriesDocuments.php
@@ -37,9 +37,17 @@ class PatchRecreateRepositoriesDocuments extends Action
         $startTime = microtime(true);
 
         if (!empty($projectId)) {
-            $project = $dbForConsole->getDocument('projects', $projectId);
-            $dbForProject = call_user_func($getProjectDB, $project);
-            $this->recreateRepositories($dbForConsole, $dbForProject, $project);
+            try {
+                $project = $dbForConsole->getDocument('projects', $projectId);
+                $dbForProject = call_user_func($getProjectDB, $project);
+                $this->recreateRepositories($dbForConsole, $dbForProject, $project);
+            } catch (\Throwable $th) {
+                Console::error("Unexpected error occured with Project ID {$projectId}");
+                Console::error('[Error] Type: ' . get_class($th));
+                Console::error('[Error] Message: ' . $th->getMessage());
+                Console::error('[Error] File: ' . $th->getFile());
+                Console::error('[Error] Line: ' . $th->getLine());
+            }
         } else {
             $queries = [];
             if (!empty($after)) {
@@ -50,8 +58,18 @@ class PatchRecreateRepositoriesDocuments extends Action
                 Console::info("Iterating all projects");
             }
             $this->foreachDocument($dbForConsole, 'projects', $queries, function (Document $project) use ($getProjectDB, $dbForConsole) {
-                $dbForProject = call_user_func($getProjectDB, $project);
-                $this->recreateRepositories($dbForConsole, $dbForProject, $project);
+                $projectId = $project->getId();
+
+                try {
+                    $dbForProject = call_user_func($getProjectDB, $project);
+                    $this->recreateRepositories($dbForConsole, $dbForProject, $project);
+                } catch (\Throwable $th) {
+                    Console::error("Unexpected error occured with Project ID {$projectId}");
+                    Console::error('[Error] Type: ' . get_class($th));
+                    Console::error('[Error] Message: ' . $th->getMessage());
+                    Console::error('[Error] File: ' . $th->getFile());
+                    Console::error('[Error] Line: ' . $th->getLine());
+                }
             });
         }
 


### PR DESCRIPTION
## What does this PR do?

Projects with missing metadata collections stop the script. Would take hundreds of commands typed manually to iterate all projects. Making error silent ensures script loops over all proejcts

## Test Plan

QA on stage server will be done

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
