### PR TITLE
fix(migration): _APP_DEFAULT_REGION is not a valid env var

### DIFF
--- a/src/Appwrite/Migration/Version/V22.php
+++ b/src/Appwrite/Migration/Version/V22.php
@@ -353,11 +353,11 @@ class V22 extends Migration
 
                 if ($project->isEmpty()) {
                     Console::warning("Project \"{$document->getAttribute('projectId')}\" not found for rule \"{$document->getId()}\"");
-                    $document->setAttribute('region', System::getEnv('_APP_DEFAULT_REGION'));
+                    $document->setAttribute('region', System::getEnv('_APP_REGION', 'default'));
                     break;
                 }
 
-                $document->setAttribute('region', $project->getAttribute('region', System::getEnv('_APP_DEFAULT_REGION')));
+                $document->setAttribute('region', $project->getAttribute('region', System::getEnv('_APP_REGION', 'default')));
 
                 $domain = $document->getAttribute('domain', '');
                 $functionsDomain = System::getEnv('_APP_DOMAIN_FUNCTIONS', '');


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Across the rest of the codebase, we use _APP_REGION with 'default' as the fallback value. This commit updates the migration to do the same.

## Test Plan

Manual

## Related PRs and Issues

Related issue:
- https://github.com/appwrite/appwrite/issues/9818

Previous attempt:
- https://github.com/appwrite/appwrite/pull/9856

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the logic for setting the "region" attribute in migrated rules to use the correct default region, improving consistency in region assignment during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->