### PR TITLE
Adds state parameter to OAuth2 flow

### DIFF
--- a/src/Appwrite/Auth/Auth.php
+++ b/src/Appwrite/Auth/Auth.php
@@ -181,6 +181,59 @@ class Auth
     }
 
     /**
+     * Generates a state code for dynamic state.
+     *
+     * @param string $success success url
+     * @param string $failure failure url
+     * @param string $secret The secret key
+     *
+     * @return string The base64-encoded state code containing the payload and its signature.
+     */
+    public static function stateGenerator(string $success, string $failure, string $secret)
+    {
+        $payload = [
+            'success' => $success,
+            'failure' => $failure,
+            'time' => time(), // The current time
+        ];
+
+        $payloadString = json_encode($payload);
+        $signature = hash_hmac('sha256', $payloadString, $secret);
+        $code = $payloadString . '--' . $signature;
+
+        // Encode the code
+        $code = base64_encode($code);
+
+        return $code;
+    }
+
+    /**
+     * Verifies string The base64-encoded state for dynamic state
+     *
+     * @param string $code base64-encoded state
+     * @param string $secret secret key
+     *
+     * @return array|false The decoded payload if code is valid, or false if verification fails.
+     */
+    public static function stateVerify(string $code, string $secret)
+    {
+        // Decode the code
+        $code = base64_decode($code);
+
+        list($payloadString, $signature) = explode('--', $code, 2);
+        $expectedSignature = hash_hmac('sha256', $payloadString, $secret);
+
+        if (!hash_equals($expectedSignature, $signature)) {
+            return false;
+        }
+
+        // The code is valid, return the payload
+        $payload = json_decode($payloadString, true);
+
+        return $payload;
+    }
+
+    /**
      * Encode.
      *
      * One-way encryption

--- a/src/Appwrite/Auth/Auth.php
+++ b/src/Appwrite/Auth/Auth.php
@@ -189,11 +189,12 @@ class Auth
      *
      * @return string The base64-encoded state code containing the payload and its signature.
      */
-    public static function stateGenerator(string $success, string $failure, string $secret)
+    public static function stateGenerator(string $success, string $failure, bool $token, string $secret)
     {
         $payload = [
             'success' => $success,
             'failure' => $failure,
+            'token' => $token,
             'time' => time(), // The current time
         ];
 


### PR DESCRIPTION
Currently appwrite OAuth2 implementation do not support the [state parameter](https://auth0.com/docs/secure/attack-protection/state-parameters) to avoid CSRF attacks

## What does this PR do?

The implementation uses `stateGenerator` to generate the state code and `stateVerify` to verify it.

The code is sent in `/v1/account/sessions/oauth2/:provider` endpoint 
and verified in `/v1/account/sessions/oauth2/:provider/redirect`

## Test Plan
Currently there is none test, I'll wait the code review

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/5520

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
