### PR TITLE
Set limit to retrieve all stats for the usage range

### DIFF
--- a/app/controllers/api/project.php
+++ b/app/controllers/api/project.php
@@ -70,7 +70,7 @@ App::get('/v1/project/usage')
             '1d' => 'Y-m-d\T00:00:00.000P',
         };
 
-        Authorization::skip(function () use ($dbForProject, $firstDay, $lastDay, $period, $metrics, &$total, &$stats) {
+        Authorization::skip(function () use ($dbForProject, $firstDay, $lastDay, $period, $metrics, $limit, &$total, &$stats) {
             foreach ($metrics['total'] as $metric) {
                 $result = $dbForProject->findOne('stats', [
                     Query::equal('metric', [$metric]),
@@ -85,6 +85,7 @@ App::get('/v1/project/usage')
                     Query::equal('period', [$period]),
                     Query::greaterThanEqual('time', $firstDay),
                     Query::lessThan('time', $lastDay),
+                    Query::limit($limit),
                     Query::orderDesc('time'),
                 ]);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because limit was not passed for the find() query, the limit defaulted to 25. As such, when requesting stats for the last 30 days, only the last 25 were retrieved.

Fixes https://github.com/appwrite/appwrite/issues/8110

## Test Plan

Manual

## Related PRs and Issues

- #8110

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
