### PR TITLE
Fix: metric time was not being written to DB

### DIFF
--- a/src/Appwrite/Platform/Workers/StatsResources.php
+++ b/src/Appwrite/Platform/Workers/StatsResources.php
@@ -354,10 +354,11 @@ class StatsResources extends Action
                     'period' => $period,
                     'region' => $region,
                     'value' => $value,
+                    'time' => $time,
                 ]);
             }
         } else {
-            $time = 'inf' === $period ? null : \date($this->periods[$period], \time());
+            $time = $period === 'inf' ? null : \date($this->periods[$period], \time());
             $id = \md5("{$time}_{$period}_{$metric}");
             $this->documents[] = new Document([
                 '$id' => $id,
@@ -365,6 +366,7 @@ class StatsResources extends Action
                 'period' => $period,
                 'region' => $region,
                 'value' => $value,
+                'time' => $time,
             ]);
         }
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- The metric's time period was not written to DB, so `time` was always null, this PR fixes it

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
