### PR TITLE
feat: Warn if null or empty key is passed

### DIFF
--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -75,6 +75,10 @@ class Client
      */
     public function setKey(string $value): self
     {
+        if( !isset($value) || $value === '') {
+            Console::warning("Empty or missing secret key.");
+        }
+
         $this->addHeader('X-Appwrite-Key', $value);
 
         return $this;


### PR DESCRIPTION
## What does this PR do?
If Client.setKey is called with a null or empty string, output a warning


## Test Plan

- instantiate a new Client (), and call it's `setKey(string)` method with an empty and/or null parameter
```php
$test = new Client()
$test.setKey(null); //Warning expected
$test.setKey(''); //Warning expected
$test.setKey('<3'); //Warning **NOT** expected
```

## Related PRs and Issues
- #8886

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
