### PR TITLE
Fix: Correct error handling for int values like documentId = 123

### DIFF
--- a/src/Appwrite/Event/Event.php
+++ b/src/Appwrite/Event/Event.php
@@ -438,7 +438,7 @@ class Event
         $action = $parsed['action'];
         $attribute = $parsed['attribute'];
 
-        if ($resource && !\in_array(\trim($resource, "\[\]"), $paramKeys)) {
+        if ($resource && !\in_array(\trim((string) $resource, "\[\]"), $paramKeys)) {
             throw new InvalidArgumentException("{$resource} is missing from the params.");
         }
 


### PR DESCRIPTION
What does this PR do?
This PR fixes a parameter validation issue in the Event.php file. Previously, passing an integer as documentId incorrectly triggered exceptions due to improper handling of array checks. I have refined the logic to ensure proper validation and prevent unnecessary exceptions.

Motivation
This is my first open-source contribution, and I genuinely enjoyed working on it. It was a great learning experience, understanding the codebase and fixing an issue.
I am also open to any feedback you might have to improve my future contributions.

Test Plan:
The following test cases were executed:
✅ No exception for documentId: 123  
✅ No exception for documentId: "123"  
❌ Exception: 789 is missing from the params.  
❌ Exception: 789 is missing from the params.  
✅ No exception for documentId: null  
✅ No exception for documentId: ""  
✅ No exception for documentId: "[123]"  
✅ No exception for documentId: 0  
The fix ensures that valid inputs no longer throw unnecessary exceptions while maintaining strict parameter validation.

Issue: Bug Report - "Incorrect Error Handling When Passing Int as documentId parameter"

Checklist
 I have read the Contributing Guidelines
 Changes have been tested successfully.
 Code follows the project’s coding standards.