### PR TITLE
Fix dead connections

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use Swoole\Constant;
+use Swoole\Database\DetectsLostConnections;
 use Swoole\Http\Request as SwooleRequest;
 use Swoole\Http\Response as SwooleResponse;
 use Swoole\Http\Server;
@@ -17,6 +18,7 @@ use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
+use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Exception\Duplicate;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
@@ -346,6 +348,15 @@ $http->on(Constant::EVENT_REQUEST, function (SwooleRequest $swooleRequest, Swool
 
         $app->run($request, $response);
     } catch (\Throwable $th) {
+        if (
+            ($th instanceof PDOException || $th instanceof DatabaseException)
+            && DetectsLostConnections::causedByLostConnection($th)
+        ) {
+            // Mark connection as unhealthy so it will be recycled on next reclaim.
+            $connectionForProject = $app->getResource('connectionForProject');
+            $connectionForProject->setHealthy(false);
+        }
+
         $version = System::getEnv('_APP_VERSION', 'UNKNOWN');
 
         $logger = $app->getResource("logger");

--- a/app/init.php
+++ b/app/init.php
@@ -74,6 +74,7 @@ use Utopia\Logger\Adapter\Raygun;
 use Utopia\Logger\Adapter\Sentry;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
+use Utopia\Pools\Connection as PoolConnection;
 use Utopia\Pools\Group;
 use Utopia\Pools\Pool;
 use Utopia\Queue;
@@ -1412,7 +1413,26 @@ App::setResource('console', function () {
     ]);
 }, []);
 
-App::setResource('dbForProject', function (Group $pools, Database $dbForPlatform, Cache $cache, Document $project) {
+App::setResource('connectionForProject', function (Group $pools, Document $project) {
+    if ($project->isEmpty() || $project->getId() === 'console') {
+        return $pools
+            ->get('console')
+            ->pop();
+    }
+
+    try {
+        $dsn = new DSN($project->getAttribute('database'));
+    } catch (\InvalidArgumentException) {
+        // TODO: Temporary until all projects are using shared tables
+        $dsn = new DSN('mysql://' . $project->getAttribute('database'));
+    }
+
+    return $pools
+        ->get($dsn->getHost())
+        ->pop();
+}, ['pools', 'project']);
+
+App::setResource('dbForProject', function (Group $pools, PoolConnection $connectionForProject, Database $dbForPlatform, Cache $cache, Document $project) {
     if ($project->isEmpty() || $project->getId() === 'console') {
         return $dbForPlatform;
     }
@@ -1424,12 +1444,7 @@ App::setResource('dbForProject', function (Group $pools, Database $dbForPlatform
         $dsn = new DSN('mysql://' . $project->getAttribute('database'));
     }
 
-    $dbAdapter = $pools
-        ->get($dsn->getHost())
-        ->pop()
-        ->getResource();
-
-    $database = new Database($dbAdapter, $cache);
+    $database = new Database($connectionForProject->getResource(), $cache);
 
     $database
         ->setMetadata('host', \gethostname())
@@ -1452,7 +1467,7 @@ App::setResource('dbForProject', function (Group $pools, Database $dbForPlatform
     }
 
     return $database;
-}, ['pools', 'dbForPlatform', 'cache', 'project']);
+}, ['pools', 'connectionForProject', 'dbForPlatform', 'cache', 'project']);
 
 App::setResource('dbForPlatform', function (Group $pools, Cache $cache) {
     $dbAdapter = $pools

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "utopia-php/migration": "0.6.*",
         "utopia-php/orchestration": "0.9.*",
         "utopia-php/platform": "0.7.*",
-        "utopia-php/pools": "dev-feat-connection-health as 0.5.0",
+        "utopia-php/pools": "0.6.*",
         "utopia-php/preloader": "0.2.*",
         "utopia-php/queue": "0.7.*",
         "utopia-php/registry": "0.5.*",

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "utopia-php/migration": "0.6.*",
         "utopia-php/orchestration": "0.9.*",
         "utopia-php/platform": "0.7.*",
-        "utopia-php/pools": "0.5.*",
+        "utopia-php/pools": "dev-feat-connection-health as 0.5.0",
         "utopia-php/preloader": "0.2.*",
         "utopia-php/queue": "0.7.*",
         "utopia-php/registry": "0.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4149,12 +4149,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "b1d35f023b3ccf0d171fad88cc833cdace0e1e67"
+                "reference": "3b1913e7e9cb01acac26215abb37eb767c0112ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/b1d35f023b3ccf0d171fad88cc833cdace0e1e67",
-                "reference": "b1d35f023b3ccf0d171fad88cc833cdace0e1e67",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/3b1913e7e9cb01acac26215abb37eb767c0112ee",
+                "reference": "3b1913e7e9cb01acac26215abb37eb767c0112ee",
                 "shasum": ""
             },
             "require": {
@@ -4192,7 +4192,7 @@
                 "issues": "https://github.com/utopia-php/pools/issues",
                 "source": "https://github.com/utopia-php/pools/tree/feat-connection-health"
             },
-            "time": "2025-01-08T03:56:11+00:00"
+            "time": "2025-01-08T07:40:13+00:00"
         },
         {
             "name": "utopia-php/preloader",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59c7d90abfa068a55426b786a244d985",
+    "content-hash": "7b5b5926b452186543903eb539f59c2d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4145,16 +4145,16 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "dev-feat-connection-health",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "3b1913e7e9cb01acac26215abb37eb767c0112ee"
+                "reference": "59414ab7b57728edfde6d5ccc5a2583b7967ac18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/3b1913e7e9cb01acac26215abb37eb767c0112ee",
-                "reference": "3b1913e7e9cb01acac26215abb37eb767c0112ee",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/59414ab7b57728edfde6d5ccc5a2583b7967ac18",
+                "reference": "59414ab7b57728edfde6d5ccc5a2583b7967ac18",
                 "shasum": ""
             },
             "require": {
@@ -4190,9 +4190,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/feat-connection-health"
+                "source": "https://github.com/utopia-php/pools/tree/0.6.0"
             },
-            "time": "2025-01-08T07:40:13+00:00"
+            "time": "2025-01-08T07:58:42+00:00"
         },
         {
             "name": "utopia-php/preloader",
@@ -8554,18 +8554,9 @@
             "time": "2024-03-07T20:33:40+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "utopia-php/pools",
-            "version": "dev-feat-connection-health",
-            "alias": "0.5.0",
-            "alias_normalized": "0.5.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "utopia-php/pools": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b136b5490c0d5d331eac0d70bb3e198",
+    "content-hash": "59c7d90abfa068a55426b786a244d985",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3929,16 +3929,16 @@
         },
         {
             "name": "utopia-php/migration",
-            "version": "0.6.13",
+            "version": "0.6.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "68d9b0a9477755afcda607e7e8109785cae17a13"
+                "reference": "59a19f09ded0ccab4c8cca35b1242c01e2b9cfd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/68d9b0a9477755afcda607e7e8109785cae17a13",
-                "reference": "68d9b0a9477755afcda607e7e8109785cae17a13",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/59a19f09ded0ccab4c8cca35b1242c01e2b9cfd2",
+                "reference": "59a19f09ded0ccab4c8cca35b1242c01e2b9cfd2",
                 "shasum": ""
             },
             "require": {
@@ -3979,9 +3979,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/0.6.13"
+                "source": "https://github.com/utopia-php/migration/tree/0.6.14"
             },
-            "time": "2024-11-26T13:57:53+00:00"
+            "time": "2025-01-08T01:07:25+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -4145,25 +4145,25 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "0.5.0",
+            "version": "dev-feat-connection-health",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "6f716a213a08db95eda1b5dddfa90983c1834817"
+                "reference": "b1d35f023b3ccf0d171fad88cc833cdace0e1e67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/6f716a213a08db95eda1b5dddfa90983c1834817",
-                "reference": "6f716a213a08db95eda1b5dddfa90983c1834817",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/b1d35f023b3ccf0d171fad88cc833cdace0e1e67",
+                "reference": "b1d35f023b3ccf0d171fad88cc833cdace0e1e67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "laravel/pint": "1.2.*",
-                "phpstan/phpstan": "1.8.*",
-                "phpunit/phpunit": "^9.3"
+                "laravel/pint": "1.*",
+                "phpstan/phpstan": "1.*",
+                "phpunit/phpunit": "11.*"
             },
             "type": "library",
             "autoload": {
@@ -4190,9 +4190,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/0.5.0"
+                "source": "https://github.com/utopia-php/pools/tree/feat-connection-health"
             },
-            "time": "2024-04-19T11:11:54+00:00"
+            "time": "2025-01-08T03:56:11+00:00"
         },
         {
             "name": "utopia-php/preloader",
@@ -8554,9 +8554,18 @@
             "time": "2024-03-07T20:33:40+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/pools",
+            "version": "dev-feat-connection-health",
+            "alias": "0.5.0",
+            "alias_normalized": "0.5.0.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "utopia-php/pools": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -8580,5 +8589,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When a PDO or database exception is thrown, and the exception was due to a lost connection, mark a pool connection as unhealthy, so that on next reclaim it will be re-created.

Introduces a `connectionForProject` resource that intercepts the project DB so that the connection can be used directly when needed for marking as unhealthy.

## Test Plan

Manual tests + library tests

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
