### PR TITLE
Allow compressed CSV

### DIFF
--- a/app/controllers/api/migrations.php
+++ b/app/controllers/api/migrations.php
@@ -4,6 +4,7 @@ use Appwrite\Auth\Auth;
 use Appwrite\Event\Event;
 use Appwrite\Event\Migration;
 use Appwrite\Extend\Exception;
+use Appwrite\OpenSSL\OpenSSL;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
@@ -31,6 +32,7 @@ use Utopia\Storage\Compression\Algorithms\GZIP;
 use Utopia\Storage\Compression\Algorithms\Zstd;
 use Utopia\Storage\Compression\Compression;
 use Utopia\Storage\Device;
+use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Integer;
 use Utopia\Validator\Text;
@@ -347,29 +349,42 @@ App::post('/v1/migrations/csv')
             throw new Exception(Exception::STORAGE_FILE_NOT_FOUND, 'File not found in ' . $path);
         }
 
-        if (!empty($file->getAttribute('openSSLCipher'))) {
-            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED, "Only unencrypted CSV files can be used for document import.");
-        }
-
+        // no encryption, compression on files above 20MB.
+        $hasEncryption = !empty($file->getAttribute('openSSLCipher'));
         $compression = $file->getAttribute('algorithm', Compression::NONE);
-        $hasCompression = $compression !== Compression::NONE; // skipped on files that are 20MB+ in size.
+        $hasCompression = $compression !== Compression::NONE;
 
-        // copy to import volume
         $migrationId = ID::unique();
         $newPath = $deviceForImports->getPath('/' . $migrationId . '_' . $fileId . '.csv');
 
-        if ($hasCompression) {
+        if ($hasEncryption || $hasCompression) {
             $source = $deviceForFiles->read($path);
 
-            switch ($compression) {
-                case Compression::ZSTD:
-                    $source = (new Zstd())->decompress($source);
-                    break;
-                case Compression::GZIP:
-                    $source = (new GZIP())->decompress($source);
-                    break;
+            // 1. decrypt
+            if ($hasEncryption) {
+                $source = OpenSSL::decrypt(
+                    $source,
+                    $file->getAttribute('openSSLCipher'),
+                    System::getEnv('_APP_OPENSSL_KEY_V' . $file->getAttribute('openSSLVersion')),
+                    0,
+                    hex2bin($file->getAttribute('openSSLIV')),
+                    hex2bin($file->getAttribute('openSSLTag'))
+                );
             }
 
+            // 2. decompress
+            if ($hasCompression) {
+                switch ($compression) {
+                    case Compression::ZSTD:
+                        $source = (new Zstd())->decompress($source);
+                        break;
+                    case Compression::GZIP:
+                        $source = (new GZIP())->decompress($source);
+                        break;
+                }
+            }
+
+            // manual write after decryption and/or decompression
             if (! $deviceForImports->write($newPath, $source, 'text/csv')) {
                 throw new \Exception("Unable to copy file");
             }

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -971,7 +971,6 @@ trait MigrationsBase
         $this->assertEquals($response['body']['required'], true);
 
         // make a bucket, upload a file to it!
-        // 1. enable encryption
         $bucketOne = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -989,33 +988,11 @@ trait MigrationsBase
 
         $bucketOneId = $bucketOne['body']['$id'];
 
-        // 2. no encryption
-        $bucketTwo = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-            'x-appwrite-key' => $this->getProject()['apiKey'],
-        ], [
-            'bucketId' => ID::unique(),
-            'name' => 'Test Bucket 2',
-            'maximumFileSize' => 2000000, //2MB
-            'allowedFileExtensions' => ['csv'],
-            'compression' => 'gzip',
-            'encryption' => false
-        ]);
-
-        $this->assertNotEmpty($bucketTwo['body']['$id']);
-        $this->assertEquals(201, $bucketTwo['headers']['status-code']);
-
-        $bucketTwoId = $bucketTwo['body']['$id'];
-
         $bucketIds = [
-            'encrypted' => $bucketOneId,
-            'unencrypted' => $bucketTwoId,
-
-            // in unencrypted buckets!
-            'missing-row' => $bucketTwoId,
-            'missing-column' => $bucketTwoId,
-            'irrelevant-column' => $bucketTwoId,
+            'default' => $bucketOneId,
+            'missing-row' => $bucketOneId,
+            'missing-column' => $bucketOneId,
+            'irrelevant-column' => $bucketOneId,
         ];
 
         $fileIds = [];
@@ -1048,20 +1025,6 @@ trait MigrationsBase
 
             $fileIds[$label] = $response['body']['$id'];
         }
-
-        // encrypted bucket, fail.
-        $encrypted = $this->performCsvMigration(
-            [
-                'fileId' => $fileIds['encrypted'],
-                'bucketId' => $bucketIds['encrypted'],
-                'resourceId' => $databaseId . ':' . $collectionId,
-            ]
-        );
-
-        // fail on compressed, encrypted buckets!
-        $this->assertEquals(400, $encrypted['body']['code']);
-        $this->assertEquals('storage_file_type_unsupported', $encrypted['body']['type']);
-        $this->assertEquals('Only unencrypted CSV files can be used for document import.', $encrypted['body']['message']);
 
         // missing attribute, fail in worker.
         $missingColumn = $this->performCsvMigration(
@@ -1150,12 +1113,12 @@ trait MigrationsBase
             );
         }, 60000, 500);
 
-        // no encryption, pass.
+        // all data exists, pass/
         $migration = $this->performCsvMigration(
             [
                 'endpoint' => 'http://localhost/v1',
-                'fileId' => $fileIds['unencrypted'],
-                'bucketId' => $bucketIds['unencrypted'],
+                'fileId' => $fileIds['default'],
+                'bucketId' => $bucketIds['default'],
                 'resourceId' => $databaseId . ':' . $collectionId,
             ]
         );

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -1061,7 +1061,7 @@ trait MigrationsBase
         // fail on compressed, encrypted buckets!
         $this->assertEquals(400, $compressed['body']['code']);
         $this->assertEquals('storage_file_type_unsupported', $compressed['body']['type']);
-        $this->assertEquals('Only uncompressed, unencrypted CSV files can be used for document import.', $compressed['body']['message']);
+        $this->assertEquals('Only unencrypted CSV files can be used for document import.', $compressed['body']['message']);
 
         // missing attribute, fail in worker.
         $missingColumn = $this->performCsvMigration(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Files over 20MB are skipped for compressions on storage buckets. This PR allows compressed files now.

## Test Plan

Manual.

## Related PRs and Issues

- #9622 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing encrypted and compressed CSV files (GZIP and Zstd) in the CSV migration process.

- **Bug Fixes**
  - Improved error handling for decryption, decompression, and file writing failures during CSV import.
  - Updated error messaging to clarify that only unencrypted CSV files are supported for document import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->