### PR TITLE
Fix create.md

### DIFF
--- a/docs/examples/1.5.x/client-web/examples/account/create.md
+++ b/docs/examples/1.5.x/client-web/examples/account/create.md
@@ -13,4 +13,4 @@ const result = await account.create(
     '<NAME>' // name (optional)
 );
 
-console.log(response);
+console.log(result);


### PR DESCRIPTION
logging the actual API return res rather than an undefined variable. Note that this error is present all around the other exemples.
