### PR TITLE
Create unique stable cache identifier

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -544,7 +544,7 @@ App::init()
             $isImageTransformation = $route->getPath() === '/v1/storage/buckets/:bucketId/files/:fileId/preview';
             $isDisabled = isset($plan['imageTransformations']) && $plan['imageTransformations'] === -1 && !Auth::isPrivilegedUser(Authorization::getRoles());
 
-            $key = md5($request->getURI() . '*' . implode('*', $request->getParams()) . '*' . APP_CACHE_BUSTER);
+            $key = $request->cacheIdentifier();
             $cacheLog  = Authorization::skip(fn () => $dbForProject->getDocument('cache', $key));
             $cache = new Cache(
                 new Filesystem(APP_STORAGE_CACHE . DIRECTORY_SEPARATOR . 'app-' . $project->getId())
@@ -803,7 +803,7 @@ App::shutdown()
                     $resourceType = $parseLabel($pattern, $responsePayload, $requestParams, $user);
                 }
 
-                $key = md5($request->getURI() . '*' . implode('*', $request->getParams()) . '*' . APP_CACHE_BUSTER);
+                $key = $request->cacheIdentifier();
                 $signature = md5($data['payload']);
                 $cacheLog  =  Authorization::skip(fn () => $dbForProject->getDocument('cache', $key));
                 $accessedAt = $cacheLog->getAttribute('accessedAt', '');

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -220,4 +220,17 @@ class Request extends UtopiaRequest
 
         return UtopiaRequest::getUserAgent($default);
     }
+
+    /**
+     * Creates a unique stable cache identifier for this GET request.
+     * Stable-sorts query params, use `serialize` to ensure key&value are part of cache keys.
+     *
+     * @return string
+     */
+    public function cacheIdentifier(): string
+    {
+        $params = $this->getParams();
+        ksort($params);
+        return md5($this->getURI() . '*' . serialize($params) . '*' . APP_CACHE_BUSTER);
+    }
 }


### PR DESCRIPTION
in the previous version
```
http://localhost:8080/v1/storage/buckets/6825af61002f22f943c9/files/6825af68001caed5d151/preview?project=6825af5c001f6a2e0f63&mode=admin&height=12
```
and 
```
http://localhost:8080/v1/storage/buckets/6825af61002f22f943c9/files/6825af68001caed5d151/preview?project=6825af5c001f6a2e0f63&mode=admin&width=12
```
would result in the same hash key because `implode()` only processes the values and not the keys.

In addition, `?project=foo&quality=10` and `quality=10&project=foo` had different hashes because implode keeps the order of the params array.