### PR TITLE
fix refreshToken missing in google oauth

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Google.php
+++ b/src/Appwrite/Auth/OAuth2/Google.php
@@ -53,7 +53,9 @@ class Google extends OAuth2
             'redirect_uri' => $this->callback,
             'scope' => \implode(' ', $this->getScopes()),
             'state' => \json_encode($this->state),
-            'response_type' => 'code'
+            'response_type' => 'code',
+            'access_type' => 'offline',
+            'prompt' => 'consent'
         ]);
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Query parameters are missing in google oauth login url , which are needed to get refreshToken from google oauth api
This PR fixes the issue #5987 by adding the necessary query params while building oauth url
(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

- Enable Google OAUTH for your project from appwrite console
- use appwrite web ( or any client side  )  sdk  and make call to account.createOAuth2Session for login
- update session by calling account.updateSession
- You may see providerAccessToken is present in session object which was missing before the fix 

## Related PRs and Issues

- #5987 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
