### PR TITLE
Change SMS verification message to only have the code

### DIFF
--- a/app/config/locale/translations/af.json
+++ b/app/config/locale/translations/af.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klik op die knoppie hieronder om veilig aan te meld by jou {{project}} rekening. Dit sal oor 1 uur verval.",
     "emails.magicSession.buttonText": "Meld aan by {{project}}",
     "emails.magicSession.clientInfo": "Hierdie teken-in is aangevra met behulp van {{agentClient}} op {{agentDevice}} {{agentOs}}. As jy nie die teken-in versoek het nie, kan jy hierdie e-pos veilig ignoreer.",
-    "sms.verification.body": "{{secret}} is jou {{project}} verifikasiekode.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Die sekuriteitsfrase vir hierdie e-pos is {{phrase}}. Jy kan hierdie e-pos vertrou as hierdie frase ooreenstem met die frase wat tydens aanmelding getoon is.",
     "emails.magicSession.optionUrl": "As u nie met die knoppie hierbo kan aanmeld nie, besoek asseblief die volgende skakel:",
     "emails.otpSession.subject": "{{project}} Aanteken",

--- a/app/config/locale/translations/ar.json
+++ b/app/config/locale/translations/ar.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "انقر على الزر أدناه لتسجيل الدخول بأمان إلى حساب {{project}} الخاص بك. سينتهي في غضون ساعة واحدة.",
     "emails.magicSession.buttonText": "تسجيل الدخول إلى {{project}}",
     "emails.magicSession.clientInfo": "تم طلب هذا الدخول باستخدام {{agentClient}} على {{agentDevice}} {{agentOs}}. إذا لم تطلب الدخول، يمكنك تجاهل هذا البريد الإلكتروني بأمان.",
-    "sms.verification.body": "{{secret}} هو رمز التحقق الخاص بمشروعك {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "عبارة الأمان لهذا البريد الإلكتروني هي {{phrase}}. يمكنك الوثوق بهذا البريد الإلكتروني إذا كانت هذه العبارة تطابق العبارة التي تظهر أثناء التسجيل.",
     "emails.magicSession.optionUrl": "إذا لم تتمكن من تسجيل الدخول باستخدام الزر أعلاه، يرجى زيارة الرابط التالي:",
     "emails.otpSession.subject": "تسجيل دخول {{project}}",

--- a/app/config/locale/translations/as.json
+++ b/app/config/locale/translations/as.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "আপোনাৰ পূৰ্বৰ প্ৰমাণপত্ৰটো প্ৰথম ব্ৰিফল হোৱাৰ দিনৰ পৰা ৩০ দিনলৈ বৈধ থাকিব। আমি এই ঘটনাটোৰ তদন্ত কৰিবলৈ উচ্চ পৰামৰ্শ দিয়ে, অন্যথা আপোনাৰ ডোমেইনটো অবৈধ SSL যোগাযোগ অবিহনে থাকিব।",
     "emails.certificate.thanks": "ধন্যবাদ",
     "emails.certificate.signature": "{{project}} দল",
-    "sms.verification.body": "{{secret}} আপোনাৰ {{project}} যাচাইকৰণ কোড।"
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/az.json
+++ b/app/config/locale/translations/az.json
@@ -232,7 +232,7 @@
     "continents.na": "Şimali Amerika",
     "continents.oc": "Okeaniya",
     "continents.sa": "Cənubi Amerika",
-    "sms.verification.body": "{{secret}} sizin {{project}} təsdiqləmə kodunuzdur.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Bu e-poçt üçün təhlükəsizlik ifadəsi {{phrase}}-dir. Əgər bu ifadə daxil olarkən göstərilən ifadə ilə üst-üstə düşürsə, bu e-poçta etibar edə bilərsiniz.",
     "emails.magicSession.optionUrl": "Əgər yuxarıdakı düyməni istifadə edərək daxil ola bilmirsizsə, zəhmət olmasa aşağıdakı linkə daxil olun:",
     "emails.otpSession.subject": "{{project}} Giriş",

--- a/app/config/locale/translations/be.json
+++ b/app/config/locale/translations/be.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "Ваш папярэдні сертыфікат будзе дзейнічаць 30 дзён з моманту першай няўдачы. Мы высока рэкамендуем расследаваць гэтую сітуацыю, інакш ваш дамен апынецца без дзейнага сертыфіката SSL-злучэння.",
     "emails.certificate.thanks": "Дзякуй",
     "emails.certificate.signature": "каманда {{project}}",
-    "sms.verification.body": "{{secret}} з'яўляецца вашым кодам праверкі для {{project}}."
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/bg.json
+++ b/app/config/locale/translations/bg.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Натиснете бутона по-долу, за да се впишете сигурно във вашия {{project}} акаунт. Той ще изтече след 1 час.",
     "emails.magicSession.buttonText": "Влезте в {{project}}",
     "emails.magicSession.clientInfo": "Този вход беше заявен чрез {{agentClient}} на {{agentDevice}} {{agentOs}}. Ако не сте поискали входа, можете безопасно да игнорирате този имейл.",
-    "sms.verification.body": "{{secret}} е вашият код за верификация за {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Фразата за сигурност на този имейл е {{phrase}}. Можете да се доверите на този имейл, ако тази фраза съвпада с фразата, показана по време на вписването.",
     "emails.magicSession.optionUrl": "Ако не можете да влезете чрез горния бутон, моля, посетете следния линк:",
     "emails.otpSession.subject": "Вход в {{project}}",

--- a/app/config/locale/translations/bh.json
+++ b/app/config/locale/translations/bh.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "तोहार पिछलका प्रमाणपत्र पहिल असफलता से 30 दिन धरी मान्य होईत। हम बहुत जोर देके सलाह देतानी कि एह मामला के जांच करीं, नहीं त तोहार डोमेन बिना कोनो मान्य SSL संवाद के रहि जाईत।",
     "emails.certificate.thanks": "धन्यवाद",
     "emails.certificate.signature": "{{project}} टीम",
-    "sms.verification.body": "{{secret}} आपके {{project}} सत्यापन कोड हवे।"
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/bn.json
+++ b/app/config/locale/translations/bn.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "নীচের বোতামে ক্লিক করুন আপনার {{project}} অ্যাকাউন্টে নিরাপদে সাইন ইন করতে। এটি ১ ঘন্টা পরে মেয়াদ উত্তীর্ণ হবে।",
     "emails.magicSession.buttonText": "{{project}}-এ সাইন ইন করুন",
     "emails.magicSession.clientInfo": "এই সাইন ইনটি {{agentClient}} ব্যবহার করে {{agentDevice}} {{agentOs}}-এ অনুরোধ করা হয়েছিল। যদি আপনি সাইন ইনের অনুরোধ করেননি, আপনি নিরাপদে এই ইমেইলটি উপেক্ষা করতে পারেন।",
-    "sms.verification.body": "{{secret}} আপনার {{project}} যাচাইকরণ কোড।",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "এই ইমেলের জন্য নিরাপত্তা বাক্যটি হল {{phrase}}। সাইন-ইনের সময় দেখানো বাক্যটির সাথে এই বাক্যটি মিলে গেলে আপনি এই ইমেইলকে বিশ্বাস করতে পারেন।",
     "emails.magicSession.optionUrl": "উপরের বোতামটি ব্যবহার করে আপনি যদি সাইন ইন করতে অক্ষম হন, অনুগ্রহ করে নিম্নলিখিত লিঙ্কটি দেখুন:",
     "emails.otpSession.subject": "{{project}} লগইন",

--- a/app/config/locale/translations/bs.json
+++ b/app/config/locale/translations/bs.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknite na dugme ispod kako biste se sigurno prijavili na svoj {{project}} račun. Istek će se dogoditi za 1 sat.",
     "emails.magicSession.buttonText": "Prijavi se na {{project}}",
     "emails.magicSession.clientInfo": "Ova prijava je zatražena korištenjem {{agentClient}} na {{agentDevice}} {{agentOs}}. Ako niste zahtjevali prijavu, možete sigurno ignorirati ovaj e-mail.",
-    "sms.verification.body": "{{secret}} je vaš {{project}} verifikacijski kod.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Sigurnosna fraza za ovaj email je {{phrase}}. Ovom emailu možete vjerovati ako se fraza poklapa sa frazom prikazanom prilikom prijave.",
     "emails.magicSession.optionUrl": "Ako ne možete da se prijavite koristeći gornje dugme, molimo posetite sledeći link:",
     "emails.otpSession.subject": "{{project}} Prijava",

--- a/app/config/locale/translations/ca.json
+++ b/app/config/locale/translations/ca.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Feu clic al botó de sota per iniciar sessió de manera segura al vostre compte {{project}}. Caducarà en 1 hora.",
     "emails.magicSession.buttonText": "Inicia sessió a {{project}}",
     "emails.magicSession.clientInfo": "Aquest inici de sessió s'ha sol·licitat utilitzant {{agentClient}} en {{agentDevice}} {{agentOs}}. Si no has sol·licitat l'inici de sessió, pots ignorar aquest correu electrònic amb seguretat.",
-    "sms.verification.body": "El {{secret}} és el vostre codi de verificació del {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La frase de seguretat d'aquest correu electrònic és {{phrase}}. Podeu confiar en aquest correu si aquesta frase coincideix amb la frase mostrada durant l'inici de sessió.",
     "emails.magicSession.optionUrl": "Si no podeu iniciar sessió utilitzant el botó de dalt, visiteu l'enllaç següent:",
     "emails.otpSession.subject": "Inici de sessió de {{project}}",

--- a/app/config/locale/translations/cs.json
+++ b/app/config/locale/translations/cs.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klikněte na tlačítko níže pro bezpečné přihlášení do vašeho účtu {{project}}. Platnost vyprší za 1 hodinu.",
     "emails.magicSession.buttonText": "Přihlaste se k {{project}}",
     "emails.magicSession.clientInfo": "Toto přihlášení bylo požadováno prostřednictvím {{agentClient}} na {{agentDevice}} {{agentOs}}. Pokud jste se nepřihlašovali, můžete tento e-mail bezpečně ignorovat.",
-    "sms.verification.body": "{{secret}} je váš ověřovací kód pro {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Bezpečnostní fráze pro tento e-mail je {{phrase}}. Tomuto e-mailu můžete důvěřovat, pokud tato fráze odpovídá frázi zobrazené při přihlášení.",
     "emails.magicSession.optionUrl": "Pokud se nemůžete přihlásit pomocí výše uvedeného tlačítka, prosím navštivte následující odkaz:",
     "emails.otpSession.subject": "{{project}} Přihlášení",

--- a/app/config/locale/translations/da.json
+++ b/app/config/locale/translations/da.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klik på knappen nedenfor for sikkert at logge ind på din {{project}} konto. Den udløber om 1 time.",
     "emails.magicSession.buttonText": "Log ind på {{project}}",
     "emails.magicSession.clientInfo": "Denne log ind blev anmodet ved hjælp af {{agentClient}} på {{agentDevice}} {{agentOs}}. Hvis du ikke anmodede om log ind, kan du trygt ignorere denne e-mail.",
-    "sms.verification.body": "{{secret}} er din {{project}} bekræftelseskode.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Sikkerhedsfrasen for denne e-mail er {{phrase}}. Du kan stole på denne e-mail, hvis denne frase matcher den viste frase under log ind.",
     "emails.magicSession.optionUrl": "Hvis du ikke kan logge ind ved at bruge knappen ovenfor, besøg venligst følgende link:",
     "emails.otpSession.subject": "{{project}} Login",

--- a/app/config/locale/translations/de.json
+++ b/app/config/locale/translations/de.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klicken Sie auf den unten stehenden Button, um sicher in Ihr {{project}}-Konto einzuloggen. Er verfällt in 1 Stunde.",
     "emails.magicSession.buttonText": "Melden Sie sich bei {{project}} an",
     "emails.magicSession.clientInfo": "Dieser Anmeldeversuch wurde über {{agentClient}} auf {{agentDevice}} {{agentOs}} angefordert. Wenn Sie die Anmeldung nicht angefordert haben, können Sie diese E-Mail getrost ignorieren.",
-    "sms.verification.body": "{{secret}} ist Ihr {{project}}-Verifizierungscode.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Die Sicherheitsphrase für diese E-Mail lautet {{phrase}}. Sie können dieser E-Mail vertrauen, wenn diese Phrase mit der Phrase übereinstimmt, die beim Anmelden angezeigt wurde.",
     "emails.magicSession.optionUrl": "Wenn Sie sich nicht über den obigen Button anmelden können, besuchen Sie bitte den folgenden Link:",
     "emails.otpSession.subject": "{{project}} Anmeldung",

--- a/app/config/locale/translations/el.json
+++ b/app/config/locale/translations/el.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Κάντε κλικ στο κουμπί παρακάτω για να συνδεθείτε με ασφάλεια στον λογαριασμό σας στο {{project}}. Θα λήξει σε 1 ώρα.",
     "emails.magicSession.buttonText": "Συνδεθείτε στο {{project}}",
     "emails.magicSession.clientInfo": "Η σύνδεση αυτή ζητήθηκε χρησιμοποιώντας το {{agentClient}} στο {{agentDevice}} {{agentOs}}. Εάν δεν ζητήσατε τη σύνδεση, μπορείτε να αγνοήσετε με ασφάλεια αυτό το email.",
-    "sms.verification.body": "το {{secret}} είναι ο κωδικός επαλήθευσης του {{project}} σας.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Η φράση ασφαλείας για αυτό το email είναι {{phrase}}. Μπορείτε να εμπιστευτείτε αυτό το email αν αυτή η φράση ταιριάζει με τη φράση που εμφανίζεται κατά την είσοδο.",
     "emails.magicSession.optionUrl": "Εάν δεν μπορείτε να συνδεθείτε χρησιμοποιώντας το παραπάνω κουμπί, παρακαλώ επισκεφτείτε τον παρακάτω σύνδεσμο:",
     "emails.otpSession.subject": "{{project}} Σύνδεση",

--- a/app/config/locale/translations/en.json
+++ b/app/config/locale/translations/en.json
@@ -43,7 +43,7 @@
     "emails.invitation.footer": "If you are not interested, you can ignore this message.",
     "emails.invitation.thanks": "Thanks",
     "emails.invitation.signature": "{{project}} team",
-    "sms.verification.body": "{{secret}} is your {{project}} verification code.",
+    "sms.verification.body": "{{secret}}",
     "locale.country.unknown": "Unknown",
     "countries.af": "Afghanistan",
     "countries.ao": "Angola",

--- a/app/config/locale/translations/eo.json
+++ b/app/config/locale/translations/eo.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Alklaku la suban butonon por sekure ensaluti al via {{project}}-konto. Ĝi eksvalidiĝos post 1 horo.",
     "emails.magicSession.buttonText": "Ensalutu al {{project}}",
     "emails.magicSession.clientInfo": "Ĉi tiu ensaluto estis petita per {{agentClient}} en {{agentDevice}} {{agentOs}}. Se vi ne petis la ensaluton, vi povas sekure ignori ĉi tiun retpoŝton.",
-    "sms.verification.body": "{{secret}} estas via {{project}} kontrolo-kodo.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La sekureca frazo por ĉi tiu retpoŝto estas {{phrase}}. Vi povas fidi ĉi tiun retpoŝton se ĉi tiu frazo kongruas kun la frazo montrita dum ensaluto.",
     "emails.magicSession.optionUrl": "Se vi ne povas ensaluti per la supra butono, bonvolu viziti la jenan ligilon:",
     "emails.otpSession.subject": "{{project}} Ensaluto",

--- a/app/config/locale/translations/es.json
+++ b/app/config/locale/translations/es.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Haz clic en el botón de abajo para iniciar sesión de forma segura en tu cuenta de {{project}}. Caducará en 1 hora.",
     "emails.magicSession.buttonText": "Iniciar sesión en {{project}}",
     "emails.magicSession.clientInfo": "Este inicio de sesión fue solicitado usando {{agentClient}} en {{agentDevice}} {{agentOs}}. Si no solicitaste el inicio de sesión, puedes ignorar este correo electrónico de forma segura.",
-    "sms.verification.body": "{{secret}} es tu código de verificación de {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La frase de seguridad para este correo electrónico es {{phrase}}. Puedes confiar en este correo electrónico si esta frase coincide con la frase que se muestra durante el inicio de sesión.",
     "emails.magicSession.optionUrl": "Si no puedes iniciar sesión utilizando el botón anterior, visita el siguiente enlace:",
     "emails.otpSession.subject": "Inicio de sesión en {{project}}",

--- a/app/config/locale/translations/fa.json
+++ b/app/config/locale/translations/fa.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "بر روی دکمه زیر کلیک کنید تا به صورت امن وارد حساب {{project}} خود شوید. این دکمه یک ساعت دیگر منقضی می‌شود.",
     "emails.magicSession.buttonText": "ورود به {{project}}",
     "emails.magicSession.clientInfo": "این ورود به سیستم با استفاده از {{agentClient}} در {{agentDevice}} {{agentOs}} درخواست شده است. اگر شما این ورود به سیستم را درخواست نکرده‌اید، می‌توانید به راحتی این ایمیل را نادیده بگیرید.",
-    "sms.verification.body": "{{secret}} کد تایید {{project}} شما است.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "عبارت امنیتی برای این ایمیل {{phrase}} است. اگر این عبارت با عبارت نشان داده شده در هنگام ورود به سیستم مطابقت داشت، می‌توانید به این ایمیل اعتماد کنید.",
     "emails.magicSession.optionUrl": "اگر قادر به ورود با استفاده از دکمه بالا نیستید، لطفاً از لینک زیر دیدن فرمایید:",
     "emails.otpSession.subject": "ورود {{project}}",

--- a/app/config/locale/translations/fi.json
+++ b/app/config/locale/translations/fi.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Napsauta alla olevaa painiketta kirjautuaksesi turvallisesti {{project}}-tiliisi. Se vanhenee tunnissa.",
     "emails.magicSession.buttonText": "Kirjaudu sisään {{project}}",
     "emails.magicSession.clientInfo": "Tämä kirjautuminen pyydettiin käyttäen {{agentClient}} {{agentDevice}} {{agentOs}}. Jos et pyytänyt kirjautumista, voit huoletta jättää tämän sähköpostin huomiotta.",
-    "sms.verification.body": "{{secret}} on sinun {{project}} vahvistuskoodisi.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Tämän sähköpostin turvalause on {{phrase}}. Voit luottaa tähän sähköpostiin, jos tämä lause vastaa kirjautumisen yhteydessä näytettyä lausetta.",
     "emails.magicSession.optionUrl": "Jos et pysty kirjautumaan sisään yllä olevaa painiketta käyttäen, käy seuraavassa linkissä:",
     "emails.otpSession.subject": "{{project}} Kirjautuminen",

--- a/app/config/locale/translations/fo.json
+++ b/app/config/locale/translations/fo.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Trýst á knøttin niðanfyri fyri at rita trygt inn á tína {{project}} konto. Tað fer at ganga út um 1 tíma.",
     "emails.magicSession.buttonText": "Innrita á {{project}}",
     "emails.magicSession.clientInfo": "Hetta innritingarbeiðið varð umbiðið við {{agentClient}} á {{agentDevice}} {{agentOs}}. Um tú ikki bað um innritingina, kanst tú trygt ignoreri hendan teldupostin.",
-    "sms.verification.body": "{{secret}} er tín {{project}} váttanarkodi.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Trygdarorðið fyri hesa teldupostadressuna er {{phrase}}. Tú kanst líta á hesa teldupostadressu, um hetta orðið samsvarar við orðið víst tá tú ritaði inn.",
     "emails.magicSession.optionUrl": "Um tú ikki fært innritað við at brúka knøttin omanfyri, vinarliga vitja hesa leinkjuna:",
     "emails.otpSession.subject": "{{project}} Ritarinn",

--- a/app/config/locale/translations/fr.json
+++ b/app/config/locale/translations/fr.json
@@ -233,7 +233,7 @@
     "emails.magicSession.buttonText": "Connectez-vous à {{project}}",
     "emails.magicSession.optionUrl": "Si le bouton ci-dessus ne s'affiche pas, utilisez le lien suivant :",
     "emails.magicSession.clientInfo": "Cette connexion a été demandée en utilisant {{agentClient}} sur {{agentDevice}} {{agentOs}}. Si vous n'avez pas demandé cette connexion, vous pouvez ignorer cet email en toute sécurité.",
-    "sms.verification.body": "{{secret}} est votre code de vérification pour {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La phrase de sécurité pour cet email est {{phrase}}. Vous pouvez faire confiance à cet email si cette phrase correspond à celle affichée lors de la connexion.",
     "emails.otpSession.subject": "Connexion {{project}}",
     "emails.otpSession.hello": "Bonjour,",

--- a/app/config/locale/translations/ga.json
+++ b/app/config/locale/translations/ga.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Cliceáil ar an gcnaipe thíos le síní isteach go sábháilte i do chuntas {{project}}. Rachaidh sé in éag i gceann 1 uair.",
     "emails.magicSession.buttonText": "Sínigh isteach i {{project}}",
     "emails.magicSession.clientInfo": "Rinneadh an logáil isteach seo a iarraidh ag baint úsáide as {{agentClient}} ar {{agentDevice}} {{agentOs}}. Mura ndearna tú an logáil isteach a iarraidh, is féidir leat neamhaird sábháilte a dhéanamh den ríomhphost seo.",
-    "sms.verification.body": "Is é {{secret}} do chód fíoraithe {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Is é an abairt slándála don ríomhphost seo ná {{phrase}}. Is féidir muinín a bheith agat as an ríomhphost seo má mheaitseálann an abairt seo leis an abairt a taispeántar le linn sínithe isteach.",
     "emails.magicSession.optionUrl": "Mura bhfuil tú in ann síniú isteach ag baint úsáid as an gcnaipe thuas, téigh chuig an nasc seo a leanas:",
     "emails.otpSession.subject": "Login {{project}}",

--- a/app/config/locale/translations/gu.json
+++ b/app/config/locale/translations/gu.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "નીચે આપેલ બટન પર ક્લિક કરો તમારા {{project}} ખાતામાં સુરક્ષિત રીતે સાઇન ઈન કરવા માટે. તે 1 કલાકમાં સમાપ્ત થઈ જશે.",
     "emails.magicSession.buttonText": "સાઇન ઇન કરો {{project}}",
     "emails.magicSession.clientInfo": "આ સાઇન ઇન વિનંતી {{agentClient}} નો ઉપયોગ કરીને {{agentDevice}} {{agentOs}} પર કરવામાં આવી હતી. જો તમે સાઇન ઇનની વિનંતી કરી ન હોય, તો આ ઇમેઇલને સલામત રીતે અવગણી શકો છો.",
-    "sms.verification.body": "{{secret}} તમારા {{project}} ચકાસણી કોડ છે.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "આ ઇમેઇલ માટેનું સુરક્ષા વાક્ય {{phrase}} છે. જો આ વાક્ય સાઇન ઇન દરમિયાન દર્શાવેલા વાક્ય સાથે મેળ ખાય તો તમે આ ઇમેઇલ પર વિશ્વાસ કરી શકો છો.",
     "emails.magicSession.optionUrl": "જો તમે ઉપરની બટનનો ઉપયોગ કરીને સાઇન ઇન કરી શકતા નથી, કૃપા કરીને નીચેની લિંક પર જાઓ:",
     "emails.otpSession.subject": "{{project}} લૉગિન",

--- a/app/config/locale/translations/he.json
+++ b/app/config/locale/translations/he.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "לחץ על הכפתור למטה כדי להיכנס לחשבון {{project}} שלך באופן מאובטח. תוקף הכניסה יפוג תוך שעה.",
     "emails.magicSession.buttonText": "היכנס ל-{{project}}",
     "emails.magicSession.clientInfo": "ההתחברות הזו נעשתה באמצעות {{agentClient}} על {{agentDevice}} {{agentOs}}. אם לא ביקשת את ההתחברות הזו, באפשרותך להתעלם בבטחה מהאימייל הזה.",
-    "sms.verification.body": "{{secret}} הוא קוד האימות שלך ל-{{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "משפט הביטחון עבור הודעת הדוא\"ל הזו הוא {{phrase}}. תוכל לסמוך על הודעת הדוא\"ל הזו אם המשפט הזה תואם למשפט שהוצג בעת ההתחברות.",
     "emails.magicSession.optionUrl": "אם אינך יכול להיכנס באמצעות הכפתור למעלה, בקר בקישור הבא:",
     "emails.otpSession.subject": "התחברות למערכת {{project}}",

--- a/app/config/locale/translations/hi.json
+++ b/app/config/locale/translations/hi.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "नीचे दिए गए बटन पर क्लिक करके अपने {{project}} खाते में सुरक्षित रूप से साइन इन करें। यह 1 घंटे में समाप्त हो जाएगा।",
     "emails.magicSession.buttonText": "{{project}} में साइन इन करें",
     "emails.magicSession.clientInfo": "यह साइन इन {{agentClient}} का उपयोग करके {{agentDevice}} {{agentOs}} पर किया गया था। यदि आपने साइन इन का अनुरोध नहीं किया है, तो आप इस ईमेल को सुरक्षित रूप से अनदेखा कर सकते हैं।",
-    "sms.verification.body": "{{secret}} आपके {{project}} सत्यापन कोड है।",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "इस ईमेल का सुरक्षा वाक्यांश {{phrase}} है। यदि यह वाक्यांश साइन इन के दौरान दिखाए गए वाक्यांश से मेल खाता है तो आप इस ईमेल पर भरोसा कर सकते हैं।",
     "emails.magicSession.optionUrl": "यदि आप ऊपर दिए गए बटन का उपयोग करके साइन इन नहीं कर पा रहे हैं, कृपया निम्नलिखित लिंक पर जाएँ:",
     "emails.otpSession.subject": "{{project}} लॉगिन",

--- a/app/config/locale/translations/hr.json
+++ b/app/config/locale/translations/hr.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknite gumb ispod kako biste sigurno prijavili u svoj {{project}} račun. Istek će za 1 sat.",
     "emails.magicSession.buttonText": "Prijavite se u {{project}}",
     "emails.magicSession.clientInfo": "Ova se prijava zatražila koristeći {{agentClient}} na uređaju {{agentDevice}} {{agentOs}}. Ako niste zatražili prijavu, možete slobodno zanemariti ovaj e-mail.",
-    "sms.verification.body": "{{secret}} je vaš verifikacijski kod za {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Sigurnosna fraza za ovaj e-mail je {{phrase}}. Ovom e-mailu možete vjerovati ako se fraza podudara s frazom prikazanom tijekom prijave.",
     "emails.magicSession.optionUrl": "Ako se ne možete prijaviti koristeći gornji gumb, posjetite sljedeću poveznicu:",
     "emails.otpSession.subject": "Prijava na {{project}}",

--- a/app/config/locale/translations/hu.json
+++ b/app/config/locale/translations/hu.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kattintson az alábbi gombra, hogy biztonságosan bejelentkezzen a {{project}} fiókjába. A link 1 óra múlva lejár.",
     "emails.magicSession.buttonText": "Jelentkezzen be a {{project}} szolgáltatásba.",
     "emails.magicSession.clientInfo": "Ezt a bejelentkezést a(z) {{agentClient}} használatával kérték az Ön {{agentDevice}} {{agentOs}} eszközén. Ha Ön nem kezdeményezte ezt a bejelentkezést, nyugodtan hagyja figyelmen kívül ezt az e-mailt.",
-    "sms.verification.body": "{{secret}} a(z) {{project}} megerősítő kódja.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Az e-mailhez tartozó biztonsági kifejezés: {{phrase}}. Megbízhat ebben az e-mailben, ha ez a kifejezés megegyezik a bejelentkezéskor megjelenített kifejezéssel.",
     "emails.magicSession.optionUrl": "Amennyiben az előző gomb használatával nem tud bejelentkezni, kérjük látogassa meg a következő linket:",
     "emails.otpSession.subject": "{{project}} Bejelentkezés",

--- a/app/config/locale/translations/hy.json
+++ b/app/config/locale/translations/hy.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Սեղմեք ներքևի կոճակը՝ ապահով մուտք գործելու {{project}} հաշիվդ։ Այն կանցնի 1 ժամից։",
     "emails.magicSession.buttonText": "Մուտք գործեք {{project}} համար",
     "emails.magicSession.clientInfo": "Սա մուտք գործելը խնդրվել է `{{agentClient}}`-ի միջոցով {{agentDevice}} {{agentOs}}-ում: Եթե դուք չեք խնդրել մուտք գործելը, ապա կարող եք անտեղյակ մնալ այս էլփոստից:",
-    "sms.verification.body": "{{secret}}-ն ձեր {{project}} վավերացման կոդն է։",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Այս էլհասցեի անվտանգության արտահայտությունը {{phrase}} է: Դուք կարող եք հավատալ այս էլհասցեին, եթե այդ արտահայտությունը համընկնում է ներմուծման պրոցեսին՝ երբ դուք գրանցվել եք։",
     "emails.magicSession.optionUrl": "Եթե չեք կարող մուտք գործել վերը նշված կոճակով, այցելեք հետևյալ հղումը՝",
     "emails.otpSession.subject": "{{project}} Մուտք",

--- a/app/config/locale/translations/id.json
+++ b/app/config/locale/translations/id.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klik tombol di bawah ini untuk masuk ke akun {{project}} Anda dengan aman. Ini akan kedaluwarsa dalam 1 jam.",
     "emails.magicSession.buttonText": "Masuk ke {{project}}",
     "emails.magicSession.clientInfo": "Tanda masuk ini diminta menggunakan {{agentClient}} di {{agentDevice}} {{agentOs}}. Jika Anda tidak meminta untuk masuk, Anda dapat mengabaikan email ini dengan aman.",
-    "sms.verification.body": "{{secret}} adalah kode verifikasi {{project}} Anda.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Frasa keamanan untuk email ini adalah {{phrase}}. Anda dapat mempercayai email ini jika frasa tersebut cocok dengan frasa yang ditampilkan saat masuk.",
     "emails.magicSession.optionUrl": "Jika Anda tidak dapat masuk menggunakan tombol di atas, silakan kunjungi tautan berikut:",
     "emails.otpSession.subject": "Login {{project}}",

--- a/app/config/locale/translations/is.json
+++ b/app/config/locale/translations/is.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Smelltu á hnappinn hér fyrir neðan til að skrá þig örugglega inn á {{project}} reikninginn þinn. Hann rennur út eftir 1 klukkustund.",
     "emails.magicSession.buttonText": "Skráðu þig inn á {{project}}",
     "emails.magicSession.clientInfo": "Þessi innskráning var óskað eftir með {{agentClient}} á {{agentDevice}} {{agentOs}}. Ef þú baðst ekki um innskráninguna geturðu hundsað þennan tölvupóst örugglega.",
-    "sms.verification.body": "{{secret}} er staðfestingarkóði {{project}} þíns.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Öryggisfrasi fyrir þetta tölvupóst er {{phrase}}. Þú getur treyst þessum tölvupósti ef þessi frasi passar við frasann sem birtist við innskráningu.",
     "emails.magicSession.optionUrl": "Ef þú getur ekki skráð þig inn með hnappnum hér að ofan, vinsamlegast heimsækðu eftirfarandi tengil:",
     "emails.otpSession.subject": "{{project}} Innskráning",

--- a/app/config/locale/translations/it.json
+++ b/app/config/locale/translations/it.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Fai clic sul pulsante qui sotto per accedere in modo sicuro al tuo account {{project}}. Scadrà tra 1 ora.",
     "emails.magicSession.buttonText": "Accedi a {{project}}",
     "emails.magicSession.clientInfo": "Questo accesso è stato richiesto utilizzando {{agentClient}} su {{agentDevice}} {{agentOs}}. Se non hai richiesto l'accesso, puoi tranquillamente ignorare questa email.",
-    "sms.verification.body": "{{secret}} è il tuo codice di verifica per {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La frase di sicurezza per questa email è {{phrase}}. Puoi fidarti di questa email se questa frase corrisponde alla frase mostrata durante l'accesso.",
     "emails.magicSession.optionUrl": "Se non riesci ad accedere utilizzando il pulsante qui sopra, ti preghiamo di visitare il seguente link:",
     "emails.otpSession.subject": "Accesso a {{project}}",

--- a/app/config/locale/translations/ja.json
+++ b/app/config/locale/translations/ja.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "以下のボタンをクリックして、安全に{{project}}アカウントにサインインしてください。有効期限は1時間です。",
     "emails.magicSession.buttonText": "{{project}} にサインイン",
     "emails.magicSession.clientInfo": "このサインインは{{agentClient}}を使用して{{agentDevice}} {{agentOs}}で要求されました。サインインを要求していない場合は、このメールを安全に無視してください。",
-    "sms.verification.body": "{{secret}} はあなたの {{project}} 認証コードです。",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "このメールのセキュリティフレーズは{{phrase}}です。サインイン時に表示されたフレーズと一致する場合、このメールは信頼できます。",
     "emails.magicSession.optionUrl": "上記のボタンを使用してサインインすることができない場合は、次のリンクにアクセスしてください：",
     "emails.otpSession.subject": "プロジェクト ログイン",

--- a/app/config/locale/translations/jv.json
+++ b/app/config/locale/translations/jv.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klik tombol ing ngisor iki kanggo mlebu kanthi aman ing akun {{project}} panjenengan. Bakal kadaluwarsa sajroning 1 jam.",
     "emails.magicSession.buttonText": "Mlebu ing {{project}}",
     "emails.magicSession.clientInfo": "Penandatanganan iki dijaluk nganggo {{agentClient}} ing {{agentDevice}} {{agentOs}}. Yen panjenengan ora njaluk penandatanganan, panjenengan bisa ngabaikan email iki kanthi aman.",
-    "sms.verification.body": "{{secret}} iku kode verifikasi {{project}} panjenengan.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Frasa keamanan kanggo email iki yaiku {{phrase}}. Sampeyan bisa percaya marang email iki yen frasa iki cocog karo frasa sing ditampilake nalika mlebu.",
     "emails.magicSession.optionUrl": "Yen sampeyan ora bisa mlebu nganggo tombol ing ndhuwur, monggo ngunjungi pranala ing ngisor iki:",
     "emails.otpSession.subject": "{{project}} Mlebu",

--- a/app/config/locale/translations/km.json
+++ b/app/config/locale/translations/km.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "ចុចប៊ូតុងខាងក្រោមដើម្បីចូលប្រើគណនី {{project}} របស់អ្នកដោយសុវត្ថិភាព។ វានឹងផុតកំណត់ក្នុងរយៈពេល 1 ម៉ោង។",
     "emails.magicSession.buttonText": "ចូលទៅកាន់ {{project}}",
     "emails.magicSession.clientInfo": "ការចូលប្រើនេះត្រូវបានស្នើរអោយប្រើ {{agentClient}} នៅលើ {{agentDevice}} {{agentOs}}។ ប្រសិនបើអ្នកមិនបានស្នើរការចូលប្រើនេះ អ្នកអាចមិនអើពើនឹងអ៊ីម៉ែលនេះបាន។",
-    "sms.verification.body": "{{secret}} ជាលេខកូដផ្ទៀងផ្ទាត់សម្រាប់{{project}}របស់អ្នក។",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "ឃ្លាសម្ងាត់សម្រាប់អ៊ីមែលនេះគឺ {{phrase}}។ អ្នកអាចទុកចិត្តលើអ៊ីមែលនេះប្រសិនបើឃ្លានេះត្រូវគ្នាជាមួយឃ្លាដែលបង្ហាញឡើងពេលចូលប្រើ។",
     "emails.magicSession.optionUrl": "ប្រសិនបើអ្នកមិនអាចចូលប្រើប្រាស់ដោយប្រើប៊ូតុងខាងលើនេះទេ សូមចូលទៅកាន់តំណភ្ជាប់ខាងក្រោម៖",
     "emails.otpSession.subject": "ការចូល {{project}}",

--- a/app/config/locale/translations/kn.json
+++ b/app/config/locale/translations/kn.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "ಕೆಳಗಿನ ಬಟನ್ ಒತ್ತಿ ನಿಮ್ಮ {{project}} ಖಾತೆಗೆ ಸುರಕ್ಷಿತವಾಗಿ ಸೈನ್ ಇನ್ ಮಾಡಿ. ಇದು 1 ಗಂಟೆಯಲ್ಲಿ ಅವಧಿ ಮುಗಿಯುತ್ತದೆ.",
     "emails.magicSession.buttonText": "ಸೈನ್ ಇನ್ ಮಾಡಿ {{project}}",
     "emails.magicSession.clientInfo": "ಈ ಸೈನ್ ಇನ್ ಅನ್ನು {{agentClient}} ಬಳಸಿ {{agentDevice}} {{agentOs}} ಮೂಲಕ ಕೋರಲಾಗಿದೆ. ನೀವು ಸೈನ್ ಇನ್ ಅನ್ನು ಕೋರಿಲ್ಲದಿದ್ದರೆ, ನೀವು ಈ ಇಮೇಲ್ ಅನ್ನು ಸುರಕ್ಷಿತವಾಗಿ ನಿರ್ಲಕ್ಷಿಸಬಹುದು.",
-    "sms.verification.body": "{{secret}} ನಿಮ್ಮ {{project}} ಪರಿಶೀಲನಾ ಸಂಕೇತವಾಗಿದೆ.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "ಈ ಇಮೇಲ್‌ಗಾಗಿ ಭದ್ರತಾ ಪದ ಇದೆ {{phrase}}. ಸೈನ್ ಇನ್ ಮಾಡುವಾಗ ತೋರಿದ ಪದವು ಈ ಪದವು ಹೊಂದಿಕೆಯಾಗಿದ್ದರೆ ನೀವು ಈ ಇಮೇಲ್‌ಅನ್ನು ನಂಬಬಹುದು.",
     "emails.magicSession.optionUrl": "ಮೇಲಿನ ಬಟನ್ ಬಳಸಿ ನೀವು ಸೈನ್ ಇನ್ ಮಾಡಲು ಅಸಮರ್ಥರಾಗಿದ್ದರೆ, ದಯವಿಟ್ಟು ಈ ಕೆಳಗಿನ ಲಿಂಕ್ ಭೇಟಿಯನ್ನು ಕೊಡಿ:",
     "emails.otpSession.subject": "{{project}} ಲಾಗಿನ್",

--- a/app/config/locale/translations/ko.json
+++ b/app/config/locale/translations/ko.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "아래 버튼을 클릭하여 안전하게 {{project}} 계정에 로그인하세요. 1시간 후에 만료됩니다.",
     "emails.magicSession.buttonText": "{{project}}에 로그인하세요",
     "emails.magicSession.clientInfo": "이 로그인은 {{agentClient}}을(를) 사용하여 {{agentDevice}} {{agentOs}}에서 요청되었습니다. 로그인을 요청하지 않았다면, 이 이메일을 안전하게 무시하셔도 됩니다.",
-    "sms.verification.body": "{{secret}}는 귀하의 {{project}} 인증 코드입니다.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "이 이메일의 보안 구절은 {{phrase}}입니다. 로그인할 때 표시되는 구절과 일치한다면 이 이메일을 신뢰할 수 있습니다.",
     "emails.magicSession.optionUrl": "위의 버튼을 사용하여 로그인할 수 없다면, 다음 링크를 방문해 주세요:",
     "emails.otpSession.subject": "{{project}} 로그인",

--- a/app/config/locale/translations/la.json
+++ b/app/config/locale/translations/la.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "Praeclarum tuum testificationem valet ad XXX dies a primo defectu. Magnopere suademus ut hoc casum investiges, alioquin dominium tuum sine valida SSL communicatione erit.",
     "emails.certificate.thanks": "Gratias",
     "emails.certificate.signature": "team {{project}}",
-    "sms.verification.body": "{{secret}} est codex verificatorius {{project}} tui."
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/lb.json
+++ b/app/config/locale/translations/lb.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klickt op de Knäppchen hei drënner fir sécher an Äre {{project}} Kont anzeloggen. Et wäert an 1 Stonn oflafen.",
     "emails.magicSession.buttonText": "Connectez-vous à {{project}}",
     "emails.magicSession.clientInfo": "Dëse Login gouf duerch {{agentClient}} op {{agentDevice}} {{agentOs}} ugefrot. Wann Dir de Login net gefrot hutt, kënnt Dir dësen E-Mail ouni weideres ignoréieren.",
-    "sms.verification.body": "{{secret}} ass äre {{project}} Verifikatiounscode.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "D'Sécherheetsphrase fir dësen E-Mail ass {{phrase}}. Dir kënnt dësem E-Mail vertrauen, wann dës Phrase mat der Phrase iwwereneestëmmt, déi beim Umellen ugewise ginn ass.",
     "emails.magicSession.optionUrl": "Wann Dir Iech net kënnt umellen andeems Dir op de Knäppchen uewendriwwer klickt, besicht w.e.g. de folgenden Link:",
     "emails.otpSession.subject": "{{project}} Aloggen",

--- a/app/config/locale/translations/lt.json
+++ b/app/config/locale/translations/lt.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Spustelėkite žemiau esantį mygtuką, kad saugiai prisijungtumėte prie savo {{project}} paskyros. Galiojimas baigsis po 1 valandos.",
     "emails.magicSession.buttonText": "Prisijunkite prie {{project}}",
     "emails.magicSession.clientInfo": "Šis prisijungimas buvo užklaustas naudojant {{agentClient}} {{agentDevice}} {{agentOs}}. Jei neprašėte prisijungimo, galite saugiai ignoruoti šį el. laišką.",
-    "sms.verification.body": "{{secret}} yra jūsų {{project}} patvirtinimo kodas.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Šio el. laiško saugumo frazė yra {{phrase}}. Šiam el. laiškui galite pasitikėti, jei ši frazė atitinka prisijungimo metu rodytą frazę.",
     "emails.magicSession.optionUrl": "Jei negalite prisijungti naudodami aukščiau esantį mygtuką, apsilankykite šioje nuorodoje:",
     "emails.otpSession.subject": "{{project}} Prisijungimas",

--- a/app/config/locale/translations/lv.json
+++ b/app/config/locale/translations/lv.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Noklikšķiniet uz zemāk esošās pogas, lai droši pieteiktos savā {{project}} kontā. Tas beigsies pēc 1 stundas.",
     "emails.magicSession.buttonText": "Pierakstieties {{project}}",
     "emails.magicSession.clientInfo": "Šī autorizācija tika pieprasīta, izmantojot {{agentClient}} ierīcē {{agentDevice}} operētājsistēmā {{agentOs}}. Ja jūs neesat pieprasījis autorizāciju, šo e-pastu varat droši ignorēt.",
-    "sms.verification.body": "{{secret}} ir jūsu {{project}} verifikācijas kods.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Drošības frāze šim e-pastam ir {{phrase}}. Šim e-pastam var uzticēties, ja šī frāze sakrīt ar frāzi, kas parādās, piesakoties sistēmā.",
     "emails.magicSession.optionUrl": "Ja nevarat pierakstīties, izmantojot iepriekš minēto pogu, lūdzu, apmeklējiet sekojošo saiti:",
     "emails.otpSession.subject": "{{project}} Pieteikšanās",

--- a/app/config/locale/translations/ml.json
+++ b/app/config/locale/translations/ml.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "നിങ്ങളുടെ മുൻപത്തെ സർട്ടിഫിക്കറ്റ് ആദ്യ പരാജയത്തിനു ശേഷം 30 ദിവസം വരെ സാധുവായിരിക്കും. ഈ കേസ് അന്വേഷിച്ചു നോക്കുന്നത് ഞങ്ങൾ ശക്തമായി ശുപാർശ ചെയ്യുന്നു, അല്ലെങ്കിൽ നിങ്ങളുടെ ഡൊമെയ്‌ൻ സാധുവായ SSL കമ്മ്യൂണിക്കേഷനില്ലാത്ത ഒരു അവസ്ഥയിലാകും.",
     "emails.certificate.thanks": "നന്ദി",
     "emails.certificate.signature": "{{project}} ടീം",
-    "sms.verification.body": "{{secret}} നിങ്ങളുടെ {{project}} പരിശോധന കോഡാണ്."
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/mr.json
+++ b/app/config/locale/translations/mr.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "खालील बटणावर क्लिक करा आणि आपल्या {{project}} खात्यात सुरक्षितपणे साइन इन करा. हे १ तासात समाप्त होईल.",
     "emails.magicSession.buttonText": "{{project}} मध्ये साइन इन करा",
     "emails.magicSession.clientInfo": "ही साइन इन विनंती केली गेली {{agentClient}} वरून {{agentDevice}} {{agentOs}} वापरून. जर आपणास ही साइन इन विनंती केली नसेल तर आपण हा ईमेल सुरक्षितपणे दुर्लक्षित करू शकता.",
-    "sms.verification.body": "{{secret}} हे तुमच्या {{project}} प्रमाणीकरण कोड आहे.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "या ईमेलसाठी सुरक्षा वाक्य हे {{phrase}} आहे. साइन इन केल्यावेळी दाखवलेले वाक्य जर हे वाक्याशी जुळत असेल तर तुम्ही या ईमेलवर विश्वास ठेवू शकता.",
     "emails.magicSession.optionUrl": "जर आपण वरील बटणाचा वापर करून साइन इन करू शकत नसाल, तर कृपया खालील दुवा भेट द्या:",
     "emails.otpSession.subject": "{{project}} लॉगिन",

--- a/app/config/locale/translations/ms.json
+++ b/app/config/locale/translations/ms.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klik butang di bawah untuk log masuk ke akaun {{project}} anda dengan selamat. Ia akan luput dalam masa 1 jam.",
     "emails.magicSession.buttonText": "Masuk ke {{project}}",
     "emails.magicSession.clientInfo": "Pendaftaran ini diminta menggunakan {{agentClient}} pada {{agentDevice}} {{agentOs}}. Jika anda tidak meminta untuk daftar masuk, anda boleh abaikan e-mel ini dengan selamat.",
-    "sms.verification.body": "{{secret}} adalah kod pengesahan {{project}} anda.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Frasa keselamatan untuk emel ini adalah {{phrase}}. Anda boleh mempercayai emel ini jika frasa ini sepadan dengan frasa yang ditunjukkan semasa log masuk.",
     "emails.magicSession.optionUrl": "Jika anda tidak dapat log masuk menggunakan butang di atas, sila kunjungi pautan berikut:",
     "emails.otpSession.subject": "Log Masuk {{project}}",

--- a/app/config/locale/translations/nb.json
+++ b/app/config/locale/translations/nb.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klikk på knappen nedenfor for å logge inn på din {{project}}-konto på en sikker måte. Den vil utløpe om 1 time.",
     "emails.magicSession.buttonText": "Logg inn på {{project}}",
     "emails.magicSession.clientInfo": "Dette innloggingen ble forespurt ved hjelp av {{agentClient}} på {{agentDevice}} {{agentOs}}. Hvis du ikke ba om innloggingen, kan du trygt se bort fra denne e-posten.",
-    "sms.verification.body": "{{secret}} er din {{project}} bekreftelseskode.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Sikkerhetsfrasen for denne e-posten er {{phrase}}. Du kan stole på denne e-posten hvis denne frasen stemmer overens med frasen som ble vist under innlogging.",
     "emails.magicSession.optionUrl": "Hvis du ikke klarer å logge inn ved å bruke knappen ovenfor, vennligst besøk følgende lenke:",
     "emails.otpSession.subject": "{{project}} Innlogging",

--- a/app/config/locale/translations/ne.json
+++ b/app/config/locale/translations/ne.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "कृपया तलको बटनमा क्लिक गरी आफ्नो {{project}} खातामा सुरक्षित रूपमा साइन इन गर्नुहोस्। यो १ घण्टामा समाप्त हुनेछ।",
     "emails.magicSession.buttonText": "Connectez-vous à {{project}}",
     "emails.magicSession.clientInfo": "यो साइन इन अनुरोध गरिएको थियो {{agentClient}} प्रयोग गरेर {{agentDevice}} {{agentOs}} मा। यदि तपाईंले साइन इन अनुरोध गर्नुभएको छैन भने, यो इमेललाई सुरक्षित रूपमा अनदेखा गर्न सक्नुहुन्छ।",
-    "sms.verification.body": "{{secret}} तपाईंको {{project}} प्रमाणीकरण कोड हो।",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "यस ईमेलको लागि सुरक्षा वाक्य {{phrase}} हो। यो वाक्य साइन इन गर्दा देखाइएको वाक्यसँग मेल खाए मात्र तपाईंले यस ईमेललाई विश्वास गर्न सक्नुहुन्छ।",
     "emails.magicSession.optionUrl": "सँगै उल्लेख गरिएको बटन प्रयोग गरेर साइन इन गर्न असमर्थ हुनुहुन्छ भने, कृपया तलको लिंकमा भ्रमण गर्नुहोस्:",
     "emails.otpSession.subject": "{{project}} लगइन",

--- a/app/config/locale/translations/nl.json
+++ b/app/config/locale/translations/nl.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klik op de knop hieronder om veilig in te loggen op uw {{project}} account. Deze zal verlopen over 1 uur.",
     "emails.magicSession.buttonText": "Meld u aan bij {{project}}",
     "emails.magicSession.clientInfo": "Deze aanmelding is aangevraagd met {{agentClient}} op {{agentDevice}} {{agentOs}}. Als u de aanmelding niet hebt aangevraagd, kunt u deze e-mail gerust negeren.",
-    "sms.verification.body": "{{secret}} is uw {{project}} verificatiecode.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "De beveiligingszin voor deze e-mail is {{phrase}}. U kunt deze e-mail vertrouwen als deze zin overeenkomt met de zin die getoond werd tijdens het aanmelden.",
     "emails.magicSession.optionUrl": "Als u zich niet kunt aanmelden via de bovenstaande knop, bezoekt u dan de volgende link:",
     "emails.otpSession.subject": "{{project}} Inloggen",

--- a/app/config/locale/translations/nn.json
+++ b/app/config/locale/translations/nn.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "Førre sertifikatet ditt vil vere gyldig i 30 dagar sidan den første feilen. Vi rår sterkt til at du undersøkjer denne saka, elles vil domenet ditt ende opp utan gyldig SSL-kommunikasjon.",
     "emails.certificate.thanks": "Takk",
     "emails.certificate.signature": "{{project}} team",
-    "sms.verification.body": "{{secret}} er verifiseringskoden din for {{project}}."
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/or.json
+++ b/app/config/locale/translations/or.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknite na gumb ispod kako biste se sigurno prijavili na svoj {{project}} račun. Istječe za 1 sat.",
     "emails.magicSession.buttonText": "Inicia sesión en {{project}}",
     "emails.magicSession.clientInfo": "Tento přihlašovací požadavek byl zaznamenán pomocí {{agentClient}} na {{agentDevice}} {{agentOs}}. Pokud jste o přihlášení nepožádali, můžete tento e-mail bezpečně ignorovat.",
-    "sms.verification.body": "{{secret}} est votre code de vérification pour {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Frase de segurança para este e-mail é {{phrase}}. Você pode confiar neste e-mail se essa frase coincidir com a frase mostrada durante o acesso.",
     "emails.magicSession.optionUrl": "אם אתם לא מצליחים להיכנס באמצעות הכפתור שמעל, אנא בקרו בקישור הבא:",
     "emails.otpSession.subject": "{{project}} ଲଗଇନ্",

--- a/app/config/locale/translations/pa.json
+++ b/app/config/locale/translations/pa.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Haz clic en el botón de abajo para iniciar sesión de manera segura en tu cuenta de {{project}}. Expirará en una hora.",
     "emails.magicSession.buttonText": "Inicia sesión en {{project}}",
     "emails.magicSession.clientInfo": "Este ingreso fue solicitado usando {{agentClient}} en {{agentDevice}} {{agentOs}}. Si no solicitaste el ingreso, puedes ignorar este correo electrónico sin problema.",
-    "sms.verification.body": "El {{secret}} es tu código de verificación de {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La frase de seguridad para este correo electrónico es {{phrase}}. Puedes confiar en este correo si esta frase coincide con la frase que se muestra al iniciar sesión.",
     "emails.magicSession.optionUrl": "Si no puedes iniciar sesión utilizando el botón superior, por favor visita el siguiente enlace:",
     "emails.otpSession.subject": "{{project}} ਲਾਗਿਨ",

--- a/app/config/locale/translations/pl.json
+++ b/app/config/locale/translations/pl.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknij przycisk poniżej, aby bezpiecznie zalogować się na swoje konto {{project}}. Link wygaśnie po 1 godzinie.",
     "emails.magicSession.buttonText": "Zaloguj się do {{project}}",
     "emails.magicSession.clientInfo": "To logowanie zostało zażądane przy użyciu {{agentClient}} na {{agentDevice}} {{agentOs}}. Jeśli nie zażądałeś logowania, możesz zignorować tę wiadomość e-mail.",
-    "sms.verification.body": "{{secret}} jest twoim kodem weryfikacyjnym do {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Hasło bezpieczeństwa dla tego e-maila to {{phrase}}. Możesz ufać temu e-mailowi, jeśli hasło to jest zgodne z hasłem wyświetlonym podczas logowania.",
     "emails.magicSession.optionUrl": "Jeśli nie możesz się zalogować, używając powyższego przycisku, odwiedź następujący link:",
     "emails.otpSession.subject": "Login do {{project}}",

--- a/app/config/locale/translations/pt-br.json
+++ b/app/config/locale/translations/pt-br.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Clique no botão abaixo para acessar sua conta {{project}} com segurança. Ele expirará em 1 hora.",
     "emails.magicSession.buttonText": "Faça login no {{project}}",
     "emails.magicSession.clientInfo": "Este acesso foi solicitado usando {{agentClient}} em {{agentDevice}} {{agentOs}}. Se você não solicitou o acesso, pode ignorar este e-mail com segurança.",
-    "sms.verification.body": "{{secret}} é o seu código de verificação do {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "A frase de segurança para este e-mail é {{phrase}}. Você pode confiar neste e-mail se essa frase corresponder à frase mostrada durante o acesso.",
     "emails.magicSession.optionUrl": "Se você não consegue fazer login usando o botão acima, por favor visite o seguinte link:",
     "emails.otpSession.subject": "Login do {{project}}",

--- a/app/config/locale/translations/pt-pt.json
+++ b/app/config/locale/translations/pt-pt.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Clique no botão abaixo para iniciar sessão na sua conta {{project}} de forma segura. Irá expirar em 1 hora.",
     "emails.magicSession.buttonText": "Inicie sessão no {{project}}",
     "emails.magicSession.clientInfo": "Este início de sessão foi solicitado usando o {{agentClient}} no {{agentDevice}} {{agentOs}}. Se não foi você quem solicitou o início de sessão, pode ignorar este e-mail com segurança.",
-    "sms.verification.body": "{{secret}} é o seu código de verificação do {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "A frase de segurança deste e-mail é {{phrase}}. Pode confiar neste e-mail se esta frase coincidir com a frase mostrada durante o início de sessão.",
     "emails.magicSession.optionUrl": "Se não conseguir iniciar sessão utilizando o botão acima, por favor visite o seguinte link:",
     "emails.otpSession.subject": "Login do {{project}}",

--- a/app/config/locale/translations/ro.json
+++ b/app/config/locale/translations/ro.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Faceți clic pe butonul de mai jos pentru a vă autentifica în siguranță în contul dvs. {{project}}. Va expira în 1 oră.",
     "emails.magicSession.buttonText": "Conectați-vă la {{project}}",
     "emails.magicSession.clientInfo": "Această autentificare a fost solicitată folosind {{agentClient}} pe {{agentDevice}} {{agentOs}}. Dacă nu ați solicitat autentificarea, puteți ignora în siguranță acest email.",
-    "sms.verification.body": "{{secret}} este codul de verificare pentru {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Frază de securitate pentru acest e-mail este {{phrase}}. Puteți avea încredere în acest e-mail dacă fraza se potrivește cu fraza afișată în timpul autentificării.",
     "emails.magicSession.optionUrl": "Dacă nu puteți să vă autentificați folosind butonul de mai sus, vă rugăm să vizitați următorul link:",
     "emails.otpSession.subject": "Conectare {{project}}",

--- a/app/config/locale/translations/ru.json
+++ b/app/config/locale/translations/ru.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Нажмите на кнопку ниже, чтобы безопасно войти в свою учетную запись {{project}}. Срок действия истечет через 1 час.",
     "emails.magicSession.buttonText": "Войти в {{project}}",
     "emails.magicSession.clientInfo": "Этот вход был запрошен с использованием {{agentClient}} на {{agentDevice}} {{agentOs}}. Если вы не запрашивали вход, можете спокойно игнорировать это письмо.",
-    "sms.verification.body": "{{secret}} – это ваш код подтверждения для {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Фраза безопасности для этого электронного письма - {{phrase}}. Вы можете доверять этому письму, если эта фраза совпадает с фразой, отображаемой при входе в систему.",
     "emails.magicSession.optionUrl": "Если вы не можете войти, используя кнопку выше, пожалуйста, посетите следующую ссылку:",
     "emails.otpSession.subject": "Вход в систему {{project}}",

--- a/app/config/locale/translations/sa.json
+++ b/app/config/locale/translations/sa.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "اضغط على الزر أدناه لتسجيل الدخول بأمان إلى حساب {{project}} الخاص بك. سينتهي في غضون ساعة واحدة.",
     "emails.magicSession.buttonText": "تسجيل الدخول إلى {{project}}",
     "emails.magicSession.clientInfo": "هذا الطلب لتسجيل الدخول قد تم باستخدام {{agentClient}} على {{agentDevice}} {{agentOs}}. إذا لم تطلب تسجيل الدخول، يمكنك تجاهل هذا البريد الإلكتروني بأمان.",
-    "sms.verification.body": "سري هو رمز التحقق الخاص بمشروعك.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "العبارة الأمنية لهذا البريد الإلكتروني هي {{phrase}}. يمكنك الوثوق بهذا البريد الإلكتروني إذا كانت هذه العبارة متطابقة مع العبارة المعروضة أثناء تسجيل الدخول.",
     "emails.magicSession.optionUrl": "إذا لم تتمكن من تسجيل الدخول باستخدام الزر أعلاه، يرجى زيارة الرابط التالي:",
     "emails.otpSession.subject": "प्रवेशनम्",

--- a/app/config/locale/translations/sd.json
+++ b/app/config/locale/translations/sd.json
@@ -247,5 +247,5 @@
     "emails.certificate.footer": "توهان جو اڳيون سرٽيفڪيٽ اولهو فئيلر جي ݙينهن کان ٣٠ ݙينهن لاءِ ماني ويندو. اسان ان جي چھان بني جي بھرپور خواهش ڪنداسين، نہ ته توهان جو ݙومين بغير ڪوري SSL ڪميونڪيشن آڻي ويندي.",
     "emails.certificate.thanks": "شُكريا",
     "emails.certificate.signature": "ٽيم",
-    "sms.verification.body": "{{secret}} توهان جي {{project}} تصديقي ڪوڊ آهي."
+    "sms.verification.body": "{{secret}}"
 }

--- a/app/config/locale/translations/si.json
+++ b/app/config/locale/translations/si.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknite spodnji gumb, da varno vstopite v svoj {{project}} račun. Poteče čez 1 uro.",
     "emails.magicSession.buttonText": "Prijavite se v {{project}}",
     "emails.magicSession.clientInfo": "Ta prijava je bila zahtevana z uporabo {{agentClient}} na {{agentDevice}} {{agentOs}}. Če te prijave niste zahtevali, lahko to e-pošto varno prezrete.",
-    "sms.verification.body": "{{secret}} je vaša {{project}} koda za preverjanje.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Zaščitna fraza za ta e-poštni naslov je {{phrase}}. Temu e-poštnemu naslovu lahko zaupate, če se ta fraza ujema s frazo, prikazano med prijavo.",
     "emails.magicSession.optionUrl": "Če se z zgornjim gumbom ne morete prijaviti, obiščite naslednjo povezavo:",
     "emails.otpSession.subject": "{{project}} පිවිසුම",

--- a/app/config/locale/translations/sk.json
+++ b/app/config/locale/translations/sk.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknite na tlačidlo nižšie, aby ste sa bezpečne prihlásili do vášho účtu {{project}}. Platnosť vyprší za 1 hodinu.",
     "emails.magicSession.buttonText": "Prihláste sa do {{project}}",
     "emails.magicSession.clientInfo": "Toto prihlásenie bolo požadované pomocou {{agentClient}} na {{agentDevice}} {{agentOs}}. Ak ste si nepožiadali o prihlásenie, tento e-mail môžete bezpečne ignorovať.",
-    "sms.verification.body": "{{secret}} je váš overovací kód pre {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Bezpečnostná fráza pre tento email je {{phrase}}. Tomuto emailu môžete dôverovať, ak sa táto fráza zhoduje s frázou zobrazenou počas prihlásenia.",
     "emails.magicSession.optionUrl": "Ak sa vám nedarí prihlásiť sa pomocou vyššie uvedeného tlačidla, prosím navštívte nasledujúci odkaz:",
     "emails.otpSession.subject": "Prihlásenie do projektu {{project}}",

--- a/app/config/locale/translations/sl.json
+++ b/app/config/locale/translations/sl.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Kliknite spodnji gumb, da se varno prijavite v svoj {{project}} račun. Poteče čez 1 uro.",
     "emails.magicSession.buttonText": "Vpišite se v {{project}}",
     "emails.magicSession.clientInfo": "Ta prijava je bila zahtevana z uporabo {{agentClient}} na {{agentDevice}} {{agentOs}}. Če te prijave niste zahtevali, lahko to e-pošto varno prezrete.",
-    "sms.verification.body": "{{secret}} je vaša koda za preverjanje {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Varnostni stavek za to e-pošto je {{phrase}}. Temu e-poštu lahko zaupate, če se ta stavek ujema s stavkom, prikazanim ob prijavi.",
     "emails.magicSession.optionUrl": "Če se ne morete prijaviti s pomočjo zgornjega gumba, prosimo obiščite naslednjo povezavo:",
     "emails.otpSession.subject": "Prijavite se v {{project}}",

--- a/app/config/locale/translations/sn.json
+++ b/app/config/locale/translations/sn.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Cliquez sur le bouton ci-dessous pour vous connecter de manière sécurisée à votre compte {{project}}. Il expirera dans 1 heure.",
     "emails.magicSession.buttonText": "Connectez-vous à {{project}}",
     "emails.magicSession.clientInfo": "Cette connexion a été demandée en utilisant {{agentClient}} sur {{agentDevice}} {{agentOs}}. Si vous n'avez pas demandé cette connexion, vous pouvez ignorer cet e-mail en toute sécurité.",
-    "sms.verification.body": "{{secret}} mooy sa koodu vérificationu {{project}} bi.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "La phrase de sécurité pour ce courriel est {{phrase}}. Vous pouvez faire confiance à ce courriel si cette phrase correspond à la phrase affichée lors de la connexion.",
     "emails.magicSession.optionUrl": "Si vous ne pouvez pas vous connecter en utilisant le bouton ci-dessus, veuillez visiter le lien suivant :",
     "emails.otpSession.subject": "{{project}} Kupinda",

--- a/app/config/locale/translations/sq.json
+++ b/app/config/locale/translations/sq.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klikoni butonin më poshtë për të hyrë në mënyrë të sigurt në llogarinë tuaj {{project}}. Do të skadojë në 1 orë.",
     "emails.magicSession.buttonText": "Kyçu në {{project}}",
     "emails.magicSession.clientInfo": "Ky hyrje është kërkuar duke përdorur {{agentClient}} në {{agentDevice}} {{agentOs}}. Nëse nuk e keni kërkuar hyrjen, mund ta injoroni këtë email pa pasur shqetësim.",
-    "sms.verification.body": "{{secret}} është kodi juaj i verifikimit për {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Fjalia e sigurisë për këtë email është {{phrase}}. Mund të besoni këtë email nëse kjo fjali përputhet me fjalën e shfaqur gjatë hyrjes në sistem.",
     "emails.magicSession.optionUrl": "Nëse nuk mund të hyni duke përdorur butonin më sipër, ju lutem vizitoni lidhjen e mëposhtme:",
     "emails.otpSession.subject": "{{project}} Hyrje",

--- a/app/config/locale/translations/sv.json
+++ b/app/config/locale/translations/sv.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Klicka på knappen nedan för att säkert logga in på ditt {{project}} konto. Den kommer att gå ut om 1 timme.",
     "emails.magicSession.buttonText": "Inicia sesión en {{project}}",
     "emails.magicSession.clientInfo": "Den här inloggningen begärdes med hjälp av {{agentClient}} på {{agentDevice}} {{agentOs}}. Om du inte begärde inloggningen kan du bortse från det här e-postmeddelandet.",
-    "sms.verification.body": "{{secret}} är din {{project}} verifieringskod.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Frasen för säkerhet i detta e-postmeddelande är {{phrase}}. Du kan lita på detta e-postmeddelande om frasen stämmer överens med den fras som visas vid inloggning.",
     "emails.magicSession.optionUrl": "Si no puedes iniciar sesión utilizando el botón de arriba, por favor visita el siguiente enlace:",
     "emails.otpSession.subject": "{{project}} Inloggning",

--- a/app/config/locale/translations/ta.json
+++ b/app/config/locale/translations/ta.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "கீழே உள்ள பொத்தானை அழுத்தி, உங்கள் {{project}} கணக்கில் பாதுகாப்பாக உள்நுழையவும். இது 1 மணி நேரத்தில் காலாவதியாகும்.",
     "emails.magicSession.buttonText": "{{project}} இல் உள்நுழைக",
     "emails.magicSession.clientInfo": "இந்த உள்நுழைவு {{agentClient}} மூலம் {{agentDevice}} {{agentOs}} இல் கோரப்பட்டது. நீங்கள் உள்நுழைவு கோரவில்லை என்றால், இந்த மின்னஞ்சலை புறக்கணிக்கலாம்.",
-    "sms.verification.body": "{{secret}} உங்கள் {{project}} சரிபார்ப்பு குறியீடு ஆகும்.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "இந்த மின்னஞ்சலுக்கான பாதுகாப்பு வாசகம் {{phrase}}. இந்த வாசகம் உள்நுழைவு போது காட்டப்பட்ட வாசகத்துடன் பொருந்தும் போது இந்த மின்னஞ்சலை நம்பலாம்.",
     "emails.magicSession.optionUrl": "மேலே உள்ள பொத்தானை பயன்படுத்தி உள்நுழைய முடியாவிட்டால், கீழே உள்ள இணைப்பை பார்வையிடவும்:",
     "emails.otpSession.subject": "{{project}} உள்நுழைவு",

--- a/app/config/locale/translations/te.json
+++ b/app/config/locale/translations/te.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "కింది బటన్ ను నొక్కి భద్రతగా మీ {{project}} ఖాతాలో సైన్ ఇన్ చేయండి. ఇది 1 గంటలో గడువు తీరుతుంది.",
     "emails.magicSession.buttonText": "{{project}}లో సైన్ ఇన్ చేయండి",
     "emails.magicSession.clientInfo": "ఈ సైన్ ఇన్ అభ్యర్థనను {{agentClient}} ఉపయోగించి {{agentDevice}} {{agentOs}} పై అభ్యర్థించారు. మీరు ఈ సైన్ ఇన్ అభ్యర్థనను చేయలేదనుకుంటే, ఈ ఈమెయిల్‌ను సురక్షితంగా పట్టించుకోకుండా ఉండవచ్చు.",
-    "sms.verification.body": "{{secret}} మీ {{project}} ధృవీకరణ కోడ్.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "ఈ ఇమెయిల్ కోసం భద్రతా పదబంధం {{phrase}}. మీరు సైన్ ఇన్ సమయంలో చూపబడిన పదబంధంతో ఈ పదబంధం సరిపోలుతుంది అయితే ఈ ఇమెయిల్ నమ్మవచ్చు.",
     "emails.magicSession.optionUrl": "పైన ఉన్న బటన్‌ను ఉపయోగించి సైన్ ఇన్ చేయలేకపోతే, దయచేసి క్రింది లింక్‌ను సందర్శించండి:",
     "emails.otpSession.subject": "{{project}} లాగిన్",

--- a/app/config/locale/translations/th.json
+++ b/app/config/locale/translations/th.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "คลิกที่ปุ่มด้านล่างเพื่อเข้าสู่บัญชี {{project}} ของคุณอย่างปลอดภัย ลิงก์นี้จะหมดอายุใน 1 ชั่วโมง",
     "emails.magicSession.buttonText": "เข้าสู่ระบบใน {{project}}",
     "emails.magicSession.clientInfo": "การลงชื่อเข้าใช้นี้ถูกขอใช้งานผ่าน {{agentClient}} บน {{agentDevice}} {{agentOs}} หากคุณไม่ได้ขอลงชื่อเข้าใช้นี้ คุณสามารถละเลยอีเมลนี้ได้อย่างปลอดภัย",
-    "sms.verification.body": "{{secret}} เป็นรหัสการตรวจสอบ{{project}}ของคุณ.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "วลีรักษาความปลอดภัยสำหรับอีเมลนี้คือ {{phrase}} คุณสามารถเชื่อถืออีเมลนี้ได้หากวลีนี้ตรงกับวลีที่แสดงในระหว่างการเข้าสู่ระบบ",
     "emails.magicSession.optionUrl": "หากคุณไม่สามารถเข้าสู่ระบบโดยใช้ปุ่มด้านบน โปรดเยี่ยมชมลิงก์ต่อไปนี้:",
     "emails.otpSession.subject": "การเข้าสู่ระบบ {{project}}",

--- a/app/config/locale/translations/tl.json
+++ b/app/config/locale/translations/tl.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "I-click ang pindutan sa ibaba upang ligtas na mag-sign in sa iyong {{project}} account. Ito ay mag-eexpire sa loob ng 1 oras.",
     "emails.magicSession.buttonText": "Mag-sign in sa {{project}}",
     "emails.magicSession.clientInfo": "Ang pag-sign in na ito ay hiniling gamit ang {{agentClient}} sa {{agentDevice}} {{agentOs}}. Kung hindi ikaw ang humiling ng pag-sign in na ito, maaari mong ligtas na huwag pansinin ang email na ito.",
-    "sms.verification.body": "{{secret}} ay ang iyong {{project}} verification code.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Ang pariralang pangseguridad para sa email na ito ay {{phrase}}. Maaari mong pagkatiwalaan ang email na ito kung ang pariralang ito ay tumutugma sa pariralang ipinakita noong nag-sign in ka.",
     "emails.magicSession.optionUrl": "Kung hindi ka makapag-sign in gamit ang pindutan sa itaas, mangyaring bisitahin ang sumusunod na link:",
     "emails.otpSession.subject": "{{project}} Pag-login",

--- a/app/config/locale/translations/tr.json
+++ b/app/config/locale/translations/tr.json
@@ -233,7 +233,7 @@
     "emails.magicSession.buttonText": "{{project}}'a giriş yapın",
     "emails.magicSession.optionUrl": "Yukarıdaki buton gözükmezse, aşağıdaki bağlantıyı kullanın:",
     "emails.magicSession.clientInfo": "Bu oturum açma işlemi, {{agentClient}} kullanılarak {{agentDevice}} {{agentOs}} üzerinde istendi. Eğer oturum açma işlemini siz talep etmediyseniz, bu e-postayı güvenle yok sayabilirsiniz.",
-    "sms.verification.body": "{{secret}} sizin {{project}} doğrulama kodunuzdur.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Bu e-postanın güvenlik ifadesi {{phrase}}'dir. Bu ifade, giriş sırasında gösterilen ifadeyle eşleşiyorsa bu e-postaya güvenebilirsiniz.",
     "emails.otpSession.subject": "{{project}} Giriş",
     "emails.otpSession.hello": "Merhaba,",

--- a/app/config/locale/translations/uk.json
+++ b/app/config/locale/translations/uk.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Натисніть кнопку нижче, щоб безпечно увійти в свій обліковий запис {{project}}. Термін дії закінчиться через 1 годину.",
     "emails.magicSession.buttonText": "Увійти в {{project}}",
     "emails.magicSession.clientInfo": "Цей запит на вхід було здійснено за допомогою {{agentClient}} на {{agentDevice}} {{agentOs}}. Якщо ви не надсилали запит на вхід, ви можете сміливо ігнорувати цей електронний лист.",
-    "sms.verification.body": "{{secret}} є вашим кодом підтвердження для {{project}}.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Фраза безпеки для цього листа - {{phrase}}. Ви можете довіряти цьому листу, якщо ця фраза збігається з фразою, показаною під час входу в систему.",
     "emails.magicSession.optionUrl": "Якщо вам не вдається увійти, використовуючи кнопку вище, будь ласка, перейдіть за наступним посиланням:",
     "emails.otpSession.subject": "вхід в {{project}}",

--- a/app/config/locale/translations/ur.json
+++ b/app/config/locale/translations/ur.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "نیچے دیئے گئے بٹن پر کلک کرکے اپنے {{project}} اکاؤنٹ میں محفوظ طریقے سے سائن ان کریں۔ یہ ایک گھنٹے میں ختم ہو جائے گا۔",
     "emails.magicSession.buttonText": "{{project}} میں سائن ان کریں",
     "emails.magicSession.clientInfo": "یہ سائن ان {{agentClient}} کا استعمال کرتے ہوئے {{agentDevice}} {{agentOs}} پر کی گئی تھی۔ اگر آپ نے سائن ان کی درخواست نہیں کی تھی، تو آپ اس ایمیل کو نظرانداز کر سکتے ہیں۔",
-    "sms.verification.body": "{{secret}} آپ کے {{project}} تصدیقی کوڈ ہے۔",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "اس ای میل کے لئے سیکیورٹی جملہ {{phrase}} ہے۔ اگر یہ جملہ سائن ان کے دوران دکھائے گئے جملے سے میل کھاتا ہے تو آپ اس ای میل پر بھروسہ کرسکتے ہیں۔",
     "emails.magicSession.optionUrl": "اگر آپ اوپر دیے گئے بٹن کا استعمال کرکے سائن ان نہیں کر سکتے تو براہ کرم مندرجہ ذیل لنک پر جائیں:",
     "emails.otpSession.subject": "{{project}} لاگ ان",

--- a/app/config/locale/translations/vi.json
+++ b/app/config/locale/translations/vi.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "Nhấp vào nút bên dưới để đăng nhập an toàn vào tài khoản {{project}} của bạn. Nó sẽ hết hạn sau 1 giờ.",
     "emails.magicSession.buttonText": "Đăng nhập vào {{project}}",
     "emails.magicSession.clientInfo": "Yêu cầu đăng nhập này được thực hiện bằng {{agentClient}} trên {{agentDevice}} {{agentOs}}. Nếu bạn không yêu cầu đăng nhập, bạn có thể bỏ qua email này một cách an toàn.",
-    "sms.verification.body": "{{secret}} là mã xác minh {{project}} của bạn.",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "Cụm từ bảo mật cho email này là {{phrase}}. Bạn có thể tin tưởng email này nếu cụm từ này khớp với cụm từ hiển thị khi đăng nhập.",
     "emails.magicSession.optionUrl": "Nếu bạn không thể đăng nhập bằng cách sử dụng nút ở trên, vui lòng truy cập liên kết sau:",
     "emails.otpSession.subject": "Đăng nhập {{project}}",

--- a/app/config/locale/translations/zh-cn.json
+++ b/app/config/locale/translations/zh-cn.json
@@ -232,7 +232,7 @@
     "emails.magicSession.optionButton": "点击下面的按钮安全登录您的{{project}}账户。该按钮将在1小时后过期。",
     "emails.magicSession.buttonText": "登录{{project}}",
     "emails.magicSession.clientInfo": "此登录是通过{{agentClient}}在{{agentDevice}} {{agentOs}}上请求的。如果你没有请求登录，可以放心地忽略此邮件。",
-    "sms.verification.body": "{{secret}} 是您的 {{project}} 验证码。",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "此电子邮件的安全短语是{{phrase}}。如果此短语与登录时显示的短语相匹配，则您可以信任此电子邮件。",
     "emails.magicSession.optionUrl": "如果您无法使用上面的按钮登录，请访问以下链接：",
     "emails.otpSession.subject": "{{project}} 登录",

--- a/app/config/locale/translations/zh-tw.json
+++ b/app/config/locale/translations/zh-tw.json
@@ -233,7 +233,7 @@
     "emails.magicSession.buttonText": "登入 {{project}}",
     "emails.magicSession.optionUrl": "如果上面的按鈕沒有顯示，請使用以下鏈接：",
     "emails.magicSession.clientInfo": "這次的登入是透過{{agentClient}}在{{agentDevice}} {{agentOs}}上請求的。如果您沒有請求這次登入，您可以放心地忽略這封電子郵件。",
-    "sms.verification.body": "{{secret}} 是您的 {{project}} 驗證碼。",
+    "sms.verification.body": "{{secret}}",
     "emails.magicSession.securityPhrase": "這封電子郵件的安全密語是{{phrase}}。如果此密語與登入時顯示的密語相符，您就可以信任此郵件。",
     "emails.otpSession.subject": "{{project}} 登入",
     "emails.otpSession.hello": "你好，",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Some providers have a limit on the length of the content. For example, MSG91 has a 30 character limit and passing a longer value wil result in an error:

     DLT Template variable exceeded max length

As such, we're going to change the content back to how we had it before 1.5 when were were only sending the code by itself until we decide on a better solution.

## Test Plan

Manually by setting the `_APP_SMS_PROVIDER` and `_APP_SMS_FROM` env vars and attempting to create a phone session, I got an SMS:

<img width="299" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/a2d9fe2b-592d-44e7-95ea-725e229cf090">

The text included "Your SMS verification code is: " because the template I used had:

```
Your SMS verification code is:
##content##
```

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/7823

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
