### PR TITLE
Fix server errors from invalid or outdated cookies

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -290,7 +290,7 @@ App::init()
             $minimumFactors = ($mfaEnabled && $hasMoreFactors) ? 2 : 1;
 
             if (!in_array('mfa', $route->getGroups())) {
-                if ($session && \count($session->getAttribute('factors')) < $minimumFactors) {
+                if ($session && !empty($session->getAttribute('factors')) && \count($session->getAttribute('factors')) < $minimumFactors) {
                     throw new Exception(Exception::USER_MORE_FACTORS_REQUIRED);
                 }
             }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -290,7 +290,7 @@ App::init()
             $minimumFactors = ($mfaEnabled && $hasMoreFactors) ? 2 : 1;
 
             if (!in_array('mfa', $route->getGroups())) {
-                if ($session && !empty($session->getAttribute('factors')) && \count($session->getAttribute('factors')) < $minimumFactors) {
+                if ($session && \count($session->getAttribute('factors', [])) < $minimumFactors) {
                     throw new Exception(Exception::USER_MORE_FACTORS_REQUIRED);
                 }
             }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR introduces an additional check before we access `factors` on the $session object to make sure it exists since invalid or outdated cookies will cause the session check to pass for factors to be null resulting in a 500 error on all requests including non-protected routes.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
