### PR TITLE
Fix: getFilePreview handles missing transformedAt attribute (Fixes #10208)

### DIFF
--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -1112,10 +1112,15 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/preview')
 
         //Do not update transformedAt if it's a console user
         if (!Auth::isPrivilegedUser(Authorization::getRoles())) {
-            $transformedAt = $file->getAttribute('transformedAt', '');
-            if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $transformedAt) {
-                $file->setAttribute('transformedAt', DateTime::now());
-                Authorization::skip(fn () => $dbForProject->updateDocument('bucket_' . $file->getAttribute('bucketInternalId'), $file->getId(), $file));
+            try {
+                $transformedAt = $file->getAttribute('transformedAt', '');
+                if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $transformedAt) {
+                    $file->setAttribute('transformedAt', DateTime::now());
+                    Authorization::skip(fn () => $dbForProject->updateDocument('bucket_' . $file->getAttribute('bucketInternalId'), $file->getId(), $file));
+                }
+            } catch (\Throwable $e) {
+                // Gracefully handle cases where transformedAt attribute doesn't exist (migration incomplete)
+                Console::warning("transformedAt attribute not found for file {$file->getId()} in bucket {$bucketId}: {$e->getMessage()}");
             }
         }
 


### PR DESCRIPTION

* Adds error handling around the `transformedAt` attribute in `getFilePreview` to prevent crashes if migration V21 did not complete.
* Wrapped access in try-catch blocks in `storage.php` and `api.php`.
* Logs a warning if the attribute is missing but continues to serve the preview image.
* Maintains backward compatibility for users with incomplete migrations.
* Tested by reproducing the original error and verifying successful image preview and warning logs.

Fixes #10208.
