### PR TITLE
Bug 5901 fix resend invitation from create invite

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -535,7 +535,7 @@ App::post('/v1/teams/:teamId/memberships')
             ]);
         } else {
             $membership = $existingMembership;
-            $membership->setAttribute('joined', DateTime::now());
+            $membership->setAttribute('invited', DateTime::now());
             $shouldCreateMembership = false;
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes bug mentioned here (https://github.com/appwrite/appwrite/issues/5901) by me -- basically it adds a new call into the `createMembership` endpoint that checks the database for an unconfirmed membership with the same userEmail. If they don't exist, it creates a membership like normal, which will throw a duplicate error like normal if the users email exists.

If they do exist, it will set the `$membership` to the found membership, and set the attribute `invited` to `DateTime::now()`, then updates the user

## Test Plan

The only possible problem this could have was in the `$dbForProject->updateDocument` (with the $collectionId or something being included like in the client SDK's was my thought) but I have looked at the other code in the `teams.php` file and they seem to be doing things the same way, so it shouldn't conflict at all.

## Related PRs and Issues

- [(Related PR or issue)](https://github.com/appwrite/appwrite/issues/5901)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
