### PR TITLE
Fix version in error response

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -742,12 +742,12 @@ App::error()
             'file' => $file,
             'line' => $line,
             'trace' => \json_encode($trace, JSON_UNESCAPED_UNICODE) === false ? [] : $trace, // check for failing encode
-            'version' => $version,
+            'version' => APP_VERSION_STABLE,
             'type' => $type,
         ] : [
             'message' => $message,
             'code' => $code,
-            'version' => $version,
+            'version' => APP_VERSION_STABLE,
             'type' => $type,
         ];
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The APP_VERSION_STABLE constant should be used for the version in API errors so that developers see a version that makes more sense (such as 1.5.5).

Fixes: #8039

## Test Plan

Before:

![Screen Shot 2024-04-29 at 3 46 24 PM](https://github.com/appwrite/appwrite/assets/1477010/e63a6b79-be31-4e22-914a-275a44eac131)


After:

![Screen Shot 2024-04-29 at 3 48 01 PM](https://github.com/appwrite/appwrite/assets/1477010/1ad53e1a-aef2-4e37-a241-c36223abf1d3)


## Related PRs and Issues

- #8039

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
