### PR TITLE
📚 Documentation: Deprecation of ${workspaceRoot} in VSCode debug config for XDebug setup. #8814

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -518,7 +518,7 @@ zend_extension=xdebug
   "request": "launch",
   "port": 9005,
   "pathMappings": {
-    "/usr/src/code": "${workspaceRoot}"
+    "/usr/src/code": "${workspaceFolder}"
   }
 }
 ```


### PR DESCRIPTION
## What does this PR do?

This PR updates the documentation to reflect the deprecation of `${workspaceRoot}` in favor of `${workspaceFolder}` in the VSCode debug configuration for XDebug setup. The new recommended configuration is provided to ensure users follow the latest best practices.

### Changes

- Updated the XDebug setup instructions in the documentation to replace `${workspaceRoot}` with the new recommended variable `${workspaceFolder}`.

## Test Plan

- No test plan necessary as no code was changed

## Related PRs and Issues

- Closes #8814

## Checklist

- [ ✅ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
