### PR TITLE
Feat: Add screenshots to site

### DIFF
--- a/app/config/collections/projects.php
+++ b/app/config/collections/projects.php
@@ -1003,6 +1003,29 @@ return [
                 'array' => false,
                 'filters' => [],
             ],
+
+            [
+                '$id' => ID::custom('deploymentScreenshotLight'), // File ID from 'screenshots' Console bucket
+                'type' => Database::VAR_STRING,
+                'format' => '',
+                'size' => 32,
+                'signed' => false,
+                'required' => false,
+                'default' => null,
+                'array' => false,
+                'filters' => [],
+            ],
+            [
+                '$id' => ID::custom('deploymentScreenshotDark'), // File ID from 'screenshots' Console bucket
+                'type' => Database::VAR_STRING,
+                'format' => '',
+                'size' => 32,
+                'signed' => false,
+                'required' => false,
+                'default' => null,
+                'array' => false,
+                'filters' => [],
+            ],
             [
                 '$id' => ID::custom('vars'),
                 'type' => Database::VAR_STRING,

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -788,7 +788,7 @@ class Builds extends Action
                         ]);
 
                         $config['sleep'] = 3000;
-                        
+
                         $frameworks = Config::getParam('frameworks', []);
                         $framework = $frameworks[$resource->getAttribute('framework', '')] ?? null;
                         if (!is_null($framework)) {
@@ -898,6 +898,8 @@ class Builds extends Action
 
                         $resource->setAttribute('deploymentId', $deployment->getId());
                         $resource->setAttribute('deploymentInternalId', $deployment->getInternalId());
+                        $resource->setAttribute('deploymentScreenshotDark', $deployment->getAttribute('screenshotDark', ''));
+                        $resource->setAttribute('deploymentScreenshotLight', $deployment->getAttribute('screenshotLight', ''));
                         $resource = $dbForProject->updateDocument('sites', $resource->getId(), $resource);
                         $queries = [
                             Query::equal("projectInternalId", [$project->getInternalId()]),

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -100,6 +100,8 @@ class Delete extends Action
             $site = $dbForProject->updateDocument('sites', $site->getId(), new Document(array_merge($site->getArrayCopy(), [
                 'deploymentId' => '',
                 'deploymentInternalId' => '',
+                'deploymentScreenshotDark' => '',
+                'deploymentScreenshotLight' => '',
             ])));
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -90,6 +90,8 @@ class Update extends Base
         $site = $dbForProject->updateDocument('sites', $site->getId(), new Document(array_merge($site->getArrayCopy(), [
             'deploymentInternalId' => $deployment->getInternalId(),
             'deploymentId' => $deployment->getId(),
+            'deploymentScreenshotDark' => $deployment->getAttribute('screenshotDark', ''),
+            'deploymentScreenshotLight' => $deployment->getAttribute('screenshotLight', ''),
         ])));
 
         $queries = [

--- a/src/Appwrite/Utopia/Response/Model/Site.php
+++ b/src/Appwrite/Utopia/Response/Model/Site.php
@@ -58,6 +58,18 @@ class Site extends Model
                 'default' => '',
                 'example' => '5e5ea5c16897e',
             ])
+            ->addRule('deploymentScreenshotLight', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Screenshot of active deployment with light theme preference file ID.',
+                'default' => '',
+                'example' => '5e5ea5c16897e',
+            ])
+            ->addRule('deploymentScreenshotDark', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Screenshot of active deployment with dark theme preference file ID.',
+                'default' => '',
+                'example' => '5e5ea5c16897e',
+            ])
             ->addRule('vars', [
                 'type' => Response::MODEL_VARIABLE,
                 'description' => 'Site variables.',

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -1816,10 +1816,14 @@ class SitesCustomServerTest extends Scope
         $this->assertStringContainsString("@media (prefers-color-scheme: dark)", $response['body']);
 
         $deployment = $this->getDeployment($siteId, $deploymentId);
-
         $this->assertEquals(200, $deployment['headers']['status-code']);
         $this->assertNotEmpty($deployment['body']['screenshotLight']);
         $this->assertNotEmpty($deployment['body']['screenshotDark']);
+
+        $site = $this->getSite($siteId);
+        $this->assertEquals(200, $site['headers']['status-code']);
+        $this->assertEquals($deployment['body']['screenshotLight'], $site['body']['deploymentScreenshotLight']);
+        $this->assertEquals($deployment['body']['screenshotDark'], $site['body']['deploymentScreenshotDark']);
 
         $screenshotId = $deployment['body']['screenshotLight'];
         $file = $this->client->call(Client::METHOD_GET, "/storage/buckets/screenshots/files/$screenshotId/view?project=console", array_merge([


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds screenshot details of active deployment on site, to prevent need for subqueries from frontend in site list view

## Test Plan

Tests updated

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for themed deployment screenshots. Deployments now include options for both light and dark mode visuals, offering clearer and more tailored deployment displays across site updates and management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->