### PR TITLE
Add `defaults` to Collection Attributes in Migration

### DIFF
--- a/src/Appwrite/Migration/Migration.php
+++ b/src/Appwrite/Migration/Migration.php
@@ -239,7 +239,7 @@ abstract class Migration
     }
 
     /**
-     * Creates colletion from the config collection.
+     * Creates collection from the config collection.
      *
      * @param string $id
      * @param string|null $name
@@ -266,6 +266,7 @@ abstract class Migration
                     'type' => $attribute['type'],
                     'size' => $attribute['size'],
                     'required' => $attribute['required'],
+                    'default' => $attribute['default'] ?? null,
                     'signed' => $attribute['signed'],
                     'array' => $attribute['array'],
                     'filters' => $attribute['filters'],


### PR DESCRIPTION
## What does this PR do?

Adds the `defaults` to collection attributes during migration.

## Test Plan

Manual.
1. `1.4.13` -

    <img width="927" alt="Screenshot 2024-06-14 at 3 49 33 PM" src="https://github.com/appwrite/appwrite/assets/20625965/68e6d3da-b3fb-4305-ab87-7c886a8ddce9">

2. Upgraded to a local `1.5.7` & ran `docker exec appwrite migrate` -

    <img width="919" alt="Screenshot 2024-06-14 at 3 56 24 PM" src="https://github.com/appwrite/appwrite/assets/20625965/28399d7f-b501-46d9-82fb-a1890e3dbbff">

3. `_metadata` -

    <img width="1604" alt="Screenshot 2024-06-14 at 3 58 12 PM" src="https://github.com/appwrite/appwrite/assets/20625965/d8495b9e-81ed-45ed-9124-7adc0e4ace6b">

4. `topics` table with defaults -

    <img width="1177" alt="Screenshot 2024-06-14 at 4 02 02 PM" src="https://github.com/appwrite/appwrite/assets/20625965/d33a65f1-3656-4d6d-9964-e124e25789c3">


## Related PRs and Issues

- #7892.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
