### PR TITLE
Only load error page for development mode

### DIFF
--- a/app/views/general/error.phtml
+++ b/app/views/general/error.phtml
@@ -479,35 +479,37 @@ switch ($type) {
             </div>
         </div>
 
-        <div x-show="page === 'trace'" class="error-trace">
-            <button class="back-button" x-on:click="page = 'error'">
-                Back
-            </button>
-            <div class="trace-grid-header">Error trace</div>
-            <?php foreach ($trace as $index => $traceItem): ?>
-                <div class="trace-grid">
-                    <?php if (isset($traceItem['file'])): ?>
-                        <div class="trace-label">file</div>
-                        <div class="trace-value"><?php echo $this->print($traceItem['file']); ?></div>
-                    <?php endif; ?>
+        <?php if ($development) : ?>
+            <div x-show="page === 'trace'" class="error-trace">
+                <button class="back-button" x-on:click="page = 'error'">
+                    Back
+                </button>
+                <div class="trace-grid-header">Error trace</div>
+                <?php foreach ($trace as $index => $traceItem): ?>
+                    <div class="trace-grid">
+                        <?php if (isset($traceItem['file'])): ?>
+                            <div class="trace-label">file</div>
+                            <div class="trace-value"><?php echo $this->print($traceItem['file']); ?></div>
+                        <?php endif; ?>
 
-                    <?php if (isset($traceItem['line'])): ?>
-                        <div class="trace-label">line</div>
-                        <div class="trace-value"><?php echo $this->print($traceItem['line']); ?></div>
-                    <?php endif; ?>
+                        <?php if (isset($traceItem['line'])): ?>
+                            <div class="trace-label">line</div>
+                            <div class="trace-value"><?php echo $this->print($traceItem['line']); ?></div>
+                        <?php endif; ?>
 
-                    <?php if (isset($traceItem['function'])): ?>
-                        <div class="trace-label">function</div>
-                        <div class="trace-value"><?php echo $this->print($traceItem['function']); ?></div>
-                    <?php endif; ?>
+                        <?php if (isset($traceItem['function'])): ?>
+                            <div class="trace-label">function</div>
+                            <div class="trace-value"><?php echo $this->print($traceItem['function']); ?></div>
+                        <?php endif; ?>
 
-                    <?php if (isset($traceItem['args'])): ?>
-                        <div class="trace-label">args</div>
-                        <div class="trace-args"><pre><?php echo $this->print(\var_export($traceItem['args'], true)); ?></pre></div>
-                    <?php endif; ?>
-                </div>
-            <?php endforeach; ?>
-        </div>
+                        <?php if (isset($traceItem['args'])): ?>
+                            <div class="trace-label">args</div>
+                            <div class="trace-args"><pre><?php echo $this->print(\var_export($traceItem['args'], true)); ?></pre></div>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
     </div>
 
     <div x-show="page === 'error'" class="brand">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Only load error page for development mode 

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Error trace details are now only visible in development mode, preventing exposure of sensitive information in non-development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->