### PR TITLE
fixed typo: Bengaluru in English is spelled as Bangalore not Banglore

### DIFF
--- a/app/config/regions.php
+++ b/app/config/regions.php
@@ -31,7 +31,7 @@ return [
     ],
     'blr' => [
         '$id' => 'blr',
-        'name' => 'Banglore',
+        'name' => 'Bangalore',
         'disabled' => true,
         'flag' => 'in',
         'default' => true,


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

I corrected the spelling of Bengaluru which is written as Bangalore  in English. Previously it was showing as Banglore (there's an 'a' between 'g' and 'l') which I noticed when creating a project on Appwrite.

![image](https://github.com/user-attachments/assets/d05c87cb-4694-49c8-bbc0-bf8a7b877f3d)


## Test Plan

There's no need of Test Plan

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
