### PR TITLE
chore: remove sdk deprecation warnings

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1081,7 +1081,7 @@ App::init()
                     $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
                 }
                 $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/server-rest/' . $replaceWith;
-                $deprecationWarning = 'Route ' . $route->getPath() . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use ' . $deprecatedMethod->getReplaceWith() . ' instead. See: ' . $deprecatedReplaceWithLink;
+                $deprecationWarning = 'Route ' . $route->getPath() . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
                 $warnings[] = $deprecationWarning;
             }
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1082,14 +1082,14 @@ App::init()
                     $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
                 }
 
-                $sdkNameHeader = $request->getHeader('x-sdk-name', '');
-                $sdkPlatformHeader = $request->getHeader('x-sdk-platform', '');
+                $sdkNameHeader = strtolower($request->getHeader('x-sdk-name', ''));
+                $sdkPlatformHeader = strtolower($request->getHeader('x-sdk-platform', ''));
 
                 $sdkExists = !empty($sdkNameHeader);
                 $sdkName = $sdkExists ? $sdkNameHeader : 'rest';
                 $sdkPlatform = !empty($sdkPlatformHeader) ? $sdkPlatformHeader : 'server';
 
-                $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . strtolower($sdkName) . '/' . $replaceWith;
+                $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . $sdkName . '/' . $replaceWith;
 
                 $deprecationWarning = (
                     !$sdkExists

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1081,11 +1081,22 @@ App::init()
                 if ($replaceWith) {
                     $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
                 }
-                $sdkName = $request->getHeader('x-sdk-name', 'rest');
-                $sdkPlatform = !empty($sdkName) ? $request->getHeader('x-sdk-platform', 'server') : 'server';
+
+                $sdkNameHeader = $request->getHeader('x-sdk-name', '');
+                $sdkPlatformHeader = $request->getHeader('x-sdk-platform', '');
+
+                $sdkExists = !empty($sdkNameHeader);
+                $sdkName = $sdkExists ? $sdkNameHeader : 'rest';
+                $sdkPlatform = !empty($sdkPlatformHeader) ? $sdkPlatformHeader : 'server';
+
                 $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . strtolower($sdkName) . '/' . $replaceWith;
 
-                $deprecationWarning = (empty($sdkName) ? 'Route ' . $route->getPath() : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`') . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
+                $deprecationWarning = (
+                    !$sdkExists
+                    ? 'Route ' . $route->getPath()
+                    : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`'
+                ) . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
+
                 $warnings[] = $deprecationWarning;
             }
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1065,7 +1065,6 @@ App::init()
          */
         /** @var \Appwrite\SDK\Method $sdk */
         $sdk = $route->getLabel('sdk', false);
-        $deprecationWarning = 'This route is deprecated. See the updated documentation for improved compatibility and migration details.';
         $sdkItems = is_array($sdk) ? $sdk : (!empty($sdk) ? [$sdk] : []);
         if (!empty($sdkItems) && count($sdkItems) > 0) {
             $allDeprecated = true;
@@ -1076,6 +1075,13 @@ App::init()
                 }
             }
             if ($allDeprecated) {
+                $deprecatedMethod = $sdkItems[0]->getDeprecated();
+                $replaceWith = $deprecatedMethod->getReplaceWith();
+                if ($replaceWith) {
+                    $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
+                }
+                $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/server-rest/' . $replaceWith;
+                $deprecationWarning = 'Route ' . $route->getPath() . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use ' . $deprecatedMethod->getReplaceWith() . ' instead. See: ' . $deprecatedReplaceWithLink;
                 $warnings[] = $deprecationWarning;
             }
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1064,42 +1064,42 @@ App::init()
          * Deprecation Warning
          */
         /** @var \Appwrite\SDK\Method $sdk */
-        $sdk = $route->getLabel('sdk', false);
-        $sdkItems = is_array($sdk) ? $sdk : (!empty($sdk) ? [$sdk] : []);
-        if (!empty($sdkItems) && count($sdkItems) > 0) {
-            $allDeprecated = true;
-            foreach ($sdkItems as $sdkItem) {
-                if (!$sdkItem->isDeprecated()) {
-                    $allDeprecated = false;
-                    break;
-                }
-            }
-            if ($allDeprecated) {
-                $deprecatedMethod = $sdkItems[0]->getDeprecated();
+        // $sdk = $route->getLabel('sdk', false);
+        // $sdkItems = is_array($sdk) ? $sdk : (!empty($sdk) ? [$sdk] : []);
+        // if (!empty($sdkItems) && count($sdkItems) > 0) {
+        //     $allDeprecated = true;
+        //     foreach ($sdkItems as $sdkItem) {
+        //         if (!$sdkItem->isDeprecated()) {
+        //             $allDeprecated = false;
+        //             break;
+        //         }
+        //     }
+        //     if ($allDeprecated) {
+        //         $deprecatedMethod = $sdkItems[0]->getDeprecated();
 
-                $replaceWith = $deprecatedMethod->getReplaceWith();
-                if ($replaceWith) {
-                    $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
-                }
+        //         $replaceWith = $deprecatedMethod->getReplaceWith();
+        //         if ($replaceWith) {
+        //             $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
+        //         }
 
-                $sdkNameHeader = strtolower($request->getHeader('x-sdk-name', ''));
-                $sdkPlatformHeader = strtolower($request->getHeader('x-sdk-platform', ''));
+        //         $sdkNameHeader = strtolower($request->getHeader('x-sdk-name', ''));
+        //         $sdkPlatformHeader = strtolower($request->getHeader('x-sdk-platform', ''));
 
-                $sdkExists = !empty($sdkNameHeader);
-                $sdkName = $sdkExists ? $sdkNameHeader : 'rest';
-                $sdkPlatform = !empty($sdkPlatformHeader) ? $sdkPlatformHeader : 'server';
+        //         $sdkExists = !empty($sdkNameHeader);
+        //         $sdkName = $sdkExists ? $sdkNameHeader : 'rest';
+        //         $sdkPlatform = !empty($sdkPlatformHeader) ? $sdkPlatformHeader : 'server';
 
-                $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . $sdkName . '/' . $replaceWith;
+        //         $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . $sdkName . '/' . $replaceWith;
 
-                $deprecationWarning = (
-                    !$sdkExists
-                    ? 'Route ' . $route->getPath()
-                    : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`'
-                ) . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
+        //         $deprecationWarning = (
+        //             !$sdkExists
+        //             ? 'Route ' . $route->getPath()
+        //             : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`'
+        //         ) . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
 
-                $warnings[] = $deprecationWarning;
-            }
-        }
+        //         $warnings[] = $deprecationWarning;
+        //     }
+        // }
 
         if (!empty($warnings)) {
             $response->addHeader('X-Appwrite-Warning', implode(';', $warnings));

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1081,7 +1081,8 @@ App::init()
                     $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
                 }
                 $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/server-rest/' . $replaceWith;
-                $deprecationWarning = 'Route ' . $route->getPath() . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
+                $isSdkUsed = !empty($request->getHeader('x-sdk-name')) || !empty($request->getHeader('x-sdk-version'));
+                $deprecationWarning = (!$isSdkUsed ? 'Route ' . $route->getPath() : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`') . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
                 $warnings[] = $deprecationWarning;
             }
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1076,13 +1076,16 @@ App::init()
             }
             if ($allDeprecated) {
                 $deprecatedMethod = $sdkItems[0]->getDeprecated();
+
                 $replaceWith = $deprecatedMethod->getReplaceWith();
                 if ($replaceWith) {
                     $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
                 }
-                $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/server-rest/' . $replaceWith;
-                $isSdkUsed = !empty($request->getHeader('x-sdk-name')) || !empty($request->getHeader('x-sdk-version'));
-                $deprecationWarning = (!$isSdkUsed ? 'Route ' . $route->getPath() : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`') . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
+                $sdkName = $request->getHeader('x-sdk-name', 'rest');
+                $sdkPlatform = $request->getHeader('x-sdk-platform', 'server');
+                $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . strtolower($sdkName) . '/' . $replaceWith;
+
+                $deprecationWarning = (!empty($sdkName) ? 'Route ' . $route->getPath() : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`') . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
                 $warnings[] = $deprecationWarning;
             }
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1060,47 +1060,6 @@ App::init()
             $response->addHeader('Access-Control-Allow-Origin', '*');
         }
 
-        /**
-         * Deprecation Warning
-         */
-        /** @var \Appwrite\SDK\Method $sdk */
-        // $sdk = $route->getLabel('sdk', false);
-        // $sdkItems = is_array($sdk) ? $sdk : (!empty($sdk) ? [$sdk] : []);
-        // if (!empty($sdkItems) && count($sdkItems) > 0) {
-        //     $allDeprecated = true;
-        //     foreach ($sdkItems as $sdkItem) {
-        //         if (!$sdkItem->isDeprecated()) {
-        //             $allDeprecated = false;
-        //             break;
-        //         }
-        //     }
-        //     if ($allDeprecated) {
-        //         $deprecatedMethod = $sdkItems[0]->getDeprecated();
-
-        //         $replaceWith = $deprecatedMethod->getReplaceWith();
-        //         if ($replaceWith) {
-        //             $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
-        //         }
-
-        //         $sdkNameHeader = strtolower($request->getHeader('x-sdk-name', ''));
-        //         $sdkPlatformHeader = strtolower($request->getHeader('x-sdk-platform', ''));
-
-        //         $sdkExists = !empty($sdkNameHeader);
-        //         $sdkName = $sdkExists ? $sdkNameHeader : 'rest';
-        //         $sdkPlatform = !empty($sdkPlatformHeader) ? $sdkPlatformHeader : 'server';
-
-        //         $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . $sdkName . '/' . $replaceWith;
-
-        //         $deprecationWarning = (
-        //             !$sdkExists
-        //             ? 'Route ' . $route->getPath()
-        //             : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`'
-        //         ) . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
-
-        //         $warnings[] = $deprecationWarning;
-        //     }
-        // }
-
         if (!empty($warnings)) {
             $response->addHeader('X-Appwrite-Warning', implode(';', $warnings));
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1082,10 +1082,10 @@ App::init()
                     $replaceWith = preg_replace('/\./', '#', $replaceWith, 1);
                 }
                 $sdkName = $request->getHeader('x-sdk-name', 'rest');
-                $sdkPlatform = $request->getHeader('x-sdk-platform', 'server');
+                $sdkPlatform = !empty($sdkName) ? $request->getHeader('x-sdk-platform', 'server') : 'server';
                 $deprecatedReplaceWithLink = 'https://appwrite.io/docs/references/cloud/' . $sdkPlatform . '-' . strtolower($sdkName) . '/' . $replaceWith;
 
-                $deprecationWarning = (!empty($sdkName) ? 'Route ' . $route->getPath() : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`') . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
+                $deprecationWarning = (empty($sdkName) ? 'Route ' . $route->getPath() : 'Method `' . $sdkItems[0]->getNamespace() . '.' . $sdkItems[0]->getMethodName() . '`') . ' is deprecated since ' . $deprecatedMethod->getSince() . '. Please use `' . $deprecatedMethod->getReplaceWith() . '` instead. See: ' . $deprecatedReplaceWithLink;
                 $warnings[] = $deprecationWarning;
             }
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

new warning:

```
Route /v1/databases/:databaseId/collections/:collectionId/documents is deprecated since 1.8.0. Please use `tablesDB.listRows` instead. See: https://appwrite.io/docs/references/cloud/server-rest/tablesDB#listRows
```

## Test Plan

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
