### PR TITLE
chore: added timeout to deployment builds in tests

### DIFF
--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -1142,49 +1142,38 @@ class UsageTest extends Scope
 
         $tries = 0;
 
-        while (true) {
-            try {
-                // Compare new values with old values
-                $response = $this->client->call(
-                    Client::METHOD_GET,
-                    '/functions/' . $functionId . '/usage?range=30d',
-                    $this->getConsoleHeaders()
-                );
+        $this->assertEventually(function () use ($functionId, $functionsMetrics, $projectMetrics) {
+            // Compare new values with old values
+            $response = $this->client->call(
+                Client::METHOD_GET,
+                '/functions/' . $functionId . '/usage?range=30d',
+                $this->getConsoleHeaders()
+            );
 
-                $this->assertEquals(200, $response['headers']['status-code']);
-                $this->assertEquals(19, count($response['body']));
-                $this->assertEquals('30d', $response['body']['range']);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertEquals(19, count($response['body']));
+            $this->assertEquals('30d', $response['body']['range']);
 
-                // Check if the new values are greater than the old values
-                $this->assertEquals($functionsMetrics['executionsTotal'] + 1, $response['body']['executionsTotal']);
-                $this->assertGreaterThan($functionsMetrics['executionsTimeTotal'], $response['body']['executionsTimeTotal']);
-                $this->assertGreaterThan($functionsMetrics['executionsMbSecondsTotal'], $response['body']['executionsMbSecondsTotal']);
+            // Check if the new values are greater than the old values
+            $this->assertEquals($functionsMetrics['executionsTotal'] + 1, $response['body']['executionsTotal']);
+            $this->assertGreaterThan($functionsMetrics['executionsTimeTotal'], $response['body']['executionsTimeTotal']);
+            $this->assertGreaterThan($functionsMetrics['executionsMbSecondsTotal'], $response['body']['executionsMbSecondsTotal']);
 
-                $response = $this->client->call(
-                    Client::METHOD_GET,
-                    '/project/usage',
-                    $this->getConsoleHeaders(),
-                    [
-                        'period' => '1h',
-                        'startDate' => self::getToday(),
-                        'endDate' => self::getTomorrow(),
-                    ]
-                );
+            $response = $this->client->call(
+                Client::METHOD_GET,
+                '/project/usage',
+                $this->getConsoleHeaders(),
+                [
+                    'period' => '1h',
+                    'startDate' => self::getToday(),
+                    'endDate' => self::getTomorrow(),
+                ]
+            );
 
-                $this->assertEquals(200, $response['headers']['status-code']);
-                $this->assertEquals($projectMetrics['executionsTotal'] + 1, $response['body']['executionsTotal']);
-                $this->assertGreaterThan($projectMetrics['executionsMbSecondsTotal'], $response['body']['executionsMbSecondsTotal']);
-
-                break;
-            } catch (ExpectationFailedException $th) {
-                if ($tries >= 5) {
-                    throw $th;
-                } else {
-                    $tries++;
-                    sleep(5);
-                }
-            }
-        }
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertEquals($projectMetrics['executionsTotal'] + 1, $response['body']['executionsTotal']);
+            $this->assertGreaterThan($projectMetrics['executionsMbSecondsTotal'], $response['body']['executionsMbSecondsTotal']);
+        });
     }
 
     public function tearDown(): void

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -53,8 +53,9 @@ trait MigrationsBase
         $this->assertNotEmpty($migration['body']);
         $this->assertNotEmpty($migration['body']['$id']);
 
-        $attempts = 0;
-        while ($attempts < 5) {
+        $migrationResult = [];
+
+        $this->assertEventually(function () use ($migration, &$migrationResult) {
             $response = $this->client->call(Client::METHOD_GET, '/migrations/' . $migration['body']['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getDestinationProject()['$id'],
@@ -66,24 +67,18 @@ trait MigrationsBase
             $this->assertNotEmpty($response['body']['$id']);
 
             if ($response['body']['status'] === 'failed') {
-                $this->fail('Migration failed', json_encode($response['body'], JSON_PRETTY_PRINT));
+                $this->fail('Migration failed' . json_encode($response['body'], JSON_PRETTY_PRINT));
             }
 
             $this->assertNotEquals('failed', $response['body']['status']);
+            $this->assertEquals('completed', $response['body']['status']);
 
-            if ($response['body']['status'] === 'completed') {
-                return $response['body'];
-            }
+            $migrationResult = $response['body'];
 
-            if ($attempts === 4) {
-                $this->assertEquals('completed', $response['body']['status']);
-            }
+            return true;
+        });
 
-            $attempts++;
-            sleep(5);
-        }
-
-        return [];
+        return $migrationResult;
     }
 
     /**

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -1311,6 +1311,8 @@ class RealtimeCustomClientTest extends Scope
         $this->assertEquals($deployment['headers']['status-code'], 202);
         $this->assertNotEmpty($deployment['body']['$id']);
 
+        $maxTimeSeconds = 10;
+        $startTime = time();
         // Poll until deployment is built
         while (true) {
             $deployment = $this->client->call(Client::METHOD_GET, '/functions/' . $function['body']['$id'] . '/deployments/' . $deploymentId, [
@@ -1324,6 +1326,10 @@ class RealtimeCustomClientTest extends Scope
                 || \in_array($deployment['body']['status'], ['ready', 'failed'])
             ) {
                 break;
+            }
+
+            if (time() - $startTime >= $maxTimeSeconds) {
+                throw new \Exception('Deployment timed out after ' . $maxTimeSeconds . ' seconds');
             }
 
             \sleep(1);

--- a/tests/e2e/Services/Webhooks/WebhooksBase.php
+++ b/tests/e2e/Services/Webhooks/WebhooksBase.php
@@ -14,6 +14,8 @@ trait WebhooksBase
 {
     protected function awaitDeploymentIsBuilt($functionId, $deploymentId, $checkForSuccess = true): void
     {
+        $maxTimeSeconds = 10;
+        $startTime = time();
         while (true) {
             $deployment = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments/' . $deploymentId, [
                 'content-type' => 'application/json',
@@ -26,6 +28,10 @@ trait WebhooksBase
                 || \in_array($deployment['body']['status'], ['ready', 'failed'])
             ) {
                 break;
+            }
+
+            if (time() - $startTime >= $maxTimeSeconds) {
+                throw new \Exception('Deployment timed out after ' . $maxTimeSeconds . ' seconds');
             }
 
             \sleep(1);

--- a/tests/e2e/Services/Webhooks/WebhooksBase.php
+++ b/tests/e2e/Services/Webhooks/WebhooksBase.php
@@ -15,19 +15,17 @@ trait WebhooksBase
 {
     use Async;
 
-    protected function awaitDeploymentIsBuilt($functionId, $deploymentId, $checkForSuccess = true): void
+    protected function awaitDeploymentIsBuilt($functionId, $deploymentId): void
     {
-        $this->assertEventually(function () use ($functionId, $deploymentId, $checkForSuccess) {
+        $this->assertEventually(function () use ($functionId, $deploymentId) {
             $deployment = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/deployments/' . $deploymentId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
             ]);
 
-            if ($checkForSuccess) {
-                $this->assertEquals(200, $deployment['headers']['status-code']);
-                $this->assertEquals('ready', $deployment['body']['status'], \json_encode($deployment['body']));
-            }
+            $this->assertEquals(200, $deployment['headers']['status-code']);
+            $this->assertEquals('ready', $deployment['body']['status'], \json_encode($deployment['body']));
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If a resource is not set properly, let's say `queueForWebhooks` these tests would keep running forever. This PR adds timeout to them.

## Test Plan

Testing by commenting out queueForWebhooks init:

<img width="1066" alt="Screenshot 2025-03-03 at 9 37 05 PM" src="https://github.com/user-attachments/assets/a112f214-d073-4e34-bcd7-156944ad0f26" />

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
