### PR TITLE
feat: cache telemetry

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -48,10 +48,10 @@ use Utopia\Storage\Device\S3;
 use Utopia\Storage\Device\Wasabi;
 use Utopia\Storage\Storage;
 use Utopia\System\System;
-use Utopia\Validator\Hostname;
-use Utopia\VCS\Adapter\Git\GitHub as VcsGitHub;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
+use Utopia\Validator\Hostname;
+use Utopia\VCS\Adapter\Git\GitHub as VcsGitHub;
 
 // Runtime Execution
 App::setResource('log', fn () => new Log());


### PR DESCRIPTION
Initialises cache using `telemetry` in resource.php.

Allows simple overriding of `telemetry` resource in cloud.