### PR TITLE
Handle string error codes

### DIFF
--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -296,11 +296,17 @@ class Exception extends \Exception
     protected array $errors = [];
     protected bool $publish;
 
-    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, \Throwable $previous = null)
+    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, $code = null, \Throwable $previous = null)
     {
         $this->errors = Config::getParam('errors');
         $this->type = $type;
         $this->code = $code ?? $this->errors[$type]['code'];
+
+        // todo: Handle better PDOExceptions or string errors
+        if(is_string($this->code)) {
+            $this->code = 500;
+        }
+
         $this->message = $message ?? $this->errors[$type]['description'];
 
         $this->publish = $this->errors[$type]['publish'] ?? ($this->code >= 500);

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -303,7 +303,7 @@ class Exception extends \Exception
         $this->code = $code ?? $this->errors[$type]['code'];
 
         // todo: Handle better PDOExceptions or string errors
-        if(is_string($this->code)) {
+        if(\is_string($this->code) && !\is_numeric($this->code)) {
             $this->code = 500;
         }
 

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -302,8 +302,12 @@ class Exception extends \Exception
         $this->type = $type;
         $this->code = $code ?? $this->errors[$type]['code'];
 
-        if(\is_string($this->code) && !\is_numeric($this->code)) {
-            $this->code = 500;
+        if(\is_string($this->code)) {
+            if (\is_numeric($this->code)) {
+                $this->code = (int) $this->code;
+            } else {
+                $this->code = 500;
+            }
         }
 
         $this->message = $message ?? $this->errors[$type]['description'];

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -302,7 +302,6 @@ class Exception extends \Exception
         $this->type = $type;
         $this->code = $code ?? $this->errors[$type]['code'];
 
-        // todo: Handle better PDOExceptions or string errors
         if(\is_string($this->code) && !\is_numeric($this->code)) {
             $this->code = 500;
         }

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -296,7 +296,7 @@ class Exception extends \Exception
     protected array $errors = [];
     protected bool $publish;
 
-    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, $code = null, \Throwable $previous = null)
+    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int|string $code = null, \Throwable $previous = null)
     {
         $this->errors = Config::getParam('errors');
         $this->type = $type;


### PR DESCRIPTION
PDOExeptions error code are string , for example:
SQLSTATE[HY000]: General error: 2006 MySQL server has gone away.

error code is = HY000

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
