### PR TITLE
Fix missing question for _APP_EMAIL_CERTIFICATES during install

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -193,7 +193,7 @@ return [
                 'introduction' => '1.5.1',
                 'default' => '',
                 'required' => true,
-                'question' => '',
+                'question' => 'Enter an email that will be used when registering for SSL certificates',
                 'filter' => ''
             ],
             [


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because the variable is required and there is no default, the user is prompted to supply a value, but because there is no question set, all they see is:

<img width="812" alt="image" src="https://github.com/user-attachments/assets/f8cd519a-5a51-4293-82dd-54ff8dc9014d">

## Test Plan

Manually tested:

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/246510e3-462d-4d06-ab1b-8d6a4674b7c7">


## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
