### PR TITLE
Bump executor version from 0.5.5 to 0.5.7

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -753,7 +753,7 @@ $image = $this->getParam('image', '');
     <<: *x-logging
     restart: unless-stopped
     stop_signal: SIGINT
-    image: openruntimes/executor:0.5.5
+    image: openruntimes/executor:0.5.7
     networks:
       - appwrite
       - runtimes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -833,7 +833,7 @@ services:
     hostname: exc1
     <<: *x-logging
     stop_signal: SIGINT
-    image: openruntimes/executor:0.5.5
+    image: openruntimes/executor:0.5.7
     restart: unless-stopped
     networks:
       - appwrite


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

One thing this update fixes are warnings like:

```
Warning: Undefined array key "listening" in /usr/local/app/http.php on line 1023
Warning: fsockopen(): Unable to connect to 66aeafc1c683e:3000 (Connection refused) in /usr/local/src/Executor/Validator/TCP.php on line 45
```

See [0.5.6](https://github.com/open-runtimes/executor/releases/tag/0.5.6) and [0.5.7](https://github.com/open-runtimes/executor/releases/tag/0.5.7) for changes.

## Test Plan

CI should pass

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
