### PR TITLE
feat: Better error message for maximum file size (storage_invalid_file_size)

### DIFF
--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -479,7 +479,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
         // Check if file size is exceeding allowed limit
         $fileSizeValidator = new FileSize($maximumFileSize);
         if (!$fileSizeValidator->isValid($fileSize)) {
-            throw new Exception(Exception::STORAGE_INVALID_FILE_SIZE, 'File size not allowed');
+            throw new Exception(Exception::STORAGE_INVALID_FILE_SIZE, "File size ($fileSize bytes) exceeds the maximum ($maximumFileSize bytes)");
         }
 
         $upload = new Upload();


### PR DESCRIPTION
<!--
It's hard to comprehend, which file size and which limit is meant when the file size is not valid. This adds the numbers to trace the actual file size and the limits, which are currently present. This helps debugging such errors.

-->

## What does this PR do?

The PR changes an Exception description for `storage_invalid_file_size`.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

WIP, maybe one can give a hint where to do that.

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
