### PR TITLE
Add recovery code to List factors

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3521,13 +3521,16 @@ App::get('/v1/account/mfa/factors')
     ->inject('user')
     ->action(function (Response $response, Document $user) {
 
+        $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
+        $recoveryCodeEnabled = \is_array($mfaRecoveryCodes) && \count($mfaRecoveryCodes) > 0;
+
         $totp = TOTP::getAuthenticatorFromUser($user);
 
         $factors = new Document([
             Type::TOTP => $totp !== null && $totp->getAttribute('verified', false),
             Type::EMAIL => $user->getAttribute('email', false) && $user->getAttribute('emailVerification', false),
             Type::PHONE => $user->getAttribute('phone', false) && $user->getAttribute('phoneVerification', false),
-            Type::RECOVERY_CODE => true
+            Type::RECOVERY_CODE => $recoveryCodeEnabled
         ]);
 
         $response->dynamic($factors, Response::MODEL_MFA_FACTORS);

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3526,7 +3526,8 @@ App::get('/v1/account/mfa/factors')
         $factors = new Document([
             Type::TOTP => $totp !== null && $totp->getAttribute('verified', false),
             Type::EMAIL => $user->getAttribute('email', false) && $user->getAttribute('emailVerification', false),
-            Type::PHONE => $user->getAttribute('phone', false) && $user->getAttribute('phoneVerification', false)
+            Type::PHONE => $user->getAttribute('phone', false) && $user->getAttribute('phoneVerification', false),
+            Type::RECOVERY_CODE => true
         ]);
 
         $response->dynamic($factors, Response::MODEL_MFA_FACTORS);

--- a/src/Appwrite/Utopia/Response/Model/MFAFactors.php
+++ b/src/Appwrite/Utopia/Response/Model/MFAFactors.php
@@ -13,19 +13,25 @@ class MFAFactors extends Model
         $this
             ->addRule(Type::TOTP, [
                 'type' => self::TYPE_BOOLEAN,
-                'description' => 'TOTP',
+                'description' => 'Can TOTP be used for MFA challenge for this account.',
                 'default' => false,
                 'example' => true
             ])
             ->addRule(Type::PHONE, [
                 'type' => self::TYPE_BOOLEAN,
-                'description' => 'Phone',
+                'description' => 'Can phone (SMS) be used for MFA challenge for this account.',
                 'default' => false,
                 'example' => true
             ])
             ->addRule(Type::EMAIL, [
                 'type' => self::TYPE_BOOLEAN,
-                'description' => 'Email',
+                'description' => 'Can email be used for MFA challenge for this account.',
+                'default' => false,
+                'example' => true
+            ])
+            ->addRule(Type::RECOVERY_CODE, [
+                'type' => self::TYPE_BOOLEAN,
+                'description' => 'Can recovery code be used for MFA challenge for this account.',
                 'default' => false,
                 'example' => true
             ])


### PR DESCRIPTION
## What does this PR do?

Adds recovery code as option in listMfaFactors. This makes implementation easier as you don't need special case for recovery code.

## Test Plan

- [x] Manual QA

Account with TOTP enabled:

![CleanShot 2024-04-11 at 09 50 52@2x](https://github.com/appwrite/appwrite/assets/19310830/7654795f-b48e-40d5-b9db-fbe20a22ac86)

Brand new account:

![CleanShot 2024-04-11 at 09 52 06@2x](https://github.com/appwrite/appwrite/assets/19310830/b073e948-977f-4115-a449-596a329f9752)



## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
