### PR TITLE
Restrict role change for sole org owner

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -1034,7 +1034,6 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
     ->param('membershipId', '', new UID(), 'Membership ID.')
     ->param('roles', [], function (Document $project) {
         if ($project->getId() === 'console') {
-            ;
             $roles = array_keys(Config::getParam('roles', []));
             array_filter($roles, function ($role) {
                 return !in_array($role, [Auth::USER_ROLE_APPS, Auth::USER_ROLE_GUESTS, Auth::USER_ROLE_USERS]);
@@ -1046,9 +1045,10 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
     ->inject('request')
     ->inject('response')
     ->inject('user')
+    ->inject('project')
     ->inject('dbForProject')
     ->inject('queueForEvents')
-    ->action(function (string $teamId, string $membershipId, array $roles, Request $request, Response $response, Document $user, Database $dbForProject, Event $queueForEvents) {
+    ->action(function (string $teamId, string $membershipId, array $roles, Request $request, Response $response, Document $user, Document $project, Database $dbForProject, Event $queueForEvents) {
 
         $team = $dbForProject->getDocument('teams', $teamId);
         if ($team->isEmpty()) {
@@ -1068,6 +1068,21 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
         $isPrivilegedUser = Auth::isPrivilegedUser(Authorization::getRoles());
         $isAppUser = Auth::isAppUser(Authorization::getRoles());
         $isOwner = Authorization::isRole('team:' . $team->getId() . '/owner');
+
+        if ($project->getId() === 'console') {
+            // Quick check: fetch up to 2 owners to determine if only one exists
+            $ownersCount = $dbForProject->count(
+                collection: 'memberships',
+                queries: [Query::contains('roles', ['owner'])],
+                max: 2
+            );
+
+            // If there's only one owner,
+            // and the requester is that owner, prevent role change
+            if ($ownersCount === 1 && $isOwner) {
+                throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'There must be at least one owner in the organization.');
+            }
+        }
 
         if (!$isOwner && !$isPrivilegedUser && !$isAppUser) { // Not owner, not admin, not app (server)
             throw new Exception(Exception::USER_UNAUTHORIZED, 'User is not allowed to modify roles');

--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -1077,9 +1077,9 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
                 max: 2
             );
 
-            // If there's only one owner,
-            // and the requester is that owner, prevent role change
-            if ($ownersCount === 1 && $isOwner) {
+            // Prevent role change if there's only one owner left,
+            // the requester is that owner, and the new `$roles` no longer include 'owner'!
+            if ($ownersCount === 1 && $isOwner && !\in_array('owner', $roles)) {
                 throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'There must be at least one owner in the organization.');
             }
         }

--- a/tests/e2e/Services/Teams/TeamsBase.php
+++ b/tests/e2e/Services/Teams/TeamsBase.php
@@ -38,29 +38,35 @@ trait TeamsBase
         $teamName = $response1['body']['name'];
 
         /**
-         * Test: Attempt to downgrade the only OWNER in a team (should fail)
+         * Test: Attempt to downgrade the only OWNER in an organization (should fail)
          */
-        // Step 1: Fetch all team memberships — only one exists at this point
-        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()));
+        if ($this->getProject()['$id'] === 'console') {
+            // Step 1: Fetch all team memberships — only one exists at this point
+            $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => [
+                    Query::limit(1)->toString(),
+                ],
+            ]);
 
-        // Step 2: Extract the membership ID of the only member (also the only OWNER)
-        $membershipID = $response['body']['memberships'][0]['$id'];
+            // Step 2: Extract the membership ID of the only member (also the only OWNER)
+            $membershipID = $response['body']['memberships'][0]['$id'];
 
-        // Step 3: Attempt to downgrade the member's role to 'developer'
-        $response = $this->client->call(Client::METHOD_PATCH, '/teams/' . $teamUid . '/memberships/' . $membershipID, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()), [
-            'roles' => ['developer']
-        ]);
+            // Step 3: Attempt to downgrade the member's role to 'developer'
+            $response = $this->client->call(Client::METHOD_PATCH, '/teams/' . $teamUid . '/memberships/' . $membershipID, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'roles' => ['developer']
+            ]);
 
-        // Step 4: Assert failure — cannot remove the only OWNER from a team
-        $this->assertEquals(400, $response['headers']['status-code']);
-        $this->assertEquals('general_argument_invalid', $response['body']['type']);
-        $this->assertEquals('There must be at least one owner in the organization.', $response['body']['message']);
+            // Step 4: Assert failure — cannot remove the only OWNER from a team
+            $this->assertEquals(400, $response['headers']['status-code']);
+            $this->assertEquals('general_argument_invalid', $response['body']['type']);
+            $this->assertEquals('There must be at least one owner in the organization.', $response['body']['message']);
+        }
 
         $teamId = ID::unique();
         $response2 = $this->client->call(Client::METHOD_POST, '/teams', array_merge([


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes an issue where an organization owner could accidentally change their own role, resulting in limited access. This PR ensures at least one owner remains to prevent accidental privilege loss.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
