### PR TITLE
chore: added optional reporting for free msgs

### DIFF
--- a/app/init.php
+++ b/app/init.php
@@ -1761,5 +1761,5 @@ App::setResource('requestTimestamp', function ($request) {
     return $requestTimestamp;
 }, ['request']);
 App::setResource('plan', function (array $plan = []) {
-    return [];
+    return array_merge(['authPhone' => -1], $plan); // unlimited free phone auth
 });

--- a/src/Appwrite/Event/Messaging.php
+++ b/src/Appwrite/Event/Messaging.php
@@ -14,6 +14,7 @@ class Messaging extends Event
     protected ?array $recipients = null;
     protected ?string $scheduledAt = null;
     protected ?string $providerType = null;
+    protected ?bool $reportUsage = true;
 
     public function __construct(protected Connection $connection)
     {
@@ -140,6 +141,29 @@ class Messaging extends Event
     }
 
     /**
+     * Sets whether to report usage for the messaging event.
+     *
+     * @param bool $reportUsage
+     * @return self
+     */
+    public function setReportUsage(bool $reportUsage): self
+    {
+        $this->reportUsage = $reportUsage;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether to report usage for the messaging event.
+     *
+     * @return bool
+     */
+    public function getReportUsage(): bool
+    {
+        return $this->reportUsage;
+    }
+
+    /**
      * Sets Scheduled delivery time for the messaging event.
      *
      * @param string $scheduledAt
@@ -192,6 +216,7 @@ class Messaging extends Event
             'message' => $this->message,
             'recipients' => $this->recipients,
             'providerType' => $this->providerType,
+            'reportUsage' => $this->reportUsage,
         ]);
     }
 }


### PR DESCRIPTION
To enable 10 free sms monthly, this PR:

- adds `authphone` as a default value in the plan object.
- uses abuse check with key `$project->getAttribute('teamId')` and time limit of `30 * 24 * 60 * 60`sec (1 month)
- introduces new param `reportUsage` to Message object.