### PR TITLE
Add assertEventually to messaging provider logs test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,6 +175,8 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     needs: setup
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/tests/e2e/Services/Messaging/MessagingConsoleClientTest.php
+++ b/tests/e2e/Services/Messaging/MessagingConsoleClientTest.php
@@ -54,8 +54,7 @@ class MessagingConsoleClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
 
-        // required for Cloud x Audits
-        sleep(10);
+        sleep(10); // required for Cloud x Audits
 
         $logs = $this->client->call(Client::METHOD_GET, '/messaging/providers/' . $provider['body']['$id'] . '/logs', \array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Messaging/MessagingConsoleClientTest.php
+++ b/tests/e2e/Services/Messaging/MessagingConsoleClientTest.php
@@ -54,6 +54,9 @@ class MessagingConsoleClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
 
+        // required for Cloud x Audits
+        sleep(10);
+
         $logs = $this->client->call(Client::METHOD_GET, '/messaging/providers/' . $provider['body']['$id'] . '/logs', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds a generic `sleep` to allow a write to Audits DB. This fixes an internal failing test issue with the new Audits approach.

## Test Plan

Manual.

With `sleep` -

![image](https://github.com/user-attachments/assets/360bffe4-e999-4cf4-b98d-0237a85ead43)

Without `sleep` -

![image](https://github.com/user-attachments/assets/ec112f0a-c9c3-4dd3-b145-48040b0a364e)

## Related PRs and Issues

N/A.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
