### PR TITLE
Fix: vcs deployment size

### DIFF
--- a/src/Appwrite/Platform/Workers/Builds.php
+++ b/src/Appwrite/Platform/Workers/Builds.php
@@ -411,7 +411,9 @@ class Builds extends Action
                 Console::execute('rm -rf ' . \escapeshellarg($tmpPath), '', $stdout, $stderr);
 
                 $build = $dbForProject->updateDocument('builds', $build->getId(), $build->setAttribute('source', $source));
-                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), $deployment->setAttribute('path', $source));
+
+                $directorySize = $deviceForFunctions->getFileSize($source);
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), $deployment->setAttribute('path', $source)->setAttribute('size', $directorySize));
 
                 $this->runGitAction('processing', $github, $providerCommitHash, $owner, $repositoryName, $project, $function, $deployment->getId(), $dbForProject, $dbForConsole);
             }


### PR DESCRIPTION
## What does this PR do?

Ensures size doesn't say 0 for deployments made with VCS.

## Test Plan

- [x] Manual QA

![CleanShot 2024-09-07 at 19 08 27@2x](https://github.com/user-attachments/assets/d7d08c2f-68ec-4030-83a7-ac409c466fa2)


## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
