### PR TITLE
Throw error when email is not available for account verification

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -211,6 +211,11 @@ return [
         'description' => 'User with the requested ID could not be found.',
         'code' => 404,
     ],
+    Exception::USER_EMAIL_NOT_FOUND => [
+        'name' => Exception::USER_EMAIL_NOT_FOUND,
+        'description' => 'User email could not be found.',
+        'code' => 400,
+    ],
     Exception::USER_EMAIL_ALREADY_EXISTS => [
         'name' => Exception::USER_EMAIL_ALREADY_EXISTS,
         'description' => 'A user with the same email already exists in the current project.',
@@ -312,10 +317,20 @@ return [
         'description' => 'OAuth2 provider returned some error.',
         'code' => 424,
     ],
+    Exception::USER_EMAIL_NOT_VERIFIED => [
+        'name' => Exception::USER_EMAIL_NOT_VERIFIED,
+        'description' => 'User email is not verified',
+        'code' => 400,
+    ],
     Exception::USER_EMAIL_ALREADY_VERIFIED => [
         'name' => Exception::USER_EMAIL_ALREADY_VERIFIED,
         'description' => 'User email is already verified',
         'code' => 409,
+    ],
+    Exception::USER_PHONE_NOT_VERIFIED => [
+        'name' => Exception::USER_PHONE_NOT_VERIFIED,
+        'description' => 'User phone is not verified',
+        'code' => 400,
     ],
     Exception::USER_PHONE_ALREADY_VERIFIED => [
         'name' => Exception::USER_PHONE_ALREADY_VERIFIED,

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3544,6 +3544,10 @@ App::post('/v1/account/verification')
             throw new Exception(Exception::GENERAL_SMTP_DISABLED, 'SMTP Disabled');
         }
 
+        if (empty($user->getAttribute('email'))) {
+            throw new Exception(Exception::USER_EMAIL_NOT_FOUND);
+        }
+
         $url = htmlentities($url);
         if ($user->getAttribute('emailVerification')) {
             throw new Exception(Exception::USER_EMAIL_ALREADY_VERIFIED);

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1864,7 +1864,7 @@ class AccountCustomClientTest extends Scope
             'url' => 'http://localhost/verification',
         ]);
 
-        $this->assertEquals(500, $response['body']['code']);
+        $this->assertEquals(400, $response['body']['code']);
         $this->assertEquals('user_email_not_found', $response['body']['type']);
 
         return [];

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1853,6 +1853,26 @@ class AccountCustomClientTest extends Scope
     /**
      * @depends testCreateAnonymousAccount
      */
+    public function testCreateAnonymousAccountVerification($session): array
+    {
+        $response = $this->client->call(Client::METHOD_POST, '/account/verification', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+        ]), [
+            'url' => 'http://localhost/verification',
+        ]);
+
+        $this->assertEquals(500, $response['body']['code']);
+        $this->assertEquals('user_email_not_found', $response['body']['type']);
+
+        return [];
+    }
+
+    /**
+     * @depends testCreateAnonymousAccount
+     */
     public function testUpdateAnonymousAccountPassword($session)
     {
         /**


### PR DESCRIPTION
Task: https://linear.app/appwrite/issue/SER-378/code-quality-setrecipient-argument-1-must-be-of-type-string-null-given