### PR TITLE
fix: encode secret in oauth workaround

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -934,12 +934,12 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                 ->setPayload($response->output($session, Response::MODEL_SESSION))
             ;
 
-            // TODO: Remove this deprecated, undocumented workaround
+            // TODO: Remove this deprecated workaround - support only token
             if ($state['success']['path'] == $oauthDefaultSuccess) {
                 $query['project'] = $project->getId();
                 $query['domain'] = Config::getParam('cookieDomain');
                 $query['key'] = Auth::$cookieName;
-                $query['secret'] = $secret;
+                $query['secret'] = Auth::encodeSession($user->getId(), $secret);
             }
 
             $response


### PR DESCRIPTION
This `secret` param should be encoded as in previous versions to prevent breaking android, flutter & dart OAuth2 session implementation.

In the future we should aim to migrate them to token flow, with extra `createSession` step to prevent session sniffing.