### PR TITLE
Use swoole process mode instead of base

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "utopia-php/cache": "0.9.*",
         "utopia-php/cli": "0.15.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "0.48.*",
+        "utopia-php/database": "0.48.2",
         "utopia-php/domains": "0.5.*",
         "utopia-php/dsn": "0.2.*",
         "utopia-php/framework": "0.33.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a65e4309e3fd851aec97be2cf5b83cb4",
+    "content-hash": "510f3498b35c5ec3289b7bed6a2ef9c9",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1552,16 +1552,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.48.3",
+            "version": "0.48.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "c7dd97d92f52a0aec9951e0b02309a100f3f24a9"
+                "reference": "0a231a2874fdbc0cf2ae2170b3f132fdee0ddfd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/c7dd97d92f52a0aec9951e0b02309a100f3f24a9",
-                "reference": "c7dd97d92f52a0aec9951e0b02309a100f3f24a9",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/0a231a2874fdbc0cf2ae2170b3f132fdee0ddfd4",
+                "reference": "0a231a2874fdbc0cf2ae2170b3f132fdee0ddfd4",
                 "shasum": ""
             },
             "require": {
@@ -1569,7 +1569,7 @@
                 "ext-pdo": "*",
                 "php": ">=8.0",
                 "utopia-php/cache": "0.9.*",
-                "utopia-php/framework": "0.33.*",
+                "utopia-php/framework": "0.*.*",
                 "utopia-php/mongo": "0.3.*"
             },
             "require-dev": {
@@ -1602,9 +1602,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.48.3"
+                "source": "https://github.com/utopia-php/database/tree/0.48.2"
             },
-            "time": "2024-02-21T08:32:09+00:00"
+            "time": "2024-02-02T14:10:14+00:00"
         },
         {
             "name": "utopia-php/domains",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Use SWOOLE_PROCESS mode instead of SWOOLE_BASE. 

SWOOLE_BASE became the default in Swoole 5 and is intended for environments where Swoole is running 1 process and 1 thread (horizontally scaling containers).

SWOOLE_PROCESS is intended for scenarios where Swoole is running multiple processes ina single container.

Also seems to fix random crashes encountered in 1.5.x after merging in main.

https://github.com/swoole/swoole-src/discussions/4856#discussioncomment-3796282
https://github.com/swoole/swoole-src/issues/1085

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
