### PR TITLE
Disable PDO persistence since we manage our own pool

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -217,7 +217,7 @@ $register->set('pools', function () {
                     return new PDOProxy(function () use ($dsnHost, $dsnPort, $dsnUser, $dsnPass, $dsnDatabase) {
                         return new PDO("mysql:host={$dsnHost};port={$dsnPort};dbname={$dsnDatabase};charset=utf8mb4", $dsnUser, $dsnPass, array(
                             PDO::ATTR_TIMEOUT => 3, // Seconds
-                            PDO::ATTR_PERSISTENT => true,
+                            PDO::ATTR_PERSISTENT => false,
                             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                             PDO::ATTR_EMULATE_PREPARES => true,
                             PDO::ATTR_STRINGIFY_FETCHES => true


### PR DESCRIPTION
Setting PDO::ATTR_PERSISTENT will [cause PDO to use an internal pool of connections, if the DSNs match](https://github.com/php/php-src/blob/master/ext/pdo/pdo_dbh.c#L391-L422). This means that if enabled with a pooling layer on top, pool connection instances may actually reference the same underlying connection.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the database connection settings to disable persistent connections, ensuring improved management of database resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->