### PR TITLE
Fix: Use `resourceInternalId` for Querying Function Deployments

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -1282,7 +1282,7 @@ App::get('/v1/functions/:functionId/deployments')
         }
 
         // Set resource queries
-        $queries[] = Query::equal('resourceId', [$function->getId()]);
+        $queries[] = Query::equal('resourceInternalId', [$function->getInternalId()]);
         $queries[] = Query::equal('resourceType', ['functions']);
 
         /**


### PR DESCRIPTION
## What does this PR do?

Uses `resourceInternalId` to query deployments instead of `resourceId`.

Fixes https://github.com/appwrite/appwrite/issues/7999

## Test Plan

Manual.
Note: Stopped the `appwrite-worker-deletes` first.

Before -

https://github.com/appwrite/appwrite/assets/20625965/087d0666-7f18-464e-8815-23ffe53a7120

After -

https://github.com/appwrite/appwrite/assets/20625965/e2dfde30-fc2d-4dcf-a874-f2781e90e621


## Related PRs and Issues

- #7999

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
