### PR TITLE
Update console redirect to include query params

### DIFF
--- a/app/controllers/web/console.php
+++ b/app/controllers/web/console.php
@@ -32,8 +32,9 @@ App::get('/')
     ->action(function (Request $request, Response $response) {
         $url = parse_url($request->getURI());
         $target = "/console{$url['path']}";
-        if ($url['query'] ?? false) {
-            $target .= "?{$url['query']}";
+        $params = $request->getParams();
+        if (!empty($params)) {
+            $target .= "?" . \http_build_query($params);
         }
         if ($url['fragment'] ?? false) {
             $target .= "#{$url['fragment']}";

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -216,4 +216,17 @@ class HTTPTest extends Scope
 
         $this->assertEquals('http://localhost', $response['headers']['access-control-allow-origin']);
     }
+
+    public function testConsoleRedirect()
+    {
+        /**
+         * Test for SUCCESS
+         */
+
+        $endpoint = '/invite?membershipId=123&userId=asdf';
+
+        $response = $this->client->call(Client::METHOD_GET, $endpoint);
+
+        $this->assertEquals('/console' . $endpoint, $response['headers']['location']);
+    }
 }


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Use `$request->getParams()` because `$request->getURI()` does not include the query string.

## Test Plan

Added test case

## Related PRs and Issues

- https://github.com/appwrite/console/pull/1332

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
