### PR TITLE
Fix 'Missing required attribute "expire"' on `users.createSession()`

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1801,6 +1801,7 @@ App::post('/v1/users/:userId/sessions')
                 'userAgent' => $request->getUserAgent('UNKNOWN'),
                 'ip' => $request->getIP(),
                 'countryCode' => ($record) ? \strtolower($record['country']['iso_code']) : '--',
+                'expire' => $expire,
             ],
             $detector->getOS(),
             $detector->getClient(),
@@ -1812,7 +1813,6 @@ App::post('/v1/users/:userId/sessions')
         $session = $dbForProject->createDocument('sessions', $session);
         $session
             ->setAttribute('secret', $secret)
-            ->setAttribute('expire', $expire)
             ->setAttribute('countryName', $countryName);
 
         $queueForEvents

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1784,7 +1784,7 @@ App::post('/v1/users/:userId/sessions')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
-        $secret = Auth::codeGenerator();
+        $secret = Auth::tokenGenerator(Auth::TOKEN_LENGTH_SESSION);
         $detector = new Detector($request->getUserAgent('UNKNOWN'));
         $record = $geodb->get($request->getIP());
 

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -290,6 +290,28 @@ trait UsersBase
         $this->assertArrayNotHasKey('secret', $token['body']);
     }
 
+    /**
+     * @depends testCreateUser
+     */
+    public function testCreateSession(array $data): void
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $response = $this->client->call(Client::METHOD_POST, '/users/' . $data['userId'] . '/sessions', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $session = $response['body'];
+        $this->assertEquals($data['userId'], $session['userId']);
+        $this->assertNotEmpty($session['secret']);
+        $this->assertNotEmpty($session['expire']);
+        $this->assertEquals('server', $session['provider']);
+    }
+
 
     /**
      * Tests all optional parameters of createUser (email, phone, anonymous..)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

### Fix expire error when creating user session 

Before this, the Create session API call would throw:

> Invalid document structure: Missing required attribute "expire"

This is because the `expire` attribute is required, but it was omitted
from the document. This PR ensures the `expire` attribute is set when
creating the session document.

Fixes #8280 

### Update session secret to be longer

The create session endpoint created a 6 character secret which is too
short. This changes the secret to be 256 characters which is in line
with the secret for `account.createEmailPasswordSession()`.

## Test Plan

Added a test case

## Related PRs and Issues

- #8280 

Parent PR:

* https://github.com/appwrite/appwrite/pull/8317

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
