### PR TITLE
fix: prevent appwrite-task-stats-resources from crashing

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -685,11 +685,9 @@ $image = $this->getParam('image', '');
     container_name: appwrite-task-stats-resources
     entrypoint: stats-resources
     <<: *x-logging
+    restart: unless-stopped
     networks:
       - appwrite
-    volumes:
-      - ./app:/usr/src/code/app
-      - ./src:/usr/src/code/src
     depends_on:
       - redis
       - mariadb


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Remove the volume mounts meant for local development from the prod docker-compose file.

Also, ensure the container restarts automatically if it crashes just like all the other containers.

Fixes https://github.com/appwrite/appwrite/issues/9756

## Test Plan

Manually removed lines from prod docker-compose.yml:

<img width="780" alt="image" src="https://github.com/user-attachments/assets/89f0cae0-6727-499d-afc5-35711c421fb9" />


## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/9756

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated service settings to improve container reliability and simplify configuration. The service will now automatically restart unless stopped, and local directory mounts have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->