### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -668,6 +668,7 @@ services:
     entrypoint: worker-usage
     <<: *x-logging
     container_name: appwrite-worker-usage
+    restart: unless-stopped
     image: appwrite-dev
     networks:
       - appwrite
@@ -699,6 +700,7 @@ services:
     entrypoint: worker-usage-dump
     <<: *x-logging
     container_name: appwrite-worker-usage-dump
+    restart: unless-stopped
     image: appwrite-dev
     networks:
       - appwrite


### PR DESCRIPTION
added restart: unless-stopped for appwrite-worker-usage and appwrite-worker-usage-dump

## What does this PR do?

add a restart for appwrite-worker-usage and appwrite-worker-usage-dump
in my case appwrite-worker-usage-dump is "exited" because redis is not ready before appwrite-worker-usage-dump

## Test Plan

add it or not :P

## Related PRs and Issues

PR

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
