### PR TITLE
Fix: Don't Override `robots.txt` for Other Domains

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -818,10 +818,25 @@ App::get('/humans.txt')
     ->desc('Humans.txt File')
     ->label('scope', 'public')
     ->label('docs', false)
+    ->inject('utopia')
+    ->inject('swooleRequest')
+    ->inject('request')
     ->inject('response')
-    ->action(function (Response $response) {
-        $template = new View(__DIR__ . '/../views/general/humans.phtml');
-        $response->text($template->render(false));
+    ->inject('dbForConsole')
+    ->inject('getProjectDB')
+    ->inject('queueForEvents')
+    ->inject('queueForUsage')
+    ->inject('geodb')
+    ->action(function (App $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Database $dbForConsole, callable $getProjectDB, Event $queueForEvents, Usage $queueForUsage, Reader $geodb) {
+        $host = $request->getHostname() ?? '';
+        $mainDomain = System::getEnv('_APP_DOMAIN', '');
+
+        if ($host === $mainDomain) {
+            $template = new View(__DIR__ . '/../views/general/humans.phtml');
+            $response->text($template->render(false));
+        } else {
+            router($utopia, $dbForConsole, $getProjectDB, $swooleRequest, $request, $response, $queueForEvents, $queueForUsage, $geodb);
+        }
     });
 
 App::get('/.well-known/acme-challenge/*')

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -793,10 +793,25 @@ App::get('/robots.txt')
     ->desc('Robots.txt File')
     ->label('scope', 'public')
     ->label('docs', false)
+    ->inject('utopia')
+    ->inject('swooleRequest')
+    ->inject('request')
     ->inject('response')
-    ->action(function (Response $response) {
-        $template = new View(__DIR__ . '/../views/general/robots.phtml');
-        $response->text($template->render(false));
+    ->inject('dbForConsole')
+    ->inject('getProjectDB')
+    ->inject('queueForEvents')
+    ->inject('queueForUsage')
+    ->inject('geodb')
+    ->action(function (App $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Database $dbForConsole, callable $getProjectDB, Event $queueForEvents, Usage $queueForUsage, Reader $geodb) {
+        $host = $request->getHostname() ?? '';
+        $mainDomain = System::getEnv('_APP_DOMAIN', '');
+
+        if ($host === $mainDomain) {
+            $template = new View(__DIR__ . '/../views/general/robots.phtml');
+            $response->text($template->render(false));
+        } else {
+            router($utopia, $dbForConsole, $getProjectDB, $swooleRequest, $request, $response, $queueForEvents, $queueForUsage, $geodb);
+        }
     });
 
 App::get('/humans.txt')


### PR DESCRIPTION
## What does this PR do?

This PR allows using custom `robots.txt` on function domains.

## Test Plan

Manual -

Robots.txt

<img width="623" alt="Screenshot 2024-05-23 at 2 58 16 PM" src="https://github.com/appwrite/appwrite/assets/20625965/6c56a14e-3ec3-4010-898f-7625d7fa10a3">

<img width="588" alt="Screenshot 2024-05-23 at 2 58 22 PM" src="https://github.com/appwrite/appwrite/assets/20625965/223f4a97-612b-496c-ab3d-3bf0d7971812">

Humans.txt

<img width="398" alt="Screenshot 2024-05-23 at 3 57 24 PM" src="https://github.com/appwrite/appwrite/assets/20625965/f15300ca-dbf7-4e83-997a-a6aeb4e037a7">

<img width="635" alt="Screenshot 2024-05-23 at 3 57 29 PM" src="https://github.com/appwrite/appwrite/assets/20625965/33f87208-dc0e-4db5-9f6c-93b6843bc7d0">

## Related PRs and Issues

N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
