### PR TITLE
feat: support twilio messaging service sid

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -450,7 +450,7 @@ return [
             ],
             [
                 'name' => '_APP_SMS_FROM',
-                'description' => 'Phone number used for sending out messages. Must start with a leading \'+\' and maximum of 15 digits without spaces (+123456789).',
+                'description' => 'Phone number used for sending out messages. If using Twilio, this may be a Messaging Service SID, starting with MG. Otherwise, the number must start with a leading \'+\' and maximum of 15 digits without spaces (+123456789). ',
                 'introduction' => '0.15.0',
                 'default' => '',
                 'required' => false,

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "utopia-php/image": "0.6.*",
         "utopia-php/locale": "0.4.*",
         "utopia-php/logger": "0.5.*",
-        "utopia-php/messaging": "0.11.*",
+        "utopia-php/messaging": "0.12.*",
         "utopia-php/migration": "0.4.*",
         "utopia-php/orchestration": "0.9.*",
         "utopia-php/platform": "0.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b37a830efbb0467d058a640b289a0a91",
+    "content-hash": "20844ba2607c2746ee92e3b9474086ab",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2120,16 +2120,16 @@
         },
         {
             "name": "utopia-php/messaging",
-            "version": "0.11.0",
+            "version": "0.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/messaging.git",
-                "reference": "b499c3ad11af711c28252c62d83f24e6106a2154"
+                "reference": "6e466d3511981291843c6ebf9ce3f44fc75e37b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/b499c3ad11af711c28252c62d83f24e6106a2154",
-                "reference": "b499c3ad11af711c28252c62d83f24e6106a2154",
+                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/6e466d3511981291843c6ebf9ce3f44fc75e37b0",
+                "reference": "6e466d3511981291843c6ebf9ce3f44fc75e37b0",
                 "shasum": ""
             },
             "require": {
@@ -2165,9 +2165,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/messaging/issues",
-                "source": "https://github.com/utopia-php/messaging/tree/0.11.0"
+                "source": "https://github.com/utopia-php/messaging/tree/0.12.0"
             },
-            "time": "2024-05-08T17:10:02+00:00"
+            "time": "2024-05-30T14:58:25+00:00"
         },
         {
             "name": "utopia-php/migration",

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -400,7 +400,9 @@ class Messaging extends Action
                 'twilio' => [
                     'accountSid' => $user,
                     'authToken' => $password,
-                    'messagingServiceSid' => $smsDSN->getParam('messagingServiceSid') ?? null
+                    // Twilio Messaging Service SIDs always start with MG
+                    // https://www.twilio.com/docs/messaging/services
+                    'messagingServiceSid' => \str_starts_with($from, 'MG') ? $from : null
                 ],
                 'textmagic' => [
                     'username' => $user,
@@ -423,7 +425,7 @@ class Messaging extends Action
             },
             'options' => match ($host) {
                 'twilio' => [
-                    'from' => $smsDSN->getParam('messagingServiceSid') ? null : $from
+                    'from' => \str_starts_with($from, 'MG') ? null : $from
                 ],
                 default => [
                     'from' => $from

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -400,9 +400,7 @@ class Messaging extends Action
                 'twilio' => [
                     'accountSid' => $user,
                     'authToken' => $password,
-                    // Twilio Messaging Service SIDs always start with MG
-                    // https://www.twilio.com/docs/messaging/services
-                    'messagingServiceSid' => \str_starts_with($from, 'MG') ? $from : null
+                    'messagingServiceSid' => $smsDSN->getParam('messagingServiceSid') ?? null
                 ],
                 'textmagic' => [
                     'username' => $user,
@@ -425,7 +423,7 @@ class Messaging extends Action
             },
             'options' => match ($host) {
                 'twilio' => [
-                    'from' => \str_starts_with($from, 'MG') ? null : $from
+                    'from' => $smsDSN->getParam('messagingServiceSid') ? null : $from
                 ],
                 default => [
                     'from' => $from


### PR DESCRIPTION
Allows `_APP_SMS_FROM` to be set to a Messaging Service Sid when using Twilio as SMS provider. See https://www.twilio.com/docs/messaging/services

