### PR TITLE
fix(builds-worker): Use outputDirectory attribute from deployment

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -692,9 +692,11 @@ class Builds extends Action
                                 // Start separation, enter build folder
                                 $listFilesCommand .= 'echo "{APPWRITE_DETECTION_SEPARATOR_START}" && cd /usr/local/build';
 
+                                $outputDirectory = $deployment->getAttribute('outputDirectory') ?? $resource->getAttribute('outputDirectory');
+
                                 // Enter output directory, if set
-                                if (!empty($resource->getAttribute('outputDirectory', ''))) {
-                                    $listFilesCommand .= ' && cd ' . \escapeshellarg($resource->getAttribute('outputDirectory', ''));
+                                if ($outputDirectory !== null) {
+                                    $listFilesCommand .= ' && cd ' . \escapeshellarg($resource->getAttribute('outputDirectory'));
                                 }
 
                                 // Print files, and end separation

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -692,10 +692,9 @@ class Builds extends Action
                                 // Start separation, enter build folder
                                 $listFilesCommand .= 'echo "{APPWRITE_DETECTION_SEPARATOR_START}" && cd /usr/local/build';
 
-                                $outputDirectory = $deployment->getAttribute('outputDirectory') ?? $resource->getAttribute('outputDirectory');
-
                                 // Enter output directory, if set
-                                if ($outputDirectory !== null) {
+                                $outputDirectory = $deployment->getAttribute('outputDirectory') ?? $resource->getAttribute('outputDirectory');
+                                if (!empty($outputDirectory)) {
                                     $listFilesCommand .= ' && cd ' . \escapeshellarg($resource->getAttribute('outputDirectory'));
                                 }
 


### PR DESCRIPTION
## What does this PR do?

- respects output directory from deployment

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
