### PR TITLE
Add a flag to install and upgrade commands to not start Appwrite

### DIFF
--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -25,12 +25,12 @@ class Install extends Action
     {
         $this
             ->desc('Install Appwrite')
-            ->param('httpPort', '', new Text(4), 'Server HTTP port', true)
-            ->param('httpsPort', '', new Text(4), 'Server HTTPS port', true)
+            ->param('http-port', '', new Text(4), 'Server HTTP port', true)
+            ->param('https-port', '', new Text(4), 'Server HTTPS port', true)
             ->param('organization', 'appwrite', new Text(0), 'Docker Registry organization', true)
             ->param('image', 'appwrite', new Text(0), 'Main appwrite docker image', true)
             ->param('interactive', 'Y', new Text(1), 'Run an interactive session', true)
-            ->param('noStart', false, new Boolean(true), 'Run an interactive session', true)
+            ->param('no-start', false, new Boolean(true), 'Run an interactive session', true)
             ->callback(fn ($httpPort, $httpsPort, $organization, $image, $interactive, $noStart) => $this->action($httpPort, $httpsPort, $organization, $image, $interactive, $noStart));
     }
 

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -8,6 +8,7 @@ use Appwrite\Docker\Env;
 use Appwrite\Utopia\View;
 use Utopia\CLI\Console;
 use Utopia\Config\Config;
+use Utopia\Validator\Boolean;
 use Utopia\Validator\Text;
 use Utopia\Platform\Action;
 
@@ -29,10 +30,11 @@ class Install extends Action
             ->param('organization', 'appwrite', new Text(0), 'Docker Registry organization', true)
             ->param('image', 'appwrite', new Text(0), 'Main appwrite docker image', true)
             ->param('interactive', 'Y', new Text(1), 'Run an interactive session', true)
-            ->callback(fn ($httpPort, $httpsPort, $organization, $image, $interactive) => $this->action($httpPort, $httpsPort, $organization, $image, $interactive));
+            ->param('noStart', false, new Boolean(true), 'Run an interactive session', true)
+            ->callback(fn ($httpPort, $httpsPort, $organization, $image, $interactive, $noStart) => $this->action($httpPort, $httpsPort, $organization, $image, $interactive, $noStart));
     }
 
-    public function action(string $httpPort, string $httpsPort, string $organization, string $image, string $interactive): void
+    public function action(string $httpPort, string $httpsPort, string $organization, string $image, string $interactive, bool $noStart): void
     {
         $config = Config::getParam('variables');
         $defaultHTTPPort = '80';
@@ -220,9 +222,11 @@ class Install extends Action
             }
         }
 
-        Console::log("Running \"docker compose up -d --remove-orphans --renew-anon-volumes\"");
-
-        $exit = Console::execute("$env docker compose --project-directory $this->path up -d --remove-orphans --renew-anon-volumes", '', $stdout, $stderr);
+        $exit = 0;
+        if (!$noStart) {
+            Console::log("Running \"docker compose up -d --remove-orphans --renew-anon-volumes\"");
+            $exit = Console::execute("$env docker compose --project-directory $this->path up -d --remove-orphans --renew-anon-volumes", '', $stdout, $stderr);
+        }
 
         if ($exit !== 0) {
             $message = 'Failed to install Appwrite dockers';

--- a/src/Appwrite/Platform/Tasks/Upgrade.php
+++ b/src/Appwrite/Platform/Tasks/Upgrade.php
@@ -17,12 +17,12 @@ class Upgrade extends Install
     {
         $this
             ->desc('Upgrade Appwrite')
-            ->param('httpPort', '', new Text(4), 'Server HTTP port', true)
-            ->param('httpsPort', '', new Text(4), 'Server HTTPS port', true)
+            ->param('http-port', '', new Text(4), 'Server HTTP port', true)
+            ->param('https-port', '', new Text(4), 'Server HTTPS port', true)
             ->param('organization', 'appwrite', new Text(0), 'Docker Registry organization', true)
             ->param('image', 'appwrite', new Text(0), 'Main appwrite docker image', true)
             ->param('interactive', 'Y', new Text(1), 'Run an interactive session', true)
-            ->param('noStart', false, new Boolean(true), 'Run an interactive session', true)
+            ->param('no-start', false, new Boolean(true), 'Run an interactive session', true)
             ->callback(fn ($httpPort, $httpsPort, $organization, $image, $interactive, $noStart) => $this->action($httpPort, $httpsPort, $organization, $image, $interactive, $noStart));
     }
 

--- a/src/Appwrite/Platform/Tasks/Upgrade.php
+++ b/src/Appwrite/Platform/Tasks/Upgrade.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Platform\Tasks;
 
 use Utopia\CLI\Console;
+use Utopia\Validator\Boolean;
 use Utopia\Validator\Text;
 
 class Upgrade extends Install
@@ -21,10 +22,11 @@ class Upgrade extends Install
             ->param('organization', 'appwrite', new Text(0), 'Docker Registry organization', true)
             ->param('image', 'appwrite', new Text(0), 'Main appwrite docker image', true)
             ->param('interactive', 'Y', new Text(1), 'Run an interactive session', true)
-            ->callback(fn ($httpPort, $httpsPort, $organization, $image, $interactive) => $this->action($httpPort, $httpsPort, $organization, $image, $interactive));
+            ->param('noStart', false, new Boolean(true), 'Run an interactive session', true)
+            ->callback(fn ($httpPort, $httpsPort, $organization, $image, $interactive, $noStart) => $this->action($httpPort, $httpsPort, $organization, $image, $interactive, $noStart));
     }
 
-    public function action(string $httpPort, string $httpsPort, string $organization, string $image, string $interactive): void
+    public function action(string $httpPort, string $httpsPort, string $organization, string $image, string $interactive, bool $noStart): void
     {
         // Check for previous installation
         $data = @file_get_contents($this->path . '/docker-compose.yml');
@@ -37,6 +39,6 @@ class Upgrade extends Install
             Console::log('      └── docker-compose.yml');
             Console::exit(1);
         }
-        parent::action($httpPort, $httpsPort, $organization, $image, $interactive);
+        parent::action($httpPort, $httpsPort, $organization, $image, $interactive, $noStart);
     }
 }


### PR DESCRIPTION
This can be useful for cases where the developer only wants the files to be generated and doesn't want to start Appwrite.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Closes https://github.com/appwrite/appwrite/issues/7223

## Test Plan

Manually ran install:

<img width="824" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/191f4820-4d68-4c99-8230-f3e780ca6b84">

Manually ran upgrade:

<img width="867" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/f6245927-f7d0-469d-86c4-630721721de4">

## Related PRs and Issues

- #7223

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
