### PR TITLE
Fix/throwing 400 for null order attributes

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -3098,6 +3098,9 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/documents')
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
+        catch(DatabaseException $e){
+            throw new Exception(Exception::GENERAL_CURSOR_NOT_FOUND,$e->getMessage());
+        }
 
         // Add $collectionId and $databaseId for all documents
         $processDocument = (function (Document $collection, Document $document) use (&$processDocument, $dbForProject, $database): bool {

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -3097,9 +3097,8 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/documents')
             throw new Exception(Exception::USER_UNAUTHORIZED);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
-        }
-        catch(DatabaseException $e){
-            throw new Exception(Exception::GENERAL_CURSOR_NOT_FOUND,$e->getMessage());
+        } catch (DatabaseException $e) {
+            throw new Exception(Exception::GENERAL_CURSOR_NOT_FOUND, $e->getMessage());
         }
 
         // Add $collectionId and $databaseId for all documents


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Previously
* It was throwing error when the attribute passed in order was having null in the document referenced by the document id in the cursor pagination

Current
* find methods of the db adapter throws error during the null cursor, so catching that and throwing 400 error instead of 500
![image](https://github.com/user-attachments/assets/ed8d984d-d610-4787-acb9-740aaa0ee0b6)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
