### PR TITLE
Fix: Templates CORS

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -2407,6 +2407,7 @@ App::delete('/v1/functions/:functionId/variables/:variableId')
     });
 
 App::get('/v1/functions/templates')
+    ->groups(['api'])
     ->desc('List function templates')
     ->label('scope', 'public')
     ->label('sdk.namespace', 'functions')


### PR DESCRIPTION
## What does this PR do?

Adds templates endpoint to API group, giving proper CORS response headers

## Test Plan

- [x] Manual QA with preview server

Before:
![CleanShot 2024-08-13 at 15 00 32@2x](https://github.com/user-attachments/assets/886a5513-bbdd-41c2-8e9d-bb94322b2c1d)

After:

![CleanShot 2024-08-13 at 15 05 27@2x](https://github.com/user-attachments/assets/84b1b1de-c3fd-4b37-98b0-861343fa802b)



## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
