### PR TITLE
Fix realtime permission change

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -668,6 +668,7 @@ App::post('/v1/teams/:teamId/memberships')
         }
 
         $queueForEvents
+            ->setParam('userId', $invitee->getId())
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId())
         ;
@@ -901,6 +902,7 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
         $dbForProject->purgeCachedDocument('users', $profile->getId());
 
         $queueForEvents
+            ->setParam('userId', $profile->getId())
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId());
 
@@ -1026,6 +1028,7 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId/status')
         Authorization::skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
 
         $queueForEvents
+            ->setParam('userId', $user->getId())
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId())
         ;
@@ -1107,6 +1110,7 @@ App::delete('/v1/teams/:teamId/memberships/:membershipId')
         }
 
         $queueForEvents
+            ->setParam('userId', $user->getId())
             ->setParam('teamId', $team->getId())
             ->setParam('membershipId', $membership->getId())
             ->setPayload($response->output($membership, Response::MODEL_MEMBERSHIP))

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -380,8 +380,10 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
                         $user = $database->getDocument('users', $userId);
 
                         $roles = Auth::getRoles($user);
+                        $channels = $realtime->connections[$connection]['channels'];
 
-                        $realtime->subscribe($projectId, $connection, $roles, $realtime->connections[$connection]['channels']);
+                        $realtime->unsubscribe($connection);
+                        $realtime->subscribe($projectId, $connection, $roles, $channels);
 
                         $register->get('pools')->reclaim();
                     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

1. add userId to queueForEvents so that the [permissionsChanged](https://github.com/appwrite/appwrite/blob/483ef3c00bcbda150102070e3a15c01692b21626/app/realtime.php#L371-L389) handler is triggered
2. unsubscribe before resubscribing on permission change to ensure old subscriptions are removed

## Test Plan

Manually tested by:

1. granting a team access to a collection
2. adding a user to the team
3. subscribing
4. updating the document to verify the user receives the event
5. removing the user from the team
6. updating hte document again to verify the user doesn't receive the event

![image](https://github.com/user-attachments/assets/744a4aa5-0490-4b9f-904c-77945d1321a5)


## Related PRs and Issues

- None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
