### PR TITLE
Fix: oauth identity check

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1534,23 +1534,23 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
              * Is verified is not used yet, since we don't know after an account is created anymore if it was verified or not.
              */
             $isVerified = $oauth2->isEmailVerified($accessToken);
-
-            $userWithEmail = $dbForProject->findOne('users', [
-                Query::equal('email', [$email]),
+            
+            $identity = $dbForProject->findOne('identities', [
+                Query::equal('provider', [$provider]),
+                Query::equal('providerUid', [$oauth2ID]),
             ]);
-            if (!$userWithEmail->isEmpty()) {
-                $user->setAttributes($userWithEmail->getArrayCopy());
+
+            if (!$identity->isEmpty()) {
+                $user = $dbForProject->getDocument('users', $identity->getAttribute('userId'));
             }
 
             // If user is not found, check if there is an identity with the same provider user ID
             if ($user === false || $user->isEmpty()) {
-                $identity = $dbForProject->findOne('identities', [
-                    Query::equal('provider', [$provider]),
-                    Query::equal('providerUid', [$oauth2ID]),
+                $userWithEmail = $dbForProject->findOne('users', [
+                    Query::equal('email', [$email]),
                 ]);
-
-                if (!$identity->isEmpty()) {
-                    $user = $dbForProject->getDocument('users', $identity->getAttribute('userId'));
+                if (!$userWithEmail->isEmpty()) {
+                    $user->setAttributes($userWithEmail->getArrayCopy());
                 }
             }
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1534,7 +1534,7 @@ App::get('/v1/account/sessions/oauth2/:provider/redirect')
              * Is verified is not used yet, since we don't know after an account is created anymore if it was verified or not.
              */
             $isVerified = $oauth2->isEmailVerified($accessToken);
-            
+
             $identity = $dbForProject->findOne('identities', [
                 Query::equal('provider', [$provider]),
                 Query::equal('providerUid', [$oauth2ID]),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Piroritize identity check in oauth flow above finding existing user based on user email.

This ensures oauth always uses identity first, which is correct behaviour in case of collision.

This fixes specific oauth flows, and should not break any existing ones.

---

If there is user A with email A but identity email B, and user with email B, such GitHub sign-in will always end up with failure:


https://github.com/user-attachments/assets/c337dd7e-6648-4e57-9a39-ba37b0c0a753

This PR fixes it, here is stage with fix:



https://github.com/user-attachments/assets/45da967f-1e67-44a6-983e-51c27c44b84b


## Test Plan

Test on stage 

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
