### PR TITLE
Fix: swoole task warning

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -54,6 +54,7 @@ $http
         'http_compression' => false,
         'package_max_length' => $payloadSize,
         'buffer_output_size' => $payloadSize,
+        'task_worker_num' => 1, // required for the task to fetch domains background
     ]);
 
 $http->on(Constant::EVENT_WORKER_START, function ($server, $workerId) {


### PR DESCRIPTION

## What does this PR do?

Leftover bug after syncing with latest chagnes:

![CleanShot 2024-11-25 at 11 03 43@2x](https://github.com/user-attachments/assets/da567197-7c17-4227-8bed-aa14c5f764c1)


## Test Plan

Before:

![CleanShot 2024-11-25 at 11 03 34@2x](https://github.com/user-attachments/assets/2e8d1f46-48c0-4319-815b-26e34b23fd1b)


AFter:
![CleanShot 2024-11-25 at 11 03 29@2x](https://github.com/user-attachments/assets/d53306b9-e73f-4046-918d-e64f04ee8d70)



## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/9016

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
