### PR TITLE
certificates: add domainType to certificate worker

### DIFF
--- a/src/Appwrite/Certificates/Adapter.php
+++ b/src/Appwrite/Certificates/Adapter.php
@@ -6,9 +6,9 @@ use Utopia\Logger\Log;
 
 interface Adapter
 {
-    public function issueCertificate(string $certName, string $domain): ?string;
+    public function issueCertificate(string $certName, string $domain, ?string $domainType): ?string;
 
-    public function isRenewRequired(string $domain, Log $log): bool;
+    public function isRenewRequired(string $domain, ?string $domainType, Log $log): bool;
 
     public function deleteCertificate(string $domain): void;
 }

--- a/src/Appwrite/Certificates/LetsEncrypt.php
+++ b/src/Appwrite/Certificates/LetsEncrypt.php
@@ -18,7 +18,7 @@ class LetsEncrypt implements Adapter
     }
 
 
-    public function issueCertificate(string $certName, string $domain): ?string
+    public function issueCertificate(string $certName, string $domain, ?string $domainType): ?string
     {
         $stdout = '';
         $stderr = '';
@@ -84,7 +84,7 @@ class LetsEncrypt implements Adapter
         return DateTime::addSeconds($dt, -60 * 60 * 24 * 30);
     }
 
-    public function isRenewRequired(string $domain, Log $log): bool
+    public function isRenewRequired(string $domain, ?string $domainType, Log $log): bool
     {
         $certPath = APP_STORAGE_CERTIFICATES . '/' . $domain . '/cert.pem';
         if (\file_exists($certPath)) {

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
@@ -173,7 +173,8 @@ class Create extends Action
         if ($rule->getAttribute('status', '') === 'verifying') {
             $queueForCertificates
                 ->setDomain(new Document([
-                    'domain' => $rule->getAttribute('domain')
+                    'domain' => $rule->getAttribute('domain'),
+                    'domainType' => 'api',
                 ]))
                 ->trigger();
         }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
@@ -191,7 +191,8 @@ class Create extends Action
         if ($rule->getAttribute('status', '') === 'verifying') {
             $queueForCertificates
                 ->setDomain(new Document([
-                    'domain' => $rule->getAttribute('domain')
+                    'domain' => $rule->getAttribute('domain'),
+                    'domainType' => 'function',
                 ]))
                 ->trigger();
         }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
@@ -179,7 +179,8 @@ class Create extends Action
         if ($rule->getAttribute('status', '') === 'verifying') {
             $queueForCertificates
                 ->setDomain(new Document([
-                    'domain' => $rule->getAttribute('domain')
+                    'domain' => $rule->getAttribute('domain'),
+                    'domainType' => 'redirect',
                 ]))
                 ->trigger();
         }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
@@ -191,7 +191,8 @@ class Create extends Action
         if ($rule->getAttribute('status', '') === 'verifying') {
             $queueForCertificates
                 ->setDomain(new Document([
-                    'domain' => $rule->getAttribute('domain')
+                    'domain' => $rule->getAttribute('domain'),
+                    'domainType' => 'site',
                 ]))
                 ->trigger();
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced certificate management by including domain type information when issuing and renewing certificates for API, function, redirect, and site domains.
- **Improvements**
  - Improved handling of domain-specific certificate actions, allowing for more precise management based on domain type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->