### PR TITLE
fix: validate SMTP credentials using SMTPAuth

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,8 @@
+modules = ["nodejs-20", "php-8.2", "bash"]
+run = "node index.js"
+
+[nix]
+channel = "stable-24_05"
+
+[deployment]
+run = ["sh", "-c", "node index.js"]

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -1683,6 +1683,7 @@ App::patch('/v1/projects/:projectId/smtp')
         if ($enabled) {
             $mail = new PHPMailer(true);
             $mail->isSMTP();
+            $mail->SMTPAuth = (!empty($username) && !empty($password)) ? true : false;
             $mail->Username = $username;
             $mail->Password = $password;
             $mail->Host = $host;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes issue [#9067](https://github.com/appwrite/appwrite/issues/9067) by enabling SMTP authentication in the projects.php controller.  
Without setting $mail->SMTPAuth, PHPMailer does not validate the provided username and password.  
This fix ensures that invalid SMTP credentials will be correctly rejected when updating a project's SMTP settings.

## Test Plan

- Reproduced the issue by attempting to update SMTP settings with an invalid username and password.
- Applied the fix by adding `$mail->SMTPAuth = (!empty($username) && !empty($password)) ? true : false;` to the validation block.
- Confirmed that the SMTP credentials are now validated before the update is accepted.
- Code reviewed in a Replit environment.

## Related PRs and Issues

- Fixes [#9067](https://github.com/appwrite/appwrite/issues/9067)

## Checklist
- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?