### PR TITLE
Fix: schedules region filtering

### DIFF
--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -10,7 +10,6 @@ use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception;
 use Utopia\Database\Query;
-use Utopia\System\System;
 
 class V19 extends Migration
 {
@@ -731,7 +730,7 @@ class V19 extends Migration
 
                 if (empty($document->getAttribute('scheduleId', null))) {
                     $schedule = $this->consoleDB->createDocument('schedules', new Document([
-                        'region' => System::getEnv('_APP_REGION', 'default'), // Todo replace with projects region
+                        'region' => $project->getAttribute('region'), // Todo replace with projects region
                         'resourceType' => 'function',
                         'resourceId' => $document->getId(),
                         'resourceInternalId' => $document->getInternalId(),

--- a/src/Appwrite/Migration/Version/V19.php
+++ b/src/Appwrite/Migration/Version/V19.php
@@ -730,7 +730,7 @@ class V19 extends Migration
 
                 if (empty($document->getAttribute('scheduleId', null))) {
                     $schedule = $this->consoleDB->createDocument('schedules', new Document([
-                        'region' => $project->getAttribute('region'), // Todo replace with projects region
+                        'region' => $project->getAttribute('region'),
                         'resourceType' => 'function',
                         'resourceId' => $document->getId(),
                         'resourceInternalId' => $document->getInternalId(),

--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -103,8 +103,15 @@ abstract class ScheduleBase extends Action
                 $paginationQueries[] = Query::cursorAfter($latestDocument);
             }
 
+            // Temporarly accepting both 'fra' and 'default'
+            // When all migrated, only use _APP_REGION with 'default' as default value
+            $regions = [System::getEnv('_APP_REGION', 'default')];
+            if (!in_array('default', $regions)) {
+                $regions[] = 'default';
+            }
+
             $results = $dbForPlatform->find('schedules', \array_merge($paginationQueries, [
-                Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
+                Query::equal('region', $regions),
                 Query::equal('resourceType', [static::getSupportedResource()]),
                 Query::equal('active', [true]),
             ]));

--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -160,8 +160,15 @@ abstract class ScheduleBase extends Action
                         $paginationQueries[] = Query::cursorAfter($latestDocument);
                     }
 
+                    // Temporarly accepting both 'fra' and 'default'
+                    // When all migrated, only use _APP_REGION with 'default' as default value
+                    $regions = [System::getEnv('_APP_REGION', 'default')];
+                    if (!in_array('default', $regions)) {
+                        $regions[] = 'default';
+                    }
+
                     $results = $dbForPlatform->find('schedules', \array_merge($paginationQueries, [
-                        Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
+                        Query::equal('region', $regions),
                         Query::equal('resourceType', [static::getSupportedResource()]),
                         Query::greaterThanEqual('resourceUpdatedAt', $lastSyncUpdate),
                     ]));

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -180,10 +180,17 @@ class Deletes extends Action
      */
     private function deleteSchedules(Database $dbForPlatform, callable $getProjectDB, string $datetime): void
     {
+        // Temporarly accepting both 'fra' and 'default'
+        // When all migrated, only use _APP_REGION with 'default' as default value
+        $regions = [System::getEnv('_APP_REGION', 'default')];
+        if (!in_array('default', $regions)) {
+            $regions[] = 'default';
+        }
+
         $this->listByGroup(
             'schedules',
             [
-                Query::equal('region', [System::getEnv('_APP_REGION', 'default')]),
+                Query::equal('region', $regions),
                 Query::lessThanEqual('resourceUpdatedAt', $datetime),
                 Query::equal('active', [false]),
             ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add temporary fix for Cloud, allowing to see schedules of both default, and fra region

## Test Plan

Not needed; test must pass

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated region assignment for scheduling tasks to use project-specific settings for improved consistency.
	- Enhanced region filtering in scheduling queries, broadening the range of accepted regions during task management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->