### PR TITLE
Fix messaging metrics

### DIFF
--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -287,18 +287,18 @@ class Messaging extends Action
                         } catch (\Throwable $e) {
                             $deliveryErrors[] = 'Failed sending to targets with error: ' . $e->getMessage();
                         } finally {
-
+                            $errorTotal = count($deliveryErrors);
                             $queueForUsage
                                 ->setProject($project)
-                                ->addMetric(METRIC_MESSAGES, ($deliveredTotal + $deliveryErrors))
+                                ->addMetric(METRIC_MESSAGES, ($deliveredTotal + $errorTotal))
                                 ->addMetric(METRIC_MESSAGES_SENT, $deliveredTotal)
-                                ->addMetric(METRIC_MESSAGES_FAILED, $deliveryErrors)
-                                ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE), ($deliveredTotal + $deliveryErrors))
+                                ->addMetric(METRIC_MESSAGES_FAILED, $errorTotal)
+                                ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE), ($deliveredTotal + $errorTotal))
                                 ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE_SENT), $deliveredTotal)
-                                ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE_FAILED), $deliveryErrors)
-                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER), ($deliveredTotal + $deliveryErrors))
+                                ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE_FAILED), $errorTotal)
+                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER), ($deliveredTotal + $errorTotal))
                                 ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER_SENT), $deliveredTotal)
-                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER_FAILED), $deliveryErrors)
+                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER_FAILED), $errorTotal)
                                 ->trigger();
 
                             return [

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -296,9 +296,9 @@ class Messaging extends Action
                                 ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE), ($deliveredTotal + $errorTotal))
                                 ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE_SENT), $deliveredTotal)
                                 ->addMetric(str_replace('{type}', $provider->getAttribute('type'), METRIC_MESSAGES_TYPE_FAILED), $errorTotal)
-                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER), ($deliveredTotal + $errorTotal))
-                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER_SENT), $deliveredTotal)
-                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $this->getSmsAdapter($provider)], METRIC_MESSAGES_TYPE_PROVIDER_FAILED), $errorTotal)
+                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $provider->getAttribute('provider')], METRIC_MESSAGES_TYPE_PROVIDER), ($deliveredTotal + $errorTotal))
+                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $provider->getAttribute('provider')], METRIC_MESSAGES_TYPE_PROVIDER_SENT), $deliveredTotal)
+                                ->addMetric(str_replace(['{type}', '{provider}'], [$provider->getAttribute('type'), $provider->getAttribute('provider')], METRIC_MESSAGES_TYPE_PROVIDER_FAILED), $errorTotal)
                                 ->trigger();
 
                             return [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because `$deliveryErrors` is an array, adding an int to it here:

https://github.com/appwrite/appwrite/blob/154993dafd175032121857b71c5e7bfce2de293a/src/Appwrite/Platform/Workers/Messaging.php#L293

results in a fatal error:

![image](https://github.com/user-attachments/assets/e72a82fb-0a5e-457c-b992-48caaeec6b1f)

We need to get a count before using it in metrics.

In addition, this PR ensure the Messaging provider is set in the metric rather than having:

```
+-----+----------------------------------+-------------------------+-------------------------+--------------+-----------------------------+---------+--------+-------------------------+--------+
| _id | _uid                             | _createdAt              | _updatedAt              | _permissions | metric                      | region  | value  | time                    | period |
+-----+----------------------------------+-------------------------+-------------------------+--------------+-----------------------------+---------+--------+-------------------------+--------+
|  40 | 743a569db21234b4d6a5d99d1a4569bf | 2024-09-17 19:10:35.878 | 2024-09-17 19:10:35.878 | []           | messages.email.             | default |      1 | 2024-09-17 19:00:00.000 | 1h     |
|  41 | dc1b97c8c61a35583838b5cf7f5b6507 | 2024-09-17 19:10:35.880 | 2024-09-17 19:10:35.880 | []           | messages.email.             | default |      1 | 2024-09-17 00:00:00.000 | 1d     |
|  42 | 2e76cb7a791f2a551c4d914e6c1d18d7 | 2024-09-17 19:10:35.882 | 2024-09-17 19:10:35.882 | []           | messages.email.             | default |      1 | NULL                    | inf    |
|  43 | 1baad8294fb1bcf8c15770575c2a5028 | 2024-09-17 19:10:35.885 | 2024-09-17 19:10:35.885 | []           | messages.email..sent        | default |      1 | 2024-09-17 19:00:00.000 | 1h     |
|  44 | 8105546c780aa595f837f84ce68a2ed8 | 2024-09-17 19:10:35.887 | 2024-09-17 19:10:35.887 | []           | messages.email..sent        | default |      1 | 2024-09-17 00:00:00.000 | 1d     |
|  45 | 59365e4664102fdb1347e523c4516c75 | 2024-09-17 19:10:35.889 | 2024-09-17 19:10:35.889 | []           | messages.email..sent        | default |      1 | NULL                    | inf    |
```

## Test Plan

Manually tested locally and I was able to successfully send a message:

![image](https://github.com/user-attachments/assets/cf1db549-dcf5-482a-b1f6-3c79bc37b2e1)

Logs also don't show any error:

<img width="788" alt="image" src="https://github.com/user-attachments/assets/57469714-0e70-4273-912d-2fed8faaf8aa">

and stats are populating:

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/bfa31843-bd04-44ba-9366-f52208105ae8">

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
