### PR TITLE
Bump response format, Fix backwards compat

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -271,7 +271,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                     ->setTwitter(APP_SOCIAL_TWITTER_HANDLE)
                     ->setDiscord(APP_SOCIAL_DISCORD_CHANNEL, APP_SOCIAL_DISCORD)
                     ->setDefaultHeaders([
-                        'X-Appwrite-Response-Format' => '1.7.0',
+                        'X-Appwrite-Response-Format' => '1.8.0',
                     ])
                     ->setExclude($language['exclude'] ?? []);
 

--- a/src/Appwrite/Utopia/Request/Filters/V20.php
+++ b/src/Appwrite/Utopia/Request/Filters/V20.php
@@ -16,7 +16,7 @@ class V20 extends Filter
         switch ($model) {
             case 'databases.getDocument':
             case 'databases.listDocuments':
-                $content = $this->manageSelectQueries($content, $model);
+                $content = $this->manageSelectQueries($content);
                 break;
         }
         return $content;
@@ -30,7 +30,7 @@ class V20 extends Filter
      * This filter preserves 1.7.x behavior by including all related documents for backward compatibility with
      * `listDocuments` and `getDocument` calls.
      */
-    protected function manageSelectQueries(array $content, string $model): array
+    protected function manageSelectQueries(array $content): array
     {
         $hasWildcard = false;
         if (! isset($content['queries'])) {
@@ -58,7 +58,10 @@ class V20 extends Filter
             }
         }
 
-        if ($hasWildcard && $model === 'databases.listDocuments') {
+        /**
+         * Add `keys.*` for all model types!
+         */
+        if ($hasWildcard) {
             $relatedKeys = $this->getRelatedCollectionKeys();
 
             if (! empty($relatedKeys)) {


### PR DESCRIPTION
## What does this PR do?

Bump response format for preview SDK and fix an issue with `getDocument` not being backwards compatible.

## Test Plan

Manual.

Code -
```ts
console.log(client.headers['X-Appwrite-Response-Format']);
const databases = new Databases(client);

const movies = await databases.getDocument(
    'theatre',
    'movies',
    'superman',
    [
        // Query.select(['*', 'reviews.*'])
    ]
);

console.log(JSON.stringify(movies, null, 2));
```

Response before fix -
<img width="788" height="235" alt="Screenshot 2025-07-22 at 9 34 43 AM" src="https://github.com/user-attachments/assets/a0579dc6-2f33-4344-ab2f-5a73a2de1cfd" />

Response after fix -
<img width="1030" height="484" alt="Screenshot 2025-07-22 at 9 32 33 AM" src="https://github.com/user-attachments/assets/4f55fe0e-feef-420a-8de3-dd2b3508db77" />

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
