### PR TITLE
Refactor localdevice injection

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -523,6 +523,8 @@ services:
     restart: unless-stopped
     networks:
       - appwrite
+    volumes:
+      - appwrite-uploads:/storage/uploads:rw
     depends_on:
       - redis
     environment:
@@ -542,6 +544,27 @@ services:
       - _APP_LOGGING_CONFIG
       - _APP_SMS_FROM
       - _APP_SMS_PROVIDER
+      - _APP_STORAGE_DEVICE
+      - _APP_STORAGE_S3_ACCESS_KEY
+      - _APP_STORAGE_S3_SECRET
+      - _APP_STORAGE_S3_REGION
+      - _APP_STORAGE_S3_BUCKET
+      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
+      - _APP_STORAGE_DO_SPACES_SECRET
+      - _APP_STORAGE_DO_SPACES_REGION
+      - _APP_STORAGE_DO_SPACES_BUCKET
+      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
+      - _APP_STORAGE_BACKBLAZE_SECRET
+      - _APP_STORAGE_BACKBLAZE_REGION
+      - _APP_STORAGE_BACKBLAZE_BUCKET
+      - _APP_STORAGE_LINODE_ACCESS_KEY
+      - _APP_STORAGE_LINODE_SECRET
+      - _APP_STORAGE_LINODE_REGION
+      - _APP_STORAGE_LINODE_BUCKET
+      - _APP_STORAGE_WASABI_ACCESS_KEY
+      - _APP_STORAGE_WASABI_SECRET
+      - _APP_STORAGE_WASABI_REGION
+      - _APP_STORAGE_WASABI_BUCKET
 
   appwrite-worker-migrations:
     image: <?php echo $organization; ?>/<?php echo $image; ?>:<?php echo $version."\n"; ?>

--- a/app/worker.php
+++ b/app/worker.php
@@ -32,7 +32,6 @@ use Utopia\Queue\Connection;
 use Utopia\Queue\Message;
 use Utopia\Queue\Server;
 use Utopia\Registry\Registry;
-use Utopia\Storage\Device\Local;
 use Utopia\System\System;
 
 Authorization::disable();
@@ -217,9 +216,6 @@ Server::setResource('deviceForCache', function (Document $project) {
     return getDevice(APP_STORAGE_CACHE . '/app-' . $project->getId());
 }, ['project']);
 
-Server::setResource('deviceForLocalFiles', function (Document $project) {
-    return new Local(APP_STORAGE_UPLOADS . '/app-' . $project->getId());
-}, ['project']);
 
 $pools = $register->get('pools');
 $platform = new Appwrite();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -569,6 +569,7 @@ services:
     networks:
       - appwrite
     volumes:
+      - appwrite-uploads:/storage/uploads:rw
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
     depends_on:
@@ -591,6 +592,27 @@ services:
       - _APP_SMS_FROM
       - _APP_SMS_PROVIDER
       - _APP_SMS_PROJECTS_DENY_LIST
+      - _APP_STORAGE_DEVICE
+      - _APP_STORAGE_S3_ACCESS_KEY
+      - _APP_STORAGE_S3_SECRET
+      - _APP_STORAGE_S3_REGION
+      - _APP_STORAGE_S3_BUCKET
+      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
+      - _APP_STORAGE_DO_SPACES_SECRET
+      - _APP_STORAGE_DO_SPACES_REGION
+      - _APP_STORAGE_DO_SPACES_BUCKET
+      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
+      - _APP_STORAGE_BACKBLAZE_SECRET
+      - _APP_STORAGE_BACKBLAZE_REGION
+      - _APP_STORAGE_BACKBLAZE_BUCKET
+      - _APP_STORAGE_LINODE_ACCESS_KEY
+      - _APP_STORAGE_LINODE_SECRET
+      - _APP_STORAGE_LINODE_REGION
+      - _APP_STORAGE_LINODE_BUCKET
+      - _APP_STORAGE_WASABI_ACCESS_KEY
+      - _APP_STORAGE_WASABI_SECRET
+      - _APP_STORAGE_WASABI_REGION
+      - _APP_STORAGE_WASABI_BUCKET
 
   appwrite-worker-migrations:
     entrypoint: worker-migrations

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -35,6 +35,7 @@ use Utopia\Messaging\Messages\SMS;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Storage\Device;
+use Utopia\Storage\Device\Local;
 use Utopia\Storage\Storage;
 use Utopia\System\System;
 
@@ -42,6 +43,8 @@ use function Swoole\Coroutine\batch;
 
 class Messaging extends Action
 {
+    private ?Local $localDevice = null;
+
     public static function getName(): string
     {
         return 'messaging';
@@ -58,9 +61,8 @@ class Messaging extends Action
             ->inject('log')
             ->inject('dbForProject')
             ->inject('deviceForFiles')
-            ->inject('deviceForLocalFiles')
             ->inject('queueForUsage')
-            ->callback(fn (Message $message, Log $log, Database $dbForProject, Device $deviceForFiles, Device $deviceForLocalFiles, Usage $queueForUsage) => $this->action($message, $log, $dbForProject, $deviceForFiles, $deviceForLocalFiles, $queueForUsage));
+            ->callback(fn (Message $message, Log $log, Database $dbForProject, Device $deviceForFiles, Usage $queueForUsage) => $this->action($message, $log, $dbForProject, $deviceForFiles, $queueForUsage));
     }
 
     /**
@@ -68,7 +70,6 @@ class Messaging extends Action
      * @param Log $log
      * @param Database $dbForProject
      * @param Device $deviceForFiles
-     * @param Device $deviceForLocalFiles
      * @param Usage $queueForUsage
      * @return void
      * @throws \Exception
@@ -78,7 +79,6 @@ class Messaging extends Action
         Log $log,
         Database $dbForProject,
         Device $deviceForFiles,
-        Device $deviceForLocalFiles,
         Usage $queueForUsage
     ): void {
         Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
@@ -101,7 +101,7 @@ class Messaging extends Action
             case MESSAGE_SEND_TYPE_EXTERNAL:
                 $message = $dbForProject->getDocument('messages', $payload['messageId']);
 
-                $this->sendExternalMessage($dbForProject, $message, $deviceForFiles, $deviceForLocalFiles, );
+                $this->sendExternalMessage($dbForProject, $message, $deviceForFiles, $project);
                 break;
             default:
                 throw new \Exception('Unknown message type: ' . $type);
@@ -112,7 +112,7 @@ class Messaging extends Action
         Database $dbForProject,
         Document $message,
         Device $deviceForFiles,
-        Device $deviceForLocalFiles,
+        Document $project,
     ): void {
         $topicIds = $message->getAttribute('topics', []);
         $targetIds = $message->getAttribute('targets', []);
@@ -218,8 +218,8 @@ class Messaging extends Action
         /**
          * @var array<array> $results
          */
-        $results = batch(\array_map(function ($providerId) use ($identifiers, &$providers, $default, $message, $dbForProject, $deviceForFiles, $deviceForLocalFiles) {
-            return function () use ($providerId, $identifiers, &$providers, $default, $message, $dbForProject, $deviceForFiles, $deviceForLocalFiles) {
+        $results = batch(\array_map(function ($providerId) use ($identifiers, &$providers, $default, $message, $dbForProject, $deviceForFiles, $project) {
+            return function () use ($providerId, $identifiers, &$providers, $default, $message, $dbForProject, $deviceForFiles, $project) {
                 if (\array_key_exists($providerId, $providers)) {
                     $provider = $providers[$providerId];
                 } else {
@@ -246,8 +246,8 @@ class Messaging extends Action
                     $adapter->getMaxMessagesPerRequest()
                 );
 
-                return batch(\array_map(function ($batch) use ($message, $provider, $adapter, $dbForProject, $deviceForFiles, $deviceForLocalFiles) {
-                    return function () use ($batch, $message, $provider, $adapter, $dbForProject, $deviceForFiles, $deviceForLocalFiles) {
+                return batch(\array_map(function ($batch) use ($message, $provider, $adapter, $dbForProject, $deviceForFiles, $project) {
+                    return function () use ($batch, $message, $provider, $adapter, $dbForProject, $deviceForFiles, $project) {
                         $deliveredTotal = 0;
                         $deliveryErrors = [];
                         $messageData = clone $message;
@@ -256,7 +256,7 @@ class Messaging extends Action
                         $data = match ($provider->getAttribute('type')) {
                             MESSAGE_TYPE_SMS => $this->buildSmsMessage($messageData, $provider),
                             MESSAGE_TYPE_PUSH => $this->buildPushMessage($messageData),
-                            MESSAGE_TYPE_EMAIL => $this->buildEmailMessage($dbForProject, $messageData, $provider, $deviceForFiles, $deviceForLocalFiles),
+                            MESSAGE_TYPE_EMAIL => $this->buildEmailMessage($dbForProject, $messageData, $provider, $deviceForFiles, $project),
                             default => throw new \Exception('Provider with the requested ID is of the incorrect type')
                         };
 
@@ -354,8 +354,8 @@ class Messaging extends Action
 
                 $path = $file->getAttribute('path', '');
 
-                if ($deviceForLocalFiles->exists($path)) {
-                    $deviceForLocalFiles->delete($path);
+                if ($this->getLocalDevice($project)->exists($path)) {
+                    $this->getLocalDevice($project)->delete($path);
                 }
             }
         }
@@ -517,7 +517,7 @@ class Messaging extends Action
         Document $message,
         Document $provider,
         Device $deviceForFiles,
-        Device $deviceForLocalFiles,
+        Document $project,
     ): Email {
         $fromName = $provider['options']['fromName'] ?? null;
         $fromEmail = $provider['options']['fromEmail'] ?? null;
@@ -579,7 +579,7 @@ class Messaging extends Action
                 }
 
                 if ($deviceForFiles->getType() !== Storage::DEVICE_LOCAL) {
-                    $deviceForFiles->transfer($path, $path, $deviceForLocalFiles);
+                    $deviceForFiles->transfer($path, $path, $this->getLocalDevice($project));
                 }
 
                 $attachment = new Attachment(
@@ -650,5 +650,14 @@ class Messaging extends Action
             $tag,
             $badge
         );
+    }
+
+    private function getLocalDevice($project): Local
+    {
+        if($this->localDevice === null) {
+            $this->localDevice = new Local(APP_STORAGE_UPLOADS . '/app-' . $project->getId());
+        }
+
+        return $this->localDevice;
     }
 }


### PR DESCRIPTION
## What does this PR do?

- Refactor the `localStorageDevice` of **Messaging Worker** to its own class.
- Mounting the `uploads` volume for local use-cases.
- Adding the storage variables.


## Test Plan
Tested against a local `1.5.5` environment with and without attachment, using the following request.

```http
POST http://localhost/v1/messaging/messages/email
x-sdk-name: Console
...

{
  "messageId": "6a131313d6a2",
  "subject": "subject",
  "content": "content",
  "topics": [],
  "users": [],
  "targets": [
    "664cf54317f85b349215"
  ],
  "attachments" : ["664b6260dbc042b1f13c:664cf2c2001a03a9a1c8"],
  "html": false
}
```


## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
