### PR TITLE
Ensure user can delete session

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1814,6 +1814,12 @@ App::post('/v1/users/:userId/sessions')
             $detector->getDevice()
         ));
 
+        $session->setAttribute('$permissions', [
+            Permission::read(Role::user($user->getId())),
+            Permission::update(Role::user($user->getId())),
+            Permission::delete(Role::user($user->getId())),
+        ]);
+
         $countryName = $locale->getText('countries.' . strtolower($session->getAttribute('countryCode')), $locale->getText('locale.country.unknown'));
 
         $session = $dbForProject->createDocument('sessions', $session);

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -318,6 +318,14 @@ trait UsersBase
         ]);
 
         $this->assertEquals(200, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_DELETE, '/account/sessions/current', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-session' => $session['secret']
+        ]);
+
+        $this->assertEquals(204, $response['headers']['status-code']);
     }
 
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The session document created by users.createSession() was missing delete permissions for the user so when the user tried to delete it, they got a 401 error.

This PR ensure the permissions are added just like if the document was created from the Account API so that the user has access to delete the document.

Fixes #9052 

## Test Plan

Updated test to check delete session case 

## Related PRs and Issues

- #9052 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
