### PR TITLE
Fix cache issues with proxy for deployment download

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Download/Get.php
@@ -105,9 +105,11 @@ class Get extends Action
 
         $response
             ->setContentType('application/gzip')
-            ->addHeader('Cache-Control', 'private, max-age=3888000') // 45 days
+            ->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+            ->addHeader('Expires', '0')
+            ->addHeader('Pragma', 'no-cache')
             ->addHeader('X-Peak', \memory_get_peak_usage())
-            ->addHeader('Content-Disposition', 'attachment; filename="' . $deploymentId . '.tar.gz"');
+            ->addHeader('Content-Disposition', 'attachment; filename="' . $deploymentId . '-' . $type . '.tar.gz"');
 
         $size = $device->getFileSize($path);
         $rangeHeader = $request->getHeader('range');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Download/Get.php
@@ -99,12 +99,14 @@ class Get extends Action
         }
 
         if (!$device->exists($path)) {
-            throw new Exception(Exception::BUILD_NOT_FOUND);
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
         $response
             ->setContentType('application/gzip')
-            ->addHeader('Expires', \date('D, d M Y H:i:s', \time() + (60 * 60 * 24 * 45)) . ' GMT') // 45 days cache
+            ->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+            ->addHeader('Expires', '0')
+            ->addHeader('Pragma', 'no-cache')
             ->addHeader('X-Peak', \memory_get_peak_usage())
             ->addHeader('Content-Disposition', 'attachment; filename="' . $deploymentId . '-' . $type . '.tar.gz"');
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Disables cache, preventing proxy issues with public cachce, and cache size limits

## Test Plan

Manual QA with Range header, works great. Later-on this resolves Staging issue when downloading large build output

## Related PRs and Issues

x

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when a requested deployment file is not found.

- **Enhancements**
  - Updated download response headers to prevent browsers from caching deployment files.
  - Downloaded deployment files now include additional details in the suggested filename for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->