### PR TITLE
chore: add readonly param to sequence, databaseId and collectionId

### DIFF
--- a/app/config/specs/open-api3-1.7.x-client.json
+++ b/app/config/specs/open-api3-1.7.x-client.json
@@ -8479,17 +8479,20 @@
                         "type": "integer",
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
-                        "format": "int32"
+                        "format": "int32",
+                        "readonly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-1.7.x-client.json
+++ b/app/config/specs/open-api3-1.7.x-client.json
@@ -8480,19 +8480,19 @@
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
                         "format": "int32",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-1.7.x-console.json
+++ b/app/config/specs/open-api3-1.7.x-console.json
@@ -37978,17 +37978,20 @@
                         "type": "integer",
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
-                        "format": "int32"
+                        "format": "int32",
+                        "readonly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$createdAt": {
                         "type": "string",
@@ -44635,6 +44638,11 @@
                         "description": "AAAA target for your Appwrite custom domains.",
                         "x-example": "::1"
                     },
+                    "_APP_DOMAIN_TARGET_CAA": {
+                        "type": "string",
+                        "description": "CAA target for your Appwrite custom domains.",
+                        "x-example": "digicert.com"
+                    },
                     "_APP_STORAGE_LIMIT": {
                         "type": "integer",
                         "description": "Maximum file size allowed for file upload in bytes.",
@@ -44692,6 +44700,7 @@
                     "_APP_DOMAIN_TARGET_CNAME",
                     "_APP_DOMAIN_TARGET_A",
                     "_APP_DOMAIN_TARGET_AAAA",
+                    "_APP_DOMAIN_TARGET_CAA",
                     "_APP_STORAGE_LIMIT",
                     "_APP_COMPUTE_SIZE_LIMIT",
                     "_APP_USAGE_STATS",
@@ -44707,6 +44716,7 @@
                     "_APP_DOMAIN_TARGET_CNAME": "appwrite.io",
                     "_APP_DOMAIN_TARGET_A": "127.0.0.1",
                     "_APP_DOMAIN_TARGET_AAAA": "::1",
+                    "_APP_DOMAIN_TARGET_CAA": "digicert.com",
                     "_APP_STORAGE_LIMIT": "30000000",
                     "_APP_COMPUTE_SIZE_LIMIT": "30000000",
                     "_APP_USAGE_STATS": "enabled",

--- a/app/config/specs/open-api3-1.7.x-console.json
+++ b/app/config/specs/open-api3-1.7.x-console.json
@@ -37979,19 +37979,19 @@
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
                         "format": "int32",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-1.7.x-server.json
+++ b/app/config/specs/open-api3-1.7.x-server.json
@@ -27864,17 +27864,20 @@
                         "type": "integer",
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
-                        "format": "int32"
+                        "format": "int32",
+                        "readonly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-1.7.x-server.json
+++ b/app/config/specs/open-api3-1.7.x-server.json
@@ -27865,19 +27865,19 @@
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
                         "format": "int32",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -8479,17 +8479,20 @@
                         "type": "integer",
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
-                        "format": "int32"
+                        "format": "int32",
+                        "readonly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -8480,19 +8480,19 @@
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
                         "format": "int32",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -37978,17 +37978,20 @@
                         "type": "integer",
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
-                        "format": "int32"
+                        "format": "int32",
+                        "readonly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$createdAt": {
                         "type": "string",
@@ -44635,6 +44638,11 @@
                         "description": "AAAA target for your Appwrite custom domains.",
                         "x-example": "::1"
                     },
+                    "_APP_DOMAIN_TARGET_CAA": {
+                        "type": "string",
+                        "description": "CAA target for your Appwrite custom domains.",
+                        "x-example": "digicert.com"
+                    },
                     "_APP_STORAGE_LIMIT": {
                         "type": "integer",
                         "description": "Maximum file size allowed for file upload in bytes.",
@@ -44692,6 +44700,7 @@
                     "_APP_DOMAIN_TARGET_CNAME",
                     "_APP_DOMAIN_TARGET_A",
                     "_APP_DOMAIN_TARGET_AAAA",
+                    "_APP_DOMAIN_TARGET_CAA",
                     "_APP_STORAGE_LIMIT",
                     "_APP_COMPUTE_SIZE_LIMIT",
                     "_APP_USAGE_STATS",
@@ -44707,6 +44716,7 @@
                     "_APP_DOMAIN_TARGET_CNAME": "appwrite.io",
                     "_APP_DOMAIN_TARGET_A": "127.0.0.1",
                     "_APP_DOMAIN_TARGET_AAAA": "::1",
+                    "_APP_DOMAIN_TARGET_CAA": "digicert.com",
                     "_APP_STORAGE_LIMIT": "30000000",
                     "_APP_COMPUTE_SIZE_LIMIT": "30000000",
                     "_APP_USAGE_STATS": "enabled",

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -37979,19 +37979,19 @@
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
                         "format": "int32",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -27864,17 +27864,20 @@
                         "type": "integer",
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
-                        "format": "int32"
+                        "format": "int32",
+                        "readonly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
-                        "x-example": "5e5ea5c15117e"
+                        "x-example": "5e5ea5c15117e",
+                        "readonly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -27865,19 +27865,19 @@
                         "description": "Document automatically incrementing ID.",
                         "x-example": 1,
                         "format": "int32",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$collectionId": {
                         "type": "string",
                         "description": "Collection ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$databaseId": {
                         "type": "string",
                         "description": "Database ID.",
                         "x-example": "5e5ea5c15117e",
-                        "readonly": true
+                        "readOnly": true
                     },
                     "$createdAt": {
                         "type": "string",

--- a/app/config/specs/swagger2-1.7.x-client.json
+++ b/app/config/specs/swagger2-1.7.x-client.json
@@ -8516,17 +8516,20 @@
                     "type": "integer",
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
-                    "format": "int32"
+                    "format": "int32",
+                    "readonly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-1.7.x-client.json
+++ b/app/config/specs/swagger2-1.7.x-client.json
@@ -8517,19 +8517,19 @@
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
                     "format": "int32",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-1.7.x-console.json
+++ b/app/config/specs/swagger2-1.7.x-console.json
@@ -38140,19 +38140,19 @@
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
                     "format": "int32",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-1.7.x-console.json
+++ b/app/config/specs/swagger2-1.7.x-console.json
@@ -38139,17 +38139,20 @@
                     "type": "integer",
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
-                    "format": "int32"
+                    "format": "int32",
+                    "readonly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$createdAt": {
                     "type": "string",
@@ -44900,6 +44903,11 @@
                     "description": "AAAA target for your Appwrite custom domains.",
                     "x-example": "::1"
                 },
+                "_APP_DOMAIN_TARGET_CAA": {
+                    "type": "string",
+                    "description": "CAA target for your Appwrite custom domains.",
+                    "x-example": "digicert.com"
+                },
                 "_APP_STORAGE_LIMIT": {
                     "type": "integer",
                     "description": "Maximum file size allowed for file upload in bytes.",
@@ -44957,6 +44965,7 @@
                 "_APP_DOMAIN_TARGET_CNAME",
                 "_APP_DOMAIN_TARGET_A",
                 "_APP_DOMAIN_TARGET_AAAA",
+                "_APP_DOMAIN_TARGET_CAA",
                 "_APP_STORAGE_LIMIT",
                 "_APP_COMPUTE_SIZE_LIMIT",
                 "_APP_USAGE_STATS",
@@ -44972,6 +44981,7 @@
                 "_APP_DOMAIN_TARGET_CNAME": "appwrite.io",
                 "_APP_DOMAIN_TARGET_A": "127.0.0.1",
                 "_APP_DOMAIN_TARGET_AAAA": "::1",
+                "_APP_DOMAIN_TARGET_CAA": "digicert.com",
                 "_APP_STORAGE_LIMIT": "30000000",
                 "_APP_COMPUTE_SIZE_LIMIT": "30000000",
                 "_APP_USAGE_STATS": "enabled",

--- a/app/config/specs/swagger2-1.7.x-server.json
+++ b/app/config/specs/swagger2-1.7.x-server.json
@@ -28093,19 +28093,19 @@
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
                     "format": "int32",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-1.7.x-server.json
+++ b/app/config/specs/swagger2-1.7.x-server.json
@@ -28092,17 +28092,20 @@
                     "type": "integer",
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
-                    "format": "int32"
+                    "format": "int32",
+                    "readonly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -8516,17 +8516,20 @@
                     "type": "integer",
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
-                    "format": "int32"
+                    "format": "int32",
+                    "readonly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -8517,19 +8517,19 @@
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
                     "format": "int32",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -38140,19 +38140,19 @@
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
                     "format": "int32",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -38139,17 +38139,20 @@
                     "type": "integer",
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
-                    "format": "int32"
+                    "format": "int32",
+                    "readonly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$createdAt": {
                     "type": "string",
@@ -44900,6 +44903,11 @@
                     "description": "AAAA target for your Appwrite custom domains.",
                     "x-example": "::1"
                 },
+                "_APP_DOMAIN_TARGET_CAA": {
+                    "type": "string",
+                    "description": "CAA target for your Appwrite custom domains.",
+                    "x-example": "digicert.com"
+                },
                 "_APP_STORAGE_LIMIT": {
                     "type": "integer",
                     "description": "Maximum file size allowed for file upload in bytes.",
@@ -44957,6 +44965,7 @@
                 "_APP_DOMAIN_TARGET_CNAME",
                 "_APP_DOMAIN_TARGET_A",
                 "_APP_DOMAIN_TARGET_AAAA",
+                "_APP_DOMAIN_TARGET_CAA",
                 "_APP_STORAGE_LIMIT",
                 "_APP_COMPUTE_SIZE_LIMIT",
                 "_APP_USAGE_STATS",
@@ -44972,6 +44981,7 @@
                 "_APP_DOMAIN_TARGET_CNAME": "appwrite.io",
                 "_APP_DOMAIN_TARGET_A": "127.0.0.1",
                 "_APP_DOMAIN_TARGET_AAAA": "::1",
+                "_APP_DOMAIN_TARGET_CAA": "digicert.com",
                 "_APP_STORAGE_LIMIT": "30000000",
                 "_APP_COMPUTE_SIZE_LIMIT": "30000000",
                 "_APP_USAGE_STATS": "enabled",

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -28093,19 +28093,19 @@
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
                     "format": "int32",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
                     "x-example": "5e5ea5c15117e",
-                    "readonly": true
+                    "readOnly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -28092,17 +28092,20 @@
                     "type": "integer",
                     "description": "Document automatically incrementing ID.",
                     "x-example": 1,
-                    "format": "int32"
+                    "format": "int32",
+                    "readonly": true
                 },
                 "$collectionId": {
                     "type": "string",
                     "description": "Collection ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$databaseId": {
                     "type": "string",
                     "description": "Database ID.",
-                    "x-example": "5e5ea5c15117e"
+                    "x-example": "5e5ea5c15117e",
+                    "readonly": true
                 },
                 "$createdAt": {
                     "type": "string",

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -686,7 +686,7 @@ class OpenAPI3 extends Format
                         break;
                 }
 
-                $readOnly = $rule['readonly'] ?? false;
+                $readonly = $rule['readonly'] ?? false;
                 if ($rule['array']) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => 'array',
@@ -700,7 +700,7 @@ class OpenAPI3 extends Format
                     if ($format) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['items']['format'] = $format;
                     }
-                    if ($readOnly) {
+                    if ($readonly) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                 } else {
@@ -713,7 +713,7 @@ class OpenAPI3 extends Format
                     if ($format) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['format'] = $format;
                     }
-                    if ($readOnly) {
+                    if ($readonly) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                 }

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -686,6 +686,7 @@ class OpenAPI3 extends Format
                         break;
                 }
 
+                $readOnly = $rule['readonly'] ?? false;
                 if ($rule['array']) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => 'array',
@@ -699,6 +700,9 @@ class OpenAPI3 extends Format
                     if ($format) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['items']['format'] = $format;
                     }
+                    if ($readOnly) {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    }
                 } else {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
@@ -708,6 +712,9 @@ class OpenAPI3 extends Format
 
                     if ($format) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['format'] = $format;
+                    }
+                    if ($readOnly) {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                 }
                 if ($items) {

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -686,7 +686,7 @@ class OpenAPI3 extends Format
                         break;
                 }
 
-                $readonly = $rule['readonly'] ?? false;
+                $readOnly = $rule['readOnly'] ?? false;
                 if ($rule['array']) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => 'array',
@@ -700,8 +700,8 @@ class OpenAPI3 extends Format
                     if ($format) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['items']['format'] = $format;
                     }
-                    if ($readonly) {
-                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    if ($readOnly) {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
                 } else {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
@@ -713,8 +713,8 @@ class OpenAPI3 extends Format
                     if ($format) {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['format'] = $format;
                     }
-                    if ($readonly) {
-                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    if ($readOnly) {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
                 }
                 if ($items) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -692,6 +692,7 @@ class Swagger2 extends Format
                         break;
                 }
 
+                $readOnly = $rule['readonly'] ?? false;
                 if ($rule['type'] == 'json') {
                     $output['definitions'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
@@ -699,6 +700,10 @@ class Swagger2 extends Format
                         'description' => $rule['description'] ?? '',
                         'x-example' => $rule['example'] ?? null,
                     ];
+
+                    if ($readOnly) {
+                        $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    }
                     continue;
                 }
 
@@ -715,6 +720,9 @@ class Swagger2 extends Format
                     if ($format) {
                         $output['definitions'][$model->getType()]['properties'][$name]['items']['format'] = $format;
                     }
+                    if ($readOnly) {
+                        $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    }
                 } else {
                     $output['definitions'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
@@ -724,6 +732,9 @@ class Swagger2 extends Format
 
                     if ($format) {
                         $output['definitions'][$model->getType()]['properties'][$name]['format'] = $format;
+                    }
+                    if ($readOnly) {
+                        $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                 }
                 if ($items) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -692,7 +692,7 @@ class Swagger2 extends Format
                         break;
                 }
 
-                $readonly = $rule['readonly'] ?? false;
+                $readOnly = $rule['readOnly'] ?? false;
                 if ($rule['type'] == 'json') {
                     $output['definitions'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
@@ -701,8 +701,8 @@ class Swagger2 extends Format
                         'x-example' => $rule['example'] ?? null,
                     ];
 
-                    if ($readonly) {
-                        $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    if ($readOnly) {
+                        $output['definitions'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
                     continue;
                 }
@@ -720,8 +720,8 @@ class Swagger2 extends Format
                     if ($format) {
                         $output['definitions'][$model->getType()]['properties'][$name]['items']['format'] = $format;
                     }
-                    if ($readonly) {
-                        $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    if ($readOnly) {
+                        $output['definitions'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
                 } else {
                     $output['definitions'][$model->getType()]['properties'][$name] = [
@@ -733,8 +733,8 @@ class Swagger2 extends Format
                     if ($format) {
                         $output['definitions'][$model->getType()]['properties'][$name]['format'] = $format;
                     }
-                    if ($readonly) {
-                        $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
+                    if ($readOnly) {
+                        $output['definitions'][$model->getType()]['properties'][$name]['readOnly'] = true;
                     }
                 }
                 if ($items) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -692,7 +692,7 @@ class Swagger2 extends Format
                         break;
                 }
 
-                $readOnly = $rule['readonly'] ?? false;
+                $readonly = $rule['readonly'] ?? false;
                 if ($rule['type'] == 'json') {
                     $output['definitions'][$model->getType()]['properties'][$name] = [
                         'type' => $type,
@@ -701,7 +701,7 @@ class Swagger2 extends Format
                         'x-example' => $rule['example'] ?? null,
                     ];
 
-                    if ($readOnly) {
+                    if ($readonly) {
                         $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                     continue;
@@ -720,7 +720,7 @@ class Swagger2 extends Format
                     if ($format) {
                         $output['definitions'][$model->getType()]['properties'][$name]['items']['format'] = $format;
                     }
-                    if ($readOnly) {
+                    if ($readonly) {
                         $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                 } else {
@@ -733,7 +733,7 @@ class Swagger2 extends Format
                     if ($format) {
                         $output['definitions'][$model->getType()]['properties'][$name]['format'] = $format;
                     }
-                    if ($readOnly) {
+                    if ($readonly) {
                         $output['definitions'][$model->getType()]['properties'][$name]['readonly'] = true;
                     }
                 }

--- a/src/Appwrite/Utopia/Response/Model.php
+++ b/src/Appwrite/Utopia/Response/Model.php
@@ -92,7 +92,7 @@ abstract class Model
             'description' => '',
             'example' => '',
             'sensitive' => false,
-            'readonly' => false
+            'readOnly' => false
         ], $options);
 
         return $this;
@@ -133,7 +133,7 @@ abstract class Model
     /**
      * Get Readonly Fields
      *
-     * Returns list of field names that are marked as readonly
+     * Returns list of field names that are marked as readOnly
      * and should not be allowed in create/update payloads
      *
      * @return array
@@ -143,7 +143,7 @@ abstract class Model
         $list = [];
 
         foreach ($this->rules as $key => $rule) {
-            if ($rule['readonly'] ?? false) {
+            if ($rule['readOnly'] ?? false) {
                 $list[] = $key;
             }
         }

--- a/src/Appwrite/Utopia/Response/Model.php
+++ b/src/Appwrite/Utopia/Response/Model.php
@@ -91,7 +91,8 @@ abstract class Model
             'array' => false,
             'description' => '',
             'example' => '',
-            'sensitive' => false
+            'sensitive' => false,
+            'readonly' => false
         ], $options);
 
         return $this;
@@ -122,6 +123,27 @@ abstract class Model
 
         foreach ($this->rules as $key => $rule) {
             if ($rule['required'] ?? false) {
+                $list[] = $key;
+            }
+        }
+
+        return $list;
+    }
+
+    /**
+     * Get Readonly Fields
+     * 
+     * Returns list of field names that are marked as readonly
+     * and should not be allowed in create/update payloads
+     *
+     * @return array
+     */
+    public function getReadonlyFields(): array
+    {
+        $list = [];
+
+        foreach ($this->rules as $key => $rule) {
+            if ($rule['readonly'] ?? false) {
                 $list[] = $key;
             }
         }

--- a/src/Appwrite/Utopia/Response/Model.php
+++ b/src/Appwrite/Utopia/Response/Model.php
@@ -132,7 +132,7 @@ abstract class Model
 
     /**
      * Get Readonly Fields
-     * 
+     *
      * Returns list of field names that are marked as readonly
      * and should not be allowed in create/update payloads
      *

--- a/src/Appwrite/Utopia/Response/Model/Document.php
+++ b/src/Appwrite/Utopia/Response/Model/Document.php
@@ -41,21 +41,21 @@ class Document extends Any
                 'description' => 'Document automatically incrementing ID.',
                 'default' => 0,
                 'example' => 1,
-                'readonly' => true,
+                'readOnly' => true,
             ])
             ->addRule('$collectionId', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Collection ID.',
                 'default' => '',
                 'example' => '5e5ea5c15117e',
-                'readonly' => true,
+                'readOnly' => true,
             ])
             ->addRule('$databaseId', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Database ID.',
                 'default' => '',
                 'example' => '5e5ea5c15117e',
-                'readonly' => true,
+                'readOnly' => true,
             ])
             ->addRule('$createdAt', [
                 'type' => self::TYPE_DATETIME,

--- a/src/Appwrite/Utopia/Response/Model/Document.php
+++ b/src/Appwrite/Utopia/Response/Model/Document.php
@@ -41,18 +41,21 @@ class Document extends Any
                 'description' => 'Document automatically incrementing ID.',
                 'default' => 0,
                 'example' => 1,
+                'readonly' => true,
             ])
             ->addRule('$collectionId', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Collection ID.',
                 'default' => '',
                 'example' => '5e5ea5c15117e',
+                'readonly' => true,
             ])
             ->addRule('$databaseId', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Database ID.',
                 'default' => '',
                 'example' => '5e5ea5c15117e',
+                'readonly' => true,
             ])
             ->addRule('$createdAt', [
                 'type' => self::TYPE_DATETIME,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

currently the sdks given an error when trying to pass in entire documents since those contain readonly attributes: sequence, databaseId and collectionId.
we need to filter them out before making the request.

why not just not allow them?
we need to allow them in sdks so the DX is easy to just update a `Document` object and pass the entire object to updateDocument method

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
