### PR TITLE
TypeScript: created extra DocumentBase containing all default attributes of Documents

### DIFF
--- a/public/sdk-console/models.ts
+++ b/public/sdk-console/models.ts
@@ -156,9 +156,10 @@ export namespace Models {
         phones: Phone[];
     }
     /**
-     * Document
+     * DocumentBase
+     * Contains the default attributes for all documents.
      */
-    export type Document = {
+    export type DocumentBase = {
         /**
          * Document ID.
          */
@@ -183,6 +184,11 @@ export namespace Models {
          * Document permissions. [Learn more about permissions](/docs/permissions).
          */
         $permissions: string[];
+    }
+    /**
+     * Document
+     */
+    export type Document = DocumentBase & {
         [key: string]: any;
     }
     /**

--- a/public/sdk-project/models.ts
+++ b/public/sdk-project/models.ts
@@ -156,9 +156,10 @@ export namespace Models {
         phones: Phone[];
     }
     /**
-     * Document
+     * DocumentBase
+     * Contains the default attributes for all documents.
      */
-    export type Document = {
+    export type DocumentBase = {
         /**
          * Document ID.
          */
@@ -183,6 +184,11 @@ export namespace Models {
          * Document permissions. [Learn more about permissions](/docs/permissions).
          */
         $permissions: string[];
+    }
+    /**
+     * Document
+     */
+    export type Document = DocumentBase & {
         [key: string]: any;
     }
     /**

--- a/public/sdk-web/models.ts
+++ b/public/sdk-web/models.ts
@@ -156,9 +156,10 @@ export namespace Models {
         phones: Phone[];
     }
     /**
-     * Document
+     * DocumentBase
+     * Contains the default attributes for all documents.
      */
-    export type Document = {
+    export type DocumentBase = {
         /**
          * Document ID.
          */
@@ -183,6 +184,11 @@ export namespace Models {
          * Document permissions. [Learn more about permissions](/docs/permissions).
          */
         $permissions: string[];
+    }
+    /**
+     * Document
+     */
+    export type Document =  DocumentBase & {
         [key: string]: any;
     }
     /**


### PR DESCRIPTION
## What does this PR do?

This PR adds a `DocumentBase` type that defines the default attributes of a Document.
The existing `Document` type now extends `DocumentBase`, adding the indexed string `[key: string]: any.`

### Why?

This PR is related to PR !... in https://github.com/appwrite/sdk-for-cli:

The [https://appwrite.io/docs/products/databases/type-generation](appwrite-cli type generation) for TypeScript defined a Document type as:

```ts
import { Models } from 'appwrite';

export type Books = Models.Document & {
  name: string;
  author: string;
  releaseYear: string | null;
  ...
}
```

However, by extending `Models.Document`, the `[key: string]: any` property makes attributes that don't exist still allowed.

By extending form the `Models.DocumentBase` type, this problem is solved.

## Test Plan

Did not write any tests for this PR; if you need any, let me know.

## Related PRs and Issues

- PR in appwrite-cli: ...
- PR in docs: ...
- @ChiragAgg5k mentioned on Discord that there is an open issue tracking this, but I can't seem to find it.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
