### PR TITLE
Set base specification CPUs to 0.5 again

### DIFF
--- a/app/config/runtimes/specifications.php
+++ b/app/config/runtimes/specifications.php
@@ -6,7 +6,7 @@ return [
     Specification::S_05VCPU_512MB => [
         'slug' => Specification::S_05VCPU_512MB,
         'memory' => 512,
-        'cpus' => 1 // TODO: revert this, it's a temporary change to test function performance.
+        'cpus' => 0.5
     ],
     Specification::S_1VCPU_512MB => [
         'slug' => Specification::S_1VCPU_512MB,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR rolls back a temporary change that set the base specification's CPU to 1 instead of 0.5

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
