### PR TITLE
fix: add retention env vars to deletes worker

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -318,6 +318,9 @@ $image = $this->getParam('image', '');
       - _APP_LOGGING_CONFIG
       - _APP_EXECUTOR_SECRET
       - _APP_EXECUTOR_HOST
+      - _APP_MAINTENANCE_RETENTION_ABUSE
+      - _APP_MAINTENANCE_RETENTION_AUDIT
+      - _APP_MAINTENANCE_RETENTION_EXECUTION
 
   appwrite-worker-databases:
     image: <?php echo $organization; ?>/<?php echo $image; ?>:<?php echo $version."\n"; ?>


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The resources are injected in the deletes worker so the env vars need to be passed to the container.

## Test Plan

Manually worked with a user to update their docker-compose.yml file

## Related PRs and Issues

* https://github.com/appwrite/appwrite/pull/8662

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
