### PR TITLE
Add storage health check

### DIFF
--- a/app/controllers/api/health.php
+++ b/app/controllers/api/health.php
@@ -702,6 +702,43 @@ App::get('/v1/health/storage/local')
         $response->dynamic(new Document($output), Response::MODEL_HEALTH_STATUS);
     });
 
+App::get('/v1/health/storage')
+    ->desc('Get storage')
+    ->groups(['api', 'health'])
+    ->label('scope', 'health.read')
+    ->label('sdk.auth', [APP_AUTH_TYPE_KEY])
+    ->label('sdk.namespace', 'health')
+    ->label('sdk.method', 'getStorage')
+    ->label('sdk.description', '/docs/references/health/get-storage.md')
+    ->label('sdk.response.code', Response::STATUS_CODE_OK)
+    ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
+    ->label('sdk.response.model', Response::MODEL_HEALTH_STATUS)
+    ->inject('response')
+    ->inject('deviceFiles')
+    ->action(function (Response $response, Device $deviceFiles) {
+
+        $checkStart = \microtime(true);
+
+        if (!$deviceFiles->write($deviceFiles->getPath('health.txt'), 'test', '')) {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed writing test file');
+        }
+
+        if ($deviceFiles->read($deviceFiles->getPath('health.txt')) !== 'test') {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed reading test file');
+        }
+
+        if (!$deviceFiles->delete($deviceFiles->getPath('health.txt'))) {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed deleting test file');
+        }
+
+        $output = [
+            'status' => 'pass',
+            'ping' => \round((\microtime(true) - $checkStart) / 1000)
+        ];
+
+        $response->dynamic(new Document($output), Response::MODEL_HEALTH_STATUS);
+    });
+
 App::get('/v1/health/anti-virus')
     ->desc('Get antivirus')
     ->groups(['api', 'health'])

--- a/docs/references/health/get-storage.md
+++ b/docs/references/health/get-storage.md
@@ -1,0 +1,1 @@
+Check the Appwrite storage device is up and connection is successful.

--- a/tests/e2e/Services/Health/HealthCustomServerTest.php
+++ b/tests/e2e/Services/Health/HealthCustomServerTest.php
@@ -407,6 +407,24 @@ class HealthCustomServerTest extends Scope
         return [];
     }
 
+    public function testStorageSuccess(): array
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $response = $this->client->call(Client::METHOD_GET, '/health/storage', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), []);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('pass', $response['body']['status']);
+        $this->assertIsInt($response['body']['ping']);
+        $this->assertLessThan(100, $response['body']['ping']);
+
+        return [];
+    }
+
     public function testStorageAntiVirusSuccess(): array
     {
         /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This health endpoint for storage will do 3 operations.
```
$device->write(uniquefile);
$device->read(uniquefile);
$device->delete(uniquefile);
```

If one fails, the endpoint fails, this way we test full range of operations. We are testing this for both local as well as remote devices.

## Test Plan
Added test and also tested locally.

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
