### PR TITLE
Fix outdated CLI commands in documentation

### DIFF
--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -98,7 +98,7 @@ $ appwrite users list
 
 To create a document you can use the following command 
 ```sh
-$ appwrite databases create-document --database-id=<DATABASE_ID> --collection-id=<COLLECTION_ID> --document-id="unique()" --data '{"name": "Walter O Brein"} --permissions 'read("any")' 'read("team:abc")'
+$ appwrite databases create-document --database-id=<DATABASE_ID> --collection-id=<COLLECTION_ID> --document-id="unique()" --data '{"name": "Walter O Brein"}' --permissions 'read("any")' 'read("team:abc")'
 ```
 
 ### Some Gotchas

--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -98,7 +98,7 @@ $ appwrite users list
 
 To create a document you can use the following command 
 ```sh
-$ appwrite databases create-document --database-id=<DATABASE_ID> --collection-id=<COLLECTION_ID> --document-id="unique()" --data '{"name": "Walter O Brein"}' --permissions 'read("any")' 'read("team:abc")'
+$ appwrite databases create-document --database-id <DATABASE_ID> --collection-id <COLLECTION_ID> --document-id "unique()" --data '{"name": "Walter O Brein"}' --permissions 'read("any")' 'read("team:abc")'
 ```
 
 ### Some Gotchas

--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -98,7 +98,7 @@ $ appwrite users list
 
 To create a document you can use the following command 
 ```sh
-$ appwrite databases create-document --database-id=<DATABASE_ID> --collection-id=<COLLECTION_ID> --document-id="unique()" --data '{"name": "Walter O Brein"}'
+$ appwrite databases create-document --database-id=<DATABASE_ID> --collection-id=<COLLECTION_ID> --document-id="unique()" --data '{"name": "Walter O Brein"} --permissions 'read("any")' 'read("team:abc")'
 ```
 
 ### Some Gotchas

--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -59,7 +59,7 @@ My Awesome Function
 You can now deploy this function using 
 
 ```sh
-$ appwrite deploy function
+$ appwrite push function
 
 ? Which functions would you like to deploy? My Awesome Function (61d1a4c81dfcd95bc834)
 ℹ Info Deploying function My Awesome Function ( 61d1a4c81dfcd95bc834 )
@@ -73,7 +73,7 @@ Your function has now been deployed on your Appwrite server! As soon as the buil
 Similarly, you can deploy all your collections to your Appwrite server using 
 
 ```sh
-appwrite deploy collections
+appwrite push collections
 ```
 
 > ### Note
@@ -98,7 +98,7 @@ $ appwrite users list
 
 To create a document you can use the following command 
 ```sh
-$ appwrite database createDocument --collectionId <ID> --documentId 'unique()' --data '{ "Name": "Iron Man" }' --permissions 'read("any")' 'read("team:abc")'
+$ appwrite databases create-document --database-id=<DATABASE_ID> --collection-id=<COLLECTION_ID> --document-id="unique()" --data '{"name": "Walter O Brein"}'
 ```
 
 ### Some Gotchas


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- It replaces the `deploy` command with a `push`
- It fixes the outdated create document command to resolve errors users might encounter.

Fixes https://github.com/appwrite/sdk-for-cli/issues/146 
Fixes https://github.com/appwrite/sdk-for-cli/issues/152

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- appwrite/sdk-for-cli#152
- https://github.com/appwrite/sdk-for-cli/issues/146

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
