### PR TITLE
fix: create email target when using email otp registration

### DIFF
--- a/tests/e2e/Services/Account/AccountBase.php
+++ b/tests/e2e/Services/Account/AccountBase.php
@@ -39,6 +39,8 @@ trait AccountBase
         $this->assertEquals($response['body']['labels'], []);
         $this->assertArrayHasKey('accessedAt', $response['body']);
         $this->assertNotEmpty($response['body']['accessedAt']);
+        $this->assertArrayHasKey('targets', $response['body']);
+        $this->assertEquals($email, $response['body']['targets'][0]['identifier']);
 
         /**
          * Test for FAILURE
@@ -159,7 +161,7 @@ trait AccountBase
             'email' => 'otpuser@appwrite.io'
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code'], );
+        $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertNotEmpty($response['body']['$createdAt']);
         $this->assertNotEmpty($response['body']['userId']);
@@ -209,6 +211,8 @@ trait AccountBase
         $this->assertEquals($userId, $response['body']['$id']);
         $this->assertEquals($userId, $response['body']['$id']);
         $this->assertTrue($response['body']['emailVerification']);
+        $this->assertArrayHasKey('targets', $response['body']);
+        $this->assertEquals('otpuser@appwrite.io', $response['body']['targets'][0]['identifier']);
 
         $response = $this->client->call(Client::METHOD_POST, '/account/sessions/token', array_merge([
             'origin' => 'http://localhost',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

An email target should be created during Email OTP login

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
