### PR TITLE
Allow filtering targets by provider type

### DIFF
--- a/src/Appwrite/Utopia/Database/Validator/Queries/Targets.php
+++ b/src/Appwrite/Utopia/Database/Validator/Queries/Targets.php
@@ -8,6 +8,7 @@ class Targets extends Base
         'userId',
         'providerId',
         'identifier',
+        'providerType',
     ];
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Allow filtering targets by provider type so that a developer can filter a user's targets by provider type:

## Test Plan

Manually filtered on type == push:

<img width="1458" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/54eb7da0-0820-4b57-a19d-711d9028bcd3">

## Related PRs and Issues

Console change:

- https://github.com/appwrite/console/pull/712

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
