### PR TITLE
Pass session data in JWT and use that to authenticate when using JWT

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -2358,8 +2358,9 @@ App::post('/v1/account/jwt')
     ->label('abuse-key', 'url:{url},userId:{userId}')
     ->inject('response')
     ->inject('user')
+    ->inject('clientSession')
     ->inject('dbForProject')
-    ->action(function (Response $response, Document $user, Database $dbForProject) {
+    ->action(function (Response $response, Document $user, array $clientSession, Database $dbForProject) {
 
 
         $sessions = $user->getAttribute('sessions', []);
@@ -2386,6 +2387,7 @@ App::post('/v1/account/jwt')
                 // 'iss'    => 'http://api.mysite.com',
                 'userId' => $user->getId(),
                 'sessionId' => $current->getId(),
+                'session' => json_encode($clientSession),
             ])]), Response::MODEL_JWT);
     });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

As per mentioned in the attached issue, when using JWT as an authentication method, if we don't pass the session in the "get session" endpoint, then the authentication fails.
But that shouldn't be the case ideally, as JWT is meant for authentication and it should be able to authenticate even without the need of session. Or more specifically it should include the session data in itself, which should be used for authentication.

- The reason why the authentication is failing because the `Auth::$secret` value which should be equals to the `$session['secret']`, where `$session` is the decoded value of the client session string.
- But when the client session string is not passed, then the `Auth::$secret` value is not populated, and that's why later where we check if the hash of `Auth::$secret` value is equal to the `secret` of the matched session object, it is failing.
- Therefore our target is to populate `Auth::$secret` value when using JWT. But that is only possible when we get the decoded value of the client session string as mentioned in the second point.
- So, to get that data we have to store that data in the JWT and then we can easily get that data.
- Now to store that data in JWT, we have to get the client session data in the `accounts/jwt` handler function. But there is not resource currently present which provides that data.
- So, we have to create a new resource called `clientSession` in `app/init.php` and now consume that resource in the above mentioned handler function and pass the data to the JWT.

## Test Plan

We can test this in Postman -
- Create a new session using`http://localhost/v1/account/sessions/email` endpoint.
  - It will automatically set the cookies. If not then in the next step you have to pass the session value using `x-appwrite-session` header.
- Now create a new JWT using this endpoint - `http://localhost/v1/account/jwt`.
  - Copy the JWT.
- Now create a request to the get session endpoint - `http://localhost/v1/account/sessions/current`, with the JWT set and also the session set.
  - It should work.
- Now delete the cookies (session). If you were using header, then remove the header.
- Now request again and it should still work (**this step should have been failed earlier without this PR changes**)

<img width="1446" alt="Screenshot 2024-06-24 at 2 51 44 PM" src="https://github.com/appwrite/appwrite/assets/39427067/40fdd515-bc66-47bc-8c69-36981e8d7dbb">

<img width="1446" alt="Screenshot 2024-06-24 at 2 52 20 PM" src="https://github.com/appwrite/appwrite/assets/39427067/20c0ff39-9d8c-4ffa-a6aa-62dc4876dfdd">


<img width="1446" alt="Screenshot 2024-06-24 at 2 52 44 PM" src="https://github.com/appwrite/appwrite/assets/39427067/b7968522-2784-463e-89bb-cfad0c7f40ed">


## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/8174

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
