### PR TITLE
Fix owner role downgrade

### DIFF
--- a/app/controllers/api/teams.php
+++ b/app/controllers/api/teams.php
@@ -1089,7 +1089,10 @@ App::patch('/v1/teams/:teamId/memberships/:membershipId')
             // Quick check: fetch up to 2 owners to determine if only one exists
             $ownersCount = $dbForProject->count(
                 collection: 'memberships',
-                queries: [Query::contains('roles', ['owner'])],
+                queries: [
+                    Query::contains('roles', ['owner']),
+                    Query::equal('teamInternalId', [$team->getInternalId()])
+                ],
                 max: 2
             );
 

--- a/tests/e2e/Services/Teams/TeamsConsoleClientTest.php
+++ b/tests/e2e/Services/Teams/TeamsConsoleClientTest.php
@@ -86,7 +86,7 @@ class TeamsConsoleClientTest extends Scope
         $session = $data['session'] ?? '';
 
         /**
-         * Test for SUCCESS
+         * Test for FAILURE
          */
         $roles = ['developer'];
         $response = $this->client->call(Client::METHOD_PATCH, '/teams/' . $teamUid . '/memberships/' . $membershipUid, array_merge([
@@ -97,12 +97,8 @@ class TeamsConsoleClientTest extends Scope
             'roles' => $roles
         ]);
 
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertNotEmpty($response['body']['$id']);
-        $this->assertNotEmpty($response['body']['userId']);
-        $this->assertNotEmpty($response['body']['teamId']);
-        $this->assertCount(count($roles), $response['body']['roles']);
-        $this->assertEquals($roles[0], $response['body']['roles'][0]);
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals('There must be at least one owner in the organization.', $response['body']['message']);
 
         /**
          * Test for unknown team


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If a user is an `Owner` in more than one org, the logic still allowed downgrade. This PR adds a `teamInternalId` to Query to prevent that case.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
