### PR TITLE
Add expiration  headers  to a missed cache response

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -462,6 +462,7 @@ App::init()
                     ->setContentType($cacheLog->getAttribute('mimeType'))
                     ->send($data);
             } else {
+
                 $response
                     ->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
                     ->addHeader('Pragma', 'no-cache')


### PR DESCRIPTION
Added a set of expiration headers to a cache missed request to enforce a fresh  file response when 
a file is overridden with the same custom ID.