### PR TITLE
Only rethrow auth and timeout in general handler

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -538,16 +538,12 @@ App::post('/v1/databases')
 
         try {
             $dbForProject->createCollection('database_' . $database->getInternalId(), $attributes, $indexes);
-        } catch (AuthorizationException) {
-            throw new Exception(Exception::USER_UNAUTHORIZED);
         } catch (DuplicateException) {
             throw new Exception(Exception::DATABASE_ALREADY_EXISTS);
         } catch (IndexException) {
             throw new Exception(Exception::INDEX_INVALID);
         } catch (LimitException) {
             throw new Exception(Exception::COLLECTION_LIMIT_EXCEEDED);
-        } catch (TimeoutException) {
-            throw new Exception(Exception::DATABASE_TIMEOUT);
         }
 
         $queueForEvents->setParam('databaseId', $database->getId());

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -37,7 +37,6 @@ use Utopia\Database\Exception\Query as QueryException;
 use Utopia\Database\Exception\Relationship as RelationshipException;
 use Utopia\Database\Exception\Restricted as RestrictedException;
 use Utopia\Database\Exception\Structure as StructureException;
-use Utopia\Database\Exception\Timeout as TimeoutException;
 use Utopia\Database\Exception\Truncate as TruncateException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -4147,7 +4147,7 @@ App::patch('/v1/databases/:databaseId/collections/:collectionId/documents/:docum
             throw new Exception(Exception::DOCUMENT_UPDATE_CONFLICT);
         } catch (DuplicateException) {
             throw new Exception(Exception::DOCUMENT_ALREADY_EXISTS);
-        }  catch (RelationshipException $e) {
+        } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {
             throw new Exception(Exception::DOCUMENT_INVALID_STRUCTURE, $e->getMessage());

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -835,35 +835,11 @@ App::error()
                         break;
                 }
                 break;
-            case 'Utopia\Database\Exception\Conflict':
-                $error = new AppwriteException(AppwriteException::DOCUMENT_UPDATE_CONFLICT, previous: $error);
-                break;
-            case 'Utopia\Database\Exception\Timeout':
-                $error = new AppwriteException(AppwriteException::DATABASE_TIMEOUT, previous: $error);
-                break;
-            case 'Utopia\Database\Exception\Query':
-                $error = new AppwriteException(AppwriteException::GENERAL_QUERY_INVALID, $error->getMessage(), previous: $error);
-                break;
-            case 'Utopia\Database\Exception\Structure':
-                $error = new AppwriteException(AppwriteException::DOCUMENT_INVALID_STRUCTURE, $error->getMessage(), previous: $error);
-                break;
-            case 'Utopia\Database\Exception\Duplicate':
-                $error = new AppwriteException(AppwriteException::DOCUMENT_ALREADY_EXISTS);
-                break;
-            case 'Utopia\Database\Exception\Restricted':
-                $error = new AppwriteException(AppwriteException::DOCUMENT_DELETE_RESTRICTED);
-                break;
             case 'Utopia\Database\Exception\Authorization':
                 $error = new AppwriteException(AppwriteException::USER_UNAUTHORIZED);
                 break;
-            case 'Utopia\Database\Exception\Relationship':
-                $error = new AppwriteException(AppwriteException::RELATIONSHIP_VALUE_INVALID, $error->getMessage(), previous: $error);
-                break;
-            case 'Utopia\Database\Exception\NotFound':
-                $error = new AppwriteException(AppwriteException::COLLECTION_NOT_FOUND, $error->getMessage(), previous: $error);
-                break;
-            case 'Utopia\Database\Exception\Dependency':
-                $error = new AppwriteException(AppwriteException::INDEX_DEPENDENCY, null, previous: $error);
+            case 'Utopia\Database\Exception\Timeout':
+                $error = new AppwriteException(AppwriteException::DATABASE_TIMEOUT, previous: $error);
                 break;
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The database controller fell back to the general error handler in a lot of cases where it should have been catching it's own exceptions. This led to users getting 400 errors that should have been treated as 500 in some cases.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified database document retrieval by removing authorization bypass wrappers and streamlining direct access.
  - Simplified route aliases and variable usage for improved consistency.
  - Cleaned up redundant code and comments.

- **Bug Fixes**
  - Enhanced exception handling with more specific error messages and improved mapping for relationship and query errors.
  - Improved cache purging reliability in database operations.

- **New Features**
  - Added authorization checks to restrict bulk document creation to privileged users only.

- **Style**
  - Simplified error handling logic for database-related errors, reducing unnecessary granularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->