### PR TITLE
Disable sending realtime stats

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -268,54 +268,54 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
         /**
          * Sending current connections to project channels on the console project every 5 seconds.
          */
-        if ($realtime->hasSubscriber('console', Role::users()->toString(), 'project')) {
-            $database = getConsoleDB();
+        // if ($realtime->hasSubscriber('console', Role::users()->toString(), 'project')) {
+        //     $database = getConsoleDB();
 
-            $payload = [];
+        //     $payload = [];
 
-            $list = Authorization::skip(fn () => $database->find('realtime', [
-                Query::greaterThan('timestamp', DateTime::addSeconds(new \DateTime(), -15)),
-            ]));
+        //     $list = Authorization::skip(fn () => $database->find('realtime', [
+        //         Query::greaterThan('timestamp', DateTime::addSeconds(new \DateTime(), -15)),
+        //     ]));
 
-            /**
-             * Aggregate stats across containers.
-             */
-            foreach ($list as $document) {
-                foreach (json_decode($document->getAttribute('value')) as $projectId => $value) {
-                    if (array_key_exists($projectId, $payload)) {
-                        $payload[$projectId] +=  $value;
-                    } else {
-                        $payload[$projectId] =  $value;
-                    }
-                }
-            }
+        //     /**
+        //      * Aggregate stats across containers.
+        //      */
+        //     foreach ($list as $document) {
+        //         foreach (json_decode($document->getAttribute('value')) as $projectId => $value) {
+        //             if (array_key_exists($projectId, $payload)) {
+        //                 $payload[$projectId] +=  $value;
+        //             } else {
+        //                 $payload[$projectId] =  $value;
+        //             }
+        //         }
+        //     }
 
-            foreach ($stats as $projectId => $value) {
-                if (!array_key_exists($projectId, $payload)) {
-                    continue;
-                }
+        //     foreach ($stats as $projectId => $value) {
+        //         if (!array_key_exists($projectId, $payload)) {
+        //             continue;
+        //         }
 
-                $event = [
-                    'project' => 'console',
-                    'roles' => ['team:' . $stats->get($projectId, 'teamId')],
-                    'data' => [
-                        'events' => ['stats.connections'],
-                        'channels' => ['project'],
-                        'timestamp' => DateTime::formatTz(DateTime::now()),
-                        'payload' => [
-                            $projectId => $payload[$projectId]
-                        ]
-                    ]
-                ];
+        //         $event = [
+        //             'project' => 'console',
+        //             'roles' => ['team:' . $stats->get($projectId, 'teamId')],
+        //             'data' => [
+        //                 'events' => ['stats.connections'],
+        //                 'channels' => ['project'],
+        //                 'timestamp' => DateTime::formatTz(DateTime::now()),
+        //                 'payload' => [
+        //                     $projectId => $payload[$projectId]
+        //                 ]
+        //             ]
+        //         ];
 
-                $server->send($realtime->getSubscribers($event), json_encode([
-                    'type' => 'event',
-                    'data' => $event['data']
-                ]));
-            }
+        //         $server->send($realtime->getSubscribers($event), json_encode([
+        //             'type' => 'event',
+        //             'data' => $event['data']
+        //         ]));
+        //     }
 
-            $register->get('pools')->reclaim();
-        }
+        //     $register->get('pools')->reclaim();
+        // }
         /**
          * Sending test message for SDK E2E tests every 5 seconds.
          */


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Disable sending realtime stats because the `$database->find('realtime')` is throwing:

> Cannot execute queries while other unbuffered queries are active.

In addition, the realtime stats are not being collected so there's no point in having this enabled.

## Test Plan

Manually confirmed realtime still works:

<img width="1765" alt="image" src="https://github.com/appwrite/appwrite/assets/1477010/92eb7dac-289d-4a7b-ab97-dc9852561df4">

## Related PRs and Issues

- None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
