### PR TITLE
Fix certificates in deletes worker

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -342,6 +342,8 @@ $image = $this->getParam('image', '');
       - _APP_MAINTENANCE_RETENTION_ABUSE
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_EXECUTION
+      - _APP_SYSTEM_SECURITY_EMAIL_ADDRESS
+      - _APP_EMAIL_CERTIFICATES
 
   appwrite-worker-databases:
     image: <?php echo $organization; ?>/<?php echo $image; ?>:<?php echo $version."\n"; ?>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The deletes worker uses the certificates resource to delete certificates, but the certificates resource requires the _APP_EMAIL_CERTIFICATES env var to be set or it will throw an exception and not process any delete jobs. This commit adds the missing env var to the deletes worker.

Fixes: https://github.com/appwrite/appwrite/issues/9488

## Test Plan

Before:

![image](https://github.com/user-attachments/assets/0e224263-f229-4785-b219-e8b476010bcb)

After:

![image](https://github.com/user-attachments/assets/c0f1c493-e25f-4594-9c6b-dee330477883)

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/9377
- https://github.com/appwrite/appwrite/issues/9488

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
