### PR TITLE
Fix request filters with multi-method routes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4769,16 +4769,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "0.40.15",
+            "version": "0.40.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "65c708b931b29b3e01c5cc7504a734ce2cc3dc95"
+                "reference": "f1f506da74033f0cb5a11e3dffcfd1ee8daf237d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/65c708b931b29b3e01c5cc7504a734ce2cc3dc95",
-                "reference": "65c708b931b29b3e01c5cc7504a734ce2cc3dc95",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/f1f506da74033f0cb5a11e3dffcfd1ee8daf237d",
+                "reference": "f1f506da74033f0cb5a11e3dffcfd1ee8daf237d",
                 "shasum": ""
             },
             "require": {
@@ -4814,9 +4814,9 @@
             "description": "Appwrite PHP library for generating API SDKs for multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/0.40.15"
+                "source": "https://github.com/appwrite/sdk-generator/tree/0.40.16"
             },
-            "time": "2025-04-25T08:50:44+00:00"
+            "time": "2025-05-09T12:06:09+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -70,11 +70,6 @@ class Request extends UtopiaRequest
             ? $matched->getNamespace() . '.' . $matched->getMethodName()
             : 'unknown.unknown';
 
-        // Filter params to valid keys
-        if ($matched !== null && !empty($methodParamNames)) {
-            $parameters = \array_intersect_key($parameters, \array_flip($methodParamNames));
-        }
-
         // Apply filters
         foreach ($this->getFilters() as $filter) {
             $parameters = $filter->parse($parameters, $id);

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -35,14 +35,20 @@ class Request extends UtopiaRequest
         }
 
         $methods = self::getRoute()->getLabel('sdk', null);
-        $methods = \is_array($methods) ? $methods : [$methods];
 
         if (empty($methods)) {
             return $parameters;
         }
 
-        $matched = null;
+        if (!\is_array($methods)) {
+            $id = $methods->getNamespace() . '.' . $methods->getMethodName();
+            foreach ($this->getFilters() as $filter) {
+                $parameters = $filter->parse($parameters, $id);
+            }
+            return $parameters;
+        }
 
+        $matched = null;
         foreach ($methods as $method) {
             /** @var Method|null $method */
             if ($method === null) {
@@ -60,7 +66,7 @@ class Request extends UtopiaRequest
             }
         }
 
-        $endpointIdentifier = $matched !== null
+        $id = $matched !== null
             ? $matched->getNamespace() . '.' . $matched->getMethodName()
             : 'unknown.unknown';
 
@@ -71,7 +77,7 @@ class Request extends UtopiaRequest
 
         // Apply filters
         foreach ($this->getFilters() as $filter) {
-            $parameters = $filter->parse($parameters, $endpointIdentifier);
+            $parameters = $filter->parse($parameters, $id);
         }
 
         return $parameters;

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -36,6 +36,11 @@ class Request extends UtopiaRequest
 
         $methods = self::getRoute()->getLabel('sdk', null);
         $methods = \is_array($methods) ? $methods : [$methods];
+
+        if (empty($methods)) {
+            return $parameters;
+        }
+
         $matched = null;
 
         foreach ($methods as $method) {
@@ -45,7 +50,7 @@ class Request extends UtopiaRequest
             }
 
             // Find the method that matches the parameters passed
-            $methodParamNames = \array_map(fn($param) => $param->getName(), $method->getParameters());
+            $methodParamNames = \array_map(fn ($param) => $param->getName(), $method->getParameters());
             $invalidParams = \array_diff(\array_keys($parameters), $methodParamNames);
 
             // No params defined, or all params are valid
@@ -60,13 +65,8 @@ class Request extends UtopiaRequest
             : 'unknown.unknown';
 
         // Filter params to valid keys
-        if ($matched !== null) {
-            $definedNames = \array_map(fn($param) => $param->getName(), $matched->getParameters());
-
-            // If matched method has explicit params, remove all other params
-            if (!empty($definedNames)) {
-                $parameters = \array_intersect_key($parameters, \array_flip($definedNames));
-            }
+        if ($matched !== null && !empty($methodParamNames)) {
+            $parameters = \array_intersect_key($parameters, \array_flip($methodParamNames));
         }
 
         // Apply filters

--- a/tests/unit/Utopia/RequestTest.php
+++ b/tests/unit/Utopia/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Utopia;
 
 use Appwrite\SDK\Method;
+use Appwrite\SDK\Parameter;
 use Appwrite\Utopia\Request;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Request as SwooleRequest;
@@ -56,5 +57,131 @@ class RequestTest extends TestCase
         $this->assertArrayHasKey('second', $output);
         $this->assertTrue($output['second']);
         $this->assertArrayNotHasKey('deleted', $output);
+    }
+
+    public function testGetParamsWithMultipleMethods(): void
+    {
+        $this->setupMultiMethodRoute();
+
+        // Pass only "foo", should match Method A
+        $this->request->setQueryString([
+            'foo' => 'valueFoo',
+        ]);
+
+        $params = $this->request->getParams();
+
+        $this->assertArrayHasKey('foo', $params);
+        $this->assertSame('valueFoo', $params['foo']);
+        $this->assertArrayNotHasKey('baz', $params);
+    }
+
+    public function testGetParamsWithAllRequired(): void
+    {
+        $this->setupMultiMethodRoute();
+
+        // Pass "foo" and "bar", should match Method A
+        $this->request->setQueryString([
+            'foo' => 'valueFoo',
+            'bar' => 'valueBar',
+        ]);
+
+        $params = $this->request->getParams();
+        $this->assertArrayHasKey('foo', $params);
+        $this->assertSame('valueFoo', $params['foo']);
+        $this->assertArrayHasKey('bar', $params);
+        $this->assertSame('valueBar', $params['bar']);
+        $this->assertArrayNotHasKey('baz', $params);
+    }
+
+    public function testGetParamsWithAllOptional(): void
+    {
+        $this->setupMultiMethodRoute();
+
+        // Pass only "bar", should match Method A
+        $this->request->setQueryString([
+            'bar' => 'valueBar',
+        ]);
+
+        $params = $this->request->getParams();
+
+        $this->assertArrayHasKey('bar', $params);
+        $this->assertSame('valueBar', $params['bar']);
+        $this->assertArrayNotHasKey('foo', $params);
+        $this->assertArrayNotHasKey('baz', $params);
+    }
+
+    public function testGetParamsMatchesMethodB(): void
+    {
+        $this->setupMultiMethodRoute();
+
+        // Pass only "baz", should match Method B
+        $this->request->setQueryString([
+            'baz' => 'valueBaz',
+        ]);
+
+        $params = $this->request->getParams();
+
+        $this->assertArrayHasKey('baz', $params);
+        $this->assertSame('valueBaz', $params['baz']);
+        $this->assertArrayNotHasKey('foo', $params);
+    }
+
+    public function testGetParamsFallbackForMixedAndUnknown(): void
+    {
+        $this->setupMultiMethodRoute();
+
+        // Mixed and unknown should fallback to raw params
+        $this->request->setQueryString([
+            'foo' => 'valueFoo',
+            'baz' => 'valueBaz',
+            'extra' => 'unexpected',
+        ]);
+
+        $params = $this->request->getParams();
+
+        $this->assertArrayHasKey('foo', $params);
+        $this->assertSame('valueFoo', $params['foo']);
+        $this->assertArrayHasKey('baz', $params);
+        $this->assertSame('valueBaz', $params['baz']);
+        $this->assertArrayHasKey('extra', $params);
+        $this->assertSame('unexpected', $params['extra']);
+    }
+
+    /**
+     * Helper to attach a route with multiple SDK methods to the request.
+     */
+    private function setupMultiMethodRoute(): void
+    {
+        $route = new Route(Request::METHOD_GET, '/multi');
+
+        $methodA = new Method(
+            namespace: 'namespace',
+            group: 'group',
+            name: 'methodA',
+            description: 'desc',
+            auth: [],
+            responses: [],
+            parameters: [
+                new Parameter('foo'),
+                new Parameter('bar', optional: true),
+            ],
+        );
+
+        $methodB = new Method(
+            namespace: 'namespace',
+            group: 'group',
+            name: 'methodB',
+            description: 'desc',
+            auth: [],
+            responses: [],
+            parameters: [
+                new Parameter('baz'),
+            ],
+        );
+
+        $route->label('sdk', [$methodA, $methodB]);
+        $this->request->addFilter(new First());
+        $this->request->addFilter(new Second());
+        $this->request->setRoute($route);
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The request getParams method was updated to handle request filters when multiple methods are present on a single route, but the implementation did not merge/check parameters correctly, so if a request filter was run, only the explicit parameters defined on last method in the list were sent to the route.

This meant that when calling `createDocument` from a version lower than 1.6.0, the `createDocuments` params were used, so `documentId` and `data` were being stripped out. This lead to valid requests returning "The document data is missing. Try again with document data populated".

## Test Plan

Updated existing tests + manual tests.

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved parameter handling for requests with multiple possible method definitions, ensuring that only parameters matching the correct method are returned.
- **Tests**
	- Added comprehensive tests to verify correct parameter matching and filtering when multiple methods are associated with a route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->