### PR TITLE
chore: improve invalid scheme error in origin check

### DIFF
--- a/src/Appwrite/Network/Validator/Origin.php
+++ b/src/Appwrite/Network/Validator/Origin.php
@@ -78,7 +78,7 @@ class Origin extends Validator
         }
 
         if (empty($platform)) {
-            return 'Invalid Scheme. The scheme used ( ' . $this->scheme . ' ) in the Origin ( ' . $this->origin . ' ) is not supported. If you are using a custom scheme, please change it to `appwrite-callback-<PROJECT_ID>`';
+            return 'Invalid Scheme. The scheme used (' . $this->scheme . ') in the Origin (' . $this->origin . ') is not supported. If you are using a custom scheme, please change it to `appwrite-callback-<PROJECT_ID>`';
         }
 
         return 'Invalid Origin. Register your new client ' . $host . ' as a new '

--- a/tests/unit/Network/Validators/OriginTest.php
+++ b/tests/unit/Network/Validators/OriginTest.php
@@ -108,6 +108,6 @@ class OriginTest extends TestCase
         $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Web (Edge Extension) platform on your project console dashboard', $validator->getDescription());
 
         $this->assertEquals(false, $validator->isValid('random-scheme://localhost'));
-        $this->assertEquals('Invalid Scheme. The scheme used ( random-scheme ) in the Origin ( random-scheme://localhost ) is not supported. If you are using a custom scheme, please change it to `appwrite-callback-<PROJECT_ID>`', $validator->getDescription());
+        $this->assertEquals('Invalid Scheme. The scheme used (random-scheme) in the Origin (random-scheme://localhost) is not supported. If you are using a custom scheme, please change it to `appwrite-callback-<PROJECT_ID>`', $validator->getDescription());
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

when an unsupported scheme is used, we show this error
<img width="903" height="99" alt="Screenshot 2025-07-18 at 10 09 30 PM" src="https://github.com/user-attachments/assets/0acf0874-52cc-407a-9829-f4d99d4634da" />

this lacks the platform user should be adding since the scheme itself is not supported. so if platform is not present, we throw an improved error showing that scheme is unsupported

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
