### PR TITLE
Fix user identity attaching to wrong user

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -550,11 +550,19 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
         if (!$user->isEmpty()) {
             $userId = $user->getId();
 
-            $identitiesWithMatchingEmail = $dbForProject->find('identities', [
+            $identityWithMatchingEmail = $dbForProject->findOne('identities', [
                 Query::equal('providerEmail', [$email]),
                 Query::notEqual('userId', $userId),
             ]);
-            if (!empty($identitiesWithMatchingEmail)) {
+            if (!empty($identityWithMatchingEmail)) {
+                throw new Exception(Exception::USER_ALREADY_EXISTS);
+            }
+
+            $userWithMatchingEmail = $dbForProject->find('users', [
+                Query::equal('email', [$email]),
+                Query::notEqual('$id', $userId),
+            ]);
+            if (!empty($userWithMatchingEmail)) {
                 throw new Exception(Exception::USER_ALREADY_EXISTS);
             }
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Suppose a user has 2 accounts on Appwrite:

1. joe@example.com
2. joe@gmail.com

Prior to this PR, if joe@example.com created a Google OAuth2 session using his joe@gmail.com email, a new joe@gmail.com identity would be created linked to joe@example.com.

This is especially problematic because if the user tried to create a Google OAuth2 session using joe@gmail.com, Appwrite would lookup the user via email and find the joe@gmail.com user, but then find an identity from joe@example.com. This mismatching user ID would then cause an error.

This PR prevents an identity from being created if the email from the OAuth2 provider matches another user's email.

Fixes #7190 

## Test Plan

Confirmed an error occurs when trying to link an identity when a user with the same email already exists:

<img width="555" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/fdf87ec5-499b-476c-819c-817b1fec6652">

## Related PRs and Issues

- #7190 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
