### PR TITLE
Add oauth2 details in session when creating session from oauth2 token

### DIFF
--- a/app/config/collections.php
+++ b/app/config/collections.php
@@ -480,6 +480,17 @@ $commonCollections = [
                 'filters' => [],
             ],
             [
+                '$id' => ID::custom('provider'),
+                'type' => Database::VAR_STRING,
+                'format' => '',
+                'size' => 128,
+                'signed' => true,
+                'required' => false,
+                'default' => null,
+                'array' => false,
+                'filters' => [],
+            ],
+            [
                 '$id' => ID::custom('type'),
                 'type' => Database::VAR_INTEGER,
                 'format' => '',


### PR DESCRIPTION
## What does this PR do?

This PR adds the required oauth2 data, i.e -
- `provider`
- `providerUid`
- `providerAccessToken`
- `providerRefreshToken`
- `providerAccessTokenExpiry`

to the session created using oauth2 token.

When we use the `/v1/account/sessions/oauth2/:provider` endpoint to create a session using Oauth2 login, these details are properly added to the session.

But when we -
- Create a oauth2 token using `/v1/account/tokens/oauth2/:provider`.
- And use the token (i.e basically the secret and userId received) to create a session using `/v1/account/sessions/token` API, these data are not added to the session.

## Test Plan

**Important note: There is a new field added in the `token` collection. So, the below steps will fail if you try these steps on an existing project. You need to create new project. I have added the necessity of this new field in the comments.**

- Create a new project.
- Enable Github Oauth2 provider for your App, and configure with details.
- Now in your browser visit - http://localhost/v1/account/tokens/oauth2/github (please make sure you provide proper `X-Appwrite-Project` request header. _P.S: You can use some browser extension to add this header to your request._
- This will do the oauth2 login (considering you have configured everything correctly) and finally redirect it to `http://localhost/auth/oauth2/success?secret=<secret>&userId=<user_id>#`
- Now in postman create a POST request to - `http://localhost/v1/account/sessions/token` with body with `userId` and `secret` set. And you should see all the provider related details in the response (**which you previously didn't get**) -
<img width="1108" alt="Screenshot 2024-07-13 at 9 41 08 AM" src="https://github.com/user-attachments/assets/2fb12c23-011f-4b8a-addb-21b0b26e2a17">
(P.S: User tokens revoked)


## Related PRs and Issues

Closes #8206 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
