### PR TITLE
core: introduce endpoint.docs in specs

### DIFF
--- a/app/config/specs/open-api3-1.6.x-client.json
+++ b/app/config/specs/open-api3-1.6.x-client.json
@@ -17,6 +17,9 @@
     },
     "servers": [
         {
+            "url": "https:\/\/cloud.appwrite.io\/v1"
+        },
+        {
             "url": "https:\/\/<REGION>.cloud.appwrite.io\/v1"
         }
     ],

--- a/app/config/specs/open-api3-1.6.x-console.json
+++ b/app/config/specs/open-api3-1.6.x-console.json
@@ -17,6 +17,9 @@
     },
     "servers": [
         {
+            "url": "https:\/\/cloud.appwrite.io\/v1"
+        },
+        {
             "url": "https:\/\/<REGION>.cloud.appwrite.io\/v1"
         }
     ],

--- a/app/config/specs/open-api3-1.6.x-server.json
+++ b/app/config/specs/open-api3-1.6.x-server.json
@@ -17,6 +17,9 @@
     },
     "servers": [
         {
+            "url": "https:\/\/cloud.appwrite.io\/v1"
+        },
+        {
             "url": "https:\/\/<REGION>.cloud.appwrite.io\/v1"
         }
     ],

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -17,6 +17,9 @@
     },
     "servers": [
         {
+            "url": "https:\/\/cloud.appwrite.io\/v1"
+        },
+        {
             "url": "https:\/\/<REGION>.cloud.appwrite.io\/v1"
         }
     ],

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -17,6 +17,9 @@
     },
     "servers": [
         {
+            "url": "https:\/\/cloud.appwrite.io\/v1"
+        },
+        {
             "url": "https:\/\/<REGION>.cloud.appwrite.io\/v1"
         }
     ],

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -17,6 +17,9 @@
     },
     "servers": [
         {
+            "url": "https:\/\/cloud.appwrite.io\/v1"
+        },
+        {
             "url": "https:\/\/<REGION>.cloud.appwrite.io\/v1"
         }
     ],

--- a/app/config/specs/swagger2-1.6.x-client.json
+++ b/app/config/specs/swagger2-1.6.x-client.json
@@ -15,7 +15,8 @@
             "url": "https:\/\/raw.githubusercontent.com\/appwrite\/appwrite\/master\/LICENSE"
         }
     },
-    "host": "<REGION>.cloud.appwrite.io",
+    "host": "cloud.appwrite.io",
+    "x-host-docs": "<REGION>.cloud.appwrite.io",
     "basePath": "\/v1",
     "schemes": [
         "https"

--- a/app/config/specs/swagger2-1.6.x-console.json
+++ b/app/config/specs/swagger2-1.6.x-console.json
@@ -15,7 +15,8 @@
             "url": "https:\/\/raw.githubusercontent.com\/appwrite\/appwrite\/master\/LICENSE"
         }
     },
-    "host": "<REGION>.cloud.appwrite.io",
+    "host": "cloud.appwrite.io",
+    "x-host-docs": "<REGION>.cloud.appwrite.io",
     "basePath": "\/v1",
     "schemes": [
         "https"

--- a/app/config/specs/swagger2-1.6.x-server.json
+++ b/app/config/specs/swagger2-1.6.x-server.json
@@ -15,7 +15,8 @@
             "url": "https:\/\/raw.githubusercontent.com\/appwrite\/appwrite\/master\/LICENSE"
         }
     },
-    "host": "<REGION>.cloud.appwrite.io",
+    "host": "cloud.appwrite.io",
+    "x-host-docs": "<REGION>.cloud.appwrite.io",
     "basePath": "\/v1",
     "schemes": [
         "https"

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -15,7 +15,8 @@
             "url": "https:\/\/raw.githubusercontent.com\/appwrite\/appwrite\/master\/LICENSE"
         }
     },
-    "host": "<REGION>.cloud.appwrite.io",
+    "host": "cloud.appwrite.io",
+    "x-host-docs": "<REGION>.cloud.appwrite.io",
     "basePath": "\/v1",
     "schemes": [
         "https"

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -15,7 +15,8 @@
             "url": "https:\/\/raw.githubusercontent.com\/appwrite\/appwrite\/master\/LICENSE"
         }
     },
-    "host": "<REGION>.cloud.appwrite.io",
+    "host": "cloud.appwrite.io",
+    "x-host-docs": "<REGION>.cloud.appwrite.io",
     "basePath": "\/v1",
     "schemes": [
         "https"

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -15,7 +15,8 @@
             "url": "https:\/\/raw.githubusercontent.com\/appwrite\/appwrite\/master\/LICENSE"
         }
     },
-    "host": "<REGION>.cloud.appwrite.io",
+    "host": "cloud.appwrite.io",
+    "x-host-docs": "<REGION>.cloud.appwrite.io",
     "basePath": "\/v1",
     "schemes": [
         "https"

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -289,7 +289,8 @@ class Specs extends Action
                 $formatInstance
                     ->setParam('name', APP_NAME)
                     ->setParam('description', 'Appwrite backend as a service cuts up to 70% of the time and costs required for building a modern application. We abstract and simplify common development tasks behind a REST APIs, to help you develop your app in a fast and secure way. For full API documentation and tutorials go to [https://appwrite.io/docs](https://appwrite.io/docs)')
-                    ->setParam('endpoint', 'https://<REGION>.cloud.appwrite.io/v1')
+                    ->setParam('endpoint', 'https://cloud.appwrite.io/v1')
+                    ->setParam('endpoint.docs', 'https://<REGION>.cloud.appwrite.io/v1')
                     ->setParam('version', APP_VERSION_STABLE)
                     ->setParam('terms', $endpoint . '/policy/terms')
                     ->setParam('support.email', $email)

--- a/src/Appwrite/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/Specification/Format/OpenAPI3.php
@@ -84,6 +84,9 @@ class OpenAPI3 extends Format
                 [
                     'url' => $this->getParam('endpoint', ''),
                 ],
+                [
+                    'url' => $this->getParam('endpoint.docs', ''),
+                ],
             ],
             'paths' => [],
             'tags' => $this->services,

--- a/src/Appwrite/Specification/Format/Swagger2.php
+++ b/src/Appwrite/Specification/Format/Swagger2.php
@@ -80,6 +80,7 @@ class Swagger2 extends Format
                 ],
             ],
             'host' => \parse_url($this->getParam('endpoint', ''), PHP_URL_HOST),
+            'x-host-docs' => \parse_url($this->getParam('endpoint.docs', ''), PHP_URL_HOST),
             'basePath' => \parse_url($this->getParam('endpoint', ''), PHP_URL_PATH),
             'schemes' => [\parse_url($this->getParam('endpoint', ''), PHP_URL_SCHEME)],
             'consumes' => ['application/json', 'multipart/form-data'],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Introduces `x-host-dcs` in the swagger specs, and another server in openapi3 specs.

## Test Plan

<img width="1392" alt="Screenshot 2025-04-24 at 4 46 29 PM" src="https://github.com/user-attachments/assets/8c32d4e6-2869-44a0-a76f-666a26722a10" />

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
