### PR TITLE
Fix: stats resources only queue projects accessed in last 3 hours

### DIFF
--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -62,7 +62,7 @@ class StatsResources extends Action
             Authorization::disable();
             Authorization::setDefaultStatus(false);
 
-            $last24Hours = (new \DateTime())->sub(\DateInterval::createFromDateString('24 hours'));
+            $last24Hours = (new \DateTime())->sub(\DateInterval::createFromDateString('3 hours'));
             /**
              * For each project that were accessed in last 24 hours
              */


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Stats resources: Queue projects only if accessed in last 3 hours instead of last 24 hours as the loop runs every hour

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
