### PR TITLE
fix(functions): treat 0 as unlimited for CPUs and memory

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -800,7 +800,7 @@ return [
             ],
             [
                 'name' => '_APP_FUNCTIONS_CPUS',
-                'description' => 'The maximum number of CPU core a single cloud function is allowed to use. Please note that setting a value higher than available cores will result in a function error, which might result in an error. The default value is empty. When it\'s empty, CPU limit will be disabled.',
+                'description' => 'The maximum number of CPU core a single cloud function is allowed to use. Please note that setting a value higher than available cores will result in a function error, which might result in an error. The default value is empty. When it\'s empty or 0, CPU limit will be disabled.',
                 'introduction' => '0.7.0',
                 'default' => '0',
                 'required' => false,
@@ -809,7 +809,7 @@ return [
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY',
-                'description' => 'The maximum amount of memory a single cloud function is allowed to use in megabytes. The default value is  empty. When it\'s empty, memory limit will be disabled.',
+                'description' => 'The maximum amount of memory a single cloud function is allowed to use in megabytes. The default value is  empty. When it\'s empty or 0, memory limit will be disabled.',
                 'introduction' => '0.7.0',
                 'default' => '0',
                 'required' => false,

--- a/app/controllers/api/functions.php
+++ b/app/controllers/api/functions.php
@@ -184,8 +184,8 @@ App::post('/v1/functions')
     ->param('specification', APP_FUNCTION_SPECIFICATION_DEFAULT, fn (array $plan) => new RuntimeSpecification(
         $plan,
         Config::getParam('runtime-specifications', []),
-        App::getEnv('_APP_FUNCTIONS_CPUS', APP_FUNCTION_CPUS_DEFAULT),
-        App::getEnv('_APP_FUNCTIONS_MEMORY', APP_FUNCTION_MEMORY_DEFAULT)
+        System::getEnv('_APP_FUNCTIONS_CPUS', 0),
+        System::getEnv('_APP_FUNCTIONS_MEMORY', 0)
     ), 'Runtime specification for the function and builds.', true, ['plan'])
     ->inject('request')
     ->inject('response')
@@ -559,8 +559,12 @@ App::get('/v1/functions/specifications')
                 $spec['enabled'] = in_array($spec['slug'], $plan['runtimeSpecifications']);
             }
 
+            $maxCpus = System::getEnv('_APP_FUNCTIONS_CPUS', 0);
+            $maxMemory = System::getEnv('_APP_FUNCTIONS_MEMORY', 0);
+
             // Only add specs that are within the limits set by environment variables
-            if ($spec['cpus'] <= System::getEnv('_APP_FUNCTIONS_CPUS', 1) && $spec['memory'] <= System::getEnv('_APP_FUNCTIONS_MEMORY', 512)) {
+            // Treat 0 as no limit
+            if ((empty($maxCpus) || $spec['cpus'] <= $maxCpus) && (empty($maxMemory) || $spec['memory'] <= $maxMemory)) {
                 $runtimeSpecs[] = $spec;
             }
         }
@@ -858,8 +862,8 @@ App::put('/v1/functions/:functionId')
     ->param('specification', APP_FUNCTION_SPECIFICATION_DEFAULT, fn (array $plan) => new RuntimeSpecification(
         $plan,
         Config::getParam('runtime-specifications', []),
-        App::getEnv('_APP_FUNCTIONS_CPUS', APP_FUNCTION_CPUS_DEFAULT),
-        App::getEnv('_APP_FUNCTIONS_MEMORY', APP_FUNCTION_MEMORY_DEFAULT)
+        System::getEnv('_APP_FUNCTIONS_CPUS', 0),
+        System::getEnv('_APP_FUNCTIONS_MEMORY', 0)
     ), 'Runtime specification for the function and builds.', true, ['plan'])
     ->inject('request')
     ->inject('response')

--- a/src/Appwrite/Functions/Validator/RuntimeSpecification.php
+++ b/src/Appwrite/Functions/Validator/RuntimeSpecification.php
@@ -34,7 +34,7 @@ class RuntimeSpecification extends Validator
         $allowedSpecifications = [];
 
         foreach ($this->specifications as $size => $values) {
-            if ($values['cpus'] <= $this->maxCpus && $values['memory'] <= $this->maxMemory) {
+            if ((empty($this->maxCpus) || $values['cpus'] <= $this->maxCpus) && (empty($this->maxMemory) || $values['memory'] <= $this->maxMemory)) {
                 if (!empty($this->plan) && array_key_exists('runtimeSpecifications', $this->plan)) {
                     if (!\in_array($size, $this->plan['runtimeSpecifications'])) {
                         continue;


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Prior versions of Appwrite treated 0 as unlimited for _APP_FUNCTIONS_CPUS and _APP_FUNCTIONS_MEMORY. As such, this PR updates the specification validator and the list specifications endpoint to also treat the default 0 value as unlimited, allowing any specification.

## Test Plan

Manually tested spinning up Appwrite with 0 for _APP_FUNCTIONS_CPUS and _APP_FUNCTIONS_MEMORY and confirmed list specifications showed all the specs:

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/47238679-f9a4-46db-bc48-be8923db7a90" />

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
