### PR TITLE
Fix Model Platform is missing response key: store 

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1148,7 +1148,7 @@ App::get('/v1/ping')
     ->inject('dbForPlatform')
     ->inject('queueForEvents')
     ->action(function (Response $response, Document $project, Database $dbForPlatform, Event $queueForEvents) {
-        if ($project->isEmpty()) {
+        if ($project->isEmpty() || $project->getId() === 'console') {
             throw new AppwriteException(AppwriteException::PROJECT_NOT_FOUND);
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

On sending a request to the `/v1/ping` endpoint without a projectId, by default console project is returned. This project does not contant the key store as its a special project, leading to 500 errors. This PR adds a check to the endpoint to prevent this.

## Test Plan

Before:
<img width="263" alt="Screenshot 2025-02-14 at 9 12 41 PM" src="https://github.com/user-attachments/assets/7ef9fc29-6e2f-4422-b0af-3319bc718b96" />

After:
<img width="674" alt="Screenshot 2025-02-14 at 9 13 01 PM" src="https://github.com/user-attachments/assets/1f0d11eb-a158-4b0e-98cd-545a9d882f91" />


## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
