### PR TITLE
Fix: Redirect rule parent resource

### DIFF
--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -25446,12 +25446,33 @@
                                             "Temporary Redirect 307",
                                             "Permanent Redirect 308"
                                         ]
+                                    },
+                                    "resourceId": {
+                                        "type": "string",
+                                        "description": "ID of parent resource.",
+                                        "x-example": "<RESOURCE_ID>"
+                                    },
+                                    "resourceType": {
+                                        "type": "string",
+                                        "description": "Type of parent resource.",
+                                        "x-example": "site",
+                                        "enum": [
+                                            "site",
+                                            "function"
+                                        ],
+                                        "x-enum-name": "ProxyResourceType",
+                                        "x-enum-keys": [
+                                            "Site",
+                                            "Function"
+                                        ]
                                     }
                                 },
                                 "required": [
                                     "domain",
                                     "url",
-                                    "statusCode"
+                                    "statusCode",
+                                    "resourceId",
+                                    "resourceType"
                                 ]
                             }
                         }

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -25696,12 +25696,35 @@
                                         "Temporary Redirect 307",
                                         "Permanent Redirect 308"
                                     ]
+                                },
+                                "resourceId": {
+                                    "type": "string",
+                                    "description": "ID of parent resource.",
+                                    "default": null,
+                                    "x-example": "<RESOURCE_ID>"
+                                },
+                                "resourceType": {
+                                    "type": "string",
+                                    "description": "Type of parent resource.",
+                                    "default": null,
+                                    "x-example": "site",
+                                    "enum": [
+                                        "site",
+                                        "function"
+                                    ],
+                                    "x-enum-name": "ProxyResourceType",
+                                    "x-enum-keys": [
+                                        "Site",
+                                        "Function"
+                                    ]
                                 }
                             },
                             "required": [
                                 "domain",
                                 "url",
-                                "statusCode"
+                                "statusCode",
+                                "resourceId",
+                                "resourceType"
                             ]
                         }
                     }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
@@ -14,6 +14,7 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
 use Utopia\Database\Helpers\ID;
+use Utopia\Database\Validator\UID;
 use Utopia\Domains\Domain;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -65,15 +66,18 @@ class Create extends Action
             ->param('domain', null, new ValidatorDomain(), 'Domain name.')
             ->param('url', null, new URL(), 'Target URL of redirection')
             ->param('statusCode', null, new WhiteList([301, 302, 307, 308]), 'Status code of redirection')
+            ->param('resourceId', '', new UID(), 'ID of parent resource.')
+            ->param('resourceType', '', new WhiteList(['site', 'function']), 'Type of parent resource.')
             ->inject('response')
             ->inject('project')
             ->inject('queueForCertificates')
             ->inject('queueForEvents')
             ->inject('dbForPlatform')
+            ->inject('dbForProject')
             ->callback([$this, 'action']);
     }
 
-    public function action(string $domain, string $url, int $statusCode, Response $response, Document $project, Certificate $queueForCertificates, Event $queueForEvents, Database $dbForPlatform)
+    public function action(string $domain, string $url, int $statusCode, string $resourceId, string $resourceType, Response $response, Document $project, Certificate $queueForCertificates, Event $queueForEvents, Database $dbForPlatform, Database $dbForProject)
     {
         $deniedDomains = [
             'localhost',
@@ -114,6 +118,15 @@ class Create extends Action
             $domain = new Domain($domain);
         } catch (\Throwable) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Domain may not start with http:// or https://.');
+        }
+
+        $collection = match ($resourceType) {
+            'site' => 'sites',
+            'function' => 'functions'
+        };
+        $resource = $dbForProject->getDocument($collection, $resourceId);
+        if ($resource->isEmpty()) {
+            throw new Exception(Exception::RULE_RESOURCE_NOT_FOUND);
         }
 
         // TODO: @christyjacob remove once we migrate the rules in 1.7.x
@@ -164,6 +177,9 @@ class Create extends Action
             'trigger' => 'manual',
             'redirectUrl' => $url,
             'redirectStatusCode' => $statusCode,
+            'deploymentResourceType' => $resourceType,
+            'deploymentResourceId' => $resource->getId(),
+            'deploymentResourceInternalId' => $resource->getInternalId(),
             'certificateId' => '',
             'search' => implode(' ', [$ruleId, $domain->get()]),
             'owner' => $owner,

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -113,6 +113,16 @@ abstract class Format
     protected function getEnumName(string $service, string $method, string $param): ?string
     {
         switch ($service) {
+            case 'proxy':
+                switch ($method) {
+                    case 'createRedirectRule':
+                        switch ($param) {
+                            case 'resourceType':
+                                return 'ProxyResourceType';
+                        }
+                        break;
+                }
+                break;
             case 'console':
                 switch ($method) {
                     case 'getResource':
@@ -441,7 +451,13 @@ abstract class Format
             case 'proxy':
                 switch ($method) {
                     case 'createRedirectRule':
-                        return ['Moved Permanently 301', 'Found 302', 'Temporary Redirect 307', 'Permanent Redirect 308'];
+                        switch ($param) {
+                            case 'statusCode':
+                                return ['Moved Permanently 301', 'Found 302', 'Temporary Redirect 307', 'Permanent Redirect 308'];
+                            case 'resourceType':
+                                return ['Site', 'Function'];
+                        }
+                        break;
                 }
                 break;
             case 'functions':

--- a/tests/e2e/Services/Proxy/ProxyBase.php
+++ b/tests/e2e/Services/Proxy/ProxyBase.php
@@ -68,7 +68,7 @@ trait ProxyBase
         return $rule;
     }
 
-    protected function createRedirectRule(string $domain, string $url, int $statusCode): mixed
+    protected function createRedirectRule(string $domain, string $url, int $statusCode, string $resourceType, string $resourceId): mixed
     {
         $rule = $this->client->call(Client::METHOD_POST, '/proxy/rules/redirect', array_merge([
             'content-type' => 'application/json',
@@ -77,6 +77,8 @@ trait ProxyBase
             'domain' => $domain,
             'url' => $url,
             'statusCode' => $statusCode,
+            'resourceType' => $resourceType,
+            'resourceId' => $resourceId,
         ]);
 
         return $rule;
@@ -115,9 +117,9 @@ trait ProxyBase
         return $rule['body']['$id'];
     }
 
-    protected function setupRedirectRule(string $domain, string $url, int $statusCode): string
+    protected function setupRedirectRule(string $domain, string $url, int $statusCode, string $resourceType, string $resourceId): string
     {
-        $rule = $this->createRedirectRule($domain, $url, $statusCode);
+        $rule = $this->createRedirectRule($domain, $url, $statusCode, $resourceType, $resourceId);
 
         $this->assertEquals(201, $rule['headers']['status-code'], 'Failed to setup rule: ' . \json_encode($rule));
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds parent to redirect type rule. Doing this allow to query it by it then, so it can be shown properly in site's rules tab in Console

## Test Plan

New tests

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redirect rules can now be explicitly linked to a specific site or function resource.
  - When creating redirect rules, users must specify the resource type ('site' or 'function') and the corresponding resource ID.

- **Bug Fixes**
  - Improved validation and error handling when associating redirect rules with resources.

- **Tests**
  - End-to-end tests updated to verify redirect rule creation and association with site resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->