### PR TITLE
fix: favicons endpoint to fallback to ico instead of throwing error

### DIFF
--- a/app/controllers/api/avatars.php
+++ b/app/controllers/api/avatars.php
@@ -375,15 +375,11 @@ App::get('/v1/avatars/favicon')
             throw new Exception(Exception::AVATAR_REMOTE_URL_FAILED);
         }
 
-        if ($res->getStatusCode() !== 200) {
-            throw new Exception(Exception::AVATAR_REMOTE_URL_FAILED);
-        }
-
         $doc = new DOMDocument();
         $doc->strictErrorChecking = false;
         @$doc->loadHTML($res->getBody());
 
-        $links = $doc->getElementsByTagName('link');
+        $links = $doc->getElementsByTagName('link') ?? [];
         $outputHref = '';
         $outputExt = '';
         $space = 0;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

many sites like those protected by cloudflare will not let you make request to them, leading to url failed to parse errors. in those cases we should fallback to `favicon.ico` fetch instead of directly giving error.

## Test Plan

<img width="846" height="552" alt="Screenshot 2025-08-04 at 5 15 47 PM" src="https://github.com/user-attachments/assets/ef12ca36-23f1-444f-8315-cd84772ba8cb" />


## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
