### PR TITLE
added checking for encrypt and plan allowing encryption of string att…

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1347,7 +1347,11 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/string
     ->inject('dbForProject')
     ->inject('queueForDatabase')
     ->inject('queueForEvents')
-    ->action(function (string $databaseId, string $collectionId, string $key, ?int $size, ?bool $required, ?string $default, bool $array, bool $encrypt, Response $response, Database $dbForProject, EventDatabase $queueForDatabase, Event $queueForEvents) {
+    ->inject('plan')
+    ->action(function (string $databaseId, string $collectionId, string $key, ?int $size, ?bool $required, ?string $default, bool $array, bool $encrypt, Response $response, Database $dbForProject, EventDatabase $queueForDatabase, Event $queueForEvents, array $plan) {
+        if ($encrypt && !isset($plan['databasesAllowEncrypt'])) {
+            throw new Exception(Exception::ATTRIBUTE_FORMAT_UNSUPPORTED, 'Encrypted string attributes are not available on your plan. Please upgrade to create encrypted string attributes.');
+        }
         // Ensure attribute default is within required size
         $validator = new Text($size, 0);
         if (!is_null($default) && !$validator->isValid($default)) {

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -195,6 +195,20 @@ trait DatabasesBase
     public function testCreateAttributes(array $data): array
     {
         $databaseId = $data['databaseId'];
+        // must fail as we are using encrypt and plan has no 'databasesAllowEncrypt'
+        $encryptStringAttribute = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $data['moviesId'] . '/attributes/string', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), [
+            'key' => 'title',
+            'size' => 256,
+            'required' => true,
+            'encrypt' => true
+        ]);
+
+        $this->assertEquals(400, $encryptStringAttribute['headers']['status-code']);
+        $this->assertEquals($encryptStringAttribute['body']['message'], 'Encrypted string attributes are not available on your plan. Please upgrade to create encrypted string attributes.');
 
         $title = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $data['moviesId'] . '/attributes/string', array_merge([
             'content-type' => 'application/json',


### PR DESCRIPTION
…ribute

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If the encrypt parameter is true but $plan['databasesAllowEncrypt'] is false or missing, throw a 400 with message 'Encrypted string attributes are not available on your plan. Please upgrade to create encrypted string attributes.'

## Test Plan
Added tests in the testCreateAttribute
## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
