### PR TITLE
Fix: double logs on failure

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1218,13 +1218,22 @@ class Builds extends Action
                 $message .= "\n[31m" . $error;
             }
 
+            // Combine with previous logs if deployment got past build process
+            $previousLogs = '';
+            if (!empty($deployment->getAttribute('buildEndedAt', ''))) {
+                $previousLogs = $deployment->getAttribute('buildLogs', '');
+                if (!empty($previousLogs)) {
+                    $message = $previousLogs . "\n" . $message;
+                }
+            }
+
             $endTime = DateTime::now();
             $durationEnd = \microtime(true);
             $deployment->setAttribute('buildEndedAt', $endTime);
             $deployment->setAttribute('buildDuration', \intval(\ceil($durationEnd - $durationStart)));
             $deployment->setAttribute('status', 'failed');
-            $deployment->setAttribute('buildLogs', $deployment->getAttribute('buildLogs', '') . "\n" . $message);
 
+            $deployment->setAttribute('buildLogs', $message);
             $deployment = $dbForProject->updateDocument('deployments', $deploymentId, $deployment);
 
             if ($deployment->getInternalId() === $resource->getAttribute('latestDeploymentInternalId', '')) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how build failure logs are stored to ensure all previous logs are included before the final error message, providing clearer build failure information to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->