### PR TITLE
Feat: CNAME validation logs

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -680,6 +680,7 @@ return [
         'name' => Exception::RULE_VERIFICATION_FAILED,
         'description' => 'Domain verification failed. Please check if your DNS records are correct and try again.',
         'code' => 401,
+        'publish' => true
     ],
     Exception::PROJECT_SMTP_CONFIG_INVALID => [
         'name' => Exception::PROJECT_SMTP_CONFIG_INVALID,

--- a/app/controllers/api/proxy.php
+++ b/app/controllers/api/proxy.php
@@ -14,6 +14,7 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
 use Utopia\Domains\Domain;
+use Utopia\Logger\Log;
 use Utopia\Validator\Domain as ValidatorDomain;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
@@ -278,7 +279,8 @@ App::patch('/v1/proxy/rules/:ruleId/verification')
     ->inject('queueForEvents')
     ->inject('project')
     ->inject('dbForConsole')
-    ->action(function (string $ruleId, Response $response, Certificate $queueForCertificates, Event $queueForEvents, Document $project, Database $dbForConsole) {
+    ->inject('log')
+    ->action(function (string $ruleId, Response $response, Certificate $queueForCertificates, Event $queueForEvents, Document $project, Database $dbForConsole, Log $log) {
         $rule = $dbForConsole->getDocument('rules', $ruleId);
 
         if ($rule->isEmpty() || $rule->getAttribute('projectInternalId') !== $project->getInternalId()) {
@@ -298,7 +300,14 @@ App::patch('/v1/proxy/rules/:ruleId/verification')
         $validator = new CNAME($target->get()); // Verify Domain with DNS records
         $domain = new Domain($rule->getAttribute('domain', ''));
 
+        $validationStart = \microtime(true);
         if (!$validator->isValid($domain->get())) {
+            $log->addExtra('dnsTiming', \strval(\microtime(true) - $validationStart));
+            $log->addTag('dnsDomain', $domain->get());
+
+            $error = $validator->getDnsResponse();
+            $log->addExtra('dnsResponse', \is_array($error) ? \json_encode($error) : \strval($error));
+
             throw new Exception(Exception::RULE_VERIFICATION_FAILED);
         }
 

--- a/app/controllers/api/proxy.php
+++ b/app/controllers/api/proxy.php
@@ -305,7 +305,7 @@ App::patch('/v1/proxy/rules/:ruleId/verification')
             $log->addExtra('dnsTiming', \strval(\microtime(true) - $validationStart));
             $log->addTag('dnsDomain', $domain->get());
 
-            $error = $validator->getDnsResponse();
+            $error = $validator->getLogs();
             $log->addExtra('dnsResponse', \is_array($error) ? \json_encode($error) : \strval($error));
 
             throw new Exception(Exception::RULE_VERIFICATION_FAILED);

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -603,9 +603,8 @@ App::error()
     ->inject('response')
     ->inject('project')
     ->inject('logger')
-    ->inject('loggerBreadcrumbs')
-    ->action(function (Throwable $error, App $utopia, Request $request, Response $response, Document $project, ?Logger $logger, array $loggerBreadcrumbs) {
-
+    ->inject('log')
+    ->action(function (Throwable $error, App $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log) {
         $version = App::getEnv('_APP_VERSION', 'UNKNOWN');
         $route = $utopia->getRoute();
         $publish = true;
@@ -615,54 +614,46 @@ App::error()
         }
 
         if ($logger && $publish) {
-            if ($error->getCode() >= 500 || $error->getCode() === 0) {
-                try {
-                    /** @var Utopia\Database\Document $user */
-                    $user = $utopia->getResource('user');
-                } catch (\Throwable $th) {
-                    // All good, user is optional information for logger
-                }
-
-                $log = new Utopia\Logger\Log();
-
-                if (isset($user) && !$user->isEmpty()) {
-                    $log->setUser(new User($user->getId()));
-                }
-
-                $log->setNamespace("http");
-                $log->setServer(\gethostname());
-                $log->setVersion($version);
-                $log->setType(Log::TYPE_ERROR);
-                $log->setMessage($error->getMessage());
-
-                $log->addTag('database', $project->getAttribute('database', 'console'));
-                $log->addTag('method', $route->getMethod());
-                $log->addTag('url', $route->getPath());
-                $log->addTag('verboseType', get_class($error));
-                $log->addTag('code', $error->getCode());
-                $log->addTag('projectId', $project->getId());
-                $log->addTag('hostname', $request->getHostname());
-                $log->addTag('locale', (string)$request->getParam('locale', $request->getHeader('x-appwrite-locale', '')));
-
-                $log->addExtra('file', $error->getFile());
-                $log->addExtra('line', $error->getLine());
-                $log->addExtra('trace', $error->getTraceAsString());
-                $log->addExtra('detailedTrace', $error->getTrace());
-                $log->addExtra('roles', Authorization::getRoles());
-
-                $action = $route->getLabel("sdk.namespace", "UNKNOWN_NAMESPACE") . '.' . $route->getLabel("sdk.method", "UNKNOWN_METHOD");
-                $log->setAction($action);
-
-                $isProduction = App::getEnv('_APP_ENV', 'development') === 'production';
-                $log->setEnvironment($isProduction ? Log::ENVIRONMENT_PRODUCTION : Log::ENVIRONMENT_STAGING);
-
-                foreach ($loggerBreadcrumbs as $loggerBreadcrumb) {
-                    $log->addBreadcrumb($loggerBreadcrumb);
-                }
-
-                $responseCode = $logger->addLog($log);
-                Console::info('Log pushed with status code: ' . $responseCode);
+            try {
+                /** @var Utopia\Database\Document $user */
+                $user = $utopia->getResource('user');
+            } catch (\Throwable $th) {
+                // All good, user is optional information for logger
             }
+
+            if (isset($user) && !$user->isEmpty()) {
+                $log->setUser(new User($user->getId()));
+            }
+
+            $log->setNamespace("http");
+            $log->setServer(\gethostname());
+            $log->setVersion($version);
+            $log->setType(Log::TYPE_ERROR);
+            $log->setMessage($error->getMessage());
+
+            $log->addTag('database', $project->getAttribute('database', 'console'));
+            $log->addTag('method', $route->getMethod());
+            $log->addTag('url', $route->getPath());
+            $log->addTag('verboseType', get_class($error));
+            $log->addTag('code', $error->getCode());
+            $log->addTag('projectId', $project->getId());
+            $log->addTag('hostname', $request->getHostname());
+            $log->addTag('locale', (string)$request->getParam('locale', $request->getHeader('x-appwrite-locale', '')));
+
+            $log->addExtra('file', $error->getFile());
+            $log->addExtra('line', $error->getLine());
+            $log->addExtra('trace', $error->getTraceAsString());
+            $log->addExtra('detailedTrace', $error->getTrace());
+            $log->addExtra('roles', Authorization::getRoles());
+
+            $action = $route->getLabel("sdk.namespace", "UNKNOWN_NAMESPACE") . '.' . $route->getLabel("sdk.method", "UNKNOWN_METHOD");
+            $log->setAction($action);
+
+            $isProduction = App::getEnv('_APP_ENV', 'development') === 'production';
+            $log->setEnvironment($isProduction ? Log::ENVIRONMENT_PRODUCTION : Log::ENVIRONMENT_STAGING);
+
+            $responseCode = $logger->addLog($log);
+            Console::info('Log pushed with status code: ' . $responseCode);
         }
 
         $code = $error->getCode();

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -613,7 +613,7 @@ App::error()
             $publish = $error->isPublishable();
         }
 
-        if ($logger && $publish) {
+        if ($logger && ($publish || $error->getCode() === 0)) {
             try {
                 /** @var Utopia\Database\Document $user */
                 $user = $utopia->getResource('user');

--- a/app/http.php
+++ b/app/http.php
@@ -263,10 +263,9 @@ $http->on('request', function (SwooleRequest $swooleRequest, SwooleResponse $swo
                 // All good, user is optional information for logger
             }
 
-            $loggerBreadcrumbs = $app->getResource("loggerBreadcrumbs");
             $route = $app->getRoute();
 
-            $log = new Utopia\Logger\Log();
+            $log = $app->getResource("log");
 
             if (isset($user) && !$user->isEmpty()) {
                 $log->setUser(new User($user->getId()));
@@ -297,10 +296,6 @@ $http->on('request', function (SwooleRequest $swooleRequest, SwooleResponse $swo
 
             $isProduction = App::getEnv('_APP_ENV', 'development') === 'production';
             $log->setEnvironment($isProduction ? Log::ENVIRONMENT_PRODUCTION : Log::ENVIRONMENT_STAGING);
-
-            foreach ($loggerBreadcrumbs as $loggerBreadcrumb) {
-                $log->addBreadcrumb($loggerBreadcrumb);
-            }
 
             $responseCode = $logger->addLog($log);
             Console::info('Log pushed with status code: ' . $responseCode);

--- a/app/init.php
+++ b/app/init.php
@@ -76,6 +76,7 @@ use Appwrite\Hooks\Hooks;
 use MaxMind\Db\Reader;
 use PHPMailer\PHPMailer\PHPMailer;
 use Swoole\Database\PDOProxy;
+use Utopia\Logger\Log;
 use Utopia\Queue;
 use Utopia\Queue\Connection;
 use Utopia\Storage\Storage;
@@ -864,6 +865,7 @@ foreach ($locales as $locale) {
 ]);
 
 // Runtime Execution
+App::setResource('log', fn() => new Log());
 App::setResource('logger', function ($register) {
     return $register->get('logger');
 }, ['register']);
@@ -871,10 +873,6 @@ App::setResource('logger', function ($register) {
 App::setResource('hooks', function ($register) {
     return $register->get('hooks');
 }, ['register']);
-
-App::setResource('loggerBreadcrumbs', function () {
-    return [];
-});
 
 App::setResource('register', fn() => $register);
 App::setResource('locale', fn() => new Locale(App::getEnv('_APP_LOCALE', 'en')));

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -238,12 +238,14 @@ class Exception extends \Exception
 
     protected string $type = '';
     protected array $errors = [];
-    protected bool $publish = true;
+    protected bool $publish;
 
     public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, \Throwable $previous = null)
     {
         $this->errors = Config::getParam('errors');
         $this->type = $type;
+
+        $this->publish = !isset($code) ? true : $code >= 500 || $code === 0;
 
         if (isset($this->errors[$type])) {
             $this->code = $this->errors[$type]['code'];

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -244,8 +244,8 @@ class Exception extends \Exception
     {
         $this->errors = Config::getParam('errors');
         $this->type = $type;
-        $this->code = $this->errors[$type]['code'] ?? $code;
-        $this->message = $this->errors[$type]['description'] ?? $message;
+        $this->code = $code ?? $this->errors[$type]['code'];
+        $this->message = $message ?? $this->errors[$type]['description'];
 
         $this->publish = $this->errors[$type]['publish'] ?? ($this->code >= 500);
 

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -244,17 +244,10 @@ class Exception extends \Exception
     {
         $this->errors = Config::getParam('errors');
         $this->type = $type;
+        $this->code = $this->errors[$type]['code'] ?? $code;
+        $this->message = $this->errors[$type]['description'] ?? $message;
 
-        $this->publish = !isset($code) ? true : $code >= 500 || $code === 0;
-
-        if (isset($this->errors[$type])) {
-            $this->code = $this->errors[$type]['code'];
-            $this->message = $this->errors[$type]['description'];
-            $this->publish = $this->errors[$type]['publish'] ?? true;
-        }
-
-        $this->message = $message ?? $this->message;
-        $this->code = $code ?? $this->code;
+        $this->publish = $this->errors[$type]['publish'] ?? ($this->code >= 500);
 
         parent::__construct($this->message, $this->code, $previous);
     }

--- a/src/Appwrite/Network/Validator/CNAME.php
+++ b/src/Appwrite/Network/Validator/CNAME.php
@@ -7,6 +7,11 @@ use Utopia\Validator;
 class CNAME extends Validator
 {
     /**
+     * @var mixed
+     */
+    protected mixed $dnsResponse;
+
+    /**
      * @var string
      */
     protected $target;
@@ -28,6 +33,14 @@ class CNAME extends Validator
     }
 
     /**
+     * @return mixed
+     */
+    public function getDnsResponse(): mixed
+    {
+        return $this->dnsResponse;
+    }
+
+    /**
      * Check if CNAME record target value matches selected target
      *
      * @param mixed $domain
@@ -42,6 +55,7 @@ class CNAME extends Validator
 
         try {
             $records = \dns_get_record($domain, DNS_CNAME);
+            $this->dnsResponse = $records;
         } catch (\Throwable $th) {
             return false;
         }

--- a/src/Appwrite/Network/Validator/CNAME.php
+++ b/src/Appwrite/Network/Validator/CNAME.php
@@ -9,7 +9,7 @@ class CNAME extends Validator
     /**
      * @var mixed
      */
-    protected mixed $dnsResponse;
+    protected mixed $logs;
 
     /**
      * @var string
@@ -35,9 +35,9 @@ class CNAME extends Validator
     /**
      * @return mixed
      */
-    public function getDnsResponse(): mixed
+    public function getLogs(): mixed
     {
-        return $this->dnsResponse;
+        return $this->logs;
     }
 
     /**
@@ -55,7 +55,7 @@ class CNAME extends Validator
 
         try {
             $records = \dns_get_record($domain, DNS_CNAME);
-            $this->dnsResponse = $records;
+            $this->logs = $records;
         } catch (\Throwable $th) {
             return false;
         }

--- a/src/Appwrite/Platform/Tasks/SSL.php
+++ b/src/Appwrite/Platform/Tasks/SSL.php
@@ -7,6 +7,7 @@ use Appwrite\Event\Certificate;
 use Utopia\App;
 use Utopia\CLI\Console;
 use Utopia\Database\Document;
+use Utopia\Validator\Boolean;
 use Utopia\Validator\Hostname;
 
 class SSL extends Action
@@ -21,19 +22,22 @@ class SSL extends Action
         $this
             ->desc('Validate server certificates')
             ->param('domain', App::getEnv('_APP_DOMAIN', ''), new Hostname(), 'Domain to generate certificate for. If empty, main domain will be used.', true)
+            ->param('skip-check', true, new Boolean(true), 'If DNS and renew check should be skipped. Defaults to true, and when true, all jobs will result in certificate generation attempt.', true)
             ->inject('queueForCertificates')
-            ->callback(fn (string $domain, Certificate $queueForCertificates) => $this->action($domain, $queueForCertificates));
+            ->callback(fn (string $domain, bool|string $skipCheck, Certificate $queueForCertificates) => $this->action($domain, $skipCheck, $queueForCertificates));
     }
 
-    public function action(string $domain, Certificate $queueForCertificates): void
+    public function action(string $domain, bool|string $skipCheck, Certificate $queueForCertificates): void
     {
+        $skipCheck = \strval($skipCheck) === 'true';
+
         Console::success('Scheduling a job to issue a TLS certificate for domain: ' . $domain);
 
         $queueForCertificates
             ->setDomain(new Document([
                 'domain' => $domain
             ]))
-            ->setSkipRenewCheck(true)
+            ->setSkipRenewCheck($skipCheck)
             ->trigger();
     }
 }

--- a/src/Appwrite/Platform/Workers/Certificates.php
+++ b/src/Appwrite/Platform/Workers/Certificates.php
@@ -280,7 +280,7 @@ class Certificates extends Action
                 $log->addExtra('dnsTiming', \strval(\microtime(true) - $validationStart));
                 $log->addTag('dnsDomain', $domain->get());
 
-                $error = $validator->getDnsResponse();
+                $error = $validator->getLogs();
                 $log->addExtra('dnsResponse', \is_array($error) ? \json_encode($error) : \strval($error));
 
                 throw new Exception('Failed to verify domain DNS records.');

--- a/src/Appwrite/Platform/Workers/Certificates.php
+++ b/src/Appwrite/Platform/Workers/Certificates.php
@@ -169,7 +169,6 @@ class Certificates extends Action
             $success = true;
         } catch (Throwable $e) {
             $logs = $e->getMessage();
-            $finalException = $e;
 
             // Set exception as log in certificate document
             $certificate->setAttribute('logs', \mb_strcut($logs, 0, 1000000));// Limit to 1MB
@@ -183,16 +182,14 @@ class Certificates extends Action
 
             // Send email to security email
             $this->notifyError($domain->get(), $e->getMessage(), $attempts, $queueForMails);
+
+            throw $e;
         } finally {
             // All actions result in new updatedAt date
             $certificate->setAttribute('updated', DateTime::now());
 
             // Save all changes we made to certificate document into database
             $this->saveCertificateDocument($domain->get(), $certificate, $success, $dbForConsole, $queueForEvents, $queueForFunctions);
-        }
-
-        if (isset($finalException)) {
-            throw $finalException;
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds logic to log cname validation errors into Sentry including many new details. Also adds parameter to SSL CLI task to configure if validation should be skipped

## Test Plan

- [x] Manual QA

Error from API:

![CleanShot 2024-01-23 at 16 16 08@2x](https://github.com/appwrite/appwrite/assets/19310830/cf9cedb9-69b8-4733-95a9-3d2e96507d76)



CLI command:

![CleanShot 2024-01-23 at 16 38 18@2x](https://github.com/appwrite/appwrite/assets/19310830/f07c862c-16cc-4e97-b603-4bf2f6d14176)

Logs on worker:
![CleanShot 2024-01-23 at 16 38 26@2x](https://github.com/appwrite/appwrite/assets/19310830/24ea9df3-5915-4125-b6c9-709497338af5)


Error from worker:

![CleanShot 2024-01-23 at 16 39 16@2x](https://github.com/appwrite/appwrite/assets/19310830/96a5c96e-130f-4899-a8fd-b5ea797426da)




## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
