### PR TITLE
Add missing 'apis' attribute to projects collection

### DIFF
--- a/src/Appwrite/Migration/Version/V20.php
+++ b/src/Appwrite/Migration/Version/V20.php
@@ -294,6 +294,13 @@ class V20 extends Migration
                         Console::warning("'oAuthProviders' from {$id}: {$th->getMessage()}");
                     }
 
+                    // Create apis attribute
+                    try {
+                        $this->createAttributeFromCollection($this->projectDB, $id, 'apis');
+                    } catch (Throwable $th) {
+                        Console::warning("'apis' from {$id}: {$th->getMessage()}");
+                    }
+
                     try {
                         $this->projectDB->purgeCachedCollection($id);
                     } catch (Throwable $th) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This change updates the V20 (1.5.x) migration script to create the `apis` attribute in the `projects` collection since it was added to the collections config.

## Test Plan

Manually confirmed the column was there after running the migrate command

Before:

<img width="584" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/55aa1705-f30e-40f5-b866-68ea73d4afbe">

After:

<img width="613" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/79edf76a-d114-4159-a2d1-ff339713d1f1">


## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/7725

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
