### PR TITLE
Ignore junction tables

### DIFF
--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -503,7 +503,18 @@ class Deletes extends Action
 
             foreach ($collections as $collection) {
                 if ($dsn->getHost() !== System::getEnv('_APP_DATABASE_SHARED_TABLES', '') || !\in_array($collection->getId(), $projectCollectionIds)) {
-                    $dbForProject->deleteCollection($collection->getId());
+                    try {
+                        $dbForProject->deleteCollection($collection->getId());
+                    } catch (Throwable $e) {
+                        Console::error('Error deleting '.$collection->getId().' '.$e->getMessage());
+
+                        /**
+                         * Ignore junction tables;
+                         */
+                        if (!preg_match('/^_\d+_\d+$/', $collection->getId())) {
+                            throw $e;
+                        }
+                    }
                 } else {
                     $this->deleteByGroup($collection->getId(), [], database: $dbForProject);
                 }


### PR DESCRIPTION
When deleting a project with many2many relations attributes with junctions tables inside _metadata collection.
While iterating _metadata collections which includes junction tables. Trying to delete them will trigger an Exception  Collection not found which will terminate the script leaving orphan collections not deleted and orphan collections inside _metadata.
This happens because if the collection or related collection holding the many2many attribute is deleted, the junction table is also deleted on the fly.