### PR TITLE
Add `resourceId`

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Migration.php
+++ b/src/Appwrite/Utopia/Response/Model/Migration.php
@@ -59,6 +59,13 @@ class Migration extends Model
                 'example' => ['user'],
                 'array' => true
             ])
+            ->addRule('resourceId', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Id of the resource to migrate.',
+                'default' => '',
+                'example' => 'databaseId:collectionId',
+                'array' => false
+            ])
             ->addRule('statusCounters', [
                 'type' => self::TYPE_JSON,
                 'description' => 'A group of counters that represent the total progress of the migration.',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

`utopia-php/migration` doesn't log the reports for documents, but for checking the status of the migration and accessing the database and collection ids, we need the `resourceId` in the response modal.

## Test Plan

Manual.

<img width="443" alt="Screenshot 2025-04-17 at 4 40 33 PM" src="https://github.com/user-attachments/assets/201bf40b-6fe6-4a2e-80b0-4b180decf0a0" />

## Related PRs and Issues

* #9622 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
