### PR TITLE
fix: phone number parsing exception handling

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -28,6 +28,7 @@ use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Database\Validator\Queries\Identities;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
+use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
 use MaxMind\Db\Reader;
 use Utopia\Abuse\Abuse;
@@ -2467,7 +2468,12 @@ App::post('/v1/account/tokens/phone')
                 $abuse = new Abuse($timelimit);
                 if ($abuse->check() && System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') === 'enabled') {
                     $helper = PhoneNumberUtil::getInstance();
-                    $countryCode = $helper->parse($phone)->getCountryCode();
+
+                    try {
+                        $countryCode = $helper->parse($phone)->getCountryCode();
+                    } catch (NumberParseException $e) {
+                        throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid phone number');
+                    }
 
                     if (!empty($countryCode)) {
                         $queueForUsage
@@ -3587,7 +3593,12 @@ App::post('/v1/account/verification/phone')
                 $abuse = new Abuse($timelimit);
                 if ($abuse->check() && System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') === 'enabled') {
                     $helper = PhoneNumberUtil::getInstance();
-                    $countryCode = $helper->parse($phone)->getCountryCode();
+
+                    try {
+                        $countryCode = $helper->parse($phone)->getCountryCode();
+                    } catch (NumberParseException $e) {
+                        throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid phone number');
+                    }
 
                     if (!empty($countryCode)) {
                         $queueForUsage
@@ -4148,7 +4159,12 @@ App::post('/v1/account/mfa/challenge')
                     $abuse = new Abuse($timelimit);
                     if ($abuse->check() && System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') === 'enabled') {
                         $helper = PhoneNumberUtil::getInstance();
-                        $countryCode = $helper->parse($phone)->getCountryCode();
+
+                        try {
+                            $countryCode = $helper->parse($phone)->getCountryCode();
+                        } catch (NumberParseException $e) {
+                            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid phone number');
+                        }
 
                         if (!empty($countryCode)) {
                             $queueForUsage

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -28,7 +28,6 @@ use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Database\Validator\Queries\Identities;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
-use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
 use MaxMind\Db\Reader;
 use Utopia\Abuse\Abuse;
@@ -2468,12 +2467,7 @@ App::post('/v1/account/tokens/phone')
                 $abuse = new Abuse($timelimit);
                 if ($abuse->check() && System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') === 'enabled') {
                     $helper = PhoneNumberUtil::getInstance();
-
-                    try {
-                        $countryCode = $helper->parse($phone)->getCountryCode();
-                    } catch (NumberParseException $e) {
-                        throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid phone number');
-                    }
+                    $countryCode = $helper->parse($phone)->getCountryCode();
 
                     if (!empty($countryCode)) {
                         $queueForUsage
@@ -3593,12 +3587,7 @@ App::post('/v1/account/verification/phone')
                 $abuse = new Abuse($timelimit);
                 if ($abuse->check() && System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') === 'enabled') {
                     $helper = PhoneNumberUtil::getInstance();
-
-                    try {
-                        $countryCode = $helper->parse($phone)->getCountryCode();
-                    } catch (NumberParseException $e) {
-                        throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid phone number');
-                    }
+                    $countryCode = $helper->parse($phone)->getCountryCode();
 
                     if (!empty($countryCode)) {
                         $queueForUsage
@@ -4159,12 +4148,7 @@ App::post('/v1/account/mfa/challenge')
                     $abuse = new Abuse($timelimit);
                     if ($abuse->check() && System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') === 'enabled') {
                         $helper = PhoneNumberUtil::getInstance();
-
-                        try {
-                            $countryCode = $helper->parse($phone)->getCountryCode();
-                        } catch (NumberParseException $e) {
-                            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid phone number');
-                        }
+                        $countryCode = $helper->parse($phone)->getCountryCode();
 
                         if (!empty($countryCode)) {
                             $queueForUsage

--- a/src/Appwrite/Auth/Validator/Phone.php
+++ b/src/Appwrite/Auth/Validator/Phone.php
@@ -52,10 +52,7 @@ class Phone extends Validator
         }
 
         try {
-            $parsedValue = $this->helper->parse($value);
-            if (!$this->helper->isValidNumber($parsedValue)) {
-                return false;
-            }
+            $this->helper->parse($value);
         } catch (NumberParseException $e) {
             return false;
         }

--- a/src/Appwrite/Auth/Validator/Phone.php
+++ b/src/Appwrite/Auth/Validator/Phone.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\Auth\Validator;
 
+use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumberUtil;
 use Utopia\Validator;
 
 /**
@@ -12,10 +14,12 @@ use Utopia\Validator;
 class Phone extends Validator
 {
     protected bool $allowEmpty;
+    protected PhoneNumberUtil $helper;
 
     public function __construct(bool $allowEmpty = false)
     {
         $this->allowEmpty = $allowEmpty;
+        $this->helper = PhoneNumberUtil::getInstance();
     }
 
     /**
@@ -45,6 +49,15 @@ class Phone extends Validator
 
         if ($this->allowEmpty && \strlen($value) === 0) {
             return true;
+        }
+
+        try {
+            $parsedValue = $this->helper->parse($value);
+            if (!$this->helper->isValidNumber($parsedValue)) {
+                return false;
+            }
+        } catch (NumberParseException $e) {
+            return false;
         }
 
         return !!\preg_match('/^\+[1-9]\d{6,14}$/', $value);

--- a/tests/unit/Auth/Validator/PhoneTest.php
+++ b/tests/unit/Auth/Validator/PhoneTest.php
@@ -31,6 +31,7 @@ class PhoneTest extends TestCase
         $this->assertEquals($this->object->isValid('+0415553452342'), false);
         $this->assertEquals($this->object->isValid('+14 155 5524564'), false);
         $this->assertEquals($this->object->isValid('+1415555245634543'), false);
+        $this->assertEquals($this->object->isValid('+8027547935'), false);
         $this->assertEquals($this->object->isValid(+14155552456), false);
 
         $this->assertEquals($this->object->isValid('+1415555'), true);

--- a/tests/unit/Auth/Validator/PhoneTest.php
+++ b/tests/unit/Auth/Validator/PhoneTest.php
@@ -31,7 +31,7 @@ class PhoneTest extends TestCase
         $this->assertEquals($this->object->isValid('+0415553452342'), false);
         $this->assertEquals($this->object->isValid('+14 155 5524564'), false);
         $this->assertEquals($this->object->isValid('+1415555245634543'), false);
-        $this->assertEquals($this->object->isValid('+8027547935'), false);
+        $this->assertEquals($this->object->isValid('+8020000000'), false);
         $this->assertEquals($this->object->isValid(+14155552456), false);
 
         $this->assertEquals($this->object->isValid('+1415555'), true);

--- a/tests/unit/Auth/Validator/PhoneTest.php
+++ b/tests/unit/Auth/Validator/PhoneTest.php
@@ -31,7 +31,7 @@ class PhoneTest extends TestCase
         $this->assertEquals($this->object->isValid('+0415553452342'), false);
         $this->assertEquals($this->object->isValid('+14 155 5524564'), false);
         $this->assertEquals($this->object->isValid('+1415555245634543'), false);
-        $this->assertEquals($this->object->isValid('+8020000000'), false);
+        $this->assertEquals($this->object->isValid('+8020000000'), false); // when country code is not present
         $this->assertEquals($this->object->isValid(+14155552456), false);
 
         $this->assertEquals($this->object->isValid('+1415555'), true);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When a invalid phone number is passed, the `libphonenumber\PhoneNumberUtil` library would throw a error which since wasn't handled properly would throw a 500 error.

This PR adds proper handling for this error, throwing a 400 error instead.

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
