### PR TITLE
added encrypt property in the attribute string response model

### DIFF
--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1063,7 +1063,6 @@ App::get('/v1/databases/:databaseId/collections/:collectionId')
             throw new Exception(Exception::COLLECTION_NOT_FOUND);
         }
 
-
         $response->dynamic($collection, Response::MODEL_COLLECTION);
     });
 

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2053,7 +2053,6 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/attributes')
         }
 
 
-
         foreach ($attributes as $attribute) {
             if ($attribute->getAttribute('type') === Database::VAR_STRING) {
                 $filters = $attribute->getAttribute('filters', []);

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1372,10 +1372,12 @@ App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/string
             'array' => $array,
             'filters' => $filters,
         ]), $response, $dbForProject, $queueForDatabase, $queueForEvents);
-
+        $stringAttribute = $attribute->getArrayCopy();
+        $stringAttribute['encrypt'] = $encrypt;
+        $stringAttribute = new Document($stringAttribute);
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-            ->dynamic($attribute, Response::MODEL_ATTRIBUTE_STRING);
+            ->dynamic($stringAttribute, Response::MODEL_ATTRIBUTE_STRING);
     });
 
 App::post('/v1/databases/:databaseId/collections/:collectionId/attributes/email')

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2051,7 +2051,6 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/attributes')
             throw new Exception(Exception::GENERAL_QUERY_INVALID);
         }
 
-
         foreach ($attributes as $attribute) {
             if ($attribute->getAttribute('type') === Database::VAR_STRING) {
                 $filters = $attribute->getAttribute('filters', []);

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -1063,13 +1063,6 @@ App::get('/v1/databases/:databaseId/collections/:collectionId')
             throw new Exception(Exception::COLLECTION_NOT_FOUND);
         }
 
-        $attributes = $collection->getAttribute('attributes');
-        foreach ($attributes as $attribute) {
-            if ($attribute->getAttribute('type') === Database::VAR_STRING) {
-                $filters = $attribute->getAttribute('filters', []);
-                $attribute->setAttribute('encrypt', in_array('encrypt', $filters));
-            }
-        }
 
         $response->dynamic($collection, Response::MODEL_COLLECTION);
     });

--- a/app/controllers/api/databases.php
+++ b/app/controllers/api/databases.php
@@ -2053,8 +2053,18 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/attributes')
             throw new Exception(Exception::GENERAL_QUERY_INVALID);
         }
 
+        $updatedAttributes = [];
+
+        foreach ($attributes as $attribute) {
+            $filters = $attribute->getAttribute('filters', []);
+            $attributeArray = $attribute->getArrayCopy();
+            $attributeArray['encrypt'] = in_array('encrypt', $filters);
+            $updatedAttribute = new Document($attributeArray);
+            $updatedAttributes[] = $updatedAttribute;
+        }
+
         $response->dynamic(new Document([
-            'attributes' => $attributes,
+            'attributes' => $updatedAttributes,
             'total' => $total,
         ]), Response::MODEL_ATTRIBUTE_LIST);
     });
@@ -2117,7 +2127,7 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/attributes/:key')
         $type = $attribute->getAttribute('type');
         $format = $attribute->getAttribute('format');
         $options = $attribute->getAttribute('options', []);
-
+        $filters = $attribute->getAttribute('filters', []);
         foreach ($options as $key => $option) {
             $attribute->setAttribute($key, $option);
         }
@@ -2137,7 +2147,9 @@ App::get('/v1/databases/:databaseId/collections/:collectionId/attributes/:key')
             },
             default => Response::MODEL_ATTRIBUTE,
         };
-
+        $attribute = $attribute->getArrayCopy();
+        $attribute['encrypt'] = in_array('encrypt', $filters);
+        $attribute = new Document($attribute);
         $response->dynamic($attribute, $model);
     });
 

--- a/app/init/database/filters.php
+++ b/app/init/database/filters.php
@@ -77,12 +77,17 @@ Database::addFilter(
         ]);
 
         foreach ($attributes as $attribute) {
-            if ($attribute->getAttribute('type') === Database::VAR_RELATIONSHIP) {
+            $attributeType = $attribute->getAttribute('type');
+            if ($attributeType === Database::VAR_RELATIONSHIP) {
                 $options = $attribute->getAttribute('options');
                 foreach ($options as $key => $value) {
                     $attribute->setAttribute($key, $value);
                 }
                 $attribute->removeAttribute('options');
+            }
+            if ($attributeType === Database::VAR_STRING) {
+                $filters = $attribute->getAttribute('filters', []);
+                $attribute->setAttribute('encrypt', in_array('encrypt', $filters));
             }
         }
 

--- a/app/init/database/filters.php
+++ b/app/init/database/filters.php
@@ -78,16 +78,20 @@ Database::addFilter(
 
         foreach ($attributes as $attribute) {
             $attributeType = $attribute->getAttribute('type');
-            if ($attributeType === Database::VAR_RELATIONSHIP) {
-                $options = $attribute->getAttribute('options');
-                foreach ($options as $key => $value) {
-                    $attribute->setAttribute($key, $value);
-                }
-                $attribute->removeAttribute('options');
-            }
-            if ($attributeType === Database::VAR_STRING) {
-                $filters = $attribute->getAttribute('filters', []);
-                $attribute->setAttribute('encrypt', in_array('encrypt', $filters));
+
+            switch ($attributeType) {
+                case Database::VAR_RELATIONSHIP:
+                    $options = $attribute->getAttribute('options');
+                    foreach ($options as $key => $value) {
+                        $attribute->setAttribute($key, $value);
+                    }
+                    $attribute->removeAttribute('options');
+                    break;
+
+                case Database::VAR_STRING:
+                    $filters = $attribute->getAttribute('filters', []);
+                    $attribute->setAttribute('encrypt', in_array('encrypt', $filters));
+                    break;
             }
         }
 

--- a/src/Appwrite/Utopia/Response/Model/AttributeString.php
+++ b/src/Appwrite/Utopia/Response/Model/AttributeString.php
@@ -24,6 +24,13 @@ class AttributeString extends Attribute
                 'required' => false,
                 'example' => 'default',
             ])
+            ->addRule('encrypt', [
+                'type' => self::TYPE_BOOLEAN,
+                'description' => 'Encryption status for the string attribute. Encryption enhances security by not storing any plain text values in the database. However, encrypted attributes cannot be queried.',
+                'default' => false,
+                'required' => false,
+                'example' => false,
+            ])
         ;
     }
 

--- a/src/Appwrite/Utopia/Response/Model/AttributeString.php
+++ b/src/Appwrite/Utopia/Response/Model/AttributeString.php
@@ -26,7 +26,7 @@ class AttributeString extends Attribute
             ])
             ->addRule('encrypt', [
                 'type' => self::TYPE_BOOLEAN,
-                'description' => 'Encryption status for the string attribute. Encryption enhances security by not storing any plain text values in the database. However, encrypted attributes cannot be queried.',
+                'description' => 'Defines whether this attribute is encrypted or not.',
                 'default' => false,
                 'required' => false,
                 'example' => false,

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -298,7 +298,7 @@ trait DatabasesBase
         $this->assertEquals($title['body']['type'], 'string');
         $this->assertEquals($title['body']['size'], 256);
         $this->assertEquals($title['body']['required'], true);
-
+        $this->assertFalse($title['body']['encrypt']);
         $this->assertEquals(202, $description['headers']['status-code']);
         $this->assertEquals($description['body']['key'], 'description');
         $this->assertEquals($description['body']['type'], 'string');

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -706,11 +706,6 @@ class DatabasesCustomServerTest extends Scope
         ]));
         $this->assertTrue($response['body']['encrypt']);
 
-        $response = $this->client->call(Client::METHOD_GET, $attributesPath, array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-            'x-appwrite-key' => $this->getProject()['apiKey'],
-        ]));
         /**
          * Check status of every attribute
          */

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -756,19 +756,15 @@ class DatabasesCustomServerTest extends Scope
             'x-appwrite-key' => $this->getProject()['apiKey']
         ]), []);
         $attributes = $actors['body']['attributes'];
-        $firstNameAttribute = null;
-        $lastNameAttribute = null;
         foreach ($attributes as $attribute) {
             $this->assertArrayHasKey('encrypt', $attribute);
             if ($attribute['key'] === 'firstName') {
-                $firstNameAttribute = $attribute['encrypt'];
+                $this->assertFalse($attribute['encrypt']);
             }
             if ($attribute['key'] === 'lastName') {
-                $lastNameAttribute = $attribute['encrypt'];
+                $this->assertTrue($attribute['encrypt']);
             }
         }
-        $this->assertTrue($lastNameAttribute);
-        $this->assertFalse($firstNameAttribute);
 
     }
 

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -748,6 +748,28 @@ class DatabasesCustomServerTest extends Scope
         $this->assertEquals(200, $document['headers']['status-code']);
         $this->assertEquals('Jonah', $document['body']['firstName']);
         $this->assertEquals('Jameson', $document['body']['lastName']);
+
+
+        $actors = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $actors['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey']
+        ]), []);
+        $attributes = $actors['body']['attributes'];
+        $firstNameAttribute = null;
+        $lastNameAttribute = null;
+        foreach ($attributes as $attribute) {
+            $this->assertArrayHasKey('encrypt', $attribute);
+            if ($attribute['key'] === 'firstName') {
+                $firstNameAttribute = $attribute['encrypt'];
+            }
+            if ($attribute['key'] === 'lastName') {
+                $lastNameAttribute = $attribute['encrypt'];
+            }
+        }
+        $this->assertTrue($lastNameAttribute);
+        $this->assertFalse($firstNameAttribute);
+
     }
 
     public function testDeleteAttribute(): array

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -698,8 +698,19 @@ class DatabasesCustomServerTest extends Scope
             'encrypt' => true
         ]);
         $this->assertTrue($lastName['body']['encrypt']);
+        sleep(1);
+        $response = $this->client->call(Client::METHOD_GET, $attributesPath . '/lastName', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]));
+        $this->assertTrue($response['body']['encrypt']);
 
-
+        $response = $this->client->call(Client::METHOD_GET, $attributesPath, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]));
         /**
          * Check status of every attribute
          */

--- a/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/DatabasesCustomServerTest.php
@@ -697,6 +697,7 @@ class DatabasesCustomServerTest extends Scope
             'required' => true,
             'encrypt' => true
         ]);
+        $this->assertTrue($lastName['body']['encrypt']);
 
 
         /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The API now explicitly includes the encryption status in responses for creating, listing, and retrieving string attributes.
- **Tests**
  - Added validations to confirm the encryption flag is correctly reflected immediately after creation and upon retrieval of attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->