### PR TITLE
executor: pass build timeout to runtimes

### DIFF
--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -72,6 +72,7 @@ class Executor
     ) {
         $runtimeId = "$projectId-$deploymentId-build";
         $route = "/runtimes";
+        $timeout = (int) App::getEnv('_APP_FUNCTIONS_BUILD_TIMEOUT', 900);
         $params = [
             'runtimeId' => $runtimeId,
             'source' => $source,
@@ -84,9 +85,8 @@ class Executor
             'cpus' => $this->cpus,
             'memory' => $this->memory,
             'version' => $version,
+            'timeout' => $timeout,
         ];
-
-        $timeout  = (int) App::getEnv('_APP_FUNCTIONS_BUILD_TIMEOUT', 900);
 
         $response = $this->call(self::METHOD_POST, $route, [ 'x-opr-runtime-id' => $runtimeId ], $params, true, $timeout);
 
@@ -111,7 +111,7 @@ class Executor
         string $projectId,
         callable $callback
     ) {
-        $timeout  = (int) App::getEnv('_APP_FUNCTIONS_BUILD_TIMEOUT', 900);
+        $timeout = (int) App::getEnv('_APP_FUNCTIONS_BUILD_TIMEOUT', 900);
 
         $runtimeId = "$projectId-$deploymentId-build";
         $route = "/runtimes/{$runtimeId}/logs";


### PR DESCRIPTION
Allow setting build timeout for app function deployment so that slower building runtimes like Swift can be used with functions.

## What does this PR do?

* Pass build timeout env var to open-runtimes

## Test Plan

1. Locally set timeout beyond 10mins (this is the default from [open-runtimes](https://github.com/open-runtimes/executor/blob/main/app/http.php#L383).
_APP_FUNCTIONS_BUILD_TIMEOUT
Note also need to set OPR_PROXY_MAX_TIMEOUT.

2. Deploy a function that takes longer than 10 minutes to build.
![Screenshot 2023-12-27 at 9 53 42 PM](https://github.com/appwrite/appwrite/assets/10065149/8a105b82-3d84-4011-b4af-46b7245bbc82)



## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/7318

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
