### PR TITLE
fix: convert docker build args from boolean to string values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,9 @@ services:
     build:
       context: .
       args:
-        DEBUG: false
-        TESTING: true
-        VERSION: dev
+        DEBUG: "false"
+        TESTING: "true"
+        VERSION: "dev"
     ports:
       - 9501:80
     networks:

--- a/tests/resources/docker/docker-compose.yml
+++ b/tests/resources/docker/docker-compose.yml
@@ -31,8 +31,8 @@ services:
     build:
       context: .
       args:
-        - TESTING=true
-        - VERSION=dev
+        TESTING: "true"
+        VERSION: "dev"
     restart: unless-stopped
     ports:
       - "9501:80"


### PR DESCRIPTION
- Fix invalid type errors in Docker build args
- Convert boolean values to strings in YAML files
- Ensure consistency with GitHub workflow format
- Fixes issue #10225

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
