### PR TITLE
fix: missed function cpu bump

### DIFF
--- a/app/init.php
+++ b/app/init.php
@@ -151,7 +151,7 @@ const APP_SOCIAL_STACKSHARE = 'https://stackshare.io/appwrite';
 const APP_SOCIAL_YOUTUBE = 'https://www.youtube.com/c/appwrite?sub_confirmation=1';
 const APP_HOSTNAME_INTERNAL = 'appwrite';
 const APP_FUNCTION_SPECIFICATION_DEFAULT = Specification::S_1VCPU_512MB;
-const APP_FUNCTION_CPUS_DEFAULT = 0.5;
+const APP_FUNCTION_CPUS_DEFAULT = 1;
 const APP_FUNCTION_MEMORY_DEFAULT = 512;
 const APP_PLATFORM_SERVER = 'server';
 const APP_PLATFORM_CLIENT = 'client';


### PR DESCRIPTION
Specification is fine, but we actually use this APP_FUNCTION_CPUS_DEFAULT as the default value in the create function endpoint, probably because the default specification can't be injected easily.  https://github.com/appwrite/appwrite/blob/fix-missed-function-cpu-bump/app/controllers/api/functions.php#L175