### PR TITLE
Fix SMTP username and password validation

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -2067,6 +2067,7 @@ App::patch('/v1/projects/:projectId/smtp')
         if ($enabled) {
             $mail = new PHPMailer(true);
             $mail->isSMTP();
+            $mail->SMTPAuth = (!empty($username) && !empty($password));
             $mail->Username = $username;
             $mail->Password = $password;
             $mail->Host = $host;


### PR DESCRIPTION
## What does this PR do?

This PR fixes the SMTP validation issue where incorrect username and password were not being properly validated when updating SMTP settings.

## Description

When updating a project's SMTP settings, the username and password were not being validated because `SMTPAuth` was not set to true before attempting the connection. This meant that even with incorrect credentials, the SMTP settings would be saved successfully.

The fix adds the `SMTPAuth` property setting before the SMTP connection test, matching the implementation in the Mails worker.

## Test Plan

1. Update a project's SMTP settings
2. Use a valid host, port, and secure protocol
3. Use an **incorrect** username and password
4. Click Update
5. **Expected**: The update should fail with an error message about invalid credentials
6. **Previous behavior**: The SMTP settings were updated successfully despite incorrect credentials

## Related Issues

Fixes #9067

## Checklist

- [x] Have you read the [Contributing Guidelines](https://github.com/appwrite/appwrite/blob/main/CONTRIBUTING.md)?
- [x] Have you had a look at our [Open Issues](https://github.com/appwrite/appwrite/issues)?
- [x] Have you checked that your issue [isn't already filed](https://github.com/appwrite/appwrite/issues)?
- [x] This change matches the implementation in `Workers/Mails.php`
- [x] The fix is minimal and focused on the specific issue