### PR TITLE
Fix MFA for OAuth2 only accounts

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -86,8 +86,8 @@ $createSession = function (string $userId, string $secret, Request $request, Res
     $factor = (match ($verifiedToken->getAttribute('type')) {
         Auth::TOKEN_TYPE_MAGIC_URL,
         Auth::TOKEN_TYPE_OAUTH2,
-        Auth::TOKEN_TYPE_EMAIL => 'email',
-        Auth::TOKEN_TYPE_PHONE => 'phone',
+        Auth::TOKEN_TYPE_EMAIL => Type::EMAIL,
+        Auth::TOKEN_TYPE_PHONE => Type::PHONE,
         Auth::TOKEN_TYPE_GENERIC => 'token',
         default => throw new Exception(Exception::USER_INVALID_TOKEN)
     });
@@ -1506,7 +1506,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                 'secret' => Auth::hash($secret), // One way hash encryption to protect DB leak
                 'userAgent' => $request->getUserAgent('UNKNOWN'),
                 'ip' => $request->getIP(),
-                'factors' => ['email'],
+                'factors' => [TYPE::EMAIL, 'oauth2'], // include a special oauth2 factor to bypass MFA checks
                 'countryCode' => ($record) ? \strtolower($record['country']['iso_code']) : '--',
                 'expire' => DateTime::addSeconds(new \DateTime(), $duration)
             ], $detector->getOS(), $detector->getClient(), $detector->getDevice()));


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Before this, users who only signed in with OAuth2 were not able to verify their sessions with MFA because their session already used an email factor and they couldn't use an additional email factor.

This commit changes the OAuth2 session to include 2 factors: email and oauth2. This second special factor is used to bypass MFA checks. It is fine to bypass MFA checks because OAuth2 is supposed to handle the entire authentication process, verifying who the user is and we, as the resource provider, only need to trust the OAuth2 provider.

Fixes https://github.com/appwrite/appwrite/issues/8211

## Test Plan

Enabled MFA and confirmed I was able to log in via GitHub only.

https://github.com/appwrite/appwrite/assets/1477010/ef01358f-ab5f-4ee1-9ed1-22f691bf90dd

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/8211

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
