### PR TITLE
Fix resend team invite if already accepted

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -356,8 +356,13 @@ return [
     ],
     Exception::TEAM_INVALID_SECRET => [
         'name' => Exception::TEAM_INVALID_SECRET,
-        'description' => 'The team invitation secret is invalid. Please request  a new invitation and try again.',
+        'description' => 'The team invitation secret is invalid. Please request a new invitation and try again.',
         'code' => 401,
+    ],
+    Exception::TEAM_MEMBERSHIP_ALREADY_EXISTS => [
+        'name' => Exception::TEAM_MEMBERSHIP_ALREADY_EXISTS,
+        'description' => 'Team membership already exists. Please check your existing memberships and try again.',
+        'code' => 409,
     ],
     Exception::TEAM_MEMBERSHIP_MISMATCH => [
         'name' => Exception::TEAM_MEMBERSHIP_MISMATCH,

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -359,11 +359,6 @@ return [
         'description' => 'The team invitation secret is invalid. Please request a new invitation and try again.',
         'code' => 401,
     ],
-    Exception::TEAM_MEMBERSHIP_ALREADY_EXISTS => [
-        'name' => Exception::TEAM_MEMBERSHIP_ALREADY_EXISTS,
-        'description' => 'Team membership already exists. Please check your existing memberships and try again.',
-        'code' => 409,
-    ],
     Exception::TEAM_MEMBERSHIP_MISMATCH => [
         'name' => Exception::TEAM_MEMBERSHIP_MISMATCH,
         'description' => 'The membership ID does not belong to the team ID.',

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -617,7 +617,7 @@ App::post('/v1/teams/:teamId/memberships')
                 $dbForProject->createDocument('memberships', $membership);
             Authorization::skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
 
-        } elseif ($membership->getAttribute('joined') === null) {
+        } elseif ($membership->getAttribute('confirm') === false) {
             $membership->setAttribute('secret', Auth::hash($secret));
             $membership->setAttribute('invited', DateTime::now());
 
@@ -630,9 +630,8 @@ App::post('/v1/teams/:teamId/memberships')
                 Authorization::skip(fn () => $dbForProject->updateDocument('memberships', $membership->getId(), $membership)) :
                 $dbForProject->updateDocument('memberships', $membership->getId(), $membership);
         } else {
-            throw new Exception(Exception::TEAM_MEMBERSHIP_ALREADY_EXISTS);
+            throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
         }
-
 
         if ($isPrivilegedUser || $isAppUser) {
             $dbForProject->purgeCachedDocument('users', $invitee->getId());

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -588,9 +588,8 @@ App::post('/v1/teams/:teamId/memberships')
             Query::equal('teamInternalId', [$team->getInternalId()]),
         ]);
 
+        $secret = Auth::tokenGenerator();
         if ($membership->isEmpty()) {
-            $secret = Auth::tokenGenerator();
-
             $membershipId = ID::unique();
             $membership = new Document([
                 '$id' => $membershipId,
@@ -618,7 +617,8 @@ App::post('/v1/teams/:teamId/memberships')
                 $dbForProject->createDocument('memberships', $membership);
             Authorization::skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
 
-        } else {
+        } elseif ($membership->getAttribute('joined') === null) {
+            $membership->setAttribute('secret', Auth::hash($secret));
             $membership->setAttribute('invited', DateTime::now());
 
             if ($isPrivilegedUser || $isAppUser) {
@@ -629,6 +629,8 @@ App::post('/v1/teams/:teamId/memberships')
             $membership = ($isPrivilegedUser || $isAppUser) ?
                 Authorization::skip(fn () => $dbForProject->updateDocument('memberships', $membership->getId(), $membership)) :
                 $dbForProject->updateDocument('memberships', $membership->getId(), $membership);
+        } else {
+            throw new Exception(Exception::TEAM_MEMBERSHIP_ALREADY_EXISTS);
         }
 
 

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -114,7 +114,6 @@ class Exception extends \Exception
     public const TEAM_NOT_FOUND                    = 'team_not_found';
     public const TEAM_INVITE_NOT_FOUND             = 'team_invite_not_found';
     public const TEAM_INVALID_SECRET               = 'team_invalid_secret';
-    public const TEAM_MEMBERSHIP_ALREADY_EXISTS    = 'team_membership_already_exists';
     public const TEAM_MEMBERSHIP_MISMATCH          = 'team_membership_mismatch';
     public const TEAM_INVITE_MISMATCH              = 'team_invite_mismatch';
     public const TEAM_ALREADY_EXISTS               = 'team_already_exists';

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -114,6 +114,7 @@ class Exception extends \Exception
     public const TEAM_NOT_FOUND                    = 'team_not_found';
     public const TEAM_INVITE_NOT_FOUND             = 'team_invite_not_found';
     public const TEAM_INVALID_SECRET               = 'team_invalid_secret';
+    public const TEAM_MEMBERSHIP_ALREADY_EXISTS    = 'team_membership_already_exists';
     public const TEAM_MEMBERSHIP_MISMATCH          = 'team_membership_mismatch';
     public const TEAM_INVITE_MISMATCH              = 'team_invite_mismatch';
     public const TEAM_ALREADY_EXISTS               = 'team_already_exists';

--- a/tests/e2e/Services/Teams/TeamsBaseClient.php
+++ b/tests/e2e/Services/Teams/TeamsBaseClient.php
@@ -226,10 +226,6 @@ trait TeamsBaseClient
         $this->assertEquals($response['body']['teamId'], substr($lastEmail['text'], strpos($lastEmail['text'], '&teamId=', 0) + 8, 20));
         $this->assertEquals($teamName, substr($lastEmail['text'], strpos($lastEmail['text'], '&teamName=', 0) + 10, 7));
 
-        $secret = substr($lastEmail['text'], strpos($lastEmail['text'], '&secret=', 0) + 8, 256);
-        $membershipUid = substr($lastEmail['text'], strpos($lastEmail['text'], '?membershipId=', 0) + 14, 20);
-        $userUid = substr($lastEmail['text'], strpos($lastEmail['text'], '&userId=', 0) + 8, 20);
-
         /**
          * Test with UserId
          * Create user
@@ -307,6 +303,11 @@ trait TeamsBaseClient
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
+
+        $lastEmail = $this->getLastEmail();
+        $membershipUid = substr($lastEmail['text'], strpos($lastEmail['text'], '?membershipId=', 0) + 14, 20);
+        $userUid = substr($lastEmail['text'], strpos($lastEmail['text'], '&userId=', 0) + 8, 20);
+        $secret = substr($lastEmail['text'], strpos($lastEmail['text'], '&secret=', 0) + 8, 256);
 
         /**
          * Test for FAILURE

--- a/tests/e2e/Services/Teams/TeamsBaseServer.php
+++ b/tests/e2e/Services/Teams/TeamsBaseServer.php
@@ -175,17 +175,10 @@ trait TeamsBaseServer
         $userUid = $response['body']['userId'];
         $membershipUid = $response['body']['$id'];
 
-        // $response = $this->client->call(Client::METHOD_GET, '/users/'.$userUid, array_merge([
-        //     'content-type' => 'application/json',
-        //     'x-appwrite-project' => $this->getProject()['$id'],
-        // ], $this->getHeaders()), []);
+        /**
+         * Test for FAILURE
+         */
 
-        // $this->assertEquals($userUid, $response['body']['$id']);
-        // $this->assertContains('team:'.$teamUid, $response['body']['roles']);
-        // $this->assertContains('team:'.$teamUid.'/admin', $response['body']['roles']);
-        // $this->assertContains('team:'.$teamUid.'/editor', $response['body']['roles']);
-
-        // test for resending invitation
         $response = $this->client->call(Client::METHOD_POST, '/teams/' . $teamUid . '/memberships', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -196,11 +189,7 @@ trait TeamsBaseServer
             'url' => 'http://localhost:5000/join-us#title'
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code']);
-
-        /**
-         * Test for FAILURE
-         */
+        $this->assertEquals(409, $response['headers']['status-code']); // membership already created
 
         $response = $this->client->call(Client::METHOD_POST, '/teams/' . $teamUid . '/memberships', array_merge([
             'content-type' => 'application/json',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Prevents resending of team invite if already accepted. It also fixes generation of a new `$secret` when resending the invite.

### Steps to reproduce:

1. Invite a team member to your organisation.
2. Accept the invite.
3. Send the invite again.

Expected:

- It should not send an invite again since the user already accepted it.

What's happening:

- Its sending the invite again. This is likely due to the recent fix that allows resending of invite but we should only do that when invitation is pending, if it's not then we should throw an error.

## Test Plan

<img width="917" alt="Screenshot 2025-02-12 at 3 23 09 PM" src="https://github.com/user-attachments/assets/5f1d8aeb-ea4d-43fd-9edc-c3335e75f8cf" />

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
