### PR TITLE
fix: Setting `path` for vsc function deployments

### DIFF
--- a/src/Appwrite/Platform/Workers/Builds.php
+++ b/src/Appwrite/Platform/Workers/Builds.php
@@ -318,6 +318,9 @@ class Builds extends Action
                     throw new \Exception("Unable to move file");
                 }
 
+                $deployment->setAttribute('path', $path);
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), $deployment);
+
                 Console::execute('rm -rf ' . $tmpPath, '', $stdout, $stderr);
 
                 $source = $path;


### PR DESCRIPTION
## What does this PR do?

Set `path` for vsc-deployed functions

## Test Plan

Was done manually 