### PR TITLE
Bug fix -> related data in realtime payload

### DIFF
--- a/src/Appwrite/Event/Event.php
+++ b/src/Appwrite/Event/Event.php
@@ -592,6 +592,7 @@ class Event
         $this->project = $event->getProject();
         $this->user = $event->getUser();
         $this->payload = $event->getPayload();
+        $this->sensitive = $event->sensitive;
         $this->event = $event->getEvent();
         $this->params = $event->getParams();
         $this->context = $event->context;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

-> Issue
Related documents are present in the realtime payload and without permissions anyone can view the document

-> Solution
`$sensitive` wasn't getting copied to the realtime queue as it was missing in the `from` method and realtime worker skipping the keys

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
