### PR TITLE
chore: revert utopia-php/database to 0.65.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "utopia-php/cache": "0.12.*",
         "utopia-php/cli": "0.15.*",
         "utopia-php/config": "0.2.*",
-        "utopia-php/database": "0.66.*",
+        "utopia-php/database": "0.65.*",
         "utopia-php/domains": "0.5.*",
         "utopia-php/dsn": "0.2.1",
         "utopia-php/framework": "0.33.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35fd85e8d566d20d8177266469c5ebcb",
+    "content-hash": "51ff891ef6cee8a3f8c4e5187b7fd479",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3497,16 +3497,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.66.0",
+            "version": "0.65.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "67d2ab418efba31dc76b3564cf043e2b3f98d027"
+                "reference": "e589efdc5da1216523a758e8af358866d4fb563f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/67d2ab418efba31dc76b3564cf043e2b3f98d027",
-                "reference": "67d2ab418efba31dc76b3564cf043e2b3f98d027",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/e589efdc5da1216523a758e8af358866d4fb563f",
+                "reference": "e589efdc5da1216523a758e8af358866d4fb563f",
                 "shasum": ""
             },
             "require": {
@@ -3547,9 +3547,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.66.0"
+                "source": "https://github.com/utopia-php/database/tree/0.65.0"
             },
-            "time": "2025-04-16T07:10:27+00:00"
+            "time": "2025-04-14T07:39:01+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -4107,16 +4107,16 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "0.8.0",
+            "version": "0.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "60733929dc328e7ea47e800579c8bbf0d49df5ba"
+                "reference": "05c67aba42eb68ac65489cc1e7fc5db83db2dd4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/60733929dc328e7ea47e800579c8bbf0d49df5ba",
-                "reference": "60733929dc328e7ea47e800579c8bbf0d49df5ba",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/05c67aba42eb68ac65489cc1e7fc5db83db2dd4d",
+                "reference": "05c67aba42eb68ac65489cc1e7fc5db83db2dd4d",
                 "shasum": ""
             },
             "require": {
@@ -4153,9 +4153,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/0.8.0"
+                "source": "https://github.com/utopia-php/pools/tree/0.8.2"
             },
-            "time": "2025-03-19T10:22:03+00:00"
+            "time": "2025-04-17T02:04:54+00:00"
         },
         {
             "name": "utopia-php/preloader",
@@ -4767,16 +4767,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "0.40.12",
+            "version": "0.40.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "182ec17848f81b78c336379bac94ff92b7a73365"
+                "reference": "c4bc0ff4589969252b99354368743a99997f0428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/182ec17848f81b78c336379bac94ff92b7a73365",
-                "reference": "182ec17848f81b78c336379bac94ff92b7a73365",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/c4bc0ff4589969252b99354368743a99997f0428",
+                "reference": "c4bc0ff4589969252b99354368743a99997f0428",
                 "shasum": ""
             },
             "require": {
@@ -4812,9 +4812,9 @@
             "description": "Appwrite PHP library for generating API SDKs for multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/0.40.12"
+                "source": "https://github.com/appwrite/sdk-generator/tree/0.40.13"
             },
-            "time": "2025-04-02T23:36:11+00:00"
+            "time": "2025-04-23T11:59:44+00:00"
         },
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

revert due to some errors with oauthproviders info not being stored correctly during oauth flow leading to provider being disabled error.

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
