### PR TITLE
Add Tunnelmole as an open source alternative to ngrok

### DIFF
--- a/docs/sdks/android/GETTING_STARTED.md
+++ b/docs/sdks/android/GETTING_STARTED.md
@@ -39,9 +39,16 @@ val client = Client(context)
   .setSelfSigned(true) // Remove in production
 ```
 
-Before starting to send any API calls to your new Appwrite instance, make sure your Android emulators has network access to the Appwrite server hostname or IP address.
+Before starting to send any API calls to your new Appwrite instance, make sure your Android emulator has network access to the Appwrite server hostname or IP address.
 
-When trying to connect to Appwrite from an emulator or a mobile device, localhost is the hostname of the device or emulator and not your local Appwrite instance. You should replace localhost with your private IP. You can also use a service like [ngrok](https://ngrok.com/) to proxy the Appwrite API.
+
+When trying to connect to Appwrite from an emulator or a mobile device, `localhost` is the hostname of the device or emulator and not your local Appwrite instance. You should replace `localhost` with your private IP. You can also use a service like [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) or [ngrok](https://ngrok.com/) to proxy the Appwrite API.
+
+To use Tunnelmole:
+1. Install it with `curl -O https://install.tunnelmole.com/aPD4m/install && sudo bash install`
+2. Run it with `tmole 8000` (replacing `8000` with the port number you are listening on if it is different). In the output, you'll see two URLs, one http and a https URL. Its best to use the https url for privacy and security.
+
+Alternatively, you can use ngrok. [ngrok](https://ngrok.com/) is a popular closed-source tunnelling tool. It can be used to proxy the Appwrite API in the same way. To use it, first download and install ngrok from [https://ngrok.com/download](https://ngrok.com/download) then run `ngrok http 8000` (again, replacing `8000` with your port number). Be sure to use the https URL in the output for the best security.
 
 ### Make Your First Request
 

--- a/docs/sdks/android/GETTING_STARTED.md
+++ b/docs/sdks/android/GETTING_STARTED.md
@@ -44,8 +44,8 @@ Before starting to send any API calls to your new Appwrite instance, make sure y
 
 When trying to connect to Appwrite from an emulator or a mobile device, `localhost` is the hostname of the device or emulator and not your local Appwrite instance. You should replace `localhost` with your private IP. You can also use a service like [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) or [ngrok](https://ngrok.com/) to proxy the Appwrite API.
 
-To use Tunnelmole:
-1. Install it with `curl -O https://install.tunnelmole.com/aPD4m/install && sudo bash install`
+Tunnelmole is an open source tunneling tool. To use it:
+1. Install it with `curl -O https://install.tunnelmole.com/aPD4m/install && sudo bash install` (on Windows, download [tmole.exe](https://tunnelmole.com/downloads/tmole.exe) 
 2. Run it with `tmole 8000` (replacing `8000` with the port number you are listening on if it is different). In the output, you'll see two URLs, one http and a https URL. Its best to use the https url for privacy and security.
 
 Alternatively, you can use ngrok. [ngrok](https://ngrok.com/) is a popular closed-source tunnelling tool. It can be used to proxy the Appwrite API in the same way. To use it, first download and install ngrok from [https://ngrok.com/download](https://ngrok.com/download) then run `ngrok http 8000` (again, replacing `8000` with your port number). Be sure to use the https URL in the output for the best security.

--- a/docs/sdks/flutter/GETTING_STARTED.md
+++ b/docs/sdks/flutter/GETTING_STARTED.md
@@ -96,8 +96,8 @@ Before starting to send any API calls to your new Appwrite instance, make sure y
 
 When trying to connect to Appwrite from an emulator or a mobile device, `localhost` is the hostname of the device or emulator and not your local Appwrite instance. You should replace `localhost` with your private IP. You can also use a service like [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) or [ngrok](https://ngrok.com/) to proxy the Appwrite API.
 
-To use Tunnelmole:
-1. Install it with `curl -O https://install.tunnelmole.com/aPD4m/install && sudo bash install`
+Tunnelmole is an open source tunneling tool. To use it:
+1. Install it with `curl -O https://install.tunnelmole.com/aPD4m/install && sudo bash install` (on Windows, download [tmole.exe](https://tunnelmole.com/downloads/tmole.exe) 
 2. Run it with `tmole 8000` (replacing `8000` with the port number you are listening on if it is different). In the output, you'll see two URLs, one http and a https URL. Its best to use the https url for privacy and security.
 
 Alternatively, you can use ngrok. [ngrok](https://ngrok.com/) is a popular closed-source tunnelling tool. It can be used to proxy the Appwrite API in the same way. To use it, first download and install ngrok from [https://ngrok.com/download](https://ngrok.com/download) then run `ngrok http 8000` (again, replacing `8000` with your port number). Be sure to use the https URL in the output for the best security.

--- a/docs/sdks/flutter/GETTING_STARTED.md
+++ b/docs/sdks/flutter/GETTING_STARTED.md
@@ -92,7 +92,7 @@ void main() {
 }
 ```
 
-Before starting to send any API calls to your new Appwrite instance, make sure your Android or iOS emulators has network access to the Appwrite server hostname or IP address.
+Before starting to send any API calls to your new Appwrite instance, make sure your Android or iOS emulator has network access to the Appwrite server hostname or IP address.
 
 When trying to connect to Appwrite from an emulator or a mobile device, `localhost` is the hostname of the device or emulator and not your local Appwrite instance. You should replace `localhost` with your private IP. You can also use a service like [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) or [ngrok](https://ngrok.com/) to proxy the Appwrite API.
 

--- a/docs/sdks/flutter/GETTING_STARTED.md
+++ b/docs/sdks/flutter/GETTING_STARTED.md
@@ -94,7 +94,13 @@ void main() {
 
 Before starting to send any API calls to your new Appwrite instance, make sure your Android or iOS emulators has network access to the Appwrite server hostname or IP address.
 
-When trying to connect to Appwrite from an emulator or a mobile device, localhost is the hostname for the device or emulator and not your local Appwrite instance. You should replace localhost with your private IP as the Appwrite endpoint's hostname. You can also use a service like [ngrok](https://ngrok.com/) to proxy the Appwrite API.
+When trying to connect to Appwrite from an emulator or a mobile device, `localhost` is the hostname of the device or emulator and not your local Appwrite instance. You should replace `localhost` with your private IP. You can also use a service like [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) or [ngrok](https://ngrok.com/) to proxy the Appwrite API.
+
+To use Tunnelmole:
+1. Install it with `curl -O https://install.tunnelmole.com/aPD4m/install && sudo bash install`
+2. Run it with `tmole 8000` (replacing `8000` with the port number you are listening on if it is different). In the output, you'll see two URLs, one http and a https URL. Its best to use the https url for privacy and security.
+
+Alternatively, you can use ngrok. [ngrok](https://ngrok.com/) is a popular closed-source tunnelling tool. It can be used to proxy the Appwrite API in the same way. To use it, first download and install ngrok from [https://ngrok.com/download](https://ngrok.com/download) then run `ngrok http 8000` (again, replacing `8000` with your port number). Be sure to use the https URL in the output for the best security.
 
 ### Make Your First Request
 


### PR DESCRIPTION
This PR adds [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) as an open source alternative to ngrok in your SDK getting started guides for Android and Flutter.

I've also improved the docs slightly by fixing typos, highlighting `localhost` etc.

Tunnelmole works out of the box and can be optionally self hosted with the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service). Both the client and service are open source.

Example:
```
➜  ~ tmole 8000
http://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
https://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
