### PR TITLE
Fix: use size actual instead

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -125,9 +125,9 @@ $databaseListener = function (string $event, Document $document, Document $proje
             $bucketInternalId  = $parts[1];
             $queueForUsage
                 ->addMetric(METRIC_FILES, $value) // per project
-                ->addMetric(METRIC_FILES_STORAGE, $document->getAttribute('sizeOriginal') * $value) // per project
+                ->addMetric(METRIC_FILES_STORAGE, $document->getAttribute('sizeActual') * $value) // per project
                 ->addMetric(str_replace('{bucketInternalId}', $bucketInternalId, METRIC_BUCKET_ID_FILES), $value) // per bucket
-                ->addMetric(str_replace('{bucketInternalId}', $bucketInternalId, METRIC_BUCKET_ID_FILES_STORAGE), $document->getAttribute('sizeOriginal') * $value); // per bucket
+                ->addMetric(str_replace('{bucketInternalId}', $bucketInternalId, METRIC_BUCKET_ID_FILES_STORAGE), $document->getAttribute('sizeActual') * $value); // per bucket
             break;
         case $document->getCollection() === 'functions':
             $queueForUsage

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -328,7 +328,7 @@ class UsageTest extends Scope
         $this->assertEquals(1, count($response['body']['requests']));
         $this->assertEquals($requestsTotal, $response['body']['requests'][array_key_last($response['body']['requests'])]['value']);
         $this->validateDates($response['body']['requests']);
-        $this->assertEquals($storageTotal, $response['body']['filesStorageTotal']);
+        $this->assertGreaterThan($storageTotal, $response['body']['filesStorageTotal']);
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -336,7 +336,7 @@ class UsageTest extends Scope
             $this->getConsoleHeaders()
         );
 
-        $this->assertEquals($storageTotal, $response['body']['storage'][array_key_last($response['body']['storage'])]['value']);
+        $this->assertGreaterThan($storageTotal, $response['body']['storage'][array_key_last($response['body']['storage'])]['value']);
         $this->validateDates($response['body']['storage']);
         $this->assertEquals($bucketsTotal, $response['body']['buckets'][array_key_last($response['body']['buckets'])]['value']);
         $this->validateDates($response['body']['buckets']);
@@ -349,7 +349,7 @@ class UsageTest extends Scope
             $this->getConsoleHeaders()
         );
 
-        $this->assertEquals($storageTotal, $response['body']['storage'][array_key_last($response['body']['storage'])]['value']);
+        $this->assertGreaterThan($storageTotal, $response['body']['storage'][array_key_last($response['body']['storage'])]['value']);
         $this->assertEquals($filesTotal, $response['body']['files'][array_key_last($response['body']['files'])]['value']);
 
         return $data;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Use file actual size after encryption/compression for usage calculation instead of using sizeOriginal

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/8919

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
