### PR TITLE
Update token tests with jwt decode

### DIFF
--- a/tests/e2e/Services/Tokens/TokensConsoleClientTest.php
+++ b/tests/e2e/Services/Tokens/TokensConsoleClientTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\E2E\Services\Tokens;
 
+use Ahc\Jwt\JWT;
+use Ahc\Jwt\JWTException;
 use CURLFile;
 use Tests\E2E\Client;
 use Tests\E2E\Scopes\ProjectCustom;
@@ -12,6 +14,7 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
+use Utopia\System\System;
 
 class TokensConsoleClientTest extends Scope
 {
@@ -67,6 +70,28 @@ class TokensConsoleClientTest extends Scope
 
         $this->assertEquals(201, $token['headers']['status-code']);
         $this->assertEquals('files', $token['body']['resourceType']);
+        $this->assertNotEmpty($token['body']['$id']);
+        $this->assertNotEmpty($token['body']['secret']);
+        
+        // Verify the generated token JWT contains correct resource information
+        $jwt = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 86400 * 365 * 10, 10); // 10 years maxAge
+        try {
+            $payload = $jwt->decode($token['body']['secret']);
+            $this->assertIsArray($payload, 'JWT payload should decode to an array');
+            $this->assertArrayHasKey('tokenId', $payload, 'JWT payload should contain tokenId');
+            $this->assertArrayHasKey('resourceId', $payload, 'JWT payload should contain resourceId');
+            $this->assertArrayHasKey('resourceType', $payload, 'JWT payload should contain resourceType');
+            $this->assertArrayHasKey('resourceInternalId', $payload, 'JWT payload should contain resourceInternalId');
+            
+            $this->assertEquals($token['body']['$id'], $payload['tokenId'], 'JWT tokenId should match token ID');
+            $this->assertEquals($fileId, $payload['resourceId'], 'JWT resourceId should match file ID');
+            $this->assertEquals('files', $payload['resourceType'], 'JWT resourceType should be files');
+            
+            // For newly created tokens without expiry, should not have exp field
+            $this->assertArrayNotHasKey('exp', $payload, 'JWT payload should not contain exp field for tokens without expiry');
+        } catch (JWTException $e) {
+            $this->fail('Failed to decode JWT: ' . $e->getMessage());
+        }
 
         return [
             'fileId' => $fileId,
@@ -94,24 +119,20 @@ class TokensConsoleClientTest extends Scope
         $dateValidator = new DatetimeValidator();
         $this->assertTrue($dateValidator->isValid($token['body']['expire']));
 
-        // Verify JWT contains correct expiration
+        // Verify JWT contains correct expiration using native JWT decode
         $this->assertNotEmpty($token['body']['secret']);
-        $jwtParts = explode('.', $token['body']['secret']);
-        $this->assertCount(3, $jwtParts, 'JWT should have 3 parts');
+        
+        $jwt = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 86400 * 365 * 10, 10); // 10 years maxAge
+        try {
+            $payload = $jwt->decode($token['body']['secret']);
+            $this->assertIsArray($payload, 'JWT payload should decode to an array');
+            $this->assertArrayHasKey('exp', $payload, 'JWT payload should contain exp field');
 
-        // Decode JWT payload (using base64url decoding)
-        $payloadB64 = $jwtParts[1];
-        // Convert base64url to base64
-        $payloadB64 = str_replace(['-', '_'], ['+', '/'], $payloadB64);
-        // Add padding if needed
-        $payloadB64 .= str_repeat('=', (4 - strlen($payloadB64) % 4) % 4);
-        $payload = json_decode(base64_decode($payloadB64), true);
-
-        $this->assertIsArray($payload, 'JWT payload should decode to an array');
-        $this->assertArrayHasKey('exp', $payload, 'JWT payload should contain exp field');
-
-        $expectedExp = (new \DateTime($expiry))->getTimestamp();
-        $this->assertEquals($expectedExp, $payload['exp'], 'JWT exp should match token expiry');
+            $expectedExp = (new \DateTime($expiry))->getTimestamp();
+            $this->assertEquals($expectedExp, $payload['exp'], 'JWT exp should match token expiry');
+        } catch (JWTException $e) {
+            $this->fail('Failed to decode JWT: ' . $e->getMessage());
+        }
 
         // Infinite expiry
         $token = $this->client->call(Client::METHOD_PATCH, '/tokens/' . $tokenId, array_merge([
@@ -123,14 +144,14 @@ class TokensConsoleClientTest extends Scope
 
         $this->assertEmpty($token['body']['expire']);
 
-        // Verify JWT does not contain exp for infinite expiry
-        $jwtParts = explode('.', $token['body']['secret']);
-        $payloadB64 = $jwtParts[1];
-        $payloadB64 = str_replace(['-', '_'], ['+', '/'], $payloadB64);
-        $payloadB64 .= str_repeat('=', (4 - strlen($payloadB64) % 4) % 4);
-        $payload = json_decode(base64_decode($payloadB64), true);
-
-        $this->assertArrayNotHasKey('exp', $payload, 'JWT payload should not contain exp field for infinite expiry');
+        // Verify JWT does not contain exp for infinite expiry using native JWT decode
+        try {
+            $payload = $jwt->decode($token['body']['secret']);
+            $this->assertIsArray($payload, 'JWT payload should decode to an array');
+            $this->assertArrayNotHasKey('exp', $payload, 'JWT payload should not contain exp field for infinite expiry');
+        } catch (JWTException $e) {
+            $this->fail('Failed to decode JWT: ' . $e->getMessage());
+        }
 
         return $data;
     }
@@ -151,6 +172,38 @@ class TokensConsoleClientTest extends Scope
 
         $this->assertIsArray($res['body']);
         $this->assertEquals(200, $res['headers']['status-code']);
+        $this->assertArrayHasKey('tokens', $res['body']);
+        $this->assertIsArray($res['body']['tokens']);
+        $this->assertGreaterThan(0, count($res['body']['tokens']), 'Should have at least one token');
+        
+        // Verify each token in the list
+        $jwt = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 86400 * 365 * 10, 10); // 10 years maxAge
+        foreach ($res['body']['tokens'] as $token) {
+            $this->assertArrayHasKey('$id', $token, 'Token should have an ID');
+            $this->assertArrayHasKey('secret', $token, 'Token should have a secret');
+            $this->assertArrayHasKey('resourceType', $token, 'Token should have resourceType');
+            $this->assertArrayHasKey('resourceId', $token, 'Token should have resourceId');
+            
+            $this->assertEquals('files', $token['resourceType'], 'Token resourceType should be files');
+            $this->assertEquals($data['fileId'], $token['resourceId'], 'Token resourceId should match file ID');
+            
+            // Verify the JWT token is valid and contains correct information
+            try {
+                $payload = $jwt->decode($token['secret']);
+                $this->assertIsArray($payload, 'JWT payload should decode to an array');
+                $this->assertArrayHasKey('tokenId', $payload, 'JWT payload should contain tokenId');
+                $this->assertArrayHasKey('resourceId', $payload, 'JWT payload should contain resourceId');
+                $this->assertArrayHasKey('resourceType', $payload, 'JWT payload should contain resourceType');
+                $this->assertArrayHasKey('resourceInternalId', $payload, 'JWT payload should contain resourceInternalId');
+                
+                $this->assertEquals($token['$id'], $payload['tokenId'], 'JWT tokenId should match token ID');
+                $this->assertEquals($data['fileId'], $payload['resourceId'], 'JWT resourceId should match file ID');
+                $this->assertEquals('files', $payload['resourceType'], 'JWT resourceType should be files');
+            } catch (JWTException $e) {
+                $this->fail('Failed to decode JWT for token ' . $token['$id'] . ': ' . $e->getMessage());
+            }
+        }
+        
         return $data;
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses comments from a previous pull request by:
*   Replacing manual JWT decoding with the native `Ahc\Jwt\JWT` library's `decode()` method in `TokensConsoleClientTest`.
*   Enhancing the `testCreateToken` and `testListTokens` methods to include comprehensive JWT validation, ensuring the token structure and payload are correct.
*   Improving the existing JWT validation in `testUpdateToken` to use the native decode method.

The goal is to improve the robustness and reliability of token-related tests by using a consistent, native JWT decoding approach and adding more thorough validation of token contents.

## Test Plan

The changes were verified by reviewing the code to ensure the correct implementation of native JWT decoding and the addition of comprehensive validation logic. The updated tests are expected to pass when run in the CI/CD pipeline.

## Related PRs and Issues

-   #10329

## Checklist

-   [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
-   [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

---
<a href="https://cursor.com/background-agent?bcId=bc-713ab5d1-f03a-4512-8a55-6bf562b3bc81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-713ab5d1-f03a-4512-8a55-6bf562b3bc81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

