### PR TITLE
chore: fix null errors on team invite

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -715,7 +715,7 @@ App::post('/v1/teams/:teamId/memberships')
                     ->setSubject($subject)
                     ->setBody($body)
                     ->setRecipient($invitee->getAttribute('email'))
-                    ->setName($name)
+                    ->setName($invitee->getAttribute('name', ''))
                     ->setVariables($emailVariables)
                     ->trigger();
 
@@ -781,7 +781,7 @@ App::post('/v1/teams/:teamId/memberships')
             ->dynamic(
                 $membership
                     ->setAttribute('teamName', $team->getAttribute('name'))
-                    ->setAttribute('userName', $name)
+                    ->setAttribute('userName', $invitee->getAttribute('name'))
                     ->setAttribute('userEmail', $invitee->getAttribute('email')),
                 Response::MODEL_MEMBERSHIP
             );

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -488,7 +488,7 @@ App::post('/v1/teams/:teamId/memberships')
         }
 
         $email = \strtolower($email);
-        $name = (empty($name)) ? $email : $name;
+        $name = empty($name) ? $email : $name;
         $team = $dbForProject->getDocument('teams', $teamId);
 
         if ($team->isEmpty()) {
@@ -507,7 +507,7 @@ App::post('/v1/teams/:teamId/memberships')
             }
             $email = $invitee->getAttribute('email', '');
             $phone = $invitee->getAttribute('phone', '');
-            $name = empty($name) ? $invitee->getAttribute('name', '') : $name;
+            $name = $invitee->getAttribute('name', '') ?: $name;
         } elseif (!empty($email)) {
             $invitee = $dbForProject->findOne('users', [Query::equal('email', [$email])]); // Get user by email address
             if (!$invitee->isEmpty() && !empty($phone) && $invitee->getAttribute('phone', '') !== $phone) {

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -715,7 +715,7 @@ App::post('/v1/teams/:teamId/memberships')
                     ->setSubject($subject)
                     ->setBody($body)
                     ->setRecipient($invitee->getAttribute('email'))
-                    ->setName($invitee->getAttribute('name'))
+                    ->setName($name)
                     ->setVariables($emailVariables)
                     ->trigger();
 
@@ -781,7 +781,7 @@ App::post('/v1/teams/:teamId/memberships')
             ->dynamic(
                 $membership
                     ->setAttribute('teamName', $team->getAttribute('name'))
-                    ->setAttribute('userName', $invitee->getAttribute('name'))
+                    ->setAttribute('userName', $name)
                     ->setAttribute('userEmail', $invitee->getAttribute('email')),
                 Response::MODEL_MEMBERSHIP
             );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

An invitee's name may be `null` on rare cases, leading to errors. The PR fixes this by replacing the value with `$name` which can either be the optional name param set by user or the invitee's email, or if the invitee's account exist then the account's name (that too if not empty).

Priority if all 3 exist:

```
Invitee's account name > Optional Name set by inviter > Invitee's email
```

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
