### PR TITLE
Fix: executor failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -847,10 +847,10 @@ services:
 
   openruntimes-executor:
     container_name: openruntimes-executor
-    hostname: appwrite-executor
+    hostname: exc1
     <<: *x-logging
     stop_signal: SIGINT
-    image: openruntimes/executor:0.4.12
+    image: openruntimes/executor:0.5.5
     restart: unless-stopped
     networks:
       - appwrite
@@ -913,7 +913,7 @@ services:
       - OPR_PROXY_LOGGING_PROVIDER=$_APP_LOGGING_PROVIDER
       - OPR_PROXY_LOGGING_CONFIG=$_APP_LOGGING_CONFIG
       - OPR_PROXY_ALGORITHM=random
-      - OPR_PROXY_EXECUTORS=appwrite-executor
+      - OPR_PROXY_EXECUTORS=exc1
       - OPR_PROXY_HEALTHCHECK_INTERVAL=10000
       - OPR_PROXY_MAX_TIMEOUT=600
       - OPR_PROXY_HEALTHCHECK=enabled


### PR DESCRIPTION
## What does this PR do?

There is warning due to Swoole Table size (on executor) when hosntame of executor is too long. That lead's to activeRuntimes on executor not be up to date. When that happens, and there is maintenance on executor, it wipes function's folders. It thinks it doesn't exist anymore, but it does.

This PR fixes that problem.

## Test Plan

- [x] Manual QA. I could no longer reproduce the issue with code being randomly deleted in the middle of the build

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
