### PR TITLE
Only delete schedule document if execution is successful

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleExecutions.php
@@ -62,7 +62,7 @@ class ScheduleExecutions extends ScheduleBase
                 $executionDelay = $executedAt->getTimestamp() - $scheduledAt->getTimestamp();
 
                 $headers = $data['headers'] ?? [];
-                $headers['x-appwrite-schedule-delay'] = (string)$executionDelay;
+                $headers['x-appwrite-execution-delay'] = (string)$executionDelay;
                 $headers['x-appwrite-scheduled-at'] = $scheduledAt->format('Y-m-d\TH:i:s.v\Z');
                 $headers['x-appwrite-executed-at'] = $executedAt->format('Y-m-d\TH:i:s.v\Z');
 

--- a/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
+++ b/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
@@ -136,30 +136,17 @@ class FunctionsScheduleTest extends Scope
             $this->assertStringContainsString('path-is-/custom-path', $execution['body']['logs']);
             $this->assertStringContainsString('user-is-' . $this->getUser()['$id'], $execution['body']['logs']);
             $this->assertStringContainsString('jwt-is-valid', $execution['body']['logs']);
+            $this->assertStringContainsString('execution-delay-is-valid', $execution['body']['logs']);
+            $this->assertStringContainsString('scheduled-at-is-valid', $execution['body']['logs']);
+            $this->assertStringContainsString('executed-at-is-valid', $execution['body']['logs']);
             $this->assertGreaterThan(0, $execution['body']['duration']);
 
-            $logs = explode("\n", $execution['body']['logs']);
-            $scheduleDelay = null;
-            $scheduledAt = null;
-            $executedAt = null;
-
-            foreach ($logs as $line) {
-                $line = trim($line);
-
-                if (str_starts_with($line, 'schedule-delay-is-')) {
-                    $scheduleDelay = (int) substr($line, strlen('schedule-delay-is-'));
-                } elseif (str_starts_with($line, 'scheduled-at-is-')) {
-                    $scheduledAt = substr($line, strlen('scheduled-at-is-'));
-                } elseif (str_starts_with($line, 'executed-at-is-')) {
-                    $executedAt = substr($line, strlen('executed-at-is-'));
-                }
-            }
-
-            $this->assertNotNull($scheduleDelay);
-            $this->assertLessThanOrEqual(5, $scheduleDelay);
-            $this->assertNotNull($scheduledAt);
-            $this->assertNotNull($executedAt);
-            $this->assertNotEquals($scheduledAt, $executedAt, );
+            $requestHeaders = array_column($execution['body']['requestHeaders'], 'value', 'name');
+            $this->assertArrayHasKey('x-appwrite-scheduled-at', $requestHeaders);
+            $this->assertArrayHasKey('x-appwrite-executed-at', $requestHeaders);
+            $this->assertArrayHasKey('x-appwrite-execution-delay', $requestHeaders);
+            $this->assertIsNumeric($requestHeaders['x-appwrite-execution-delay']);
+            $this->assertGreaterThan($requestHeaders['x-appwrite-scheduled-at'], $requestHeaders['x-appwrite-executed-at']);
         }, 10000, 500);
 
         /* Test for FAILURE */

--- a/tests/resources/functions/basic/index.js
+++ b/tests/resources/functions/basic/index.js
@@ -37,9 +37,6 @@ module.exports = async(context) => {
     context.log('method-is-' + (context.req.method ?? '').toLowerCase());
     context.log('path-is-' + (context.req.path ?? ''));
     context.log('user-is-' + (context.req.headers['x-appwrite-user-id'] ?? ''));
-    context.log('schedule-delay-is-' + (context.req.headers['x-appwrite-schedule-delay'] ?? ''));
-    context.log('scheduled-at-is-' + (context.req.headers['x-appwrite-scheduled-at'] ?? ''));
-    context.log('executed-at-is-' + (context.req.headers['x-appwrite-executed-at'] ?? ''));
     
     const statusCode = context.req.query['code'] || '200';
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If task-scheduler goes down for sometime and comes back up later, it was never executing schedules that were supposed to be executed during downtime. This PR fixes that and ensures that `schedule` document is only deleted if execution is successful.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
