### PR TITLE
Fix flaky certificate test

### DIFF
--- a/tests/e2e/Services/Health/HealthCustomServerTest.php
+++ b/tests/e2e/Services/Health/HealthCustomServerTest.php
@@ -455,7 +455,7 @@ class HealthCustomServerTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('/CN=www.google.com', $response['body']['name']);
         $this->assertEquals('www.google.com', $response['body']['subjectSN']);
-        $this->assertEquals('Google Trust Services LLC', $response['body']['issuerOrganisation']);
+        $this->assertStringContainsString('Google Trust Services', $response['body']['issuerOrganisation']);
         $this->assertIsInt($response['body']['validFrom']);
         $this->assertIsInt($response['body']['validTo']);
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There seems to be a load balancer in front of www.google.com that has either a certificate issuer of "Google Trust Services LLC" or "Google Trust Services". This causes the test to fail intermittently.

This PR updates the test to check for the substring "Google Trust Services" instead of the exact string "Google Trust Services LLC".

## Test Plan

CI should pass

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
