### PR TITLE
update docker image to use the latest image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ The easiest way to start running your Appwrite server is by running our docker-c
 ### Unix
 
 ```bash
-docker run -it --rm \
+docker run -it --rm \               
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$(pwd)"/appwrite:/usr/src/code/appwrite:rw \
     --entrypoint="install" \
-    appwrite/appwrite:1.6.0
+    appwrite/appwrite:latest
 ```
 
 ### Windows
@@ -87,7 +87,7 @@ docker run -it --rm ^
     --volume //var/run/docker.sock:/var/run/docker.sock ^
     --volume "%cd%"/appwrite:/usr/src/code/appwrite:rw ^
     --entrypoint="install" ^
-    appwrite/appwrite:1.6.0
+    appwrite/appwrite:latest
 ```
 
 #### PowerShell
@@ -97,7 +97,7 @@ docker run -it --rm `
     --volume /var/run/docker.sock:/var/run/docker.sock `
     --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw `
     --entrypoint="install" `
-    appwrite/appwrite:1.6.0
+    appwrite/appwrite:latest
 ```
 
 Once the Docker installation is complete, go to http://localhost to access the Appwrite console from your browser. Please note that on non-Linux native hosts, the server might take a few minutes to start after completing the installation.


### PR DESCRIPTION
the docker installation command isn't working (tested on macOS) instead of 1.6.0 I used the latest image tag `appwrite/appwrite:latest` to pull it automatically

