### PR TITLE
Fix: Email OTP verified account

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -123,7 +123,8 @@ $createSession = function (string $userId, string $secret, Request $request, Res
     Authorization::skip(fn () => $dbForProject->deleteDocument('tokens', $verifiedToken->getId()));
     $dbForProject->purgeCachedDocument('users', $user->getId());
 
-    if ($verifiedToken->getAttribute('type') === Auth::TOKEN_TYPE_MAGIC_URL) {
+    // Magic URL + Email OTP
+    if ($verifiedToken->getAttribute('type') === Auth::TOKEN_TYPE_MAGIC_URL || $verifiedToken->getAttribute('type') === Auth::TOKEN_TYPE_EMAIL) {
         $user->setAttribute('emailVerification', true);
     }
 

--- a/tests/e2e/Services/Account/AccountBase.php
+++ b/tests/e2e/Services/Account/AccountBase.php
@@ -202,6 +202,8 @@ trait AccountBase
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals($userId, $response['body']['$id']);
+        $this->assertEquals($userId, $response['body']['$id']);
+        $this->assertTrue($response['body']['emailVerification']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/token', array_merge([
             'origin' => 'http://localhost',


### PR DESCRIPTION
## What does this PR do?

Marks account emailVerified after email OTP sign-in. Similarly, to how it already does for email Magic URLs.

## Test Plan

- [x] Update existing tests

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
