### PR TITLE
Replace expectException with try/catch

### DIFF
--- a/tests/e2e/Services/Realtime/RealtimeBase.php
+++ b/tests/e2e/Services/Realtime/RealtimeBase.php
@@ -49,8 +49,12 @@ trait RealtimeBase
         $this->assertEquals(1008, $payload['data']['code']);
         $this->assertEquals('Missing channels', $payload['data']['message']);
         \usleep(250000); // 250ms
-        $this->expectException(ConnectionException::class); // Check if server disconnnected client
-        $client->close();
+
+        try {
+            $client->close();
+        } catch (ConnectionException $e) {
+            $this->assertInstanceOf(ConnectionException::class, $e); // Check if server disconnected client
+        }
     }
 
     public function testConnectionFailureUnknownProject(): void
@@ -68,7 +72,11 @@ trait RealtimeBase
         $this->assertEquals(1008, $payload['data']['code']);
         $this->assertEquals('Missing or unknown project ID', $payload['data']['message']);
         \usleep(250000); // 250ms
-        $this->expectException(ConnectionException::class); // Check if server disconnnected client
-        $client->close();
+
+        try {
+            $client->close();
+        } catch (ConnectionException $e) {
+            $this->assertInstanceOf(ConnectionException::class, $e); // Check if server disconnected client
+        }
     }
 }

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -228,10 +228,17 @@ class RealtimeCustomClientTest extends Scope
         $this->assertArrayHasKey('data', $payload);
         $this->assertEquals('error', $payload['type']);
         $this->assertEquals(1008, $payload['data']['code']);
-        $this->assertEquals('Invalid Origin. Register your new client (appwrite.unknown) as a new Web platform on your project console dashboard', $payload['data']['message']);
+        $this->assertEquals(
+            'Invalid Origin. Register your new client (appwrite.unknown) as a new Web platform on your project console dashboard',
+            $payload['data']['message']
+        );
         \usleep(250000); // 250ms
-        $this->expectException(ConnectionException::class); // Check if server disconnnected client
-        $client->close();
+
+        try {
+            $client->close();
+        } catch (ConnectionException $e) {
+            $this->assertInstanceOf(ConnectionException::class, $e); // Check if server disconnected client
+        }
     }
 
     public function testChannelAccount()

--- a/tests/unit/Auth/AuthTest.php
+++ b/tests/unit/Auth/AuthTest.php
@@ -173,12 +173,15 @@ class AuthTest extends TestCase
 
     public function testUnknownAlgo()
     {
-        $this->expectExceptionMessage('Hashing algorithm \'md8\' is not supported.');
-
         // Bcrypt - Cost 5
         $plain = 'whatIsMd8?!?';
-        $generatedHash = Auth::passwordHash($plain, 'md8');
-        $this->assertEquals(true, Auth::passwordVerify($plain, $generatedHash, 'md8'));
+
+        try {
+            $generatedHash = Auth::passwordHash($plain, 'md8');
+            $this->assertEquals(true, Auth::passwordVerify($plain, $generatedHash, 'md8'));
+        } catch (\Exception $e) {
+            $this->assertEquals('Hashing algorithm \'md8\' is not supported.', $e->getMessage());
+        }
     }
 
     public function testPasswordGenerator(): void

--- a/tests/unit/Utopia/ResponseTest.php
+++ b/tests/unit/Utopia/ResponseTest.php
@@ -100,11 +100,14 @@ class ResponseTest extends TestCase
 
     public function testResponseModelRequiredException(): void
     {
-        $this->expectException(Exception::class);
-        $this->response->output(new Document([
-            'integer' => 123,
-            'boolean' => true,
-        ]), 'single');
+        try {
+            $this->response->output(new Document([
+                'integer' => 123,
+                'boolean' => true,
+            ]), 'single');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+        }
     }
 
     public function testResponseModelLists(): void


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Replace `expectException` with try-catch so that tests don't pass if behaviour is incorrect.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
