### PR TITLE
chore: abstract token secret hiding to response model

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1979,16 +1979,10 @@ App::post('/v1/account/tokens/magic-url')
             ->setRecipient($email)
             ->trigger();
 
-        // Set to unhashed secret for events and server responses
         $token->setAttribute('secret', $tokenSecret);
 
         $queueForEvents
             ->setPayload($response->output($token, Response::MODEL_TOKEN), sensitive: ['secret']);
-
-        // Hide secret for clients
-        if (!$isPrivilegedUser && !$isAppUser) {
-            $token->setAttribute('secret', '');
-        }
 
         if (!empty($phrase)) {
             $token->setAttribute('phrase', $phrase);
@@ -2208,16 +2202,10 @@ App::post('/v1/account/tokens/email')
             ->setRecipient($email)
             ->trigger();
 
-        // Set to unhashed secret for events and server responses
         $token->setAttribute('secret', $tokenSecret);
 
         $queueForEvents
             ->setPayload($response->output($token, Response::MODEL_TOKEN), sensitive: ['secret']);
-
-        // Hide secret for clients
-        if (!$isPrivilegedUser && !$isAppUser) {
-            $token->setAttribute('secret', '');
-        }
 
         if (!empty($phrase)) {
             $token->setAttribute('phrase', $phrase);
@@ -2481,13 +2469,12 @@ App::post('/v1/account/tokens/phone')
             }
         }
 
-        // Set to unhashed secret for events and server responses
         $token->setAttribute('secret', $secret);
 
         $queueForEvents
             ->setPayload($response->output($token, Response::MODEL_TOKEN), sensitive: ['secret']);
 
-        // Hide secret for clients
+        // Encode secret for clients
         $token->setAttribute('secret', ($isPrivilegedUser || $isAppUser) ? Auth::encodeSession($user->getId(), $secret) : '');
 
         $response
@@ -3139,7 +3126,6 @@ App::post('/v1/account/recovery')
             ->setSubject($subject)
             ->trigger();
 
-        // Set to unhashed secret for events and server responses
         $recovery->setAttribute('secret', $secret);
 
         $queueForEvents
@@ -3147,11 +3133,6 @@ App::post('/v1/account/recovery')
             ->setParam('tokenId', $recovery->getId())
             ->setUser($profile)
             ->setPayload($response->output($recovery, Response::MODEL_TOKEN), sensitive: ['secret']);
-
-        // Hide secret for clients
-        if (!$isPrivilegedUser && !$isAppUser) {
-            $recovery->setAttribute('secret', '');
-        }
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
@@ -3390,18 +3371,12 @@ App::post('/v1/account/verification')
             ->setName($user->getAttribute('name') ?? '')
             ->trigger();
 
-        // Set to unhashed secret for events and server responses
         $verification->setAttribute('secret', $verificationSecret);
 
         $queueForEvents
             ->setParam('userId', $user->getId())
             ->setParam('tokenId', $verification->getId())
             ->setPayload($response->output($verification, Response::MODEL_TOKEN), sensitive: ['secret']);
-
-        // Hide secret for clients
-        if (!$isPrivilegedUser && !$isAppUser) {
-            $verification->setAttribute('secret', '');
-        }
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
@@ -3601,18 +3576,12 @@ App::post('/v1/account/verification/phone')
             }
         }
 
-        // Set to unhashed secret for events and server responses
         $verification->setAttribute('secret', $secret);
 
         $queueForEvents
             ->setParam('userId', $user->getId())
             ->setParam('tokenId', $verification->getId())
             ->setPayload($response->output($verification, Response::MODEL_TOKEN), sensitive: ['secret']);
-
-        // Hide secret for clients
-        if (!$isPrivilegedUser && !$isAppUser) {
-            $verification->setAttribute('secret', '');
-        }
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)

--- a/src/Appwrite/Utopia/Response.php
+++ b/src/Appwrite/Utopia/Response.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Utopia;
 
+use Appwrite\Auth\Auth;
 use Appwrite\Utopia\Fetch\BodyMultipart;
 use Appwrite\Utopia\Response\Filter;
 use Appwrite\Utopia\Response\Model;
@@ -113,6 +114,7 @@ use JsonException;
 use Swoole\Http\Response as SwooleHTTPResponse;
 // Keep last
 use Utopia\Database\Document;
+use Utopia\Database\Validator\Authorization;
 use Utopia\Swoole\Response as SwooleResponse;
 
 /**
@@ -665,6 +667,16 @@ class Response extends SwooleResponse
             } else {
                 if ($data[$key] instanceof Document) {
                     $data[$key] = $this->output($data[$key], $rule['type']);
+                }
+            }
+
+            if ($rule['sensitive']) {
+                $roles = Authorization::getRoles();
+                $isPrivilegedUser = Auth::isPrivilegedUser($roles);
+                $isAppUser = Auth::isAppUser($roles);
+
+                if (!$isPrivilegedUser && !$isAppUser) {
+                    $data->setAttribute($key, '');
                 }
             }
 

--- a/src/Appwrite/Utopia/Response/Model.php
+++ b/src/Appwrite/Utopia/Response/Model.php
@@ -90,7 +90,8 @@ abstract class Model
             'required' => true,
             'array' => false,
             'description' => '',
-            'example' => ''
+            'example' => '',
+            'sensitive' => false
         ], $options);
 
         return $this;

--- a/src/Appwrite/Utopia/Response/Model/Token.php
+++ b/src/Appwrite/Utopia/Response/Model/Token.php
@@ -33,6 +33,7 @@ class Token extends Model
                 'description' => 'Token secret key. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
                 'default' => '',
                 'example' => '',
+                'sensitive' => true,
             ])
             ->addRule('expire', [
                 'type' => self::TYPE_DATETIME,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR abstracts the secret hiding logic for the Token responses across various places by introduces a new attribute called `sensitive` to Response Model, which when set checks if user is appUser or priviledgedUser, and if not it sets the key as empty.

## Test Plan

I tested it for createEmailToken endpoint and it works like it did before.

test code:
```js
const client = new Client()
    .setEndpoint(endpoint)  
    .setProject(projectId)
    .setKey(apiKey);

const account = new Account(client);
const token = await account.createEmailToken(ID.unique(), 'test6@test.com', true);
console.log(token);
```

without apikey:
<img width="365" alt="Screenshot 2025-01-10 at 7 00 37 PM" src="https://github.com/user-attachments/assets/8efeb614-2342-441a-b1b1-c52d21f43d91" />

with apikey:
<img width="373" alt="Screenshot 2025-01-10 at 7 01 02 PM" src="https://github.com/user-attachments/assets/7e8823b5-138e-46a1-a815-b634fc7e8515" />


## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
