### PR TITLE
Only return allowed runtimes in runtime list route

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -420,17 +420,23 @@ App::get('/v1/functions/runtimes')
     ->label('sdk.response.model', Response::MODEL_RUNTIME_LIST)
     ->inject('response')
     ->action(function (Response $response) {
-
         $runtimes = Config::getParam('runtimes');
 
-        $runtimes = array_map(function ($key) use ($runtimes) {
+        $allowList = \array_filter(\explode(',', App::getEnv('_APP_FUNCTIONS_RUNTIMES', '')));
+
+        $allowed = [];
+        foreach ($runtimes as $key => $runtime) {
+            if (!empty($allowList) && !\in_array($key, $allowList)) {
+                continue;
+            }
+
             $runtimes[$key]['$id'] = $key;
-            return $runtimes[$key];
-        }, array_keys($runtimes));
+            $allowed[] = $runtimes[$key];
+        }
 
         $response->dynamic(new Document([
-            'total' => count($runtimes),
-            'runtimes' => $runtimes
+            'total' => count($allowed),
+            'runtimes' => $allowed
         ]), Response::MODEL_RUNTIME_LIST);
     });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix runtime list route returning all runtimes instead of allowed only

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
