### PR TITLE
Handle SQL error code 'HY000' in realtime

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -511,16 +511,22 @@ $server->onOpen(function (int $connection, SwooleRequest $request) use ($server,
     } catch (Throwable $th) {
         call_user_func($logError, $th, "initServer");
 
+        // Handle SQL error code is 'HY000'
+        $code = $th->getCode();
+        if (!is_int($code)) {
+            $code = 500;
+        }
+
         $response = [
             'type' => 'error',
             'data' => [
-                'code' => $th->getCode(),
+                'code' => $code,
                 'message' => $th->getMessage()
             ]
         ];
 
         $server->send([$connection], json_encode($response));
-        $server->close($connection, $th->getCode());
+        $server->close($connection, $code);
 
         if (App::isDevelopment()) {
             Console::error('[Error] Connection Error');


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

SQL can throw an error where the code is a string like 'HY000':

```
appwrite-realtime | [Error] Type: PDOException
appwrite-realtime | [Error] Message: SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.
appwrite-realtime | [Error] File: @swoole/library/core/Database/PDOStatementProxy.php
appwrite-realtime | [Error] Line: 44
appwrite-realtime | 
appwrite-realtime | Fatal error: Uncaught TypeError: Utopia\WebSocket\Server::close(): Argument #2 ($code) must be of type int, string given, called in /usr/src/code/vendor/appwrite/server-ce/app/realtime.php on line 523 and defined in /usr/src/code/vendor/utopia-php/websocket/src/WebSocket/Server.php:92
appwrite-realtime | Stack trace:
appwrite-realtime | #0 /usr/src/code/vendor/appwrite/server-ce/app/realtime.php(523): Utopia\WebSocket\Server->close(34577, 'HY000')
appwrite-realtime | #1 [internal function]: {closure}(34577, Object(Appwrite\Utopia\Request))
appwrite-realtime | #2 /usr/src/code/vendor/utopia-php/websocket/src/WebSocket/Adapter/Swoole.php(93): call_user_func(Object(Closure), 34577, Object(Swoole\Http\Request))
appwrite-realtime | #3 [internal function]: Utopia\WebSocket\Adapter\Swoole->Utopia\WebSocket\Adapter\{closure}(Object(Swoole\WebSocket\Server), Object(Swoole\Http\Request))
appwrite-realtime | #4 {main}
appwrite-realtime |   thrown in /usr/src/code/vendor/utopia-php/websocket/src/WebSocket/Server.php on line 92
appwrite-realtime | [2024-05-08 22:04:49 *22786.21] ERROR   php_swoole_server_rshutdown() (ERRNO 503): Fatal error: Uncaught TypeError: Utopia\WebSocket\Server::close(): Argument #2 ($code) must be of type int, string given, called in /usr/src/code/vendor/appwrite/server-ce/app/realtime.php on line 523 and defined in /usr/src/code/vendor/utopia-php/websocket/src/WebSocket/Server.php:92
appwrite-realtime | Stack trace:
appwrite-realtime | #0 /usr/src/code/vendor/appwrite/server-ce/app/realtime.php(523): Utopia\WebSocket\Server->close(34577, 'HY000')
appwrite-realtime | #1 [internal function]: {closure}(34577, Object(Appwrite\Utopia\Request))
appwrite-realtime | #2 /usr/src/code/vendor/utopia-php/websocket/src/WebSocket/Adapter/Swoole.php(93): call_user_func(Object(Closure), 34577, Object(Swoole\Http\Request))
appwrite-realtime | #3 [internal function]: Utopia\WebSocket\Adapter\Swoole->Utopia\WebSocket\Adapter\{closure}(Object(Swoole\WebSocket\Server), Object(Swoole\Http\Request))
appwrite-realtime | #4 {main}
appwrite-realtime |   thrown in /usr/src/code/vendor/utopia-php/websocket/src/WebSocket/Server.php on line 92
```

but `$server->close()` expects an integer. This change ensures we only pass an integer into `$server->close()`.

## Test Plan

None

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
