### PR TITLE
Ask users to have backups before installing the new version and fix cap letter.

### DIFF
--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -62,7 +62,7 @@ class Install extends Action
 
         if ($data !== false) {
             if ($interactive == 'Y' && Console::isInteractive()) {
-                $answer = Console::confirm('Previous installation found, do you want to overwrite it (a backup will be created before overwriting)? (Y/n)');
+                $answer = Console::confirm('Previous installation found, do you want to overwrite it? (make sure to have backups before proceeding) (y/N)');
 
                 if (\strtolower($answer) !== 'y') {
                     Console::info('No action taken.');


### PR DESCRIPTION
The previous message is being understood like appwrite performing backups by default prior to installing the next version.
However this is not true and only the docker compose file is being backed-up.

This way people makes sure to have a backup prior to upgrading and prevents them from breaking things.


Also the Y letter is capitalized, but it's not the default option. Toggled it to N.
