### PR TITLE
Added DB environment variables to appwrite-worker-mails

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -498,6 +498,11 @@ services:
       - _APP_OPENSSL_KEY_V1
       - _APP_SYSTEM_EMAIL_NAME
       - _APP_SYSTEM_EMAIL_ADDRESS
+      - _APP_DB_HOST
+      - _APP_DB_PORT
+      - _APP_DB_SCHEMA
+      - _APP_DB_USER
+      - _APP_DB_PASS
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER


### PR DESCRIPTION
## What does this PR do?

I found a similar issue and PR like this for such an error but on `webhooks` worker container...
`webhooks` container issue: #7844
PR for that issue: #7848

The same error is happening on `mails` worker 

Fixes: #8001

## Test Plan

After installing the version from my PR, I can observe in `docker-compose.yml` in `appwrite` directory that service named `appwrite-worker-mails` now contains
```
      - _APP_DB_HOST
      - _APP_DB_PORT
      - _APP_DB_SCHEMA
      - _APP_DB_USER
      - _APP_DB_PASS
```

Also after sending the invite, I got no errors while watching logs of `appwrite-worker-mails` container

## Related PRs and Issues

* #8001

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
