### PR TITLE
Replace sleep with await method in functions

### DIFF
--- a/tests/e2e/Services/Functions/FunctionsBase.php
+++ b/tests/e2e/Services/Functions/FunctionsBase.php
@@ -40,6 +40,32 @@ trait FunctionsBase
         }
     }
 
+    protected function awaitExecutionIsComplete($functionId, $executionId): void
+    {
+        while (true) {
+            $execution = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+
+            var_dump($execution['body']);
+
+            if (
+                $execution['headers']['status-code'] >= 400
+                || \in_array($execution['body']['status'], ['completed', 'failed'])
+            ) {
+                break;
+            }
+
+            \sleep(1);
+        }
+
+        // assert that execution status is completed or failed
+        $this->assertEquals(200, $execution['headers']['status-code']);
+        $this->assertContains($execution['body']['status'], ['completed', 'failed'], \json_encode($execution['body']));
+    }
+
     // /**
     //  * @depends testCreateTeam
     //  */

--- a/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomClientTest.php
@@ -458,7 +458,7 @@ class FunctionsCustomClientTest extends Scope
 
         $executionId = $execution['body']['$id'] ?? '';
 
-        sleep(5);
+        $this->awaitExecutionIsComplete($functionId, $executionId);
 
         $execution = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, [
             'content-type' => 'application/json',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Replace `sleep` in tests with while(true) loops so that we only sleep until execution or deployment is complete.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
