### PR TITLE
Add endpoint to list a message's targets

### DIFF
--- a/docs/references/messaging/list-message-targets.md
+++ b/docs/references/messaging/list-message-targets.md
@@ -1,0 +1,1 @@
+List the targets associated with a message as set via the targets attribute.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This endpoint is needed so that the Console can fetch the associated targets to display when viewing the details of a message or going in to edit a message.

## Test Plan

Manually tested the endpoint:

<img width="602" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/da51be9a-00e3-467c-b32f-acd652e8a187">

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
