### PR TITLE
Fix: function redeployments

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -1459,7 +1459,8 @@ App::post('/v1/functions/:functionId/deployments/:deploymentId/build')
     ->inject('project')
     ->inject('queueForEvents')
     ->inject('queueForBuilds')
-    ->action(function (string $functionId, string $deploymentId, string $buildId, Request $request, Response $response, Database $dbForProject, Document $project, Event $queueForEvents, Build $queueForBuilds) {
+    ->inject('deviceForFunctions')
+    ->action(function (string $functionId, string $deploymentId, string $buildId, Request $request, Response $response, Database $dbForProject, Document $project, Event $queueForEvents, Build $queueForBuilds, Device $deviceForFunctions) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
         if ($function->isEmpty()) {
@@ -1471,13 +1472,23 @@ App::post('/v1/functions/:functionId/deployments/:deploymentId/build')
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
+        $path = $deployment->getAttribute('path');
+        if(empty($path) || !$deviceForFunctions->exists($path)) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
         $deploymentId = ID::unique();
+
+        $destination = $deviceForFunctions->getPath($deploymentId . '.' . \pathinfo('code.tar.gz', PATHINFO_EXTENSION));
+        $deviceForFunctions->transfer($path, $destination, $deviceForFunctions);
 
         $deployment->removeAttribute('$internalId');
         $deployment = $dbForProject->createDocument('deployments', $deployment->setAttributes([
+            '$internalId' => '',
             '$id' => $deploymentId,
             'buildId' => '',
             'buildInternalId' => '',
+            'path' => $destination,
             'entrypoint' => $function->getAttribute('entrypoint'),
             'commands' => $function->getAttribute('commands', ''),
             'search' => implode(' ', [$deploymentId, $function->getAttribute('entrypoint')]),

--- a/src/Appwrite/Platform/Workers/Builds.php
+++ b/src/Appwrite/Platform/Workers/Builds.php
@@ -333,6 +333,7 @@ class Builds extends Action
                 $source = $path;
 
                 $build = $dbForProject->updateDocument('builds', $build->getId(), $build->setAttribute('source', $source));
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), $deployment->setAttribute('path', $source));
 
                 $this->runGitAction('processing', $github, $providerCommitHash, $owner, $repositoryName, $project, $function, $deployment->getId(), $dbForProject, $dbForConsole);
             }


### PR DESCRIPTION
## What does this PR do?

Fixes following flows:

1. Create deployment A -> redeploy (B) -> delete A -> redeploy B (fails, no file found in build logs)
2. Create deployment A -> redeploy (B) -> delete A -> redeploy B -> delete B (server error, cannot delete file)
3. Push to git (deployment A) -> download A (fails, deployment not found)

## Test Plan

- [x] Manual QA

![CleanShot 2024-07-25 at 10 38 14@2x](https://github.com/user-attachments/assets/b4e07438-81f2-47aa-8086-6c904076dbaa)

![CleanShot 2024-07-25 at 10 38 37@2x](https://github.com/user-attachments/assets/c677e5c2-543c-46ae-bfb6-8ede5ff0a16c)


## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
