### PR TITLE
Fix: cross-project scheduler stability

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -74,6 +74,7 @@ abstract class ScheduleBase extends Action
             );
 
             return [
+                '$internalId' => $schedule->getInternalId(),
                 '$id' => $schedule->getId(),
                 'resourceId' => $schedule->getAttribute('resourceId'),
                 'schedule' => $schedule->getAttribute('schedule'),
@@ -110,7 +111,7 @@ abstract class ScheduleBase extends Action
 
             foreach ($results as $document) {
                 try {
-                    $this->schedules[$document['resourceId']] = $getSchedule($document);
+                    $this->schedules[$document->getInternalId()] = $getSchedule($document);
                 } catch (\Throwable $th) {
                     $collectionId = match ($document->getAttribute('resourceType')) {
                         'function' => 'functions',
@@ -172,10 +173,10 @@ abstract class ScheduleBase extends Action
 
                         if (!$document['active']) {
                             Console::info("Removing: {$document['resourceId']}");
-                            unset($this->schedules[$document['resourceId']]);
+                            unset($this->schedules[$document->getInternalId()]);
                         } elseif ($new !== $org) {
                             Console::info("Updating: {$document['resourceId']}");
-                            $this->schedules[$document['resourceId']] = $getSchedule($document);
+                            $this->schedules[$document->getInternalId()] = $getSchedule($document);
                         }
                     }
 

--- a/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
@@ -36,7 +36,7 @@ class ScheduleExecutions extends ScheduleBase
                     $schedule['$id'],
                 );
 
-                unset($this->schedules[$schedule['resourceId']]);
+                unset($this->schedules[$schedule['$internalId']]);
                 continue;
             }
 
@@ -70,7 +70,7 @@ class ScheduleExecutions extends ScheduleBase
                 $schedule['$id'],
             );
 
-            unset($this->schedules[$schedule['resourceId']]);
+            unset($this->schedules[$schedule['$internalId']]);
         }
 
         $queue->reclaim();

--- a/src/Appwrite/Platform/Tasks/ScheduleMessages.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleMessages.php
@@ -53,7 +53,7 @@ class ScheduleMessages extends ScheduleBase
 
                 $queue->reclaim();
 
-                unset($this->schedules[$schedule['resourceId']]);
+                unset($this->schedules[$schedule['$internalId']]);
             });
         }
     }


### PR DESCRIPTION

## What does this PR do?

Uses schedule doc internal ID as in-memory key of scheduler. This prevent issues with same resource ID across different projects.

## Test Plan

No new tests; existing tests must pass

- [x] Manual QA; 2 projects (different IDs), 1 function in each (same function ID); scheduler every minute

Project `66dc8ecf00208a16edb8`, function `66dc8ebb001477bdfcf0`:
![CleanShot 2024-09-07 at 19 40 05@2x](https://github.com/user-attachments/assets/7e807246-11c1-4116-8871-12caaf16dbf1)


Project `66dc8eb30013a1a2f5e8`, function `66dc8ebb001477bdfcf0`:


![CleanShot 2024-09-07 at 19 40 12@2x](https://github.com/user-attachments/assets/7b346447-f588-40ec-ab2a-5370b498c5af)


^ Notice both have executions every minute, so scheduler works as expected for this scehario.

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/8583

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
