### PR TITLE
fix: prevent injected $user from being shadowed

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1461,9 +1461,9 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
         if (!empty($nameOAuth)) {
             $name = $nameOAuth;
         } elseif ($userParam !== null) {
-            $user = \json_decode($userParam, true);
-            if (isset($user['name']['firstName']) && isset($user['name']['lastName'])) {
-                $name = $user['name']['firstName'] . ' ' . $user['name']['lastName'];
+            $userDecoded = \json_decode($userParam, true);
+            if (isset($userDecoded['name']['firstName']) && isset($userDecoded['name']['lastName'])) {
+                $name = $userDecoded['name']['firstName'] . ' ' . $userDecoded['name']['lastName'];
             }
         }
         $email = $oauth2->getUserEmail($accessToken);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

`$user` is supposed to be the injected `$user`, but it's being shadowed by this block

## Test Plan

Manually locally

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/10130

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
