### PR TITLE
Fix XDebug Extension not being removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,10 +92,10 @@ RUN chmod +x /usr/local/bin/doctor && \
 RUN mkdir -p /etc/letsencrypt/live/ && chmod -Rf 755 /etc/letsencrypt/live/
 
 # Enable Extensions
-RUN if [ "$DEBUG" == "true" ]; then cp /usr/src/code/dev/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini; fi
-RUN if [ "$DEBUG" == "true" ]; then mkdir -p /tmp/xdebug; fi
-RUN if [ "$DEBUG" == "false" ]; then rm -rf /usr/src/code/dev; fi
-RUN if [ "$DEBUG" == "false" ]; then rm -f /usr/local/lib/php/extensions/no-debug-non-zts-20230831/xdebug.so; fi
+RUN if [ "$DEBUG" = "true" ]; then cp /usr/src/code/dev/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini; fi
+RUN if [ "$DEBUG" = "true" ]; then mkdir -p /tmp/xdebug; fi
+RUN if [ "$DEBUG" = "false" ]; then rm -rf /usr/src/code/dev; fi
+RUN if [ "$DEBUG" = "false" ]; then rm -f /usr/local/lib/php/extensions/no-debug-non-zts-20230831/xdebug.so; fi
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ RUN mkdir -p /etc/letsencrypt/live/ && chmod -Rf 755 /etc/letsencrypt/live/
 # Enable Extensions
 RUN if [ "$DEBUG" == "true" ]; then cp /usr/src/code/dev/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini; fi
 RUN if [ "$DEBUG" == "true" ]; then mkdir -p /tmp/xdebug; fi
-RUN if [ "$DEBUG" = "false" ]; then rm -rf /usr/src/code/dev; fi
-RUN if [ "$DEBUG" = "false" ]; then rm -f /usr/local/lib/php/extensions/no-debug-non-zts-20220829/xdebug.so; fi
+RUN if [ "$DEBUG" == "false" ]; then rm -rf /usr/src/code/dev; fi
+RUN if [ "$DEBUG" == "false" ]; then rm -f /usr/local/lib/php/extensions/no-debug-non-zts-20230831/xdebug.so; fi
 
 EXPOSE 80
 


### PR DESCRIPTION
XDebug's Zend API version changed with 8.3 so the xdebug.so file was not being correctly removed. This PR fixes the Zend API folder version.