### PR TITLE
Fix: email (smtp) to multiple recipients

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "utopia-php/image": "0.8.*",
         "utopia-php/locale": "0.4.*",
         "utopia-php/logger": "0.6.*",
-        "utopia-php/messaging": "0.14.*",
+        "utopia-php/messaging": "0.16.*",
         "utopia-php/migration": "0.6.*",
         "utopia-php/orchestration": "0.9.*",
         "utopia-php/platform": "0.7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1d26d441fe1fb6a26978d99ef01985f",
+    "content-hash": "5e45619efebf755a1753eb91535bf387",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3919,16 +3919,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.33.16",
+            "version": "0.33.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "e91d4c560d1b809e25faa63d564fef034363b50f"
+                "reference": "73fac6fbce9f56282dba4e52a58cf836ec434644"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/e91d4c560d1b809e25faa63d564fef034363b50f",
-                "reference": "e91d4c560d1b809e25faa63d564fef034363b50f",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/73fac6fbce9f56282dba4e52a58cf836ec434644",
+                "reference": "73fac6fbce9f56282dba4e52a58cf836ec434644",
                 "shasum": ""
             },
             "require": {
@@ -3960,9 +3960,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/0.33.16"
+                "source": "https://github.com/utopia-php/http/tree/0.33.17"
             },
-            "time": "2025-01-16T15:58:50+00:00"
+            "time": "2025-02-24T17:35:48+00:00"
         },
         {
             "name": "utopia-php/image",
@@ -4120,16 +4120,16 @@
         },
         {
             "name": "utopia-php/messaging",
-            "version": "0.14.1",
+            "version": "0.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/messaging.git",
-                "reference": "4ba356a3aa382802727f7e13e0f0152bcc1fc535"
+                "reference": "5f3083697102b1821d6624938186761b1e09c54e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/4ba356a3aa382802727f7e13e0f0152bcc1fc535",
-                "reference": "4ba356a3aa382802727f7e13e0f0152bcc1fc535",
+                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/5f3083697102b1821d6624938186761b1e09c54e",
+                "reference": "5f3083697102b1821d6624938186761b1e09c54e",
                 "shasum": ""
             },
             "require": {
@@ -4165,9 +4165,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/messaging/issues",
-                "source": "https://github.com/utopia-php/messaging/tree/0.14.1"
+                "source": "https://github.com/utopia-php/messaging/tree/0.16.0"
             },
-            "time": "2025-01-28T06:14:28+00:00"
+            "time": "2025-02-18T08:27:00+00:00"
         },
         {
             "name": "utopia-php/migration",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

According to issue mentioned below, sending emails to multiple recipients can lead to data privacy issues.
This PR makes the messaging worker send a separate mail for each recipient if the provider is **SMTP** as for sendgrid and mailgun there are api endpoints for _batch-sending_

> Note: If users want to send a single email, they can use `cc`, and don't want to expose emails to all recipients, they can use `bcc`

## Test Plan

## Related PRs and Issues

* #8261 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
