### PR TITLE
Fix: recovery code removal

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3821,6 +3821,7 @@ App::delete('/v1/account/mfa/authenticators/:type')
             $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
             if (in_array($otp, $mfaRecoveryCodes)) {
                 $mfaRecoveryCodes = array_diff($mfaRecoveryCodes, [$otp]);
+                $mfaRecoveryCodes = array_values($mfaRecoveryCodes);
                 $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
                 $dbForProject->updateDocument('users', $user->getId(), $user);
 
@@ -4069,6 +4070,7 @@ App::put('/v1/account/mfa/challenge')
                 $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
                 if (in_array($otp, $mfaRecoveryCodes)) {
                     $mfaRecoveryCodes = array_diff($mfaRecoveryCodes, [$otp]);
+                    $mfaRecoveryCodes = array_values($mfaRecoveryCodes);
                     $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
                     $dbForProject->updateDocument('users', $user->getId(), $user);
 


### PR DESCRIPTION
## What does this PR do?

When recovery code gets used, its removed fro marray but indexes arent fixed.
Because of that, Appwrite then returns those as object instead of array:

![CleanShot 2024-04-10 at 16 00 39@2x](https://github.com/appwrite/appwrite/assets/19310830/6da629d8-bc9b-40ed-8371-f715197b88f4)

I know this is issue with index 0 missing, as per test here:

![CleanShot 2024-04-10 at 16 00 24@2x](https://github.com/appwrite/appwrite/assets/19310830/78ab1048-bba2-464c-a424-9841d9f01cfa)

Code in this PR ensires array is recreated and has proper indexing - will remain proper array everywhere. Performance isn't concern as it has only a few codes always.

## Test Plan

None

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
