### PR TITLE
feat: automatic pr creation in sdk release script

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -319,8 +319,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                     Console::success("Pushed {$language['name']} SDK to {$gitUrl}");
 
                     if ($createPr) {
-                        $prTitle = "feat: {$language['name']} SDK update for version {$version}";
-                        $prBody = "This PR contains updates to the {$language['name']} SDK for Appwrite version {$version}.\\n\\nCommit: {$message}";
+                        $prTitle = "feat: {$language['name']} SDK update for version {$language['version']}";
+                        $prBody = "This PR contains updates to the {$language['name']} SDK for version {$language['version']}.";
 
                         $repoName = $language['gitRepoName'];
                         if (!$production) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

adds ability to automatically create prs during sdk release

to use it, add this to your `Dockerfile`:
```env
ARG GH_TOKEN
ENV GH_TOKEN=ghp_xxxx
RUN git config --global user.email "chirag@appwrite.io"
RUN apk add --update --no-cache openssh-client github-cli
```

and mount ssh keys by adding this to the volume mounts in appwrite container:
```
- ~/.ssh:/root/.ssh
```

## Test Plan

- https://github.com/appwrite/sdk-for-cli/pull/196

## Related PRs and Issues

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
