### PR TITLE
Fix databases worker cache clearing bug

### DIFF
--- a/src/Appwrite/Platform/Workers/Databases.php
+++ b/src/Appwrite/Platform/Workers/Databases.php
@@ -225,9 +225,11 @@ class Databases extends Action
 
             if (! $relatedCollection->isEmpty()) {
                 $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $relatedCollection->getId());
+                $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $relatedCollection->getSequence());
             }
 
             $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $collectionId);
+            $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $collection->getSequence());
         }
     }
 
@@ -383,9 +385,11 @@ class Databases extends Action
             }
         } finally {
             $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $collectionId);
+            $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $collection->getSequence());
 
             if (! $relatedCollection->isEmpty()) {
                 $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $relatedCollection->getId());
+                $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $relatedCollection->getSequence());
             }
         }
     }
@@ -444,6 +448,7 @@ class Databases extends Action
         } finally {
             $this->trigger($database, $collection, $project, $event, $queueForRealtime, null, $index);
             $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $collectionId);
+            $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $collection->getSequence());
         }
     }
 
@@ -500,6 +505,7 @@ class Databases extends Action
         } finally {
             $this->trigger($database, $collection, $project, $event, $queueForRealtime, null, $index);
             $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $collection->getId());
+            $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $collection->getSequence());
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes a cache invalidation issue in the Databases worker (`src/Appwrite/Platform/Workers/Databases.php`). Previously, after creating or deleting attributes and indexes, the collection structure cache was not being properly purged. This led to the UI displaying attributes as `processing` even after successful creation, as it was still serving stale cached data.

The fix ensures that both the collection document cache and the collection structure cache are purged, forcing the UI to fetch the most up-to-date collection information.

## Test Plan

1.  **Reproduce the bug (before fix):**
    *   Create a new database and collection.
    *   Add a new attribute to the collection (e.g., a string attribute).
    *   Observe the attribute status in the UI. It might remain in a `processing` state indefinitely or until another collection-modifying action is performed.
2.  **Verify the fix (after fix):**
    *   Repeat the steps above.
    *   After creating the attribute, it should immediately or very quickly reflect its active status in the UI without needing further actions.
    *   Test with deleting attributes and creating/deleting indexes to ensure consistency.

## Related PRs and Issues

-   N/A

## Checklist

-   [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
-   [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

---
<a href="https://cursor.com/background-agent?bcId=bc-6918e06f-3b24-4568-80f5-787b3d2129a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6918e06f-3b24-4568-80f5-787b3d2129a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

