### PR TITLE
Fix: Don't set the target field if the existing target document is false

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -290,7 +290,9 @@ App::post('/v1/account')
                 $existingTarget = $dbForProject->findOne('targets', [
                     Query::equal('identifier', [$email]),
                 ]);
-                $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                if($existingTarget) {
+                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                }
             }
 
             $dbForProject->purgeCachedDocument('users', $user->getId());

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -291,7 +291,7 @@ App::post('/v1/account')
                     Query::equal('identifier', [$email]),
                 ]);
                 if($existingTarget) {
-                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                    $user->setAttribute('targets', $existingTarget, Document::SET_TYPE_APPEND);
                 }
             }
 

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -138,7 +138,9 @@ function createUser(string $hash, mixed $hashOptions, string $userId, ?string $e
                 $existingTarget = $dbForProject->findOne('targets', [
                     Query::equal('identifier', [$email]),
                 ]);
-                $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                if($existingTarget) {
+                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                }
             }
         }
 
@@ -160,7 +162,9 @@ function createUser(string $hash, mixed $hashOptions, string $userId, ?string $e
                 $existingTarget = $dbForProject->findOne('targets', [
                     Query::equal('identifier', [$phone]),
                 ]);
-                $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                if($existingTarget) {
+                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                }
             }
         }
 

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -139,7 +139,7 @@ function createUser(string $hash, mixed $hashOptions, string $userId, ?string $e
                     Query::equal('identifier', [$email]),
                 ]);
                 if($existingTarget) {
-                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                    $user->setAttribute('targets', $existingTarget, Document::SET_TYPE_APPEND);
                 }
             }
         }
@@ -163,7 +163,7 @@ function createUser(string $hash, mixed $hashOptions, string $userId, ?string $e
                     Query::equal('identifier', [$phone]),
                 ]);
                 if($existingTarget) {
-                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget]);
+                    $user->setAttribute('targets', $existingTarget, Document::SET_TYPE_APPEND);
                 }
             }
         }

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -150,7 +150,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
         $this->assertEquals($response['body']['name'], $name);
         $this->assertArrayHasKey('accessedAt', $response['body']);
@@ -294,7 +294,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsNumeric($response['body']['total']);
         $this->assertEquals("user.create", $response['body']['logs'][2]['event']);
         $this->assertEquals(filter_var($response['body']['logs'][2]['ip'], FILTER_VALIDATE_IP), $response['body']['logs'][2]['ip']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['logs'][2]['time']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['logs'][2]['time']));
 
         $this->assertEquals('Windows', $response['body']['logs'][1]['osName']);
         $this->assertEquals('WIN', $response['body']['logs'][1]['osCode']);
@@ -327,7 +327,6 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals('desktop', $response['body']['logs'][2]['deviceName']);
         $this->assertEquals('', $response['body']['logs'][2]['deviceBrand']);
         $this->assertEquals('', $response['body']['logs'][2]['deviceModel']);
-        $this->assertEquals($response['body']['logs'][2]['ip'], filter_var($response['body']['logs'][2]['ip'], FILTER_VALIDATE_IP));
 
         $this->assertEquals('--', $response['body']['logs'][2]['countryCode']);
         $this->assertEquals('Unknown', $response['body']['logs'][2]['countryName']);
@@ -343,7 +342,7 @@ class AccountCustomClientTest extends Scope
             ]
         ]);
 
-        $this->assertEquals($responseLimit['headers']['status-code'], 200);
+        $this->assertEquals(200, $responseLimit['headers']['status-code']);
         $this->assertIsArray($responseLimit['body']['logs']);
         $this->assertNotEmpty($responseLimit['body']['logs']);
         $this->assertCount(1, $responseLimit['body']['logs']);
@@ -382,7 +381,7 @@ class AccountCustomClientTest extends Scope
             ]
         ]);
 
-        $this->assertEquals($responseLimitOffset['headers']['status-code'], 200);
+        $this->assertEquals(200, $responseLimitOffset['headers']['status-code']);
         $this->assertIsArray($responseLimitOffset['body']['logs']);
         $this->assertNotEmpty($responseLimitOffset['body']['logs']);
         $this->assertCount(1, $responseLimitOffset['body']['logs']);
@@ -430,7 +429,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
         $this->assertEquals($response['body']['name'], $newName);
 
@@ -497,7 +496,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
@@ -587,7 +586,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $newEmail);
 
         /**
@@ -629,7 +628,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $data['email']);
         $this->assertEquals($response['body']['name'], $data['name']);
 
@@ -771,7 +770,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEmpty($response['body']['secret']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['expire']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['expire']));
 
         $lastEmail = $this->getLastEmail();
 
@@ -1073,7 +1072,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEmpty($response['body']['secret']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['expire']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['expire']));
 
         $lastEmail = $this->getLastEmail();
 
@@ -1668,7 +1667,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
@@ -1756,12 +1755,10 @@ class AccountCustomClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals($response['body']['$id'], $userId);
-        $this->assertEquals($response['body']['name'], 'User Name');
-        $this->assertEquals($response['body']['email'], 'useroauth@localhost.test');
+        $this->assertEquals('User Name', $response['body']['name']);
+        $this->assertEquals('useroauth@localhost.test', $response['body']['email']);
 
         // Since we only support one oauth user, let's also check updateSession here
-
-        $this->assertEquals(200, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account/sessions/current', array_merge([
             'origin' => 'http://localhost',
@@ -1808,7 +1805,7 @@ class AccountCustomClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEmpty($response['body']['secret']);
-        $this->assertEquals($response['body']['provider'], 'anonymous');
+        $this->assertEquals('anonymous', $response['body']['provider']);
 
         $sessionID = $response['body']['$id'];
 
@@ -1821,7 +1818,7 @@ class AccountCustomClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEmpty($response['body']['secret']);
-        $this->assertEquals($response['body']['provider'], 'anonymous');
+        $this->assertEquals('anonymous', $response['body']['provider']);
 
         $response = $this->client->call(Client::METHOD_GET, '/account/sessions/97823askjdkasd80921371980', array_merge([
             'origin' => 'http://localhost',
@@ -1934,7 +1931,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEmpty($response['body']['secret']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['expire']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['expire']));
 
         $userId = $response['body']['userId'];
 
@@ -2085,7 +2082,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
@@ -2127,7 +2124,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['phone'], $newPhone);
 
         /**
@@ -2240,7 +2237,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEmpty($response['body']['secret']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['expire']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['expire']));
 
         $smsRequest = $this->getLastRequest();
 
@@ -2327,7 +2324,7 @@ class AccountCustomClientTest extends Scope
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEmpty($response['body']['secret']);
         $this->assertEmpty($response['body']['phrase']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['expire']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['expire']));
 
         $userId = $response['body']['userId'];
 
@@ -2452,7 +2449,7 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
         $this->assertTrue($response['body']['emailVerification']);
 
@@ -2512,7 +2509,7 @@ class AccountCustomClientTest extends Scope
         $this->assertIsArray($response['body']);
         $this->assertNotEmpty($response['body']);
         $this->assertNotEmpty($response['body']['$id']);
-        $this->assertEquals(true, (new DatetimeValidator())->isValid($response['body']['registration']));
+        $this->assertTrue((new DatetimeValidator())->isValid($response['body']['registration']));
         $this->assertEquals($response['body']['email'], $email);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([


### PR DESCRIPTION
If you create a user, set the target then delete the user and the target from console and then create a user again, you get a type error in the User Model
![image](https://github.com/appwrite/appwrite/assets/62933155/d60c0041-1cff-4547-a08e-d01d2f6e6245)

This happens cause it tries to populate the target field but the response was false

Adds a check if the document exists then set the target

## Test Plan

WIP

## Related PRs and Issues

https://discord.com/channels/564160730845151244/1062789941727338577/1247967828015972362

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
