### PR TITLE
Fix Attribute not found when migrating users collection

### DIFF
--- a/src/Appwrite/Migration/Version/V20.php
+++ b/src/Appwrite/Migration/Version/V20.php
@@ -127,7 +127,11 @@ class V20 extends Migration
                         }
                     }
 
-                    $this->projectDB->updateAttribute($id, $attribute['$id'], $attribute['type']);
+                    try {
+                        $this->projectDB->updateAttribute($id, $attribute['$id'], $attribute['type']);
+                    } catch (Throwable $th) {
+                        Console::warning("'{$attribute['$id']}' from {$id}: {$th->getMessage()}");
+                    }
                 }
             }
 


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This throws because Appwrite tries to migrate attributes that don't exist yet like mfaRecoveryCodes. Since the attribute doesn't exist yet, just log a warning and continue.

## Test Plan

Manually tested:

<img width="401" alt="Screen Shot 2024-03-11 at 1 04 36 AM" src="https://github.com/appwrite/appwrite/assets/1477010/969faaa3-dcab-4c12-a154-a634887b8619">

...

<img width="249" alt="Screen Shot 2024-03-11 at 1 04 16 AM" src="https://github.com/appwrite/appwrite/assets/1477010/12f57949-3164-4364-a56e-dfa5500af7d4">


## Related PRs and Issues

It might be good to merge https://github.com/appwrite/appwrite/pull/7781 into 1.5.x first and then change the base of this to 1.5.x.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
