### PR TITLE
chore: restore unique filename for health check #9842

### DIFF
--- a/app/controllers/api/health.php
+++ b/app/controllers/api/health.php
@@ -845,15 +845,18 @@ App::get('/v1/health/storage')
         $checkStart = \microtime(true);
 
         foreach ($devices as $device) {
-            if (!$device->write($device->getPath('health.txt'), 'test', 'text/plain')) {
+            $uniqueFileName = \uniqid('health', true);
+            $filePath = $device->getPath($uniqueFileName);
+
+            if (!$device->write($filePath, 'test', 'text/plain')) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed writing test file to ' . $device->getRoot());
             }
 
-            if ($device->read($device->getPath('health.txt')) !== 'test') {
+            if ($device->read($filePath) !== 'test') {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed reading test file from ' . $device->getRoot());
             }
 
-            if (!$device->delete($device->getPath('health.txt'))) {
+            if (!$device->delete($filePath)) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed deleting test file from ' . $device->getRoot());
             }
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

restores using unique filenames for healthcheck to ensure multiple calls to the health endpoint don't conflict with eachother.

## Test Plan

## Related PRs and Issues

* https://github.com/appwrite/appwrite/pull/9842

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of storage device health checks by using a unique, randomly generated filename for each test, reducing the risk of conflicts during health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->