### PR TITLE
PEA-233-prevent console user deletion before deleting their team

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -251,7 +251,7 @@ return [
         'description' => 'User phone is already verified',
         'code' => 409
     ],
-    Exception::USER_DELETION_WITH_ACTIVE_TEAMS => [
+    Exception::USER_DELETION_PROHIBITED => [
         'name' => Exception::USER_DELETION_WITH_ACTIVE_TEAMS,
         'description' => 'User deletion is not allowed for users with active memberships. Please delete all confirmed memberships before deleting the account.',
         'code' => 400

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -252,7 +252,7 @@ return [
         'code' => 409
     ],
     Exception::USER_DELETION_PROHIBITED => [
-        'name' => Exception::USER_DELETION_WITH_ACTIVE_TEAMS,
+        'name' => Exception::USER_DELETION_PROHIBITED,
         'description' => 'User deletion is not allowed for users with active memberships. Please delete all confirmed memberships before deleting the account.',
         'code' => 400
     ],

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -251,6 +251,11 @@ return [
         'description' => 'User phone is already verified',
         'code' => 409
     ],
+    Exception::USER_DELETION_WITH_ACTIVE_TEAMS => [
+        'name' => Exception::USER_DELETION_WITH_ACTIVE_TEAMS,
+        'description' => 'Delete all your teams before trying to delete your account.',
+        'code' => 400
+    ],
 
     /** Teams */
     Exception::TEAM_NOT_FOUND => [

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -253,7 +253,7 @@ return [
     ],
     Exception::USER_DELETION_WITH_ACTIVE_TEAMS => [
         'name' => Exception::USER_DELETION_WITH_ACTIVE_TEAMS,
-        'description' => 'Delete all your teams before trying to delete your account.',
+        'description' => 'User deletion is not allowed for users with active memberships. Please delete all confirmed memberships before deleting the account.',
         'code' => 400
     ],
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3040,12 +3040,15 @@ App::delete('/v1/account')
         if ($user->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
         }
-
+        
         if ($project->getId() === 'console') {
-            // get active memberships
+            // get all memberships
             $memberships = $user->getAttribute('memberships', []);
-            if (count($memberships) > 0) {
-                throw new Exception(Exception::USER_DELETION_WITH_ACTIVE_TEAMS);
+            foreach ($memberships as $membership) {
+                // prevent deletion if at lease one active membership
+                if($membership->getAttribute('confirm', false)) {
+                    throw new Exception(Exception::USER_DELETION_WITH_ACTIVE_TEAMS);
+                }
             }
         }
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3045,7 +3045,7 @@ App::delete('/v1/account')
             // get all memberships
             $memberships = $user->getAttribute('memberships', []);
             foreach ($memberships as $membership) {
-                // prevent deletion if at lease one active membership
+                // prevent deletion if at least one active membership
                 if ($membership->getAttribute('confirm', false)) {
                     throw new Exception(Exception::USER_DELETION_WITH_ACTIVE_TEAMS);
                 }

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3047,7 +3047,7 @@ App::delete('/v1/account')
             foreach ($memberships as $membership) {
                 // prevent deletion if at least one active membership
                 if ($membership->getAttribute('confirm', false)) {
-                    throw new Exception(Exception::USER_DELETION_WITH_ACTIVE_TEAMS);
+                    throw new Exception(Exception::USER_DELETION_PROHIBITED);
                 }
             }
         }

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3040,13 +3040,13 @@ App::delete('/v1/account')
         if ($user->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
         }
-        
+
         if ($project->getId() === 'console') {
             // get all memberships
             $memberships = $user->getAttribute('memberships', []);
             foreach ($memberships as $membership) {
                 // prevent deletion if at lease one active membership
-                if($membership->getAttribute('confirm', false)) {
+                if ($membership->getAttribute('confirm', false)) {
                     throw new Exception(Exception::USER_DELETION_WITH_ACTIVE_TEAMS);
                 }
             }

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -86,7 +86,7 @@ class Exception extends \Exception
     public const USER_OAUTH2_PROVIDER_ERROR        = 'user_oauth2_provider_error';
     public const USER_EMAIL_ALREADY_VERIFIED        = 'user_email_alread_verified';
     public const USER_PHONE_ALREADY_VERIFIED        = 'user_phone_already_verified';
-    public const USER_DELETION_PROHIBITED    = 'USER_DELETION_PROHIBITED';
+    public const USER_DELETION_PROHIBITED    = 'user_deletion_prohibited';
 
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -86,7 +86,7 @@ class Exception extends \Exception
     public const USER_OAUTH2_PROVIDER_ERROR        = 'user_oauth2_provider_error';
     public const USER_EMAIL_ALREADY_VERIFIED        = 'user_email_alread_verified';
     public const USER_PHONE_ALREADY_VERIFIED        = 'user_phone_already_verified';
-    public const USER_DELETION_WITH_ACTIVE_TEAMS    = 'user_deletion_with_active_teams';
+    public const USER_DELETION_PROHIBITED    = 'USER_DELETION_PROHIBITED';
 
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -86,6 +86,7 @@ class Exception extends \Exception
     public const USER_OAUTH2_PROVIDER_ERROR        = 'user_oauth2_provider_error';
     public const USER_EMAIL_ALREADY_VERIFIED        = 'user_email_alread_verified';
     public const USER_PHONE_ALREADY_VERIFIED        = 'user_phone_already_verified';
+    public const USER_DELETION_WITH_ACTIVE_TEAMS    = 'user_deletion_with_active_teams';
 
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -84,9 +84,9 @@ class Exception extends \Exception
     public const USER_OAUTH2_BAD_REQUEST           = 'user_oauth2_bad_request';
     public const USER_OAUTH2_UNAUTHORIZED          = 'user_oauth2_unauthorized';
     public const USER_OAUTH2_PROVIDER_ERROR        = 'user_oauth2_provider_error';
-    public const USER_EMAIL_ALREADY_VERIFIED        = 'user_email_alread_verified';
-    public const USER_PHONE_ALREADY_VERIFIED        = 'user_phone_already_verified';
-    public const USER_DELETION_PROHIBITED    = 'user_deletion_prohibited';
+    public const USER_EMAIL_ALREADY_VERIFIED       = 'user_email_alread_verified';
+    public const USER_PHONE_ALREADY_VERIFIED       = 'user_phone_already_verified';
+    public const USER_DELETION_PROHIBITED          = 'user_deletion_prohibited';
 
     /** Teams */
     public const TEAM_NOT_FOUND                    = 'team_not_found';

--- a/tests/e2e/Services/Account/AccountConsoleClientTest.php
+++ b/tests/e2e/Services/Account/AccountConsoleClientTest.php
@@ -2,13 +2,11 @@
 
 namespace Tests\E2E\Services\Account;
 
-use Appwrite\Extend\Exception;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\ProjectConsole;
 use Tests\E2E\Scopes\SideClient;
 use Utopia\Database\Helpers\ID;
 use Tests\E2E\Client;
-use Utopia\Database\Validator\Datetime as DatetimeValidator;
 
 class AccountConsoleClientTest extends Scope
 {

--- a/tests/e2e/Services/Account/AccountConsoleClientTest.php
+++ b/tests/e2e/Services/Account/AccountConsoleClientTest.php
@@ -15,4 +15,79 @@ class AccountConsoleClientTest extends Scope
     use AccountBase;
     use ProjectConsole;
     use SideClient;
+
+    public function testDeleteAccount(): void
+    {
+         $email = uniqid() . 'user@localhost.test';
+         $password = 'password';
+         $name = 'User Name';
+
+         $response = $this->client->call(Client::METHOD_POST, '/account', array_merge([
+             'origin' => 'http://localhost',
+             'content-type' => 'application/json',
+             'x-appwrite-project' => $this->getProject()['$id'],
+         ]), [
+             'userId' => ID::unique(),
+             'email' => $email,
+             'password' => $password,
+             'name' => $name,
+         ]);
+
+         $this->assertEquals($response['headers']['status-code'], 201);
+
+         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
+             'origin' => 'http://localhost',
+             'content-type' => 'application/json',
+             'x-appwrite-project' => $this->getProject()['$id'],
+         ]), [
+             'email' => $email,
+             'password' => $password,
+         ]);
+
+         $this->assertEquals($response['headers']['status-code'], 201);
+
+         $session = $response['cookies']['a_session_' . $this->getProject()['$id']];
+
+         // create team
+         $team = $this->client->call(Client::METHOD_POST, '/teams', [
+            'origin' => 'http://localhost',
+             'content-type' => 'application/json',
+             'x-appwrite-project' => $this->getProject()['$id'],
+             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+         ], [
+            'teamId' => 'unique()',
+            'name' => 'myteam'
+         ]);
+         $this->assertEquals($team['headers']['status-code'], 201);
+
+         $teamId = $team['body']['$id'];
+
+         $response = $this->client->call(Client::METHOD_DELETE, '/account', array_merge([
+             'origin' => 'http://localhost',
+             'content-type' => 'application/json',
+             'x-appwrite-project' => $this->getProject()['$id'],
+             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+         ]));
+
+         $this->assertEquals($response['headers']['status-code'], 400);
+
+         // DELETE TEAM
+         $response = $this->client->call(Client::METHOD_DELETE, '/teams/' . $teamId, array_merge([
+             'origin' => 'http://localhost',
+             'content-type' => 'application/json',
+             'x-appwrite-project' => $this->getProject()['$id'],
+             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+         ]));
+         $this->assertEquals($response['headers']['status-code'], 204);
+         sleep(2);
+
+         $response = $this->client->call(Client::METHOD_DELETE, '/account', array_merge([
+             'origin' => 'http://localhost',
+             'content-type' => 'application/json',
+             'x-appwrite-project' => $this->getProject()['$id'],
+             'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+         ]));
+
+         $this->assertEquals($response['headers']['status-code'], 204);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Deleting a console user, throw an error if they are a member of active organization

## Test Plan

- updated the existing `testAccountDelete` in AccountConsoleClientTest.php

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
