### PR TITLE
fix: redirect to failure url on OAuth exceptions

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1374,7 +1374,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                 Query::notEqual('userInternalId', $user->getInternalId()),
             ]);
             if (!empty($identityWithMatchingEmail)) {
-                throw new Exception(Exception::USER_ALREADY_EXISTS);
+                $failureRedirect(Exception::USER_ALREADY_EXISTS);
             }
 
             $userWithMatchingEmail = $dbForProject->find('users', [
@@ -1382,7 +1382,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                 Query::notEqual('$id', $userId),
             ]);
             if (!empty($userWithMatchingEmail)) {
-                throw new Exception(Exception::USER_ALREADY_EXISTS);
+                $failureRedirect(Exception::USER_ALREADY_EXISTS);
             }
 
             $sessionUpgrade = true;
@@ -1411,7 +1411,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
 
         if ($user === false || $user->isEmpty()) { // No user logged in or with OAuth2 provider ID, create new one or connect with account with same email
             if (empty($email)) {
-                throw new Exception(Exception::USER_UNAUTHORIZED, 'OAuth provider failed to return email.');
+                $failureRedirect(Exception::USER_UNAUTHORIZED, 'OAuth provider failed to return email.');
             }
 
             /**
@@ -1454,7 +1454,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                     Query::equal('providerEmail', [$email]),
                 ]);
                 if ($identityWithMatchingEmail !== false && !$identityWithMatchingEmail->isEmpty()) {
-                    throw new Exception(Exception::GENERAL_BAD_REQUEST); /** Return a generic bad request to prevent exposing existing accounts */
+                    $failureRedirect(Exception::GENERAL_BAD_REQUEST); /** Return a generic bad request to prevent exposing existing accounts */
                 }
 
                 try {
@@ -1525,7 +1525,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
                 Query::notEqual('userInternalId', $user->getInternalId()),
             ]);
             if (!empty($identitiesWithMatchingEmail)) {
-                throw new Exception(Exception::GENERAL_BAD_REQUEST); /** Return a generic bad request to prevent exposing existing accounts */
+                $failureRedirect(Exception::GENERAL_BAD_REQUEST); /** Return a generic bad request to prevent exposing existing accounts */
             }
 
             $dbForProject->createDocument('identities', new Document([


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This allows the client to gracefully handle these OAuth exceptions instead of presenting a generic error page to users.

## Test Plan

I have patched my local version to confirm it does redirect to the failure url on exceptions.

## Related PRs and Issues

- #7021
- <https://appwrite.io/threads/1326770257406328930> (I am open to discussion here or in this PR)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
