### PR TITLE
Fix migration stuck at "Starting Data Migration [...]"

### DIFF
--- a/src/Appwrite/Platform/Tasks/Migrate.php
+++ b/src/Appwrite/Platform/Tasks/Migrate.php
@@ -43,8 +43,8 @@ class Migrate extends Action
     private function clearProjectsCache(Document $project)
     {
         try {
+            $iterator = null;
             do {
-                $iterator = null;
                 $pattern = "default-cache-_{$project->getInternalId()}:*";
                 $keys = $this->redis->scan($iterator, $pattern, 1000);
                 if ($keys !== false) {


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The iterator was in the loop so it was always reset to null and the same data set to be scanned.

For cases where this happened, the iterator was not empty, but the keys returned from the scan was empty. According to [redis](https://redis.io/docs/latest/commands/scan/#number-of-elements-returned-at-every-scan-call), this is expected behavior.

> SCAN family functions do not guarantee that the number of elements returned per call are in a given range. The commands are also allowed to return zero elements, and the client should not consider the iteration complete as long as the returned cursor is not zero.

As such, we must make sure we're using the new iterator returned to continue scanning the keys.

Fixes https://github.com/appwrite/appwrite/issues/8518

## Test Plan

Manually tested:

<img width="633" alt="image" src="https://github.com/user-attachments/assets/25359dad-f548-433d-9854-bc7ff26bb0c5">

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/8518

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
