### PR TITLE
Fix: backwards compatibility for function creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "utopia-php/platform": "0.7.*",
         "utopia-php/pools": "0.8.*",
         "utopia-php/preloader": "0.2.*",
-        "utopia-php/queue": "0.9.*",
+        "utopia-php/queue": "0.10.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "0.18.*",
         "utopia-php/swoole": "0.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "735023e2b70ce47fe65985f195b257bd",
+    "content-hash": "b6f5295db11727cb4e88e702dc97809d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4104,16 +4104,16 @@
         },
         {
             "name": "utopia-php/platform",
-            "version": "0.7.4",
+            "version": "0.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/platform.git",
-                "reference": "a5b93d8177702ec458c3af9137663133c012b71b"
+                "reference": "6bc7fbb43ec2b7f9ee5bdef5d4b5e4a81860950b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/platform/zipball/a5b93d8177702ec458c3af9137663133c012b71b",
-                "reference": "a5b93d8177702ec458c3af9137663133c012b71b",
+                "url": "https://api.github.com/repos/utopia-php/platform/zipball/6bc7fbb43ec2b7f9ee5bdef5d4b5e4a81860950b",
+                "reference": "6bc7fbb43ec2b7f9ee5bdef5d4b5e4a81860950b",
                 "shasum": ""
             },
             "require": {
@@ -4122,11 +4122,11 @@
                 "php": ">=8.0",
                 "utopia-php/cli": "0.15.*",
                 "utopia-php/framework": "0.33.*",
-                "utopia-php/queue": "0.9.*"
+                "utopia-php/queue": "0.10.*"
             },
             "require-dev": {
-                "laravel/pint": "1.2.*",
-                "phpunit/phpunit": "^9.3"
+                "laravel/pint": "1.*",
+                "phpunit/phpunit": "9.*"
             },
             "type": "library",
             "autoload": {
@@ -4148,9 +4148,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/platform/issues",
-                "source": "https://github.com/utopia-php/platform/tree/0.7.4"
+                "source": "https://github.com/utopia-php/platform/tree/0.7.6"
             },
-            "time": "2025-03-13T13:00:12+00:00"
+            "time": "2025-05-18T20:31:24+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -4259,16 +4259,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "0.9.1",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "32b6f84c55aae761db5a5ae76cc91ca8dbc8bc32"
+                "reference": "0eccc559168ea72241c39a4c482d868314666be1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/32b6f84c55aae761db5a5ae76cc91ca8dbc8bc32",
-                "reference": "32b6f84c55aae761db5a5ae76cc91ca8dbc8bc32",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/0eccc559168ea72241c39a4c482d868314666be1",
+                "reference": "0eccc559168ea72241c39a4c482d868314666be1",
                 "shasum": ""
             },
             "require": {
@@ -4277,6 +4277,7 @@
                 "utopia-php/cli": "0.15.*",
                 "utopia-php/fetch": "0.4.*",
                 "utopia-php/framework": "0.33.*",
+                "utopia-php/pools": "0.8.*",
                 "utopia-php/telemetry": "0.1.*"
             },
             "require-dev": {
@@ -4318,9 +4319,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/0.9.1"
+                "source": "https://github.com/utopia-php/queue/tree/0.10.0"
             },
-            "time": "2025-03-28T19:49:36+00:00"
+            "time": "2025-04-17T12:15:52+00:00"
         },
         {
             "name": "utopia-php/registry",
@@ -8240,7 +8241,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -8264,5 +8265,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -309,6 +309,10 @@ class OpenAPI3 extends Format
             $bodyRequired = [];
 
             foreach ($route->getParams() as $name => $param) { // Set params
+                if ($param['deprecated']) {
+                    continue;
+                }
+
                 /**
                  * @var \Utopia\Validator $validator
                  */

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -314,6 +314,10 @@ class Swagger2 extends Format
             );
 
             foreach ($parameters as $name => $param) { // Set params
+                if ($param['deprecated']) {
+                    continue;
+                }
+
                 /** @var Validator $validator */
                 $validator = (\is_callable($param['validator']))
                     ? ($param['validator'])(...$this->app->getResources($param['injections']))

--- a/src/Appwrite/Utopia/Request/Filters/V19.php
+++ b/src/Appwrite/Utopia/Request/Filters/V19.php
@@ -10,6 +10,16 @@ class V19 extends Filter
     public function parse(array $content, string $model): array
     {
         switch ($model) {
+            case 'functions.list':
+                $content = $this->convertQueryAttribute($content, 'deployment', 'deploymentId');
+                break;
+            case 'functions.listDeployments':
+                $content = $this->convertQueryAttribute($content, 'size', 'deploymentSize');
+                break;
+            case 'proxy.listRules':
+                $content = $this->convertQueryAttribute($content, 'resourceType', 'deploymentResourceType');
+                $content = $this->convertQueryAttribute($content, 'resourceId', 'deploymentResourceId');
+                break;
             case 'functions.create':
                 unset($content['templateRepository']);
                 unset($content['templateOwner']);
@@ -26,6 +36,21 @@ class V19 extends Filter
                 $content['secret'] = false;
                 break;
         }
+        return $content;
+    }
+
+    public function convertQueryAttribute(array $content, string $old, string $new)
+    {
+        if (isset($content['queries']) && is_array($content['queries'])) {
+            foreach ($content['queries'] as $index => $query) {
+                $query = \json_decode($query, true);
+                if (($query['attribute'] ?? '') === $old) {
+                    $query['attribute'] = $new;
+                }
+                $content['queries'][$index] = \json_encode($query);
+            }
+        }
+
         return $content;
     }
 }


### PR DESCRIPTION
QA:


![CleanShot 2025-05-18 at 22 19 54@2x](https://github.com/user-attachments/assets/38eb3e90-5845-4547-9537-d73d15df83a5)

![CleanShot 2025-05-18 at 22 19 50@2x](https://github.com/user-attachments/assets/6a99cd6e-4560-4303-9b4d-c1fd64711d97)

Notice function is created, with a deployment, and has a domain.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved backward compatibility for clients using response formats older than version 1.7.0, ensuring continued support for deprecated function template parameters.
- **Bug Fixes**
  - Deprecated parameters are now excluded from generated OpenAPI and Swagger specifications, resulting in cleaner and more accurate API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->