### PR TITLE
feat: moving team deletion to api

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -38,7 +38,6 @@ use Utopia\Database\Validator\Query\Limit;
 use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\UID;
 use Utopia\Locale\Locale;
-use Utopia\Storage\Device;
 use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Assoc;

--- a/app/init.php
+++ b/app/init.php
@@ -1423,10 +1423,6 @@ App::setResource('deviceForBuilds', function ($project) {
     return getDevice(APP_STORAGE_BUILDS . '/app-' . $project->getId());
 }, ['project']);
 
-App::setResource('deviceForCache', function (Document $project) {
-    return getDevice(APP_STORAGE_CACHE . '/app-' . $project->getId());
-}, ['project']);
-
 function getDevice($root): Device
 {
     $connection = System::getEnv('_APP_CONNECTIONS_STORAGE', '');

--- a/app/init.php
+++ b/app/init.php
@@ -167,7 +167,6 @@ const DELETE_TYPE_PROJECTS = 'projects';
 const DELETE_TYPE_FUNCTIONS = 'functions';
 const DELETE_TYPE_DEPLOYMENTS = 'deployments';
 const DELETE_TYPE_USERS = 'users';
-const DELETE_TYPE_TEAMS = 'teams';
 const DELETE_TYPE_EXECUTIONS = 'executions';
 const DELETE_TYPE_AUDIT = 'audit';
 const DELETE_TYPE_ABUSE = 'abuse';
@@ -1422,6 +1421,10 @@ App::setResource('deviceForFunctions', function ($project) {
 
 App::setResource('deviceForBuilds', function ($project) {
     return getDevice(APP_STORAGE_BUILDS . '/app-' . $project->getId());
+}, ['project']);
+
+App::setResource('deviceForCache', function (Document $project) {
+    return getDevice(APP_STORAGE_CACHE . '/app-' . $project->getId());
 }, ['project']);
 
 function getDevice($root): Device

--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -67,6 +67,7 @@ services:
       - appwrite-config:/storage/config:rw
       - appwrite-certificates:/storage/certificates:rw
       - appwrite-functions:/storage/functions:rw
+      - appwrite-builds:/storage/builds:rw
     depends_on:
       - mariadb
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       - appwrite-config:/storage/config:rw
       - appwrite-certificates:/storage/certificates:rw
       - appwrite-functions:/storage/functions:rw
+      - appwrite-builds:/storage/builds:r
       - ./phpunit.xml:/usr/src/code/phpunit.xml
       - ./tests:/usr/src/code/tests
       - ./app:/usr/src/code/app

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -93,12 +93,6 @@ class Deletes extends Action
                     case DELETE_TYPE_USERS:
                         $this->deleteUser($getProjectDB, $document, $project);
                         break;
-                    case DELETE_TYPE_TEAMS:
-                        $this->deleteMemberships($getProjectDB, $document, $project);
-                        if ($project->getId() === 'console') {
-                            $this->deleteProjectsByTeam($dbForConsole, $getProjectDB, $deviceForFiles, $deviceForFunctions, $deviceForBuilds, $deviceForCache, $document);
-                        }
-                        break;
                     case DELETE_TYPE_BUCKETS:
                         $this->deleteBucket($getProjectDB, $deviceForFiles, $document, $project);
                         break;
@@ -408,54 +402,6 @@ class Deletes extends Action
             Query::lessThan('time', $hourlyUsageRetentionDatetime),
             Query::equal('period', ['1h']),
         ], $dbForProject);
-    }
-
-    /**
-     * @param callable $getProjectDB
-     * @param Document $document teams document
-     * @param Document $project
-     * @return void
-     * @throws Exception
-     */
-    private function deleteMemberships(callable $getProjectDB, Document $document, Document $project): void
-    {
-        $dbForProject = $getProjectDB($project);
-        $teamInternalId = $document->getInternalId();
-
-        // Delete Memberships
-        $this->deleteByGroup(
-            'memberships',
-            [
-                Query::equal('teamInternalId', [$teamInternalId])
-            ],
-            $dbForProject,
-            function (Document $membership) use ($dbForProject) {
-                $userId = $membership->getAttribute('userId');
-                $dbForProject->purgeCachedDocument('users', $userId);
-            }
-        );
-    }
-
-    /**
-     * @param Database $dbForConsole
-     * @param Document $document
-     * @return void
-     * @throws Authorization
-     * @throws \Utopia\Database\Exception
-     * @throws Conflict
-     * @throws Restricted
-     * @throws Structure
-     */
-    private function deleteProjectsByTeam(Database $dbForConsole, callable $getProjectDB, Device $deviceForFiles, Device $deviceForFunctions, Device $deviceForBuilds, Device $deviceForCache, Document $document): void
-    {
-
-        $projects = $dbForConsole->find('projects', [
-            Query::equal('teamInternalId', [$document->getInternalId()])
-        ]);
-        foreach ($projects as $project) {
-            $this->deleteProject($dbForConsole, $getProjectDB, $deviceForFiles, $deviceForFunctions, $deviceForBuilds, $deviceForCache, $project);
-            $dbForConsole->deleteDocument('projects', $project->getId());
-        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Moving (and copying when necessary) team and organization logic to the API instead queuing it to the deleting worker

## Test Plan

Tested against local `1.5.5` instance, 
1. All of the projects were pulled using the CLI and pushed into a new Organization with different project IDs.
2. A few resources and files were added manually 
3. Delete organization, delete everything.

## Related PRs and Issues

Close #7939 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
