### PR TITLE
Docs: Update read["any"] in SDK examples

### DIFF
--- a/docs/examples/1.5.x/client-android/java/databases/create-document.md
+++ b/docs/examples/1.5.x/client-android/java/databases/create-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ databases.createDocument(
     "<COLLECTION_ID>", // collectionId 
     "<DOCUMENT_ID>", // documentId 
     mapOf( "a" to "b" ), // data 
-    listOf(Permission.read('any')), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/databases/create-document.md
+++ b/docs/examples/1.5.x/client-android/java/databases/create-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
+import io.appwrite.Permission;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ databases.createDocument(
     "<COLLECTION_ID>", // collectionId 
     "<DOCUMENT_ID>", // documentId 
     mapOf( "a" to "b" ), // data 
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read('any')), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/databases/update-document.md
+++ b/docs/examples/1.5.x/client-android/java/databases/update-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ databases.updateDocument(
     "<COLLECTION_ID>", // collectionId 
     "<DOCUMENT_ID>", // documentId 
     mapOf( "a" to "b" ), // data (optional)
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/databases/update-document.md
+++ b/docs/examples/1.5.x/client-android/java/databases/update-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
+import io.appwrite.Permission;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ databases.updateDocument(
     "<COLLECTION_ID>", // collectionId 
     "<DOCUMENT_ID>", // documentId 
     mapOf( "a" to "b" ), // data (optional)
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/storage/create-file.md
+++ b/docs/examples/1.5.x/client-android/java/storage/create-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.models.InputFile;
 import io.appwrite.services.Storage;
+import io.appwrite.Permission;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ storage.createFile(
     "<BUCKET_ID>", // bucketId 
     "<FILE_ID>", // fileId 
     InputFile.fromPath("file.png"), // file 
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/storage/create-file.md
+++ b/docs/examples/1.5.x/client-android/java/storage/create-file.md
@@ -3,6 +3,7 @@ import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.models.InputFile;
 import io.appwrite.services.Storage;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ storage.createFile(
     "<BUCKET_ID>", // bucketId 
     "<FILE_ID>", // fileId 
     InputFile.fromPath("file.png"), // file 
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/storage/update-file.md
+++ b/docs/examples/1.5.x/client-android/java/storage/update-file.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
+import io.appwrite.Permission;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -12,7 +13,7 @@ storage.updateFile(
     "<BUCKET_ID>", // bucketId 
     "<FILE_ID>", // fileId 
     "<NAME>", // name (optional)
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/java/storage/update-file.md
+++ b/docs/examples/1.5.x/client-android/java/storage/update-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ storage.updateFile(
     "<BUCKET_ID>", // bucketId 
     "<FILE_ID>", // fileId 
     "<NAME>", // name (optional)
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/client-android/kotlin/databases/create-document.md
+++ b/docs/examples/1.5.x/client-android/kotlin/databases/create-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val result = databases.createDocument(
     collectionId = "<COLLECTION_ID>", 
     documentId = "<DOCUMENT_ID>", 
     data = mapOf( "a" to "b" ), 
-    permissions = listOf(Permission.read("any")), // (optional)
+    permissions = listOf(Permission.read(Role.any())), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/databases/create-document.md
+++ b/docs/examples/1.5.x/client-android/kotlin/databases/create-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
+import io.appwrite.Permission
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,5 +14,5 @@ val result = databases.createDocument(
     collectionId = "<COLLECTION_ID>", 
     documentId = "<DOCUMENT_ID>", 
     data = mapOf( "a" to "b" ), 
-    permissions = listOf("read("any")"), // (optional)
+    permissions = listOf(Permission.read("any")), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/databases/update-document.md
+++ b/docs/examples/1.5.x/client-android/kotlin/databases/update-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
+import io.appwrite.Permission
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,5 +14,5 @@ val result = databases.updateDocument(
     collectionId = "<COLLECTION_ID>", 
     documentId = "<DOCUMENT_ID>", 
     data = mapOf( "a" to "b" ), // (optional)
-    permissions = listOf("read("any")"), // (optional)
+    permissions = listOf(Permission.read("any")), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/databases/update-document.md
+++ b/docs/examples/1.5.x/client-android/kotlin/databases/update-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val result = databases.updateDocument(
     collectionId = "<COLLECTION_ID>", 
     documentId = "<DOCUMENT_ID>", 
     data = mapOf( "a" to "b" ), // (optional)
-    permissions = listOf(Permission.read("any")), // (optional)
+    permissions = listOf(Permission.read(Role.any())), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/storage/create-file.md
+++ b/docs/examples/1.5.x/client-android/kotlin/storage/create-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.models.InputFile
 import io.appwrite.services.Storage
+import io.appwrite.Permission
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,5 +14,5 @@ val result = storage.createFile(
     bucketId = "<BUCKET_ID>", 
     fileId = "<FILE_ID>", 
     file = InputFile.fromPath("file.png"), 
-    permissions = listOf("read("any")"), // (optional)
+    permissions = listOf(Permission.read("any")), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/storage/create-file.md
+++ b/docs/examples/1.5.x/client-android/kotlin/storage/create-file.md
@@ -3,6 +3,7 @@ import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.models.InputFile
 import io.appwrite.services.Storage
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val result = storage.createFile(
     bucketId = "<BUCKET_ID>", 
     fileId = "<FILE_ID>", 
     file = InputFile.fromPath("file.png"), 
-    permissions = listOf(Permission.read("any")), // (optional)
+    permissions = listOf(Permission.read(Role.any())), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/storage/update-file.md
+++ b/docs/examples/1.5.x/client-android/kotlin/storage/update-file.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
+import io.appwrite.Permission
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -12,5 +13,5 @@ val result = storage.updateFile(
     bucketId = "<BUCKET_ID>", 
     fileId = "<FILE_ID>", 
     name = "<NAME>", // (optional)
-    permissions = listOf("read("any")"), // (optional)
+    permissions = listOf(Permission.read("any")), // (optional)
 )

--- a/docs/examples/1.5.x/client-android/kotlin/storage/update-file.md
+++ b/docs/examples/1.5.x/client-android/kotlin/storage/update-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client(context)
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,5 +14,5 @@ val result = storage.updateFile(
     bucketId = "<BUCKET_ID>", 
     fileId = "<FILE_ID>", 
     name = "<NAME>", // (optional)
-    permissions = listOf(Permission.read("any")), // (optional)
+    permissions = listOf(Permission.read(Role.any())), // (optional)
 )

--- a/docs/examples/1.5.x/client-apple/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-apple/examples/databases/create-document.md
@@ -11,6 +11,6 @@ let document = try await databases.createDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:],
-    permissions: ["read("any")"] // optional
+    permissions: [Permission.read("any")] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-apple/examples/databases/create-document.md
@@ -11,6 +11,6 @@ let document = try await databases.createDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:],
-    permissions: [Permission.read("any")] // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-apple/examples/databases/update-document.md
@@ -11,6 +11,6 @@ let document = try await databases.updateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:], // optional
-    permissions: [Permission.read("any")] // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-apple/examples/databases/update-document.md
@@ -11,6 +11,6 @@ let document = try await databases.updateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:], // optional
-    permissions: ["read("any")"] // optional
+    permissions: [Permission.read("any")] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-apple/examples/storage/create-file.md
@@ -10,6 +10,6 @@ let file = try await storage.createFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     file: InputFile.fromPath("file.png"),
-    permissions: [Permission.read("any")] // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-apple/examples/storage/create-file.md
@@ -10,6 +10,6 @@ let file = try await storage.createFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     file: InputFile.fromPath("file.png"),
-    permissions: ["read("any")"] // optional
+    permissions: [Permission.read("any")] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-apple/examples/storage/update-file.md
@@ -10,6 +10,6 @@ let file = try await storage.updateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     name: "<NAME>", // optional
-    permissions: ["read("any")"] // optional
+    permissions: [Permission.read("any")] // optional
 )
 

--- a/docs/examples/1.5.x/client-apple/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-apple/examples/storage/update-file.md
@@ -10,6 +10,6 @@ let file = try await storage.updateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     name: "<NAME>", // optional
-    permissions: [Permission.read("any")] // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/client-flutter/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-flutter/examples/databases/create-document.md
@@ -11,5 +11,5 @@ Document result = await databases.createDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {},
-    permissions: [Permission.read('any')], // optional
+    permissions: [Permission.read(Role.any())], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-flutter/examples/databases/create-document.md
@@ -11,5 +11,5 @@ Document result = await databases.createDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {},
-    permissions: ["read("any")"], // optional
+    permissions: [Permission.read('any')], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-flutter/examples/databases/update-document.md
@@ -11,5 +11,5 @@ Document result = await databases.updateDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {}, // optional
-    permissions: ["read("any")"], // optional
+    permissions: [Permission.read('any')], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-flutter/examples/databases/update-document.md
@@ -11,5 +11,5 @@ Document result = await databases.updateDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {}, // optional
-    permissions: [Permission.read('any')], // optional
+    permissions: [Permission.read(Role.any())], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-flutter/examples/storage/create-file.md
@@ -11,5 +11,5 @@ File result = await storage.createFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: InputFile(path: './path-to-files/image.jpg', filename: 'image.jpg'),
-    permissions: [Permission.read('any')], // optional
+    permissions: [Permission.read(Role.any())], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-flutter/examples/storage/create-file.md
@@ -11,5 +11,5 @@ File result = await storage.createFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: InputFile(path: './path-to-files/image.jpg', filename: 'image.jpg'),
-    permissions: ["read("any")"], // optional
+    permissions: [Permission.read('any')], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-flutter/examples/storage/update-file.md
@@ -10,5 +10,5 @@ File result = await storage.updateFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     name: '<NAME>', // optional
-    permissions: [Permission.read('any')], // optional
+    permissions: [Permission.read(Role.any())], // optional
 );

--- a/docs/examples/1.5.x/client-flutter/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-flutter/examples/storage/update-file.md
@@ -10,5 +10,5 @@ File result = await storage.updateFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     name: '<NAME>', // optional
-    permissions: ["read("any")"], // optional
+    permissions: [Permission.read('any')], // optional
 );

--- a/docs/examples/1.5.x/client-react-native/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-react-native/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "react-native-appwrite";
+import { Client, Databases, Permission, Role } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-react-native/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-react-native/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "react-native-appwrite";
+import { Client, Databases, Permission } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-react-native/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-react-native/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "react-native-appwrite";
+import { Client, Databases, Permission } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-react-native/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-react-native/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "react-native-appwrite";
+import { Client, Databases, Permission, Role } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-react-native/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-react-native/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "react-native-appwrite";
+import { Client, Storage, Permission, Role } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     await pickSingle(), // file
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-react-native/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-react-native/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "react-native-appwrite";
+import { Client, Storage, Permission } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     await pickSingle(), // file
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-react-native/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-react-native/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "react-native-appwrite";
+import { Client, Storage, Permission, Role } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-react-native/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-react-native/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "react-native-appwrite";
+import { Client, Storage, Permission } from "react-native-appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-web/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-web/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "appwrite";
+import { Client, Databases, Permission, Role } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-web/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/client-web/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "appwrite";
+import { Client, Databases, Permission } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-web/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-web/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "appwrite";
+import { Client, Databases, Permission } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-web/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/client-web/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "appwrite";
+import { Client, Databases, Permission, Role } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-web/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-web/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "appwrite";
+import { Client, Storage, Permission } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     document.getElementById('uploader').files[0], // file
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/client-web/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/client-web/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "appwrite";
+import { Client, Storage, Permission, Role } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     document.getElementById('uploader').files[0], // file
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-web/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-web/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "appwrite";
+import { Client, Storage, Permission, Role } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/client-web/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/client-web/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "appwrite";
+import { Client, Storage, Permission } from "appwrite";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/console-web/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/create-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "@appwrite.io/console";
+import { Client, Databases, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,9 +10,9 @@ const result = await databases.createCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/create-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "@appwrite.io/console";
+import { Client, Databases, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await databases.createCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/console-web/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "@appwrite.io/console";
+import { Client, Databases, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/console-web/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "@appwrite.io/console";
+import { Client, Databases, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/update-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "@appwrite.io/console";
+import { Client, Databases, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,9 +10,9 @@ const result = await databases.updateCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/update-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "@appwrite.io/console";
+import { Client, Databases, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await databases.updateCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/console-web/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "@appwrite.io/console";
+import { Client, Databases, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/console-web/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/console-web/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "@appwrite.io/console";
+import { Client, Databases, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/create-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage,  } from "@appwrite.io/console";
+import { Client, Storage, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -9,7 +9,7 @@ const storage = new Storage(client);
 const result = await storage.createBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/console-web/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/create-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "@appwrite.io/console";
+import { Client, Storage, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -9,7 +9,7 @@ const storage = new Storage(client);
 const result = await storage.createBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)
@@ -19,4 +19,4 @@ const result = await storage.createBucket(
     false // antivirus (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "@appwrite.io/console";
+import { Client, Storage, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     document.getElementById('uploader').files[0], // file
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "@appwrite.io/console";
+import { Client, Storage, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     document.getElementById('uploader').files[0], // file
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/console-web/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/update-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage,  } from "@appwrite.io/console";
+import { Client, Storage, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -9,7 +9,7 @@ const storage = new Storage(client);
 const result = await storage.updateBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/console-web/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/update-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "@appwrite.io/console";
+import { Client, Storage, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -9,7 +9,7 @@ const storage = new Storage(client);
 const result = await storage.updateBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)
@@ -19,4 +19,4 @@ const result = await storage.updateBucket(
     false // antivirus (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/console-web/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "@appwrite.io/console";
+import { Client, Storage, Permission } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );
 
 console.log(response);

--- a/docs/examples/1.5.x/console-web/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/console-web/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "@appwrite.io/console";
+import { Client, Storage, Permission, Role } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );
 
-console.log(response);
+console.log(result);

--- a/docs/examples/1.5.x/server-dart/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/create-collection.md
@@ -11,7 +11,7 @@ Collection result = await databases.createCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
     documentSecurity: false, // (optional)
     enabled: false, // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/create-collection.md
@@ -11,7 +11,7 @@ Collection result = await databases.createCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
     documentSecurity: false, // (optional)
     enabled: false, // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/create-document.md
@@ -12,5 +12,5 @@ Document result = await databases.createDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {},
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/update-collection.md
@@ -11,7 +11,7 @@ Collection result = await databases.updateCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
     documentSecurity: false, // (optional)
     enabled: false, // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/update-collection.md
@@ -11,7 +11,7 @@ Collection result = await databases.updateCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
     documentSecurity: false, // (optional)
     enabled: false, // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/update-document.md
@@ -12,5 +12,5 @@ Document result = await databases.updateDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {}, // (optional)
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-dart/examples/databases/update-document.md
@@ -12,5 +12,5 @@ Document result = await databases.updateDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: {}, // (optional)
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/create-bucket.md
@@ -10,7 +10,7 @@ Storage storage = Storage(client);
 Bucket result = await storage.createBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
     fileSecurity: false, // (optional)
     enabled: false, // (optional)
     maximumFileSize: 1, // (optional)

--- a/docs/examples/1.5.x/server-dart/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/create-bucket.md
@@ -10,7 +10,7 @@ Storage storage = Storage(client);
 Bucket result = await storage.createBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
     fileSecurity: false, // (optional)
     enabled: false, // (optional)
     maximumFileSize: 1, // (optional)

--- a/docs/examples/1.5.x/server-dart/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/create-file.md
@@ -12,5 +12,5 @@ File result = await storage.createFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: InputFile(path: './path-to-files/image.jpg', filename: 'image.jpg'),
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/create-file.md
@@ -12,5 +12,5 @@ File result = await storage.createFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: InputFile(path: './path-to-files/image.jpg', filename: 'image.jpg'),
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/update-bucket.md
@@ -10,7 +10,7 @@ Storage storage = Storage(client);
 Bucket result = await storage.updateBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
     fileSecurity: false, // (optional)
     enabled: false, // (optional)
     maximumFileSize: 1, // (optional)

--- a/docs/examples/1.5.x/server-dart/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/update-bucket.md
@@ -10,7 +10,7 @@ Storage storage = Storage(client);
 Bucket result = await storage.updateBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
     fileSecurity: false, // (optional)
     enabled: false, // (optional)
     maximumFileSize: 1, // (optional)

--- a/docs/examples/1.5.x/server-dart/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/update-file.md
@@ -11,5 +11,5 @@ File result = await storage.updateFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     name: '<NAME>', // (optional)
-    permissions: ["read("any")"], // (optional)
+    permissions: [Permission.read('any')], // (optional)
 );

--- a/docs/examples/1.5.x/server-dart/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-dart/examples/storage/update-file.md
@@ -11,5 +11,5 @@ File result = await storage.updateFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     name: '<NAME>', // (optional)
-    permissions: [Permission.read('any')], // (optional)
+    permissions: [Permission.read(Role.any())], // (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/create-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const response = await databases.createCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/create-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const response = await databases.createCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,5 +12,5 @@ const response = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/create-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,5 +12,5 @@ const response = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/update-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const response = await databases.updateCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/update-collection.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,7 +11,7 @@ const response = await databases.updateCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,5 +12,5 @@ const response = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-deno/examples/databases/update-document.md
@@ -1,4 +1,4 @@
-import { Client, Databases, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Databases, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,5 +12,5 @@ const response = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/create-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const storage = new Storage(client);
 const response = await storage.createBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-deno/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/create-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage,  } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const storage = new Storage(client);
 const response = await storage.createBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-deno/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,5 +11,5 @@ const response = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     InputFile.fromPath('/path/to/file.png', 'file.png'), // file
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/create-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,5 +11,5 @@ const response = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     InputFile.fromPath('/path/to/file.png', 'file.png'), // file
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/update-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission} from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const storage = new Storage(client);
 const response = await storage.updateBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    Permission.read('any'), // permissions (optional)
+    [Permission.read(Role.any())], // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-deno/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/update-bucket.md
@@ -1,4 +1,4 @@
-import { Client, Storage,  } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission} from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -10,7 +10,7 @@ const storage = new Storage(client);
 const response = await storage.updateBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    Permission.read('any'), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-deno/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,5 +11,5 @@ const response = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    ["read("any")"] // permissions (optional)
+    Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-deno/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-deno/examples/storage/update-file.md
@@ -1,4 +1,4 @@
-import { Client, Storage, Permission } from "https://deno.land/x/appwrite/mod.ts";
+import { Client, Storage, Permission, Role } from "https://deno.land/x/appwrite/mod.ts";
 
 const client = new Client()
     .setEndpoint('https://cloud.appwrite.io/v1') // Your API Endpoint
@@ -11,5 +11,5 @@ const response = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    Permission.read('any') // permissions (optional)
+    [Permission.read(Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/create-collection.md
@@ -13,7 +13,7 @@ Collection result = await databases.CreateCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: new List<string> { Permission.Read("any") }, // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/create-collection.md
@@ -13,7 +13,7 @@ Collection result = await databases.CreateCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: new List<string> { Permission.Read("any") }, // optional
+    permissions: new List<string> { Permission.Read(Role.any()) }, // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/create-document.md
@@ -14,5 +14,5 @@ Document result = await databases.CreateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [object],
-    permissions: ["read("any")"] // optional
+    permissions: new List<string> { Permission.Read("any") }, // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/create-document.md
@@ -14,5 +14,5 @@ Document result = await databases.CreateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [object],
-    permissions: new List<string> { Permission.Read("any") }, // optional
+    permissions: new List<string> { Permission.Read(Role.any()) }, // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/update-collection.md
@@ -13,7 +13,7 @@ Collection result = await databases.UpdateCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: new List<string> { Permission.Read("any") }, // optional
+    permissions: new List<string> { Permission.Read(Role.any()) }, // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/update-collection.md
@@ -13,7 +13,7 @@ Collection result = await databases.UpdateCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: new List<string> { Permission.Read("any") }, // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/update-document.md
@@ -14,5 +14,5 @@ Document result = await databases.UpdateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [object], // optional
-    permissions: ["read("any")"] // optional
+    permissions: new List<string> { Permission.Read("any") } // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/databases/update-document.md
@@ -14,5 +14,5 @@ Document result = await databases.UpdateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [object], // optional
-    permissions: new List<string> { Permission.Read("any") } // optional
+    permissions: new List<string> { Permission.Read(Role.any()) } // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/create-bucket.md
@@ -13,7 +13,7 @@ Storage storage = new Storage(client);
 Bucket result = await storage.CreateBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: new List<string> { Permission.Read("any") }, // optional
+    permissions: new List<string> { Permission.Read(Role.any()) }, // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/create-bucket.md
@@ -13,7 +13,7 @@ Storage storage = new Storage(client);
 Bucket result = await storage.CreateBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: new List<string> { Permission.Read("any") }, // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/create-file.md
@@ -13,5 +13,5 @@ File result = await storage.CreateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     file: InputFile.FromPath("./path-to-files/image.jpg"),
-    permissions: ["read("any")"] // optional
+    permissions: new List<string> { Permission.Read("any") } // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/create-file.md
@@ -13,5 +13,5 @@ File result = await storage.CreateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     file: InputFile.FromPath("./path-to-files/image.jpg"),
-    permissions: new List<string> { Permission.Read("any") } // optional
+    permissions: new List<string> { Permission.Read(Role.any()) } // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/update-bucket.md
@@ -13,7 +13,7 @@ Storage storage = new Storage(client);
 Bucket result = await storage.UpdateBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: new List<string> { Permission.Read("any") }, // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/update-bucket.md
@@ -13,7 +13,7 @@ Storage storage = new Storage(client);
 Bucket result = await storage.UpdateBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: new List<string> { Permission.Read("any") }, // optional
+    permissions: new List<string> { Permission.Read(Role.any()) }, // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/update-file.md
@@ -13,5 +13,5 @@ File result = await storage.UpdateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     name: "<NAME>", // optional
-    permissions: ["read("any")"] // optional
+    permissions: new List<string> { Permission.Read("any") } // optional
 );

--- a/docs/examples/1.5.x/server-dotnet/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-dotnet/examples/storage/update-file.md
@@ -13,5 +13,5 @@ File result = await storage.UpdateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     name: "<NAME>", // optional
-    permissions: new List<string> { Permission.Read("any") } // optional
+    permissions: new List<string> { Permission.Read(Role.any()) } // optional
 );

--- a/docs/examples/1.5.x/server-kotlin/java/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/create-collection.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ databases.createCollection(
     "<DATABASE_ID>", // databaseId
     "<COLLECTION_ID>", // collectionId
     "<NAME>", // name
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     false, // documentSecurity (optional)
     false, // enabled (optional)
     new CoroutineCallback<>((result, error) -> {

--- a/docs/examples/1.5.x/server-kotlin/java/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/create-collection.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ databases.createCollection(
     "<DATABASE_ID>", // databaseId
     "<COLLECTION_ID>", // collectionId
     "<NAME>", // name
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     false, // documentSecurity (optional)
     false, // enabled (optional)
     new CoroutineCallback<>((result, error) -> {

--- a/docs/examples/1.5.x/server-kotlin/java/databases/create-document.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/create-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ databases.createDocument(
     "<COLLECTION_ID>", // collectionId
     "<DOCUMENT_ID>", // documentId
     mapOf( "a" to "b" ), // data
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/databases/create-document.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/create-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -15,7 +16,7 @@ databases.createDocument(
     "<COLLECTION_ID>", // collectionId
     "<DOCUMENT_ID>", // documentId
     mapOf( "a" to "b" ), // data
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/update-collection.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ databases.updateCollection(
     "<DATABASE_ID>", // databaseId
     "<COLLECTION_ID>", // collectionId
     "<NAME>", // name
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     false, // documentSecurity (optional)
     false, // enabled (optional)
     new CoroutineCallback<>((result, error) -> {

--- a/docs/examples/1.5.x/server-kotlin/java/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/update-collection.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ databases.updateCollection(
     "<DATABASE_ID>", // databaseId
     "<COLLECTION_ID>", // collectionId
     "<NAME>", // name
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     false, // documentSecurity (optional)
     false, // enabled (optional)
     new CoroutineCallback<>((result, error) -> {

--- a/docs/examples/1.5.x/server-kotlin/java/databases/update-document.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/update-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -15,7 +16,7 @@ databases.updateDocument(
     "<COLLECTION_ID>", // collectionId
     "<DOCUMENT_ID>", // documentId
     mapOf( "a" to "b" ), // data (optional)
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/databases/update-document.md
+++ b/docs/examples/1.5.x/server-kotlin/java/databases/update-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Databases;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ databases.updateDocument(
     "<COLLECTION_ID>", // collectionId
     "<DOCUMENT_ID>", // documentId
     mapOf( "a" to "b" ), // data (optional)
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/create-bucket.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -12,7 +13,7 @@ Storage storage = new Storage(client);
 storage.createBucket(
     "<BUCKET_ID>", // bucketId
     "<NAME>", // name
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-kotlin/java/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/create-bucket.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ Storage storage = new Storage(client);
 storage.createBucket(
     "<BUCKET_ID>", // bucketId
     "<NAME>", // name
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-kotlin/java/storage/create-file.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/create-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.models.InputFile;
 import io.appwrite.services.Storage;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ storage.createFile(
     "<BUCKET_ID>", // bucketId
     "<FILE_ID>", // fileId
     InputFile.fromPath("file.png"), // file
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/storage/create-file.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/create-file.md
@@ -3,6 +3,7 @@ import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.models.InputFile;
 import io.appwrite.services.Storage;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -15,7 +16,7 @@ storage.createFile(
     "<BUCKET_ID>", // bucketId
     "<FILE_ID>", // fileId
     InputFile.fromPath("file.png"), // file
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/update-bucket.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -12,7 +13,7 @@ Storage storage = new Storage(client);
 storage.updateBucket(
     "<BUCKET_ID>", // bucketId
     "<NAME>", // name
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-kotlin/java/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/update-bucket.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ Storage storage = new Storage(client);
 storage.updateBucket(
     "<BUCKET_ID>", // bucketId
     "<NAME>", // name
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-kotlin/java/storage/update-file.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/update-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
 import io.appwrite.Permission;
+import io.appwrite.Role;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ storage.updateFile(
     "<BUCKET_ID>", // bucketId
     "<FILE_ID>", // fileId
     "<NAME>", // name (optional)
-    listOf(Permission.read("any")), // permissions (optional)
+    listOf(Permission.read(Role.any())), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/java/storage/update-file.md
+++ b/docs/examples/1.5.x/server-kotlin/java/storage/update-file.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client;
 import io.appwrite.coroutines.CoroutineCallback;
 import io.appwrite.services.Storage;
+import io.appwrite.Permission;
 
 Client client = new Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ storage.updateFile(
     "<BUCKET_ID>", // bucketId
     "<FILE_ID>", // fileId
     "<NAME>", // name (optional)
-    listOf("read("any")"), // permissions (optional)
+    listOf(Permission.read("any")), // permissions (optional)
     new CoroutineCallback<>((result, error) -> {
         if (error != null) {
             error.printStackTrace();

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-collection.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ val response = databases.createCollection(
     databaseId = "<DATABASE_ID>",
     collectionId = "<COLLECTION_ID>",
     name = "<NAME>",
-    permissions = listOf(Permission.read("any")), // optional
+    permissions = listOf(Permission.read(Role.any())), // optional
     documentSecurity = false, // optional
     enabled = false // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-collection.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ val response = databases.createCollection(
     databaseId = "<DATABASE_ID>",
     collectionId = "<COLLECTION_ID>",
     name = "<NAME>",
-    permissions = listOf("read("any")"), // optional
+    permissions = listOf(Permission.read("any")), // optional
     documentSecurity = false, // optional
     enabled = false // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-document.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -15,5 +16,5 @@ val response = databases.createDocument(
     collectionId = "<COLLECTION_ID>",
     documentId = "<DOCUMENT_ID>",
     data = mapOf( "a" to "b" ),
-    permissions = listOf(Permission.read("any")) // optional
+    permissions = listOf(Permission.read(Role.any())) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-document.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/create-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val response = databases.createDocument(
     collectionId = "<COLLECTION_ID>",
     documentId = "<DOCUMENT_ID>",
     data = mapOf( "a" to "b" ),
-    permissions = listOf("read("any")") // optional
+    permissions = listOf(Permission.read("any")) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-collection.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ val response = databases.updateCollection(
     databaseId = "<DATABASE_ID>",
     collectionId = "<COLLECTION_ID>",
     name = "<NAME>",
-    permissions = listOf("read("any")"), // optional
+    permissions = listOf(Permission.read("any")), // optional
     documentSecurity = false, // optional
     enabled = false // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-collection.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,7 +15,7 @@ val response = databases.updateCollection(
     databaseId = "<DATABASE_ID>",
     collectionId = "<COLLECTION_ID>",
     name = "<NAME>",
-    permissions = listOf(Permission.read("any")), // optional
+    permissions = listOf(Permission.read(Role.any())), // optional
     documentSecurity = false, // optional
     enabled = false // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-document.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-document.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val response = databases.updateDocument(
     collectionId = "<COLLECTION_ID>",
     documentId = "<DOCUMENT_ID>",
     data = mapOf( "a" to "b" ), // optional
-    permissions = listOf("read("any")") // optional
+    permissions = listOf(Permission.read("any")) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-document.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/databases/update-document.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Databases
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -15,5 +16,5 @@ val response = databases.updateDocument(
     collectionId = "<COLLECTION_ID>",
     documentId = "<DOCUMENT_ID>",
     data = mapOf( "a" to "b" ), // optional
-    permissions = listOf(Permission.read("any")) // optional
+    permissions = listOf(Permission.read(Role.any())) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-bucket.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ val storage = Storage(client)
 val response = storage.createBucket(
     bucketId = "<BUCKET_ID>",
     name = "<NAME>",
-    permissions = listOf(Permission.read("any")), // optional
+    permissions = listOf(Permission.read(Role.any())), // optional
     fileSecurity = false, // optional
     enabled = false, // optional
     maximumFileSize = 1, // optional

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-bucket.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -12,7 +13,7 @@ val storage = Storage(client)
 val response = storage.createBucket(
     bucketId = "<BUCKET_ID>",
     name = "<NAME>",
-    permissions = listOf("read("any")"), // optional
+    permissions = listOf(Permission.read("any")), // optional
     fileSecurity = false, // optional
     enabled = false, // optional
     maximumFileSize = 1, // optional

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-file.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.models.InputFile
 import io.appwrite.services.Storage
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val response = storage.createFile(
     bucketId = "<BUCKET_ID>",
     fileId = "<FILE_ID>",
     file = InputFile.fromPath("file.png"),
-    permissions = listOf("read("any")") // optional
+    permissions = listOf(Permission.read("any")) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-file.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/create-file.md
@@ -3,6 +3,7 @@ import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.models.InputFile
 import io.appwrite.services.Storage
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -15,5 +16,5 @@ val response = storage.createFile(
     bucketId = "<BUCKET_ID>",
     fileId = "<FILE_ID>",
     file = InputFile.fromPath("file.png"),
-    permissions = listOf(Permission.read("any")) // optional
+    permissions = listOf(Permission.read(Role.any())) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-bucket.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,7 +14,7 @@ val storage = Storage(client)
 val response = storage.updateBucket(
     bucketId = "<BUCKET_ID>",
     name = "<NAME>",
-    permissions = listOf(Permission.read("any")), // optional
+    permissions = listOf(Permission.read(Role.any())), // optional
     fileSecurity = false, // optional
     enabled = false, // optional
     maximumFileSize = 1, // optional

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-bucket.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -12,7 +13,7 @@ val storage = Storage(client)
 val response = storage.updateBucket(
     bucketId = "<BUCKET_ID>",
     name = "<NAME>",
-    permissions = listOf("read("any")"), // optional
+    permissions = listOf(Permission.read("any")), // optional
     fileSecurity = false, // optional
     enabled = false, // optional
     maximumFileSize = 1, // optional

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-file.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-file.md
@@ -1,6 +1,7 @@
 import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
+import io.appwrite.Permission
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -13,5 +14,5 @@ val response = storage.updateFile(
     bucketId = "<BUCKET_ID>",
     fileId = "<FILE_ID>",
     name = "<NAME>", // optional
-    permissions = listOf("read("any")") // optional
+    permissions = listOf(Permission.read("any")) // optional
 )

--- a/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-file.md
+++ b/docs/examples/1.5.x/server-kotlin/kotlin/storage/update-file.md
@@ -2,6 +2,7 @@ import io.appwrite.Client
 import io.appwrite.coroutines.CoroutineCallback
 import io.appwrite.services.Storage
 import io.appwrite.Permission
+import io.appwrite.Role
 
 val client = Client()
     .setEndpoint("https://cloud.appwrite.io/v1") // Your API Endpoint
@@ -14,5 +15,5 @@ val response = storage.updateFile(
     bucketId = "<BUCKET_ID>",
     fileId = "<FILE_ID>",
     name = "<NAME>", // optional
-    permissions = listOf(Permission.read("any")) // optional
+    permissions = listOf(Permission.read(Role.any())) // optional
 )

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/create-collection.md
@@ -11,7 +11,7 @@ const result = await databases.createCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    sdk.Permission.read('any'), // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/create-collection.md
@@ -11,7 +11,7 @@ const result = await databases.createCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    sdk.Permission.read('any'), // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())], // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/create-document.md
@@ -12,5 +12,5 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    ["read("any")"] // permissions (optional)
+    sdk.Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/create-document.md
@@ -12,5 +12,5 @@ const result = await databases.createDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data
-    sdk.Permission.read('any') // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/update-collection.md
@@ -11,7 +11,7 @@ const result = await databases.updateCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    sdk.Permission.read('any'), // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())], // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/update-collection.md
@@ -11,7 +11,7 @@ const result = await databases.updateCollection(
     '<DATABASE_ID>', // databaseId
     '<COLLECTION_ID>', // collectionId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    sdk.Permission.read('any'), // permissions (optional)
     false, // documentSecurity (optional)
     false // enabled (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/update-document.md
@@ -12,5 +12,5 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    sdk.Permission.read('any') // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/databases/update-document.md
@@ -12,5 +12,5 @@ const result = await databases.updateDocument(
     '<COLLECTION_ID>', // collectionId
     '<DOCUMENT_ID>', // documentId
     {}, // data (optional)
-    ["read("any")"] // permissions (optional)
+    sdk.Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/create-bucket.md
@@ -10,7 +10,7 @@ const storage = new sdk.Storage(client);
 const result = await storage.createBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    sdk.Permission.read('any'), // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())], // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/create-bucket.md
@@ -10,7 +10,7 @@ const storage = new sdk.Storage(client);
 const result = await storage.createBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    sdk.Permission.read('any'), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/create-file.md
@@ -12,5 +12,5 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     InputFile.fromPath('/path/to/file', 'filename'), // file
-    ["read("any")"] // permissions (optional)
+    sdk.Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/create-file.md
@@ -12,5 +12,5 @@ const result = await storage.createFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     InputFile.fromPath('/path/to/file', 'filename'), // file
-    sdk.Permission.read('any') // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/update-bucket.md
@@ -10,7 +10,7 @@ const storage = new sdk.Storage(client);
 const result = await storage.updateBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    sdk.Permission.read('any'), // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())], // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/update-bucket.md
@@ -10,7 +10,7 @@ const storage = new sdk.Storage(client);
 const result = await storage.updateBucket(
     '<BUCKET_ID>', // bucketId
     '<NAME>', // name
-    ["read("any")"], // permissions (optional)
+    sdk.Permission.read('any'), // permissions (optional)
     false, // fileSecurity (optional)
     false, // enabled (optional)
     1, // maximumFileSize (optional)

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/update-file.md
@@ -11,5 +11,5 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    sdk.Permission.read('any') // permissions (optional)
+    [sdk.Permission.read(sdk.Role.any())] // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-nodejs/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-nodejs/examples/storage/update-file.md
@@ -11,5 +11,5 @@ const result = await storage.updateFile(
     '<BUCKET_ID>', // bucketId
     '<FILE_ID>', // fileId
     '<NAME>', // name (optional)
-    ["read("any")"] // permissions (optional)
+    sdk.Permission.read('any') // permissions (optional)
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/create-collection.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -14,7 +15,7 @@ $result = $databases->createCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read('any'), // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/create-collection.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -15,7 +16,7 @@ $result = $databases->createCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: Permission.read('any'), // optional
+    permissions: [Permission::read(Role::any())], // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/create-document.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -15,5 +16,5 @@ $result = $databases->createDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: [],
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read('any') // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/create-document.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -16,5 +17,5 @@ $result = $databases->createDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: [],
-    permissions: Permission.read('any') // optional
+    permissions: Permission::read(Role::any()) // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/update-collection.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -14,7 +15,7 @@ $result = $databases->updateCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read('any'), // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/update-collection.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -15,7 +16,7 @@ $result = $databases->updateCollection(
     databaseId: '<DATABASE_ID>',
     collectionId: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: Permission.read('any'), // optional
+    permissions: Permission::read(Role::any()), // optional
     documentSecurity: false, // optional
     enabled: false // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/update-document.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -15,5 +16,5 @@ $result = $databases->updateDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: [], // optional
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read('any') // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-php/examples/databases/update-document.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Databases;
 
 $client = (new Client())
@@ -16,5 +17,5 @@ $result = $databases->updateDocument(
     collectionId: '<COLLECTION_ID>',
     documentId: '<DOCUMENT_ID>',
     data: [], // optional
-    permissions: Permission.read('any') // optional
+    permissions: Permission::read(Role::any()) // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/create-bucket.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -13,7 +14,7 @@ $storage = new Storage($client);
 $result = $storage->createBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read('any'), // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-php/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/create-bucket.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -14,7 +15,7 @@ $storage = new Storage($client);
 $result = $storage->createBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: Permission.read('any'), // optional
+    permissions: Permission::read(Role::any()), // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-php/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/create-file.md
@@ -3,6 +3,7 @@
 use Appwrite\Client;
 use Appwrite\InputFile;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -16,5 +17,5 @@ $result = $storage->createFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: InputFile::withPath('file.png'),
-    permissions: Permission.read('any') // optional
+    permissions: Permission::read(Role::any()) // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/create-file.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\InputFile;
+use Appwrite\Permission;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -15,5 +16,5 @@ $result = $storage->createFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: InputFile::withPath('file.png'),
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read('any') // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/update-bucket.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -14,7 +15,7 @@ $storage = new Storage($client);
 $result = $storage->updateBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: Permission.read('any'), // optional
+    permissions: Permission::read(Role::any()), // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-php/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/update-bucket.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -13,7 +14,7 @@ $storage = new Storage($client);
 $result = $storage->updateBucket(
     bucketId: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read('any'), // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-php/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/update-file.md
@@ -2,6 +2,7 @@
 
 use Appwrite\Client;
 use Appwrite\Permission;
+use Appwrite\Role;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -15,5 +16,5 @@ $result = $storage->updateFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     name: '<NAME>', // optional
-    permissions: Permission.read('any') // optional
+    permissions: Permission::read(Role::any()) // optional
 );

--- a/docs/examples/1.5.x/server-php/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-php/examples/storage/update-file.md
@@ -1,6 +1,7 @@
 <?php
 
 use Appwrite\Client;
+use Appwrite\Permission;
 use Appwrite\Services\Storage;
 
 $client = (new Client())
@@ -14,5 +15,5 @@ $result = $storage->updateFile(
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     name: '<NAME>', // optional
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read('any') // optional
 );

--- a/docs/examples/1.5.x/server-python/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/create-collection.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -11,7 +12,7 @@ result = databases.create_collection(
     database_id = '<DATABASE_ID>',
     collection_id = '<COLLECTION_ID>',
     name = '<NAME>',
-    permissions = ["read("any")"], # optional
+    permissions = Permission.read('any'), # optional
     document_security = False, # optional
     enabled = False # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/create-collection.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -12,7 +13,7 @@ result = databases.create_collection(
     database_id = '<DATABASE_ID>',
     collection_id = '<COLLECTION_ID>',
     name = '<NAME>',
-    permissions = Permission.read('any'), # optional
+    permissions = [Permission.read(Role.any())], # optional
     document_security = False, # optional
     enabled = False # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/create-document.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -13,5 +14,5 @@ result = databases.create_document(
     collection_id = '<COLLECTION_ID>',
     document_id = '<DOCUMENT_ID>',
     data = {},
-    permissions = [Permission.read('any')] # optional
+    permissions = [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/create-document.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -12,5 +13,5 @@ result = databases.create_document(
     collection_id = '<COLLECTION_ID>',
     document_id = '<DOCUMENT_ID>',
     data = {},
-    permissions = ["read("any")"] # optional
+    permissions = [Permission.read('any')] # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/update-collection.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -12,7 +13,7 @@ result = databases.update_collection(
     database_id = '<DATABASE_ID>',
     collection_id = '<COLLECTION_ID>',
     name = '<NAME>',
-    permissions = Permission.read('any'), # optional
+    permissions = [Permission.read(Role.any())], # optional
     document_security = False, # optional
     enabled = False # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/update-collection.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -11,7 +12,7 @@ result = databases.update_collection(
     database_id = '<DATABASE_ID>',
     collection_id = '<COLLECTION_ID>',
     name = '<NAME>',
-    permissions = ["read("any")"], # optional
+    permissions = Permission.read('any'), # optional
     document_security = False, # optional
     enabled = False # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/update-document.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -13,5 +14,5 @@ result = databases.update_document(
     collection_id = '<COLLECTION_ID>',
     document_id = '<DOCUMENT_ID>',
     data = {}, # optional
-    permissions = Permission.read('any') # optional
+    permissions = [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-python/examples/databases/update-document.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -12,5 +13,5 @@ result = databases.update_document(
     collection_id = '<COLLECTION_ID>',
     document_id = '<DOCUMENT_ID>',
     data = {}, # optional
-    permissions = ["read("any")"] # optional
+    permissions = Permission.read('any') # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/create-bucket.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -10,7 +11,7 @@ storage = Storage(client)
 result = storage.create_bucket(
     bucket_id = '<BUCKET_ID>',
     name = '<NAME>',
-    permissions = ["read("any")"], # optional
+    permissions = Permission.read('any'), # optional
     file_security = False, # optional
     enabled = False, # optional
     maximum_file_size = 1, # optional

--- a/docs/examples/1.5.x/server-python/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/create-bucket.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -11,7 +12,7 @@ storage = Storage(client)
 result = storage.create_bucket(
     bucket_id = '<BUCKET_ID>',
     name = '<NAME>',
-    permissions = Permission.read('any'), # optional
+    permissions = [Permission.read(Role.any())], # optional
     file_security = False, # optional
     enabled = False, # optional
     maximum_file_size = 1, # optional

--- a/docs/examples/1.5.x/server-python/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/create-file.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.input_file import InputFile
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -12,5 +13,5 @@ result = storage.create_file(
     bucket_id = '<BUCKET_ID>',
     file_id = '<FILE_ID>',
     file = InputFile.from_path('file.png'),
-    permissions = ["read("any")"] # optional
+    permissions = Permission.read('any') # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/create-file.md
@@ -1,6 +1,7 @@
 from appwrite.client import Client
 from appwrite.input_file import InputFile
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -13,5 +14,5 @@ result = storage.create_file(
     bucket_id = '<BUCKET_ID>',
     file_id = '<FILE_ID>',
     file = InputFile.from_path('file.png'),
-    permissions = Permission.read('any') # optional
+    permissions = [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/update-bucket.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -11,7 +12,7 @@ storage = Storage(client)
 result = storage.update_bucket(
     bucket_id = '<BUCKET_ID>',
     name = '<NAME>',
-    permissions = Permission.read('any'), # optional
+    permissions = [Permission.read(Role.any())], # optional
     file_security = False, # optional
     enabled = False, # optional
     maximum_file_size = 1, # optional

--- a/docs/examples/1.5.x/server-python/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/update-bucket.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -10,7 +11,7 @@ storage = Storage(client)
 result = storage.update_bucket(
     bucket_id = '<BUCKET_ID>',
     name = '<NAME>',
-    permissions = ["read("any")"], # optional
+    permissions = Permission.read('any'), # optional
     file_security = False, # optional
     enabled = False, # optional
     maximum_file_size = 1, # optional

--- a/docs/examples/1.5.x/server-python/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/update-file.md
@@ -1,4 +1,5 @@
 from appwrite.client import Client
+from appwrite.permission import Permission
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -11,5 +12,5 @@ result = storage.update_file(
     bucket_id = '<BUCKET_ID>',
     file_id = '<FILE_ID>',
     name = '<NAME>', # optional
-    permissions = ["read("any")"] # optional
+    permissions = Permission.read('any') # optional
 )

--- a/docs/examples/1.5.x/server-python/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-python/examples/storage/update-file.md
@@ -1,5 +1,6 @@
 from appwrite.client import Client
 from appwrite.permission import Permission
+from appwrite.role import Role
 
 client = Client()
 client.set_endpoint('https://cloud.appwrite.io/v1') # Your API Endpoint
@@ -12,5 +13,5 @@ result = storage.update_file(
     bucket_id = '<BUCKET_ID>',
     file_id = '<FILE_ID>',
     name = '<NAME>', # optional
-    permissions = Permission.read('any') # optional
+    permissions = [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/create-collection.md
@@ -13,7 +13,7 @@ result = databases.create_collection(
     database_id: '<DATABASE_ID>',
     collection_id: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: Permissions.read(Role.any()), # optional
+    permissions: [Permission.read(Role.any())], # optional
     document_security: false, # optional
     enabled: false # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/create-collection.md
@@ -13,7 +13,7 @@ result = databases.create_collection(
     database_id: '<DATABASE_ID>',
     collection_id: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], # optional
+    permissions: Permissions.read(Role.any()), # optional
     document_security: false, # optional
     enabled: false # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/create-document.md
@@ -14,5 +14,5 @@ result = databases.create_document(
     collection_id: '<COLLECTION_ID>',
     document_id: '<DOCUMENT_ID>',
     data: {},
-    permissions: ["read("any")"] # optional
+    permissions: Permissions.read(Role.any()) # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/create-document.md
@@ -14,5 +14,5 @@ result = databases.create_document(
     collection_id: '<COLLECTION_ID>',
     document_id: '<DOCUMENT_ID>',
     data: {},
-    permissions: Permissions.read(Role.any()) # optional
+    permissions: [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/update-collection.md
@@ -13,7 +13,7 @@ result = databases.update_collection(
     database_id: '<DATABASE_ID>',
     collection_id: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], # optional
+    permissions: Permissions.read(Role.any()), # optional
     document_security: false, # optional
     enabled: false # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/update-collection.md
@@ -13,7 +13,7 @@ result = databases.update_collection(
     database_id: '<DATABASE_ID>',
     collection_id: '<COLLECTION_ID>',
     name: '<NAME>',
-    permissions: Permissions.read(Role.any()), # optional
+    permissions: [Permission.read(Role.any())], # optional
     document_security: false, # optional
     enabled: false # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/update-document.md
@@ -14,5 +14,5 @@ result = databases.update_document(
     collection_id: '<COLLECTION_ID>',
     document_id: '<DOCUMENT_ID>',
     data: {}, # optional
-    permissions: Permissions.read(Role.any()) # optional
+    permissions: [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-ruby/examples/databases/update-document.md
@@ -14,5 +14,5 @@ result = databases.update_document(
     collection_id: '<COLLECTION_ID>',
     document_id: '<DOCUMENT_ID>',
     data: {}, # optional
-    permissions: ["read("any")"] # optional
+    permissions: Permissions.read(Role.any()) # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/create-bucket.md
@@ -12,7 +12,7 @@ storage = Storage.new(client)
 result = storage.create_bucket(
     bucket_id: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], # optional
+    permissions: Permissions.read(Role.any()), # optional
     file_security: false, # optional
     enabled: false, # optional
     maximum_file_size: 1, # optional

--- a/docs/examples/1.5.x/server-ruby/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/create-bucket.md
@@ -12,7 +12,7 @@ storage = Storage.new(client)
 result = storage.create_bucket(
     bucket_id: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: Permissions.read(Role.any()), # optional
+    permissions: [Permission.read(Role.any())], # optional
     file_security: false, # optional
     enabled: false, # optional
     maximum_file_size: 1, # optional

--- a/docs/examples/1.5.x/server-ruby/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/create-file.md
@@ -13,5 +13,5 @@ result = storage.create_file(
     bucket_id: '<BUCKET_ID>',
     file_id: '<FILE_ID>',
     file: InputFile.from_path('dir/file.png'),
-    permissions: ["read("any")"] # optional
+    permissions: Permissions.read(Role.any()) # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/create-file.md
@@ -13,5 +13,5 @@ result = storage.create_file(
     bucket_id: '<BUCKET_ID>',
     file_id: '<FILE_ID>',
     file: InputFile.from_path('dir/file.png'),
-    permissions: Permissions.read(Role.any()) # optional
+    permissions: [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/update-bucket.md
@@ -12,7 +12,7 @@ storage = Storage.new(client)
 result = storage.update_bucket(
     bucket_id: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: ["read("any")"], # optional
+    permissions: Permissions.read(Role.any()), # optional
     file_security: false, # optional
     enabled: false, # optional
     maximum_file_size: 1, # optional

--- a/docs/examples/1.5.x/server-ruby/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/update-bucket.md
@@ -12,7 +12,7 @@ storage = Storage.new(client)
 result = storage.update_bucket(
     bucket_id: '<BUCKET_ID>',
     name: '<NAME>',
-    permissions: Permissions.read(Role.any()), # optional
+    permissions: [Permission.read(Role.any())], # optional
     file_security: false, # optional
     enabled: false, # optional
     maximum_file_size: 1, # optional

--- a/docs/examples/1.5.x/server-ruby/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/update-file.md
@@ -13,5 +13,5 @@ result = storage.update_file(
     bucket_id: '<BUCKET_ID>',
     file_id: '<FILE_ID>',
     name: '<NAME>', # optional
-    permissions: Permissions.read(Role.any()) # optional
+    permissions: [Permission.read(Role.any())] # optional
 )

--- a/docs/examples/1.5.x/server-ruby/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-ruby/examples/storage/update-file.md
@@ -13,5 +13,5 @@ result = storage.update_file(
     bucket_id: '<BUCKET_ID>',
     file_id: '<FILE_ID>',
     name: '<NAME>', # optional
-    permissions: ["read("any")"] # optional
+    permissions: Permissions.read(Role.any()) # optional
 )

--- a/docs/examples/1.5.x/server-swift/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/create-collection.md
@@ -11,7 +11,7 @@ let collection = try await databases.createCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: Permission.read(Role.any()), // optional
+    permissions: [Permission.read(Role.any())], // optional
     documentSecurity: false, // optional
     enabled: false // optional
 )

--- a/docs/examples/1.5.x/server-swift/examples/databases/create-collection.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/create-collection.md
@@ -11,7 +11,7 @@ let collection = try await databases.createCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read(Role.any()), // optional
     documentSecurity: false, // optional
     enabled: false // optional
 )

--- a/docs/examples/1.5.x/server-swift/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/create-document.md
@@ -12,6 +12,6 @@ let document = try await databases.createDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:],
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read(Role.any()) // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/databases/create-document.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/create-document.md
@@ -12,6 +12,6 @@ let document = try await databases.createDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:],
-    permissions: Permission.read(Role.any()) // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/databases/update-collection.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/update-collection.md
@@ -11,7 +11,7 @@ let collection = try await databases.updateCollection(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read(Role.any()), // optional
     documentSecurity: false, // optional
     enabled: false // optional
 )

--- a/docs/examples/1.5.x/server-swift/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/update-document.md
@@ -12,6 +12,6 @@ let document = try await databases.updateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:], // optional
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read(Role.any()) // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/databases/update-document.md
+++ b/docs/examples/1.5.x/server-swift/examples/databases/update-document.md
@@ -12,6 +12,6 @@ let document = try await databases.updateDocument(
     collectionId: "<COLLECTION_ID>",
     documentId: "<DOCUMENT_ID>",
     data: [:], // optional
-    permissions: Permission.read(Role.any()) // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/create-bucket.md
@@ -11,7 +11,7 @@ let storage = Storage(client)
 let bucket = try await storage.createBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read(Role.any()), // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-swift/examples/storage/create-bucket.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/create-bucket.md
@@ -11,7 +11,7 @@ let storage = Storage(client)
 let bucket = try await storage.createBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: Permission.read(Role.any()), // optional
+    permissions: [Permission.read(Role.any())], // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-swift/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/create-file.md
@@ -11,6 +11,6 @@ let file = try await storage.createFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     file: InputFile.fromPath("file.png"),
-    permissions: Permission.read(Role.any()) // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/storage/create-file.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/create-file.md
@@ -11,6 +11,6 @@ let file = try await storage.createFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     file: InputFile.fromPath("file.png"),
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read(Role.any()) // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/update-bucket.md
@@ -11,7 +11,7 @@ let storage = Storage(client)
 let bucket = try await storage.updateBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: Permission.read(Role.any()), // optional
+    permissions: [Permission.read(Role.any())], // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-swift/examples/storage/update-bucket.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/update-bucket.md
@@ -11,7 +11,7 @@ let storage = Storage(client)
 let bucket = try await storage.updateBucket(
     bucketId: "<BUCKET_ID>",
     name: "<NAME>",
-    permissions: ["read("any")"], // optional
+    permissions: Permission.read(Role.any()), // optional
     fileSecurity: false, // optional
     enabled: false, // optional
     maximumFileSize: 1, // optional

--- a/docs/examples/1.5.x/server-swift/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/update-file.md
@@ -11,6 +11,6 @@ let file = try await storage.updateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     name: "<NAME>", // optional
-    permissions: Permission.read(Role.any()) // optional
+    permissions: [Permission.read(Role.any())] // optional
 )
 

--- a/docs/examples/1.5.x/server-swift/examples/storage/update-file.md
+++ b/docs/examples/1.5.x/server-swift/examples/storage/update-file.md
@@ -11,6 +11,6 @@ let file = try await storage.updateFile(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
     name: "<NAME>", // optional
-    permissions: ["read("any")"] // optional
+    permissions: Permission.read(Role.any()) // optional
 )
 


### PR DESCRIPTION
## What does this PR do?

- Replace `["read("any")"]` with `Permission.read(Role.any())`
- Add imports whenever necessary for different runtimes
- Update `console.log(response)` for `console.log(result)` for accuracy

## Test Plan

Manually used code snippets for each runtime to ensure accuracy of imports and permission parameters

## Related PRs and Issues

X

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [X] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
