### PR TITLE
Fix stale action close reason

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,6 @@ jobs:
           days-before-close: 14
           remove-stale-when-updated: true
           close-issue-message: "This issue has been closed due to inactivity. If you still require assistance, please provide the requested information."
-          close-issue-reason: "not-planned"
+          close-issue-reason: "not_planned"
           operations-per-run: 100
           only-labels: "question"


### PR DESCRIPTION
Due to failures, changing to not_planned

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes error as called in failed workflow 

```
Error: Unrecognized close-issue-reason "not-planned", valid values are: completed, not_planned
Error: Error: Unrecognized close-issue-reason "not-planned", valid values are: completed, not_planned
Error: Unrecognized close-issue-reason "not-planned", valid values are: completed, not_planned
```

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
