### PR TITLE
fix(realtime): decrement connectionCounter only if connection is known

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -678,10 +678,9 @@ $server->onMessage(function (int $connection, string $message) use ($server, $re
 $server->onClose(function (int $connection) use ($realtime, $stats, $register) {
     if (array_key_exists($connection, $realtime->connections)) {
         $stats->decr($realtime->connections[$connection]['projectId'], 'connectionsTotal');
+        $register->get('telemetry.connectionCounter')->add(-1);
     }
     $realtime->unsubscribe($connection);
-
-    $register->get('telemetry.connectionCounter')->add(-1);
 
     Console::info('Connection close: ' . $connection);
 });


### PR DESCRIPTION
The counter is incremented after it's added to `$realtime->connections`. Only decrement the counter if the connection is known.