### PR TITLE
Replace missing domain paths in README.md

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -11,6 +11,7 @@
 </p>
 
 <!-- [![Build Status](https://img.shields.io/travis/com/appwrite/appwrite?style=flat-square)](https://travis-ci.com/appwrite/appwrite) -->
+
 [![We're Hiring](https://img.shields.io/static/v1?label=We're&message=Hiring&color=blue&style=flat-square)](https://appwrite.io/company/careers)
 [![Hacktoberfest](https://img.shields.io/static/v1?label=hacktoberfest&message=friendly&color=191120&style=flat-square)](https://hacktoberfest.appwrite.io)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord?r=Github)
@@ -25,7 +26,7 @@
 
 [**Appwrite 云公开测试版！立即注册！**](https://cloud.appwrite.io)
 
-Appwrite是一个基于Docker的端到端开发者平台，其容器化的微服务库可应用于网页端，移动端，以及后端。Appwrite 通过视觉化界面简化了从零开始编写 API 的繁琐过程，在保证软件安全的前提下为开发者创造了一个高效的开发环境。
+Appwrite 是一个基于 Docker 的端到端开发者平台，其容器化的微服务库可应用于网页端，移动端，以及后端。Appwrite 通过视觉化界面简化了从零开始编写 API 的繁琐过程，在保证软件安全的前提下为开发者创造了一个高效的开发环境。
 
 Appwrite 可以提供给开发者用户验证，外部授权，用户数据读写检索，文件储存，图像处理，云函数计算，[等多种服务](https://appwrite.io/docs).
 
@@ -93,7 +94,6 @@ docker run -it --rm `
 
 运行后，可以在浏览器上访问 http://localhost 找到 Appwrite 控制台。在非 Linux 的本机主机上完成安装后，服务器可能需要几分钟才能启动。
 
-
 需要自定义容器构架，请查看我们的 Docker [环境变量](https://appwrite.io/docs/environment-variables) 文档。您还可以参考我们的 [docker-compose.yml](https://appwrite.io/install/compose) 和 [.env](https://appwrite.io/install/env) 文件手动设置环境。
 
 ### 从旧版本升级
@@ -104,71 +104,73 @@ docker run -it --rm `
 
 开始使用 Appwrite 只需要在控制台创建一个新项目，选择开发平台，然后抓取我们的开发套件。您可以从以下的教程中找到你喜欢的平台开始使用 Appwrite。
 
-| 类别                | 技术 |
-|---------------------|------|
-| **Web 应用**         | [Web 快速开始](/docs/quick-starts/web) |
-|                     | [Next.js 快速开始](/docs/quick-starts/nextjs) |
-|                     | [React 快速开始](/docs/quick-starts/react) |
-|                     | [Vue.js 快速开始](/docs/quick-starts/vue) |
-|                     | [Nuxt 快速开始](/docs/quick-starts/nuxt) |
-|                     | [SvelteKit 快速开始](/docs/quick-starts/sveltekit) |
-|                     | [Refine 快速开始](/docs/quick-starts/refine) |
-|                     | [Angular 快速开始](/docs/quick-starts/angular) |
-| **苹果于安卓应用**    | [React Native 快速开始](/docs/quick-starts/react-native) |
-|                     | [Flutter 快速开始](/docs/quick-starts/flutter) |
-|                     | [Apple 快速开始](/docs/quick-starts/apple) |
-|                     | [Android 快速开始](/docs/quick-starts/android) |
-| **服务器**           | [Node.js 快速开始](/docs/quick-starts/node) |
-|                     | [Python 快速开始](/docs/quick-starts/python) |
-|                     | [.NET 快速开始](/docs/quick-starts/dotnet) |
-|                     | [Dart 快速开始](/docs/quick-starts/dart) |
-|                     | [Ruby 快速开始](/docs/quick-starts/ruby) |
-|                     | [Deno 快速开始](/docs/quick-starts/deno) |
-|                     | [PHP 快速开始](/docs/quick-starts/php) |
-|                     | [Kotlin 快速开始](/docs/quick-starts/kotlin) |
-|                     | [Swift 快速开始](/docs/quick-starts/swift) |
+| 类别               | 技术                                                                        |
+| ------------------ | --------------------------------------------------------------------------- |
+| **Web 应用**       | [Web 快速开始](https://appwrite.io/docs/quick-starts/web)                   |
+|                    | [Next.js 快速开始](https://appwrite.io/docs/quick-starts/nextjs)            |
+|                    | [React 快速开始](https://appwrite.io/docs/quick-starts/react)               |
+|                    | [Vue.js 快速开始](https://appwrite.io/docs/quick-starts/vue)                |
+|                    | [Nuxt 快速开始](https://appwrite.io/docs/quick-starts/nuxt)                 |
+|                    | [SvelteKit 快速开始](https://appwrite.io/docs/quick-starts/sveltekit)       |
+|                    | [Refine 快速开始](https://appwrite.io/docs/quick-starts/refine)             |
+|                    | [Angular 快速开始](https://appwrite.io/docs/quick-starts/angular)           |
+| **苹果于安卓应用** | [React Native 快速开始](https://appwrite.io/docs/quick-starts/react-native) |
+|                    | [Flutter 快速开始](https://appwrite.io/docs/quick-starts/flutter)           |
+|                    | [Apple 快速开始](https://appwrite.io/docs/quick-starts/apple)               |
+|                    | [Android 快速开始](https://appwrite.io/docs/quick-starts/android)           |
+| **服务器**         | [Node.js 快速开始](https://appwrite.io/docs/quick-starts/node)              |
+|                    | [Python 快速开始](https://appwrite.io/docs/quick-starts/python)             |
+|                    | [.NET 快速开始](https://appwrite.io/docs/quick-starts/dotnet)               |
+|                    | [Dart 快速开始](https://appwrite.io/docs/quick-starts/dart)                 |
+|                    | [Ruby 快速开始](https://appwrite.io/docs/quick-starts/ruby)                 |
+|                    | [Deno 快速开始](https://appwrite.io/docs/quick-starts/deno)                 |
+|                    | [PHP 快速开始](https://appwrite.io/docs/quick-starts/php)                   |
+|                    | [Kotlin 快速开始](https://appwrite.io/docs/quick-starts/kotlin)             |
+|                    | [Swift 快速开始](https://appwrite.io/docs/quick-starts/swift)               |
 
 ### 软件服务
 
-* [**帐户**](https://appwrite.io/docs/references/cloud/client-web/account) -管理当前用户的帐户和登录方式。跟踪和管理用户 Session，登录设备，登录方法和查看相关记录。
-* [**用户**](https://appwrite.io/docs/server/users) - 在以管理员模式登录时管理和列出所有用户。
-* [**团队**](https://appwrite.io/docs/references/cloud/client-web/teams) - 管理用户分组。邀请成员，管理团队中的用户权限和用户角色。
-* [**数据库**](https://appwrite.io/docs/references/cloud/client-web/databases) - 管理数据库文档和文档集。用检索界面来对文档和文档集进行读取，创建，更新，和删除。
-* [**贮存**](https://appwrite.io/docs/references/cloud/client-web/storage) - 管理文件的阅读、创建、删除和预览。设置文件的预览来满足程序的个性化需求。所有文件都由 ClamAV 扫描并安全存储和加密。
-* [**云函数**](https://appwrite.io/docs/server/functions) - 在安全，隔离的环境中运行自定义代码。这些代码可以被事件，CRON，或者手动操作触发。
-* [**消息传递**](https://appwrite.io/docs/references/cloud/client-web/messaging) - 使用 Appwrite 消息传递功能通过推送通知、电子邮件和短信与用户进行通信。
-* [**语言适配**](https://appwrite.io/docs/references/cloud/client-web/locale) - 根据用户所在的的国家和地区做出合适的语言适配。
-* [**头像**](https://appwrite.io/docs/references/cloud/client-web/avatars) -管理用户头像、国家旗帜、浏览器图标、信用卡符号，和生成二维码。 
-如需完整的 API 界面文档，请访问 [https://appwrite.io/docs](https://appwrite.io/docs)。如需更多教程、新闻和公告，请订阅我们的 [博客](https://medium.com/appwrite-io) 和 加入我们的[Discord 社区](https://discord.gg/GSeTUeA)。
+- [**帐户**](https://appwrite.io/docs/references/cloud/client-web/account) -管理当前用户的帐户和登录方式。跟踪和管理用户 Session，登录设备，登录方法和查看相关记录。
+- [**用户**](https://appwrite.io/docs/server/users) - 在以管理员模式登录时管理和列出所有用户。
+- [**团队**](https://appwrite.io/docs/references/cloud/client-web/teams) - 管理用户分组。邀请成员，管理团队中的用户权限和用户角色。
+- [**数据库**](https://appwrite.io/docs/references/cloud/client-web/databases) - 管理数据库文档和文档集。用检索界面来对文档和文档集进行读取，创建，更新，和删除。
+- [**贮存**](https://appwrite.io/docs/references/cloud/client-web/storage) - 管理文件的阅读、创建、删除和预览。设置文件的预览来满足程序的个性化需求。所有文件都由 ClamAV 扫描并安全存储和加密。
+- [**云函数**](https://appwrite.io/docs/server/functions) - 在安全，隔离的环境中运行自定义代码。这些代码可以被事件，CRON，或者手动操作触发。
+- [**消息传递**](https://appwrite.io/docs/references/cloud/client-web/messaging) - 使用 Appwrite 消息传递功能通过推送通知、电子邮件和短信与用户进行通信。
+- [**语言适配**](https://appwrite.io/docs/references/cloud/client-web/locale) - 根据用户所在的的国家和地区做出合适的语言适配。
+- [**头像**](https://appwrite.io/docs/references/cloud/client-web/avatars) -管理用户头像、国家旗帜、浏览器图标、信用卡符号，和生成二维码。
+  如需完整的 API 界面文档，请访问 [https://appwrite.io/docs](https://appwrite.io/docs)。如需更多教程、新闻和公告，请订阅我们的 [博客](https://medium.com/appwrite-io) 和 加入我们的[Discord 社区](https://discord.gg/GSeTUeA)。
 
 ### 开发套件
 
 以下是当前支持的平台和语言列表。如果您想帮助我们为您选择的平台添加支持，您可以访问我们的 [SDK 生成器](https://github.com/appwrite/sdk-generator) 项目并查看我们的 [贡献指南](https://github.com/appwrite/sdk-generator/blob/master/CONTRIBUTING.md)。
 
 #### 客户端
-* ✅  &nbsp; [Web](https://github.com/appwrite/sdk-for-web) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Flutter](https://github.com/appwrite/sdk-for-flutter) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Apple](https://github.com/appwrite/sdk-for-apple) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Android](https://github.com/appwrite/sdk-for-android) (由 Appwrite 团队维护)
-* ✅  &nbsp; [React Native](https://github.com/appwrite/sdk-for-react-native) - **公测** (由 Appwrite 团队维护)
+
+- ✅ &nbsp; [Web](https://github.com/appwrite/sdk-for-web) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Flutter](https://github.com/appwrite/sdk-for-flutter) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Apple](https://github.com/appwrite/sdk-for-apple) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Android](https://github.com/appwrite/sdk-for-android) (由 Appwrite 团队维护)
+- ✅ &nbsp; [React Native](https://github.com/appwrite/sdk-for-react-native) - **公测** (由 Appwrite 团队维护)
 
 #### 服务器
-* ✅  &nbsp; [NodeJS](https://github.com/appwrite/sdk-for-node) (由 Appwrite 团队维护)
-* ✅  &nbsp; [PHP](https://github.com/appwrite/sdk-for-php) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Dart](https://github.com/appwrite/sdk-for-dart) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Deno](https://github.com/appwrite/sdk-for-deno) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Ruby](https://github.com/appwrite/sdk-for-ruby) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Python](https://github.com/appwrite/sdk-for-python) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Kotlin](https://github.com/appwrite/sdk-for-kotlin) (由 Appwrite 团队维护)
-* ✅  &nbsp; [Swift](https://github.com/appwrite/sdk-for-swift) (由 Appwrite 团队维护)
-* ✅  &nbsp; [.NET](https://github.com/appwrite/sdk-for-dotnet) - **公测** (由 Appwrite 团队维护)
+
+- ✅ &nbsp; [NodeJS](https://github.com/appwrite/sdk-for-node) (由 Appwrite 团队维护)
+- ✅ &nbsp; [PHP](https://github.com/appwrite/sdk-for-php) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Dart](https://github.com/appwrite/sdk-for-dart) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Deno](https://github.com/appwrite/sdk-for-deno) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Ruby](https://github.com/appwrite/sdk-for-ruby) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Python](https://github.com/appwrite/sdk-for-python) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Kotlin](https://github.com/appwrite/sdk-for-kotlin) (由 Appwrite 团队维护)
+- ✅ &nbsp; [Swift](https://github.com/appwrite/sdk-for-swift) (由 Appwrite 团队维护)
+- ✅ &nbsp; [.NET](https://github.com/appwrite/sdk-for-dotnet) - **公测** (由 Appwrite 团队维护)
 
 #### 开发者社区
-* ✅  &nbsp; [Appcelerator Titanium](https://github.com/m1ga/ti.appwrite) (维护者 [Michael Gangolf](https://github.com/m1ga/))  
-* ✅  &nbsp; [Godot Engine](https://github.com/GodotNuts/appwrite-sdk) (维护者 [fenix-hub @GodotNuts](https://github.com/fenix-hub))  
 
-找不到需要的的 SDK？ - 欢迎通过发起PR来帮助我们完善Appwrite的软件生态环境 [SDK 生成器](https://github.com/appwrite/sdk-generator)!
+- ✅ &nbsp; [Appcelerator Titanium](https://github.com/m1ga/ti.appwrite) (维护者 [Michael Gangolf](https://github.com/m1ga/))
+- ✅ &nbsp; [Godot Engine](https://github.com/GodotNuts/appwrite-sdk) (维护者 [fenix-hub @GodotNuts](https://github.com/fenix-hub))
 
+找不到需要的的 SDK？ - 欢迎通过发起 PR 来帮助我们完善 Appwrite 的软件生态环境 [SDK 生成器](https://github.com/appwrite/sdk-generator)!
 
 ## 软件架构
 
@@ -180,13 +182,13 @@ Appwrite API 界面层利用后台缓存和任务委派来提供极速的响应�
 
 ## 贡献代码
 
-为了确保正确审查，所有代码贡献 - 包括来自具有直接提交更改权限的贡献者 - 都必须提交PR请求并在合并分支之前得到核心开发人员的批准。
+为了确保正确审查，所有代码贡献 - 包括来自具有直接提交更改权限的贡献者 - 都必须提交 PR 请求并在合并分支之前得到核心开发人员的批准。
 
-我们欢迎所有人提交PR！如果您愿意提供帮助，可以在 [贡献指南](CONTRIBUTING.md) 中了解有关如何为项目做出贡献的更多信息。
+我们欢迎所有人提交 PR！如果您愿意提供帮助，可以在 [贡献指南](CONTRIBUTING.md) 中了解有关如何为项目做出贡献的更多信息。
 
 ## 安全
 
-为了保护您的隐私，请避免在GitHub 上发布安全问题。发送问题至 security@appwrite.io，我们将为您做更细致的解答。
+为了保护您的隐私，请避免在 GitHub 上发布安全问题。发送问题至 security@appwrite.io，我们将为您做更细致的解答。
 
 ## 订阅我们
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
     <br />
 </p>
 
-
 <!-- [![Build Status](https://img.shields.io/travis/com/appwrite/appwrite?style=flat-square)](https://travis-ci.com/appwrite/appwrite) -->
 
 [![We're Hiring](https://img.shields.io/static/v1?label=We're&message=Hiring&color=blue&style=flat-square)](https://appwrite.io/company/careers)
@@ -142,29 +141,29 @@ Choose from one of the providers below:
 
 Getting started with Appwrite is as easy as creating a new project, choosing your platform, and integrating its SDK into your code. You can easily get started with your platform of choice by reading one of our Getting Started tutorials.
 
-| Platform           | Technology |
-|--------------------|------------|
-| **Web app**        | [Quick start for Web](/docs/quick-starts/web) |
-|                    | [Quick start for Next.js](/docs/quick-starts/nextjs) |
-|                    | [Quick start for React](/docs/quick-starts/react) |
-|                    | [Quick start for Vue.js](/docs/quick-starts/vue) |
-|                    | [Quick start for Nuxt](/docs/quick-starts/nuxt) |
-|                    | [Quick start for SvelteKit](/docs/quick-starts/sveltekit) |
-|                    | [Quick start for Refine](/docs/quick-starts/refine) |
-|                    | [Quick start for Angular](/docs/quick-starts/angular) |
-| **Mobile and Native** | [Quick start for React Native](/docs/quick-starts/react-native) |
-|                    | [Quick start for Flutter](/docs/quick-starts/flutter) |
-|                    | [Quick start for Apple](/docs/quick-starts/apple) |
-|                    | [Quick start for Android](/docs/quick-starts/android) |
-| **Server**         | [Quick start for Node.js](/docs/quick-starts/node) |
-|                    | [Quick start for Python](/docs/quick-starts/python) |
-|                    | [Quick start for .NET](/docs/quick-starts/dotnet) |
-|                    | [Quick start for Dart](/docs/quick-starts/dart) |
-|                    | [Quick start for Ruby](/docs/quick-starts/ruby) |
-|                    | [Quick start for Deno](/docs/quick-starts/deno) |
-|                    | [Quick start for PHP](/docs/quick-starts/php) |
-|                    | [Quick start for Kotlin](/docs/quick-starts/kotlin) |
-|                    | [Quick start for Swift](/docs/quick-starts/swift) |
+| Platform              | Technology                                                                         |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| **Web app**           | [Quick start for Web](https://appwrite.io/docs/quick-starts/web)                   |
+|                       | [Quick start for Next.js](https://appwrite.io/docs/quick-starts/nextjs)            |
+|                       | [Quick start for React](https://appwrite.io/docs/quick-starts/react)               |
+|                       | [Quick start for Vue.js](https://appwrite.io/docs/quick-starts/vue)                |
+|                       | [Quick start for Nuxt](https://appwrite.io/docs/quick-starts/nuxt)                 |
+|                       | [Quick start for SvelteKit](https://appwrite.io/docs/quick-starts/sveltekit)       |
+|                       | [Quick start for Refine](https://appwrite.io/docs/quick-starts/refine)             |
+|                       | [Quick start for Angular](https://appwrite.io/docs/quick-starts/angular)           |
+| **Mobile and Native** | [Quick start for React Native](https://appwrite.io/docs/quick-starts/react-native) |
+|                       | [Quick start for Flutter](https://appwrite.io/docs/quick-starts/flutter)           |
+|                       | [Quick start for Apple](https://appwrite.io/docs/quick-starts/apple)               |
+|                       | [Quick start for Android](https://appwrite.io/docs/quick-starts/android)           |
+| **Server**            | [Quick start for Node.js](https://appwrite.io/docs/quick-starts/node)              |
+|                       | [Quick start for Python](https://appwrite.io/docs/quick-starts/python)             |
+|                       | [Quick start for .NET](https://appwrite.io/docs/quick-starts/dotnet)               |
+|                       | [Quick start for Dart](https://appwrite.io/docs/quick-starts/dart)                 |
+|                       | [Quick start for Ruby](https://appwrite.io/docs/quick-starts/ruby)                 |
+|                       | [Quick start for Deno](https://appwrite.io/docs/quick-starts/deno)                 |
+|                       | [Quick start for PHP](https://appwrite.io/docs/quick-starts/php)                   |
+|                       | [Quick start for Kotlin](https://appwrite.io/docs/quick-starts/kotlin)             |
+|                       | [Quick start for Swift](https://appwrite.io/docs/quick-starts/swift)               |
 
 ### Products
 


### PR DESCRIPTION
## What does this PR do?

Restores removed domain paths for Getting Started links in README.md.

Fixes: #8040 

## Test Plan

No code changes.

## Related PRs and Issues

* #8040 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
