### PR TITLE
Fix MFA email verification code font

### DIFF
--- a/app/config/locale/templates/email-mfa-challenge.tpl
+++ b/app/config/locale/templates/email-mfa-challenge.tpl
@@ -5,7 +5,7 @@
 <table border="0" cellspacing="0" cellpadding="0" style="padding-top: 10px; padding-bottom: 10px; display: inline-block;">
     <tr>
         <td align="center" style="border-radius: 8px; background-color: #ffffff;">
-            <p style="font-size: 24px; text-indent: 18px; letter-spacing: 18px; font-family: Inter; color: #414146; text-decoration: none; border-radius: 8px; padding: 24px 12px; border: 1px solid #EDEDF0; display: inline-block; font-weight: bold; ">{{otp}}</p>
+            <p style="font-size: 24px; text-indent: 18px; letter-spacing: 18px; font-family: 'Inter', sans-serif; color: #414146; text-decoration: none; border-radius: 8px; padding: 24px 12px; border: 1px solid #EDEDF0; display: inline-block; font-weight: bold; ">{{otp}}</p>
         </td>
     </tr>
 </table>


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The font family was set to Inter without any fallback and since the Inter isn't available in emails, the font rendered the default font, Times New Roman. This commit adds a fallback font to the font-family ensuring an sans-serif font like Inter is used.

## Test Plan

Tested by triggering the email into Maildev and then forwarding it to Gmail:

Before:

<img width="734" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/992e0526-603f-43d4-9bfa-bf84e9157e84">

After:

<img width="712" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/b805a025-b2b8-4b77-bfca-0be01c8fd24f">


## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
