### PR TITLE
Fix undefined adapter variable in build worker

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -868,6 +868,7 @@ class Builds extends Action
 
             $deployment->setAttribute('buildLogs', $logs);
 
+            $adapter = null;
             if ($resource->getCollection() === 'sites' && !empty($detectionLogs)) {
                 $files = \explode("\n", $detectionLogs); // Parse output
                 $files = \array_filter($files); // Remove empty


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the `adapter` field on a site could end up with unexpected values (like random numbers) due to an undefined variable.

## Root Cause

The `$adapter` variable was only initialized on line 884 inside a conditional block:

```php
if ($resource->getCollection() === 'sites' && !empty($detectionLogs)) {
    $adapter = $resource->getAttribute('adapter', '');
    ...
}
```

But it was used unconditionally on line 904:

```php
$this->afterBuildSuccess($queueForRealtime, $dbForProject, $deployment, $runtime, $adapter);
```

### When the Bug Occurs

The `$adapter` variable would be undefined when:
1. The resource is a function (not a site), OR
2. The resource is a site but `$detectionLogs` is empty

This could result in the adapter field containing unexpected values instead of the expected 'static' or 'ssr'.

## Changes Made

- Initialize `$adapter = null;` before line 872 to ensure it always has a defined value
- The `afterBuildSuccess()` method already accepts nullable string `?string $adapter`, so this is safe

## Test Plan

- Verify that sites with adapter values work correctly
- Verify that function deployments don't cause errors
- Verify that sites without detection logs work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>