### PR TITLE
Update size to specification for variable runtimes

### DIFF
--- a/src/Appwrite/Migration/Version/V21.php
+++ b/src/Appwrite/Migration/Version/V21.php
@@ -92,11 +92,11 @@ class V21 extends Migration
                         Console::warning("'scopes' from {$id}: {$th->getMessage()}");
                     }
 
-                    // Create size attribute
+                    // Create specification attribute
                     try {
-                        $this->createAttributeFromCollection($this->projectDB, $id, 'size');
+                        $this->createAttributeFromCollection($this->projectDB, $id, 'specification');
                     } catch (Throwable $th) {
-                        Console::warning("'size' from {$id}: {$th->getMessage()}");
+                        Console::warning("'specification' from {$id}: {$th->getMessage()}");
                     }
 
                     break;
@@ -177,7 +177,7 @@ class V21 extends Migration
                 $document->setAttribute('scopes', []);
 
                 // Add size attribute
-                $document->setAttribute('size', 's-1vcpu-512m');
+                $document->setAttribute('specification', APP_FUNCTION_BASE_SPECIFICATION);
         }
 
         return $document;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Rename the `size` attribute migration for variable runtimes to `specification` this PR uses the default from the const `APP_FUNCTION_BASE_SPECIFICATION` and needs variable runtimes to be first merged into 1.5.x and for that to be synced with 1.6.x

## Related PRs and Issues

- #8384 

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
