### PR TITLE
fix: validate SMTP username and password during SMTP settings

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -1,5 +1,6 @@
 <?php
 
+
 use Ahc\Jwt\JWT;
 use Appwrite\Auth\Auth;
 use Appwrite\Auth\Validator\MockNumber;
@@ -1682,17 +1683,18 @@ App::patch('/v1/projects/:projectId/smtp')
         // validate SMTP settings
         if ($enabled) {
             $mail = new PHPMailer(true);
-            $mail->isSMTP();
+            $mail->isSMTP();        
             $mail->Username = $username;
             $mail->Password = $password;
             $mail->Host = $host;
             $mail->Port = $port;
             $mail->SMTPSecure = $secure;
+            $mail->SMTPAuth = (!empty($username) && !empty($password));
             $mail->SMTPAutoTLS = false;
             $mail->Timeout = 5;
 
             try {
-                $valid = $mail->SmtpConnect();
+                $valid = $mail->SmtpConnect(); 
 
                 if (!$valid) {
                     throw new Exception('Connection is not valid.');

--- a/tests/unit/Projects/SMTPValidationTest.php
+++ b/tests/unit/Projects/SMTPValidationTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Tests\Unit\Projects;
+use PHPUnit\Framework\TestCase;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+class SMTPValidationTest extends TestCase
+{
+    public function testInvalidSMTPCredentials()
+    {
+        $mail = new PHPMailer(true);
+        $mail->isSMTP();
+        $mail->SMTPAuth = true;
+        $mail->Username = 'fakeuser@gmail.com';
+        $mail->Password = 'wrongpassword';
+        $mail->Host = 'smtp.gmail.com';
+        $mail->Port = 587;
+        $mail->SMTPSecure = 'tls';
+        $mail->SMTPAutoTLS = false;
+        $mail->Timeout = 5;
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/Could not authenticate/i');
+        $mail->SmtpConnect();
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the bug where invalid passwords and usernames could be used to update the SMTP settings.

Added unit test: SMTPValidationTest.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

![image](https://github.com/user-attachments/assets/46c891c4-4854-470b-a64d-64e1a39bfa18)

## Related PRs and Issues

- (Related PR or issue)
Issue #9067 

## Checklist

- [✅] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [✅] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
