### PR TITLE
fix(storage): do not preview gif input/output

### DIFF
--- a/app/config/storage/inputs.php
+++ b/app/config/storage/inputs.php
@@ -4,7 +4,6 @@ return [
     // Accepted inputs files
     "jpg" => "image/jpeg",
     "jpeg" => "image/jpeg",
-    "gif" => "image/gif",
     "png" => "image/png",
     "heic" => "image/heic",
     "webp" => "image/webp",

--- a/app/config/storage/outputs.php
+++ b/app/config/storage/outputs.php
@@ -4,7 +4,6 @@ return [
     // Accepted outputs files
     "jpg" => "image/jpeg",
     "jpeg" => "image/jpeg",
-    "gif" => "image/gif",
     "png" => "image/png",
     "webp" => "image/webp",
     "heic" => "image/heic",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Processing a gif file can consume large amounts of memory causing the container to crash.

As a safety precaution, don't output to gif either. Any attempt to output to gif will result in an error.

## Test Plan

Tests should pass

Manually tested output of png to gif:

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/00b42e81-0541-4001-bcbd-f696b4c8abc0" />

Manually tested output of gif:

<img width="240" alt="image" src="https://github.com/user-attachments/assets/729ea3af-532e-48df-8bdc-8280a347dd22" />


## Related PRs and Issues

Reference for high memory usage of gifs:

* https://github.com/ImageMagick/ImageMagick/issues/3418

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
