### PR TITLE
Fix: Email image endpoints

### DIFF
--- a/app/config/locale/templates/email-base-styled.tpl
+++ b/app/config/locale/templates/email-base-styled.tpl
@@ -160,7 +160,7 @@
                     <td>
                         <img
                             height="32px"
-                            src="https://appwrite.io/assets/logotype/white.png"
+                            src="https://cloud.appwrite.io/images/mails/logo.png"
                         />
                     </td>
                 </tr>
@@ -200,7 +200,7 @@
                             class="social-icon"
                             title="Twitter"
                         >
-                            <img src="https://appwrite.io/email/x.png" height="24" width="24" />
+                            <img src="https://cloud.appwrite.io/images/mails/x.png" height="24" width="24" />
                         </a>
                     </td>
                     <td style="padding-left: 4px; padding-right: 4px">
@@ -208,7 +208,7 @@
                             href="https://appwrite.io/discord"
                             class="social-icon"
                         >
-                            <img src="https://appwrite.io/email/discord.png" height="24" width="24" />
+                            <img src="https://cloud.appwrite.io/images/mails/discord.png" height="24" width="24" />
                         </a>
                     </td>
                     <td style="padding-left: 4px; padding-right: 4px">
@@ -216,7 +216,7 @@
                             href="https://github.com/appwrite/appwrite"
                             class="social-icon"
                         >
-                            <img src="https://appwrite.io/email/github.png" height="24" width="24" />
+                            <img src="https://cloud.appwrite.io/images/mails/github.png" height="24" width="24" />
                         </a>
                     </td>
                 </tr>


### PR DESCRIPTION
## What does this PR do?

Decouple email images from landing page, and move it to Cloud instead.

## Test Plan

- [x] Manual QA
![CleanShot 2024-01-20 at 12 09 13@2x](https://github.com/appwrite/appwrite/assets/19310830/36f1d799-4fe5-4e1e-8087-590acb4d9267)

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
