### PR TITLE
Fix worker crash when using custom SMTP provider

### DIFF
--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Workers;
 
 use Appwrite\Event\Usage;
 use Appwrite\Messaging\Status as MessageStatus;
+use Swoole\Runtime;
 use Utopia\App;
 use Utopia\CLI\Console;
 use Utopia\Config\Config;
@@ -80,6 +81,7 @@ class Messaging extends Action
         Device $deviceForLocalFiles,
         Usage $queueForUsage
     ): void {
+        Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
         $payload = $message->getPayload() ?? [];
 
         if (empty($payload)) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Due to a bug in the Swoole TCP hook, the worker crashes when doing the TLS handshake. This PR disables the Swoole TCP hook just like we do in the mails worker.

Fixes: https://github.com/appwrite/appwrite/issues/7914

## Test Plan

Manually created an email and the logs show it was processed successfully:

```
appwrite-worker-messaging  | [Worker] Worker 0 is ready!
appwrite-worker-messaging  | Worker messaging  started
appwrite-worker-messaging  | [Job] Received Job (660dbf5c37b395.78058781).
appwrite-worker-messaging  | [Job] (660dbf5c37b395.78058781) successfully run.
appwrite-worker-messaging  | [Job] Received Job (660dc049d8a217.47574305).
appwrite-worker-messaging  | [Job] (660dc049d8a217.47574305) successfully run.
```

The Console also shows success for the email:

<img width="1215" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/901af045-e9f6-42c6-9f87-6c4848edbdf9">

Note: the SMS failed, but that's because of the provider returned an error message. This is still good because it proves API calls still send as expected. 

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/7914
* https://github.com/appwrite/appwrite/pull/6966
* https://github.com/swoole/swoole-src/issues/4909

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
