### PR TITLE
Fix logging config

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -859,11 +859,9 @@ App::error()
             $publish = $error->getCode() === 0 || $error->getCode() >= 500;
         }
 
-        if ($error->getCode() >= 400 && $error->getCode() < 500) {
+        $providerConfig = System::getEnv('_APP_EXPERIMENT_LOGGING_CONFIG', '');
+        if (!empty($providerConfig) && $error->getCode() >= 400 && $error->getCode() < 500) {
             // Register error logger
-            $providerName = System::getEnv('_APP_EXPERIMENT_LOGGING_PROVIDER', '');
-            $providerConfig = System::getEnv('_APP_EXPERIMENT_LOGGING_CONFIG', '');
-
             try {
                 $loggingProvider = new DSN($providerConfig ?? '');
                 $providerName = $loggingProvider->getScheme();

--- a/app/init.php
+++ b/app/init.php
@@ -817,6 +817,10 @@ $register->set('logger', function () {
     $providerName = System::getEnv('_APP_LOGGING_PROVIDER', '');
     $providerConfig = System::getEnv('_APP_LOGGING_CONFIG', '');
 
+    if (empty($providerConfig)) {
+        return;
+    }
+
     try {
         $loggingProvider = new DSN($providerConfig ?? '');
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If the _APP_EXPERIMENT_LOGGING_CONFIG env var isn't set, every 4XX error
outputs this warning:

Failed to initialize logging provider: Unable to parse DSN: scheme is
required

To reduce this unnecessary clutter when _APP_EXPERIMENT_LOGGING_CONFIG
isn't set, this PR adds a check to only attempt to initialize the
logging provider if the env var is set.

## Test Plan

Before:

![image](https://github.com/user-attachments/assets/4435e8f8-70f1-4d7f-ab4a-4ce892f0a14f)


## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/9377

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
