### PR TITLE
Create failed execution from worker if deployment doesn't exist

### DIFF
--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -238,7 +238,7 @@ class Functions extends Action
             'deploymentId' => '',
             'trigger' => $trigger,
             'status' => 'failed',
-            'responseStatusCode' => 400,
+            'responseStatusCode' => 0,
             'responseHeaders' => [],
             'requestPath' => $path,
             'requestMethod' => $method,
@@ -326,7 +326,7 @@ class Functions extends Action
         /** Check if the build exists */
         $build = $dbForProject->getDocument('builds', $deployment->getAttribute('buildId', ''));
         if ($build->isEmpty()) {
-            $errorMessage = 'The execution could not be completed because a corresponding build was not found. A function build needs to be created before it can be executed. Please create a build for your function and try again.';
+            $errorMessage = 'The execution could not be completed because a corresponding deployment was not found. A function deployment needs to be created before it can be executed. Please create a deployment for your function and try again.';
             $this->fail($errorMessage, $dbForProject, $function, $trigger, $path, $method, $user, $jwt, $event);
             return;
         }

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1069,6 +1069,8 @@ class FunctionsCustomServerTest extends Scope
             'async' => false
         ]);
 
+        var_dump($execution['body']);
+
         $executionId = $execution['body']['$id'] ?? '';
         $output = json_decode($execution['body']['responseBody'], true);
 

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1069,8 +1069,6 @@ class FunctionsCustomServerTest extends Scope
             'async' => false
         ]);
 
-        var_dump($execution['body']);
-
         $executionId = $execution['body']['$id'] ?? '';
         $output = json_decode($execution['body']['responseBody'], true);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

For a scenario where an execution is triggered through worker and deployment doesn't exist, we would create a failed execution to let user know about the failure.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
