### PR TITLE
Add spatial column validation during required mode and tests for exis…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1352,16 +1352,16 @@
         },
         {
             "name": "open-telemetry/gen-otlp-protobuf",
-            "version": "1.5.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/gen-otlp-protobuf.git",
-                "reference": "585bafddd4ae6565de154610b10a787a455c9ba0"
+                "reference": "673af5b06545b513466081884b47ef15a536edde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/gen-otlp-protobuf/zipball/585bafddd4ae6565de154610b10a787a455c9ba0",
-                "reference": "585bafddd4ae6565de154610b10a787a455c9ba0",
+                "url": "https://api.github.com/repos/opentelemetry-php/gen-otlp-protobuf/zipball/673af5b06545b513466081884b47ef15a536edde",
+                "reference": "673af5b06545b513466081884b47ef15a536edde",
                 "shasum": ""
             },
             "require": {
@@ -1411,7 +1411,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-15T23:07:07+00:00"
+            "time": "2025-09-17T23:10:12+00:00"
         },
         {
             "name": "open-telemetry/sdk",
@@ -3635,16 +3635,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "1.4.9",
+            "version": "1.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "066e2bda7b728bb843776db3640737d7350ba035"
+                "reference": "5514bb7346e75996d061d08040248fe842f73785"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/066e2bda7b728bb843776db3640737d7350ba035",
-                "reference": "066e2bda7b728bb843776db3640737d7350ba035",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/5514bb7346e75996d061d08040248fe842f73785",
+                "reference": "5514bb7346e75996d061d08040248fe842f73785",
                 "shasum": ""
             },
             "require": {
@@ -3685,9 +3685,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/1.4.9"
+                "source": "https://github.com/utopia-php/database/tree/1.4.10"
             },
-            "time": "2025-09-16T13:31:52+00:00"
+            "time": "2025-09-18T02:42:25+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -5278,16 +5278,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a"
+                "reference": "595de38458c6b0ab4cae4bcc769c2e5c5d5b8e96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0345f3b05f136801af8c339f9d16ef29e6b4df8a",
-                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/595de38458c6b0ab4cae4bcc769c2e5c5d5b8e96",
+                "reference": "595de38458c6b0ab4cae4bcc769c2e5c5d5b8e96",
                 "shasum": ""
             },
             "require": {
@@ -5298,9 +5298,9 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.82.2",
-                "illuminate/view": "^11.45.1",
-                "larastan/larastan": "^3.5.0",
+                "friendsofphp/php-cs-fixer": "^3.87.2",
+                "illuminate/view": "^11.46.0",
+                "larastan/larastan": "^3.7.1",
                 "laravel-zero/framework": "^11.45.0",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.3.1",
@@ -5311,9 +5311,6 @@
             ],
             "type": "project",
             "autoload": {
-                "files": [
-                    "overrides/Runner/Parallel/ProcessFactory.php"
-                ],
                 "psr-4": {
                     "App\\": "app/",
                     "Database\\Seeders\\": "database/seeders/",
@@ -5343,7 +5340,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-07-10T18:09:32+00:00"
+            "time": "2025-09-17T01:36:44+00:00"
         },
         {
             "name": "matthiasmullie/minify",

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
@@ -122,7 +122,7 @@ abstract class Action extends UtopiaAction
     /**
      * Get the correct invalid structure message.
      */
-    protected function getInvalidStructureException(): string
+    protected function getStructureException(): string
     {
         return $this->isCollectionsAPI()
             ? Exception::DOCUMENT_INVALID_STRUCTURE
@@ -366,9 +366,16 @@ abstract class Action extends UtopiaAction
                 'filters' => $filters,
                 'options' => $options,
             ]);
-            if (!$dbForProject->getAdapter()->getSupportForSpatialIndexNull() && in_array($attribute->getAttribute('type'), Database::SPATIAL_TYPES) && $attribute->getAttribute('required')) {
-                $existingDataPresent = $dbForProject->findOne('database_' . $db->getSequence() . '_collection_' . $collection->getSequence());
-                if (count($existingDataPresent)) {
+            if (
+                !$dbForProject->getAdapter()->getSupportForSpatialIndexNull() &&
+                \in_array($attribute->getAttribute('type'), Database::SPATIAL_TYPES) &&
+                $attribute->getAttribute('required')
+            ) {
+                $hasData = !Authorization::skip(fn () => $dbForProject
+                    ->findOne('database_' . $db->getSequence() . '_collection_' . $collection->getSequence()))
+                    ->isEmpty();
+
+                if ($hasData) {
                     throw new StructureException('Failed to add required spatial column: existing rows present. Make the column optional.');
                 }
             }
@@ -379,7 +386,7 @@ abstract class Action extends UtopiaAction
         } catch (LimitException) {
             throw new Exception($this->getLimitException());
         } catch (StructureException $e) {
-            throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+            throw new Exception($this->getStructureException(), $e->getMessage());
         } catch (Throwable $e) {
             $dbForProject->purgeCachedDocument('database_' . $db->getSequence(), $collectionId);
             $dbForProject->purgeCachedCollection('database_' . $db->getSequence() . '_collection_' . $collection->getSequence());
@@ -423,7 +430,7 @@ abstract class Action extends UtopiaAction
             } catch (LimitException) {
                 throw new Exception($this->getLimitException());
             } catch (StructureException) {
-                throw new Exception($this->getInvalidStructureException());
+                throw new Exception($this->getStructureException());
             } catch (Throwable $e) {
                 $dbForProject->deleteDocument('attributes', $attribute->getId());
                 throw $e;
@@ -587,7 +594,7 @@ abstract class Action extends UtopiaAction
             } catch (RelationshipException $e) {
                 throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
             } catch (StructureException $e) {
-                throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+                throw new Exception($this->getStructureException(), $e->getMessage());
             }
 
             if ($primaryDocumentOptions['twoWay']) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -160,7 +160,7 @@ abstract class Action extends AppwriteAction
     /**
      * Get the correct invalid structure message.
      */
-    protected function getInvalidStructureException(): string
+    protected function getStructureException(): string
     {
         return $this->isCollectionsAPI()
             ? Exception::DOCUMENT_INVALID_STRUCTURE

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Update.php
@@ -149,7 +149,7 @@ class Update extends Action
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {
-            throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+            throw new Exception($this->getStructureException(), $e->getMessage());
         }
 
         foreach ($documents as $document) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
@@ -130,7 +130,7 @@ class Upsert extends Action
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {
-            throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+            throw new Exception($this->getStructureException(), $e->getMessage());
         }
 
         foreach ($upserted as $document) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -375,7 +375,7 @@ class Create extends Action
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {
-            throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+            throw new Exception($this->getStructureException(), $e->getMessage());
         }
 
         $queueForEvents

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
@@ -247,7 +247,7 @@ class Update extends Action
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {
-            throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+            throw new Exception($this->getStructureException(), $e->getMessage());
         }
 
         $collectionsCache = [];

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
@@ -258,7 +258,7 @@ class Upsert extends Action
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {
-            throw new Exception($this->getInvalidStructureException(), $e->getMessage());
+            throw new Exception($this->getStructureException(), $e->getMessage());
         }
 
         $collectionsCache = [];

--- a/tests/e2e/Services/Databases/Legacy/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/Legacy/DatabasesBase.php
@@ -8027,7 +8027,7 @@ trait DatabasesBase
         ]);
 
         $this->assertEquals(202, $poly['headers']['status-code']);
-        
+
         // Wait for attributes to be available
         sleep(2);
 
@@ -8047,7 +8047,7 @@ trait DatabasesBase
             ]
         ]);
         $this->assertEquals(201, $newDocument['headers']['status-code']);
-        
+
         $newDocumentId = $newDocument['body']['$id'];
 
         // Fetch the document to verify default values are applied
@@ -8055,9 +8055,9 @@ trait DatabasesBase
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
-        
+
         $this->assertEquals(200, $fetchedDocument['headers']['status-code']);
-        
+
         // Verify default values are applied
         $this->assertEquals([0.0, 0.0], $fetchedDocument['body']['loc']);
         $this->assertEquals([[0.0, 0.0], [1.0, 1.0]], $fetchedDocument['body']['route']);

--- a/tests/e2e/Services/Databases/Legacy/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/Legacy/DatabasesBase.php
@@ -8027,5 +8027,40 @@ trait DatabasesBase
         ]);
 
         $this->assertEquals(202, $poly['headers']['status-code']);
+        
+        // Wait for attributes to be available
+        sleep(2);
+
+        // Create a new document without spatial data to test default values
+        $newDocument = $this->client->call(Client::METHOD_POST, '/databases/' . $databaseId . '/collections/' . $colId . '/documents', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'documentId' => ID::unique(),
+            'data' => [
+                'description' => 'test default values'
+            ],
+            'permissions' => [
+                Permission::read(Role::user($this->getUser()['$id'])),
+                Permission::update(Role::user($this->getUser()['$id'])),
+                Permission::delete(Role::user($this->getUser()['$id'])),
+            ]
+        ]);
+        $this->assertEquals(201, $newDocument['headers']['status-code']);
+        
+        $newDocumentId = $newDocument['body']['$id'];
+
+        // Fetch the document to verify default values are applied
+        $fetchedDocument = $this->client->call(Client::METHOD_GET, '/databases/' . $databaseId . '/collections/' . $colId . '/documents/' . $newDocumentId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+        
+        $this->assertEquals(200, $fetchedDocument['headers']['status-code']);
+        
+        // Verify default values are applied
+        $this->assertEquals([0.0, 0.0], $fetchedDocument['body']['loc']);
+        $this->assertEquals([[0.0, 0.0], [1.0, 1.0]], $fetchedDocument['body']['route']);
+        $this->assertEquals([[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]], $fetchedDocument['body']['area']);
     }
 }

--- a/tests/e2e/Services/Databases/TablesDB/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/TablesDB/DatabasesBase.php
@@ -9056,7 +9056,7 @@ trait DatabasesBase
         ]);
 
         $this->assertEquals(202, $poly['headers']['status-code']);
-        
+
         // Wait for columns to be available
         sleep(2);
 
@@ -9076,7 +9076,7 @@ trait DatabasesBase
             ]
         ]);
         $this->assertEquals(201, $newRow['headers']['status-code']);
-        
+
         $newRowId = $newRow['body']['$id'];
 
         // Fetch the row to verify default values are applied
@@ -9084,9 +9084,9 @@ trait DatabasesBase
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
-        
+
         $this->assertEquals(200, $fetchedRow['headers']['status-code']);
-        
+
         // Verify default values are applied
         $this->assertEquals([0.0, 0.0], $fetchedRow['body']['loc']);
         $this->assertEquals([[0.0, 0.0], [1.0, 1.0]], $fetchedRow['body']['route']);


### PR DESCRIPTION
…ting data in databases

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* Previously , when we have existing data and creating a required spatial col it was getting failed;

* Reasons
1. When we generate cols we generate with not required
2. Now when we are creating a spatial col with required -> we already have previous data -> so the column is getting filled with null
3. The spatial col is meant to be not null at the sql if required is checked
4. So insertion of null to not null giving error

* Fix
Adding a check to send error message to user as a validation step

* Why no changes in utopia database lib?
We can add changes to utopia lib but that runs in the workers. For validation steps, they are done in the api level before
creating the attribute. 
Also the database namespace will not be available internally in the utopia lib and can be added as a separate independent pr

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
