### PR TITLE
fix: Missing Translation For "countries.hk" in `lb.json`

### DIFF
--- a/app/config/locale/translations/lb.json
+++ b/app/config/locale/translations/lb.json
@@ -103,6 +103,7 @@
     "countries.hn": "Honduras",
     "countries.hr": "Kroatien",
     "countries.ht": "Haïti",
+    "countries.hk": "Hongkong",
     "countries.hu": "Ungarn",
     "countries.id": "Indonesien",
     "countries.in": "Indien",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When comparing two PRs (#8179 and #8257) that address the same issue, I noticed a difference in the number of files changed. I identified the missing JSON file and fixed the discrepancy.

## Related PRs and Issues

- It is an extra commit for the PR #8179 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
