### PR TITLE
bug:7628 resolve the issue of Incorrect Error Handling When Passing Int as documentId parameter

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2923,7 +2923,9 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/documents')
         $cursor = \reset($cursor);
 
         if ($cursor) {
-            $documentId = $cursor->getValue();
+            $value = $cursor->getValue();
+            $documentId = (string) $value;
+
 
             $cursorDocument = Authorization::skip(fn() => $dbForProject->getDocument('database_' . $database->getInternalId() . '_collection_' . $collection->getInternalId(), $documentId));
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
this PR changes the data type of documentID variable from int to string
(Provide a description of what this PR does and why it's needed.)
to resolve this bug :error: AppwriteException: Invalid documentId param: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char
## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
