### PR TITLE
Update Chinese language native names in languages.php

### DIFF
--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -926,12 +926,12 @@ return [
     [
         "code" => "zh-cn",
         "name" => "Chinese (Simplified)",
-        "nativeName" => "中国人"
+        "nativeName" => "中文"
     ],
     [
         "code" => "zh-tw",
         "name" => "Chinese (Traditional)",
-        "nativeName" => "中國人"
+        "nativeName" => "中文"
     ],
     [
         "code" => "zu",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

TLTR: for Chinese language, say **中國人** which means "Chinese Citizen" when the language should be **中文**

This PR updates the native names for the Chinese language in the languages.php file. The changes ensure that the language names are correctly represented in their native script, improving localization and user experience for Chinese-speaking users.

## Related PRs and Issues

- None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
