### PR TITLE
Make 0 equal unlimited for functions environment variables

### DIFF
--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -550,7 +550,9 @@ App::get('/v1/functions/specifications')
             }
 
             // Only add specs that are within the limits set by environment variables
-            if ($spec['cpus'] <= System::getEnv('_APP_FUNCTIONS_CPUS', 1) && $spec['memory'] <= System::getEnv('_APP_FUNCTIONS_MEMORY', 512)) {
+            if (
+                ($spec['cpus'] <= System::getEnv('_APP_FUNCTIONS_CPUS', 1) || System::getEnv('_APP_FUNCTIONS_CPUS', 1) === 0) &&
+                ($spec['memory'] <= System::getEnv('_APP_FUNCTIONS_MEMORY', 512)) || System::getEnv('_APP_FUNCTIONS_MEMORY', 512) === 0) {
                 $runtimeSpecs[] = $spec;
             }
         }

--- a/src/Appwrite/Functions/Validator/RuntimeSpecification.php
+++ b/src/Appwrite/Functions/Validator/RuntimeSpecification.php
@@ -34,7 +34,7 @@ class RuntimeSpecification extends Validator
         $allowedSpecifications = [];
 
         foreach ($this->specifications as $size => $values) {
-            if ($values['cpus'] <= $this->maxCpus && $values['memory'] <= $this->maxMemory) {
+            if (($values['cpus'] <= $this->maxCpus || $this->maxCpus === 0) && ($values['memory'] <= $this->maxMemory || $this->maxMemory === 0)) {
                 if (!empty($this->plan) && array_key_exists('runtimeSpecifications', $this->plan)) {
                     if (!\in_array($size, $this->plan['runtimeSpecifications'])) {
                         continue;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR makes it so if `_APP_FUNCTIONS_CPUS` and `_APP_FUNCTIONS_MEMORY` are set to 0 it will mean unlimited. This fits how these variables worked before variable runtime specifications.

## Test Plan

All existing tests should work as intended and I have manually tested the API's and Console to ensure everything is functional.
## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
