### PR TITLE
chore: skipped job instead of throwing error

### DIFF
--- a/src/Appwrite/Platform/Workers/Certificates.php
+++ b/src/Appwrite/Platform/Workers/Certificates.php
@@ -147,7 +147,8 @@ class Certificates extends Action
 
                 // If certificate exists already, double-check expiry date. Skip if job is forced
                 if (!$certificates->isRenewRequired($domain->get(), $log)) {
-                    throw new Exception('Renew isn\'t required.');
+                    Console::info("Skipping, renew isn't required");
+                    return;
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When renew wasn't required in Certificate.php, it would throw a 500 error that was not required. Instead we just want the job to be skipped.

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
