### PR TITLE
Docs: clarify update endpoints only work on draft messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dev/yasd_init.php
 Makefile
 appwrite.json
 /.zed/
+.history

--- a/docs/references/messaging/update-email.md
+++ b/docs/references/messaging/update-email.md
@@ -1,1 +1,1 @@
-Update an email message by its unique ID.
+Update an email message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.

--- a/docs/references/messaging/update-push.md
+++ b/docs/references/messaging/update-push.md
@@ -1,1 +1,1 @@
-Update a push notification by its unique ID.
+Update a push notification message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.

--- a/docs/references/messaging/update-sms.md
+++ b/docs/references/messaging/update-sms.md
@@ -1,1 +1,1 @@
-Update an SMS message by its unique ID.
+Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.


### PR DESCRIPTION
## What does this PR do?
Updates documentation for updateEmail(), updatePush(), and updateSms() endpoints to state that they only work on messages in draft status.

## Related PRs and Issues
https://github.com/appwrite/appwrite/issues/9057
