### PR TITLE
Disable validation for project DBs during migration

### DIFF
--- a/src/Appwrite/Platform/Tasks/Migrate.php
+++ b/src/Appwrite/Platform/Tasks/Migrate.php
@@ -93,6 +93,7 @@ class Migrate extends Action
                     // TODO: Iterate through all project DBs
                     /** @var Database $projectDB */
                     $projectDB = $getProjectDB($project);
+                    $projectDB->disableValidation();
                     $migration
                         ->setProject($project, $projectDB, $dbForConsole)
                         ->setPDO($register->get('db', true))


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Skip the validation so that queries that typically fail can pass. This is fine because the validation is failing on internal attributes such as an $id for cache key with * and $id for attributes that are too long because we prefix the $id with the internal database and collection id.

## Test Plan

Before:

<img width="1501" alt="Screenshot 2024-06-20 at 3 57 12 PM" src="https://github.com/appwrite/appwrite/assets/1477010/79f7477d-df18-4321-9367-5d4a5dd1a48f">

After:

<img width="405" alt="Screenshot 2024-06-20 at 4 00 33 PM" src="https://github.com/appwrite/appwrite/assets/1477010/1da70cc9-c2cc-4916-85c5-e8b54b081c4b">

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/6196
- https://github.com/appwrite/appwrite/issues/7887

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
