### PR TITLE
[Fix]: Remove internal attributes on select query

### DIFF
--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -4068,6 +4068,8 @@ trait DatabasesBase
         $this->assertEquals(2, count($response['body']['documents']));
         $this->assertEquals(null, $response['body']['documents'][0]['fullName']);
         $this->assertArrayNotHasKey("libraries", $response['body']['documents'][0]);
+        $this->assertArrayNotHasKey('$databaseId', $response['body']['documents'][0]);
+        $this->assertArrayNotHasKey('$collectionId', $response['body']['documents'][0]);
     }
 
     /**
@@ -4087,6 +4089,8 @@ trait DatabasesBase
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertArrayNotHasKey('libraries', $response['body']['documents'][0]);
+        $this->assertArrayNotHasKey('$databaseId', $response['body']['documents'][0]);
+        $this->assertArrayNotHasKey('$collectionId', $response['body']['documents'][0]);
 
         $response = $this->client->call(Client::METHOD_GET, '/databases/' . $data['databaseId'] . '/collections/' . $data['personCollection'] . '/documents', array_merge([
             'content-type' => 'application/json',
@@ -4099,6 +4103,8 @@ trait DatabasesBase
         $document = $response['body']['documents'][0];
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertArrayHasKey('libraries', $document);
+        $this->assertArrayNotHasKey('$databaseId', $document);
+        $this->assertArrayNotHasKey('$collectionId', $document);
 
         $response = $this->client->call(Client::METHOD_GET, '/databases/' . $data['databaseId'] . '/collections/' . $data['personCollection'] . '/documents/' . $document['$id'], array_merge([
             'content-type' => 'application/json',


### PR DESCRIPTION
## What does this PR do?

Remove Internal Attributes ( $databaseId and $collectionId ) on Query select from List Documents API.

## Test Plan

```
await databases.listDocuments("test", "test", [Query.select(["status"])]);
```
Response
```
{
  "total": 6,
  "documents": [
    { "status": "active" },
    { "status": "inactive" },
    { "status": "active" },
    { "status": "active" },
    { "status": "active" },
    { "status": "active" }
  ]
}

```

## Related PRs and Issues

- #7587 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

