### PR TITLE
Fix: variables sharing across resources

### DIFF
--- a/app/init/database/filters.php
+++ b/app/init/database/filters.php
@@ -245,10 +245,16 @@ Database::addFilter(
         return;
     },
     function (mixed $value, Document $document, Database $database) {
+        $resourceType = match ($document->getCollection()) {
+            'functions' => ['function'],
+            'sites' => ['site'],
+            default => ['function', 'site']
+        };
+
         return $database
             ->find('variables', [
                 Query::equal('resourceInternalId', [$document->getSequence()]),
-                Query::equal('resourceType', ['function', 'site']),
+                Query::equal('resourceType', $resourceType),
                 Query::limit(APP_LIMIT_SUBQUERY),
             ]);
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

On dedicated tables, fixes scenario when project has 1 site and 1 function, and they unintentionally share variables.

## Test Plan

Wanted to do automated, but it would be tricky, or need to be skipepd on Cloud shared DB. so I did manual QA

Before (function having variables when I set none; they are coming from site where I set them)

<img width="2506" height="760" alt="CleanShot 2025-08-12 at 16 56 02@2x" src="https://github.com/user-attachments/assets/72114670-0f11-44a0-9842-c99155dd3b95" />

After (fix + cache wipe makes function not see variables)

<img width="2530" height="694" alt="CleanShot 2025-08-12 at 17 00 48@2x" src="https://github.com/user-attachments/assets/b00c117f-7d93-471c-94d9-460d02c1db60" />


## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
