### PR TITLE
Stale Issues Workflow Creation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
           days-before-stale: 7
           days-before-close: 14
           remove-stale-when-updated: true
-          close-issue-message: "This issue has been closed due to inactivity. If you still require assistance, please provide the requested information and reopen the issue."
+          close-issue-message: "This issue has been closed due to inactivity. If you still require assistance, please provide the requested information."
           close-issue-label: "not-planned"
           operations-per-run: 100
           only-labels: "question"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,6 @@ jobs:
           days-before-close: 14
           remove-stale-when-updated: true
           close-issue-message: "This issue has been closed due to inactivity. If you still require assistance, please provide the requested information."
-          close-issue-label: "not-planned"
+          close-issue-reason: "not-planned"
           operations-per-run: 100
           only-labels: "question"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue has been labeled as 'pending-requestor-info', indicating that it requires additional information from the requestor. It has been inactive for 7 days. If no further activity occurs, this issue will be closed in 14 days."
+          stale-issue-message: "This issue has been labeled as a 'question', indicating that it requires additional information from the requestor. It has been inactive for 7 days. If no further activity occurs, this issue will be closed in 14 days."
           stale-issue-label: "stale"
           days-before-stale: 7
           days-before-close: 14
           remove-stale-when-updated: true
           close-issue-message: "This issue has been closed due to inactivity. If you still require assistance, please provide the requested information and reopen the issue."
-          close-issue-label: "closed-due-to-inactivity"
+          close-issue-label: "not-planned"
           operations-per-run: 100
-          only-labels: "pending-requestor-info"
+          only-labels: "question"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Midnight Runtime
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been labeled as 'pending-requestor-info', indicating that it requires additional information from the requestor. It has been inactive for 7 days. If no further activity occurs, this issue will be closed in 14 days."
+          stale-issue-label: "stale"
+          days-before-stale: 7
+          days-before-close: 14
+          remove-stale-when-updated: true
+          close-issue-message: "This issue has been closed due to inactivity. If you still require assistance, please provide the requested information and reopen the issue."
+          close-issue-label: "closed-due-to-inactivity"
+          operations-per-run: 100
+          only-labels: "pending-requestor-info"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This GitHub Actions workflow automatically marks and closes stale issues in the Appwrite/Appwrite repo. It helps maintain a clean and up-to-date issue tracker by identifying issues that have been inactive for a specified period of time.

1. The workflow identifies issues labeled as "pending-requestor-info", indicating that they require additional information from the requestor.

2. If an issue labeled as "pending-requestor-info" has been inactive for 7 days, it will be marked as stale and labeled with "stale".

3. A comment will be posted on the stale issue, informing the requestor that the issue will be closed if no further activity occurs within the next 14 days.

4. If the stale issue receives any activity (e.g., comments or updates), the "stale" label will be automatically removed.

5. If no activity occurs on the stale issue within 14 days, the issue will be closed and labeled with "closed-due-to-inactivity".

6. A comment will be posted on the closed issue, informing the requestor that the issue has been closed due to inactivity and providing instructions on how to reopen the issue if assistance is still required.

## Test Plan

N/A

## Related PRs and Issues

N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
