### PR TITLE
Rename verification SDK methods to be more specific

### DIFF
--- a/app/config/specs/open-api3-1.8.x-client.json
+++ b/app/config/specs/open-api3-1.8.x-client.json
@@ -3464,7 +3464,7 @@
                 }
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3712,7 +3712,7 @@
                 }
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/open-api3-1.8.x-client.json
+++ b/app/config/specs/open-api3-1.8.x-client.json
@@ -3464,7 +3464,7 @@
                 }
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/open-api3-1.8.x-client.json
+++ b/app/config/specs/open-api3-1.8.x-client.json
@@ -3467,7 +3467,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3486,12 +3486,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3502,6 +3502,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3535,7 +3585,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3554,12 +3604,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3570,6 +3620,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-1.8.x-console.json
+++ b/app/config/specs/open-api3-1.8.x-console.json
@@ -3476,7 +3476,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3495,12 +3495,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3511,6 +3511,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3543,7 +3593,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3562,12 +3612,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3578,6 +3628,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-1.8.x-console.json
+++ b/app/config/specs/open-api3-1.8.x-console.json
@@ -3473,7 +3473,7 @@
                 }
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/open-api3-1.8.x-console.json
+++ b/app/config/specs/open-api3-1.8.x-console.json
@@ -3473,7 +3473,7 @@
                 }
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3719,7 +3719,7 @@
                 }
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/open-api3-1.8.x-server.json
+++ b/app/config/specs/open-api3-1.8.x-server.json
@@ -3161,7 +3161,7 @@
                 }
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/open-api3-1.8.x-server.json
+++ b/app/config/specs/open-api3-1.8.x-server.json
@@ -3164,7 +3164,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3183,12 +3183,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3199,6 +3199,58 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3233,7 +3285,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3252,12 +3304,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3268,6 +3320,62 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []

--- a/app/config/specs/open-api3-1.8.x-server.json
+++ b/app/config/specs/open-api3-1.8.x-server.json
@@ -3161,7 +3161,7 @@
                 }
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3415,7 +3415,7 @@
                 }
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -3464,7 +3464,7 @@
                 }
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3712,7 +3712,7 @@
                 }
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -3464,7 +3464,7 @@
                 }
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -3467,7 +3467,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3486,12 +3486,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3502,6 +3502,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3535,7 +3585,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3554,12 +3604,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3570,6 +3620,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -3476,7 +3476,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3495,12 +3495,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3511,6 +3511,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3543,7 +3593,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3562,12 +3612,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3578,6 +3628,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -3473,7 +3473,7 @@
                 }
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -3473,7 +3473,7 @@
                 }
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3719,7 +3719,7 @@
                 }
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -3161,7 +3161,7 @@
                 }
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -3164,7 +3164,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3183,12 +3183,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3199,6 +3199,58 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3233,7 +3285,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "tags": [
                     "account"
                 ],
@@ -3252,12 +3304,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3268,6 +3320,62 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/components\/schemas\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -3161,7 +3161,7 @@
                 }
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3415,7 +3415,7 @@
                 }
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/swagger2-1.8.x-client.json
+++ b/app/config/specs/swagger2-1.8.x-client.json
@@ -3602,7 +3602,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3623,12 +3623,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3639,6 +3639,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3673,7 +3723,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3694,12 +3744,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3710,6 +3760,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-1.8.x-client.json
+++ b/app/config/specs/swagger2-1.8.x-client.json
@@ -3599,7 +3599,7 @@
                 ]
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3854,7 +3854,7 @@
                 ]
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/swagger2-1.8.x-client.json
+++ b/app/config/specs/swagger2-1.8.x-client.json
@@ -3599,7 +3599,7 @@
                 ]
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/swagger2-1.8.x-console.json
+++ b/app/config/specs/swagger2-1.8.x-console.json
@@ -3618,7 +3618,7 @@
                 ]
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/swagger2-1.8.x-console.json
+++ b/app/config/specs/swagger2-1.8.x-console.json
@@ -3621,7 +3621,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3642,12 +3642,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3658,6 +3658,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3691,7 +3741,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3712,12 +3762,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3728,6 +3778,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-1.8.x-console.json
+++ b/app/config/specs/swagger2-1.8.x-console.json
@@ -3618,7 +3618,7 @@
                 ]
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3871,7 +3871,7 @@
                 ]
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/swagger2-1.8.x-server.json
+++ b/app/config/specs/swagger2-1.8.x-server.json
@@ -3302,7 +3302,7 @@
                 ]
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/swagger2-1.8.x-server.json
+++ b/app/config/specs/swagger2-1.8.x-server.json
@@ -3305,7 +3305,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3326,12 +3326,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3342,6 +3342,58 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3377,7 +3429,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3398,12 +3450,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3414,6 +3466,62 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []

--- a/app/config/specs/swagger2-1.8.x-server.json
+++ b/app/config/specs/swagger2-1.8.x-server.json
@@ -3302,7 +3302,7 @@
                 ]
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3563,7 +3563,7 @@
                 ]
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -3602,7 +3602,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3623,12 +3623,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3639,6 +3639,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3673,7 +3723,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3694,12 +3744,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3710,6 +3760,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -3599,7 +3599,7 @@
                 ]
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3854,7 +3854,7 @@
                 ]
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -3599,7 +3599,7 @@
                 ]
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -3618,7 +3618,7 @@
                 ]
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -3621,7 +3621,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3642,12 +3642,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3658,6 +3658,56 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }
@@ -3691,7 +3741,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3712,12 +3762,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3728,6 +3778,60 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -3618,7 +3618,7 @@
                 ]
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3871,7 +3871,7 @@
                 ]
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -3302,7 +3302,7 @@
                 ]
             }
         },
-        "\/account\/verification": {
+        "\/account\/verification\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -3305,7 +3305,7 @@
         "\/account\/verification": {
             "post": {
                 "summary": "Create email verification",
-                "operationId": "accountCreateVerification",
+                "operationId": "accountCreateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3326,12 +3326,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "createVerification",
+                    "method": "createEmailVerification",
                     "group": "verification",
                     "weight": 41,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/create-verification.md",
+                    "demo": "account\/create-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/create-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3342,6 +3342,58 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "createEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-email-verification.md"
+                        },
+                        {
+                            "name": "createVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "url"
+                            ],
+                            "required": [
+                                "url"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 201,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
+                            "demo": "account\/create-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.createEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3377,7 +3429,7 @@
             },
             "put": {
                 "summary": "Update email verification (confirmation)",
-                "operationId": "accountUpdateVerification",
+                "operationId": "accountUpdateEmailVerification",
                 "consumes": [
                     "application\/json"
                 ],
@@ -3398,12 +3450,12 @@
                 },
                 "deprecated": false,
                 "x-appwrite": {
-                    "method": "updateVerification",
+                    "method": "updateEmailVerification",
                     "group": "verification",
                     "weight": 42,
                     "cookies": false,
                     "type": "",
-                    "demo": "account\/update-verification.md",
+                    "demo": "account\/update-email-verification.md",
                     "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master\/docs\/references\/account\/update-email-verification.md",
                     "rate-limit": 10,
                     "rate-time": 3600,
@@ -3414,6 +3466,62 @@
                         "server"
                     ],
                     "packaging": false,
+                    "methods": [
+                        {
+                            "name": "updateEmailVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-email-verification.md"
+                        },
+                        {
+                            "name": "updateVerification",
+                            "namespace": "account",
+                            "desc": "",
+                            "auth": {
+                                "Project": [],
+                                "Session": []
+                            },
+                            "parameters": [
+                                "userId",
+                                "secret"
+                            ],
+                            "required": [
+                                "userId",
+                                "secret"
+                            ],
+                            "responses": [
+                                {
+                                    "code": 200,
+                                    "model": "#\/definitions\/token"
+                                }
+                            ],
+                            "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
+                            "demo": "account\/update-verification.md",
+                            "deprecated": {
+                                "since": "1.8.0",
+                                "replaceWith": "account.updateEmailVerification"
+                            }
+                        }
+                    ],
                     "auth": {
                         "Project": [],
                         "Session": []

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -3302,7 +3302,7 @@
                 ]
             }
         },
-        "\/account\/verification\/email": {
+        "\/account\/verifications\/email": {
             "post": {
                 "summary": "Create email verification",
                 "operationId": "accountCreateEmailVerification",
@@ -3563,7 +3563,7 @@
                 ]
             }
         },
-        "\/account\/verification\/phone": {
+        "\/account\/verifications\/phone": {
             "post": {
                 "summary": "Create phone verification",
                 "operationId": "accountCreatePhoneVerification",

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3513,20 +3513,40 @@ App::post('/v1/account/verification')
     ->label('event', 'users.[userId].verification.[tokenId].create')
     ->label('audits.event', 'verification.create')
     ->label('audits.resource', 'user/{response.userId}')
-    ->label('sdk', new Method(
-        namespace: 'account',
-        group: 'verification',
-        name: 'createVerification',
-        description: '/docs/references/account/create-email-verification.md',
-        auth: [AuthType::SESSION, AuthType::JWT],
-        responses: [
-            new SDKResponse(
-                code: Response::STATUS_CODE_CREATED,
-                model: Response::MODEL_TOKEN,
-            )
-        ],
-        contentType: ContentType::JSON,
-    ))
+    ->label('sdk', [
+        new Method(
+            namespace: 'account',
+            group: 'verification',
+            name: 'createEmailVerification',
+            description: '/docs/references/account/create-email-verification.md',
+            auth: [AuthType::SESSION, AuthType::JWT],
+            responses: [
+                new SDKResponse(
+                    code: Response::STATUS_CODE_CREATED,
+                    model: Response::MODEL_TOKEN,
+                )
+            ],
+            contentType: ContentType::JSON,
+        ),
+        new Method(
+            namespace: 'account',
+            group: 'verification',
+            name: 'createVerification',
+            description: '/docs/references/account/create-email-verification.md',
+            auth: [AuthType::SESSION, AuthType::JWT],
+            responses: [
+                new SDKResponse(
+                    code: Response::STATUS_CODE_CREATED,
+                    model: Response::MODEL_TOKEN,
+                )
+            ],
+            contentType: ContentType::JSON,
+            deprecated: new Deprecated(
+                since: '1.8.0',
+                replaceWith: 'account.createEmailVerification'
+            ),
+        )
+    ])
     ->label('abuse-limit', 10)
     ->label('abuse-key', 'url:{url},userId:{userId}')
     ->param('url', '', fn ($platforms, $devKey) => $devKey->isEmpty() ? new Redirect($platforms) : new URL(), 'URL to redirect the user back to your app from the verification email. Only URLs from hostnames in your project platform list are allowed. This requirement helps to prevent an [open redirect](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html) attack against your project API.', false, ['platforms', 'devKey']) // TODO add built-in confirm page
@@ -3679,20 +3699,40 @@ App::put('/v1/account/verification')
     ->label('event', 'users.[userId].verification.[tokenId].update')
     ->label('audits.event', 'verification.update')
     ->label('audits.resource', 'user/{response.userId}')
-    ->label('sdk', new Method(
-        namespace: 'account',
-        group: 'verification',
-        name: 'updateVerification',
-        description: '/docs/references/account/update-email-verification.md',
-        auth: [AuthType::SESSION, AuthType::JWT],
-        responses: [
-            new SDKResponse(
-                code: Response::STATUS_CODE_OK,
-                model: Response::MODEL_TOKEN,
-            )
-        ],
-        contentType: ContentType::JSON
-    ))
+    ->label('sdk', [
+        new Method(
+            namespace: 'account',
+            group: 'verification',
+            name: 'updateEmailVerification',
+            description: '/docs/references/account/update-email-verification.md',
+            auth: [AuthType::SESSION, AuthType::JWT],
+            responses: [
+                new SDKResponse(
+                    code: Response::STATUS_CODE_OK,
+                    model: Response::MODEL_TOKEN,
+                )
+            ],
+            contentType: ContentType::JSON
+        ),
+        new Method(
+            namespace: 'account',
+            group: 'verification',
+            name: 'updateVerification',
+            description: '/docs/references/account/update-email-verification.md',
+            auth: [AuthType::SESSION, AuthType::JWT],
+            responses: [
+                new SDKResponse(
+                    code: Response::STATUS_CODE_OK,
+                    model: Response::MODEL_TOKEN,
+                )
+            ],
+            contentType: ContentType::JSON,
+            deprecated: new Deprecated(
+                since: '1.8.0',
+                replaceWith: 'account.updateEmailVerification'
+            ),
+        )
+    ])
     ->label('abuse-limit', 10)
     ->label('abuse-key', 'url:{url},userId:{param-userId}')
     ->param('userId', '', new UID(), 'User ID.')

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3506,7 +3506,7 @@ App::put('/v1/account/recovery')
         $response->dynamic($recoveryDocument, Response::MODEL_TOKEN);
     });
 
-App::post('/v1/account/verification/email')
+App::post('/v1/account/verifications/email')
     ->alias('/v1/account/verification')
     ->desc('Create email verification')
     ->groups(['api', 'account'])
@@ -3693,7 +3693,7 @@ App::post('/v1/account/verification/email')
             ->dynamic($verification, Response::MODEL_TOKEN);
     });
 
-App::put('/v1/account/verification/email')
+App::put('/v1/account/verifications/email')
     ->alias('/v1/account/verification')
     ->desc('Update email verification (confirmation)')
     ->groups(['api', 'account'])
@@ -3781,7 +3781,8 @@ App::put('/v1/account/verification/email')
         $response->dynamic($verification, Response::MODEL_TOKEN);
     });
 
-App::post('/v1/account/verification/phone')
+App::post('/v1/account/verifications/phone')
+    ->alias('/v1/account/verification/phone')
     ->desc('Create phone verification')
     ->groups(['api', 'account', 'auth'])
     ->label('scope', 'account')
@@ -3930,7 +3931,8 @@ App::post('/v1/account/verification/phone')
             ->dynamic($verification, Response::MODEL_TOKEN);
     });
 
-App::put('/v1/account/verification/phone')
+App::put('/v1/account/verifications/phone')
+    ->alias('/v1/account/verification/phone')
     ->desc('Update phone verification (confirmation)')
     ->groups(['api', 'account'])
     ->label('scope', 'public')

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3506,7 +3506,8 @@ App::put('/v1/account/recovery')
         $response->dynamic($recoveryDocument, Response::MODEL_TOKEN);
     });
 
-App::post('/v1/account/verification')
+App::post('/v1/account/verification/email')
+    ->alias('/v1/account/verification')
     ->desc('Create email verification')
     ->groups(['api', 'account'])
     ->label('scope', 'account')
@@ -3692,7 +3693,8 @@ App::post('/v1/account/verification')
             ->dynamic($verification, Response::MODEL_TOKEN);
     });
 
-App::put('/v1/account/verification')
+App::put('/v1/account/verification/email')
+    ->alias('/v1/account/verification')
     ->desc('Update email verification (confirmation)')
     ->groups(['api', 'account'])
     ->label('scope', 'public')

--- a/docs/examples/1.8.x/client-android/java/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-android/java/account/create-email-verification.md
@@ -1,0 +1,22 @@
+import io.appwrite.Client;
+import io.appwrite.coroutines.CoroutineCallback;
+import io.appwrite.services.Account;
+
+Client client = new Client(context)
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>"); // Your project ID
+
+Account account = new Account(client);
+
+account.createEmailVerification(
+    "https://example.com", // url 
+    new CoroutineCallback<>((result, error) -> {
+        if (error != null) {
+            error.printStackTrace();
+            return;
+        }
+
+        Log.d("Appwrite", result.toString());
+    })
+);
+

--- a/docs/examples/1.8.x/client-android/java/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-android/java/account/update-email-verification.md
@@ -1,0 +1,23 @@
+import io.appwrite.Client;
+import io.appwrite.coroutines.CoroutineCallback;
+import io.appwrite.services.Account;
+
+Client client = new Client(context)
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>"); // Your project ID
+
+Account account = new Account(client);
+
+account.updateEmailVerification(
+    "<USER_ID>", // userId 
+    "<SECRET>", // secret 
+    new CoroutineCallback<>((result, error) -> {
+        if (error != null) {
+            error.printStackTrace();
+            return;
+        }
+
+        Log.d("Appwrite", result.toString());
+    })
+);
+

--- a/docs/examples/1.8.x/client-android/kotlin/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-android/kotlin/account/create-email-verification.md
@@ -1,0 +1,13 @@
+import io.appwrite.Client
+import io.appwrite.coroutines.CoroutineCallback
+import io.appwrite.services.Account
+
+val client = Client(context)
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+
+val account = Account(client)
+
+val result = account.createEmailVerification(
+    url = "https://example.com", 
+)

--- a/docs/examples/1.8.x/client-android/kotlin/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-android/kotlin/account/update-email-verification.md
@@ -1,0 +1,14 @@
+import io.appwrite.Client
+import io.appwrite.coroutines.CoroutineCallback
+import io.appwrite.services.Account
+
+val client = Client(context)
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+
+val account = Account(client)
+
+val result = account.updateEmailVerification(
+    userId = "<USER_ID>", 
+    secret = "<SECRET>", 
+)

--- a/docs/examples/1.8.x/client-apple/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-apple/examples/account/create-email-verification.md
@@ -1,0 +1,12 @@
+import Appwrite
+
+let client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+
+let account = Account(client)
+
+let token = try await account.createEmailVerification(
+    url: "https://example.com"
+)
+

--- a/docs/examples/1.8.x/client-apple/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-apple/examples/account/update-email-verification.md
@@ -1,0 +1,13 @@
+import Appwrite
+
+let client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+
+let account = Account(client)
+
+let token = try await account.updateEmailVerification(
+    userId: "<USER_ID>",
+    secret: "<SECRET>"
+)
+

--- a/docs/examples/1.8.x/client-flutter/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-flutter/examples/account/create-email-verification.md
@@ -1,0 +1,11 @@
+import 'package:appwrite/appwrite.dart';
+
+Client client = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+Account account = Account(client);
+
+Token result = await account.createEmailVerification(
+    url: 'https://example.com',
+);

--- a/docs/examples/1.8.x/client-flutter/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-flutter/examples/account/update-email-verification.md
@@ -1,0 +1,12 @@
+import 'package:appwrite/appwrite.dart';
+
+Client client = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+Account account = Account(client);
+
+Token result = await account.updateEmailVerification(
+    userId: '<USER_ID>',
+    secret: '<SECRET>',
+);

--- a/docs/examples/1.8.x/client-graphql/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-graphql/examples/account/create-email-verification.md
@@ -1,0 +1,12 @@
+mutation {
+    accountCreateEmailVerification(
+        url: "https://example.com"
+    ) {
+        _id
+        _createdAt
+        userId
+        secret
+        expire
+        phrase
+    }
+}

--- a/docs/examples/1.8.x/client-graphql/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-graphql/examples/account/update-email-verification.md
@@ -1,0 +1,13 @@
+mutation {
+    accountUpdateEmailVerification(
+        userId: "<USER_ID>",
+        secret: "<SECRET>"
+    ) {
+        _id
+        _createdAt
+        userId
+        secret
+        expire
+        phrase
+    }
+}

--- a/docs/examples/1.8.x/client-react-native/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-react-native/examples/account/create-email-verification.md
@@ -1,0 +1,13 @@
+import { Client, Account } from "react-native-appwrite";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const account = new Account(client);
+
+const result = await account.createEmailVerification({
+    url: 'https://example.com'
+});
+
+console.log(result);

--- a/docs/examples/1.8.x/client-react-native/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-react-native/examples/account/update-email-verification.md
@@ -1,0 +1,14 @@
+import { Client, Account } from "react-native-appwrite";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const account = new Account(client);
+
+const result = await account.updateEmailVerification({
+    userId: '<USER_ID>',
+    secret: '<SECRET>'
+});
+
+console.log(result);

--- a/docs/examples/1.8.x/client-rest/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/create-email-verification.md
@@ -1,0 +1,11 @@
+POST /v1/account/verification HTTP/1.1
+Host: cloud.appwrite.io
+Content-Type: application/json
+X-Appwrite-Response-Format: 1.8.0
+X-Appwrite-Project: <YOUR_PROJECT_ID>
+X-Appwrite-Session: 
+X-Appwrite-JWT: <YOUR_JWT>
+
+{
+  "url": "https://example.com"
+}

--- a/docs/examples/1.8.x/client-rest/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/update-email-verification.md
@@ -1,0 +1,12 @@
+PUT /v1/account/verification HTTP/1.1
+Host: cloud.appwrite.io
+Content-Type: application/json
+X-Appwrite-Response-Format: 1.8.0
+X-Appwrite-Project: <YOUR_PROJECT_ID>
+X-Appwrite-Session: 
+X-Appwrite-JWT: <YOUR_JWT>
+
+{
+  "userId": "<USER_ID>",
+  "secret": "<SECRET>"
+}

--- a/docs/examples/1.8.x/client-web/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-web/examples/account/create-email-verification.md
@@ -1,0 +1,13 @@
+import { Client, Account } from "appwrite";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const account = new Account(client);
+
+const result = await account.createEmailVerification({
+    url: 'https://example.com'
+});
+
+console.log(result);

--- a/docs/examples/1.8.x/client-web/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-web/examples/account/update-email-verification.md
@@ -1,0 +1,14 @@
+import { Client, Account } from "appwrite";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const account = new Account(client);
+
+const result = await account.updateEmailVerification({
+    userId: '<USER_ID>',
+    secret: '<SECRET>'
+});
+
+console.log(result);

--- a/docs/examples/1.8.x/console-cli/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/console-cli/examples/account/create-email-verification.md
@@ -1,0 +1,2 @@
+appwrite account create-email-verification \
+    --url https://example.com

--- a/docs/examples/1.8.x/console-cli/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/console-cli/examples/account/update-email-verification.md
@@ -1,0 +1,3 @@
+appwrite account update-email-verification \
+    --user-id <USER_ID> \
+    --secret <SECRET>

--- a/docs/examples/1.8.x/console-web/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/console-web/examples/account/create-email-verification.md
@@ -1,0 +1,13 @@
+import { Client, Account } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const account = new Account(client);
+
+const result = await account.createEmailVerification({
+    url: 'https://example.com'
+});
+
+console.log(result);

--- a/docs/examples/1.8.x/console-web/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/console-web/examples/account/update-email-verification.md
@@ -1,0 +1,14 @@
+import { Client, Account } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const account = new Account(client);
+
+const result = await account.updateEmailVerification({
+    userId: '<USER_ID>',
+    secret: '<SECRET>'
+});
+
+console.log(result);

--- a/docs/examples/1.8.x/server-dart/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-dart/examples/account/create-email-verification.md
@@ -1,0 +1,12 @@
+import 'package:dart_appwrite/dart_appwrite.dart';
+
+Client client = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>') // Your project ID
+    .setSession(''); // The user session to authenticate with
+
+Account account = Account(client);
+
+Token result = await account.createEmailVerification(
+    url: 'https://example.com',
+);

--- a/docs/examples/1.8.x/server-dart/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-dart/examples/account/update-email-verification.md
@@ -1,0 +1,13 @@
+import 'package:dart_appwrite/dart_appwrite.dart';
+
+Client client = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>') // Your project ID
+    .setSession(''); // The user session to authenticate with
+
+Account account = Account(client);
+
+Token result = await account.updateEmailVerification(
+    userId: '<USER_ID>',
+    secret: '<SECRET>',
+);

--- a/docs/examples/1.8.x/server-dotnet/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-dotnet/examples/account/create-email-verification.md
@@ -1,0 +1,14 @@
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetSession(""); // The user session to authenticate with
+
+Account account = new Account(client);
+
+Token result = await account.CreateEmailVerification(
+    url: "https://example.com"
+);

--- a/docs/examples/1.8.x/server-dotnet/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-dotnet/examples/account/update-email-verification.md
@@ -1,0 +1,15 @@
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetSession(""); // The user session to authenticate with
+
+Account account = new Account(client);
+
+Token result = await account.UpdateEmailVerification(
+    userId: "<USER_ID>",
+    secret: "<SECRET>"
+);

--- a/docs/examples/1.8.x/server-go/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-go/examples/account/create-email-verification.md
@@ -1,0 +1,19 @@
+package main
+
+import (
+    "fmt"
+    "github.com/appwrite/sdk-for-go/client"
+    "github.com/appwrite/sdk-for-go/account"
+)
+
+client := client.New(
+    client.WithEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    client.WithProject("<YOUR_PROJECT_ID>")
+    client.WithSession("")
+)
+
+service := account.New(client)
+
+response, error := service.CreateEmailVerification(
+    "https://example.com",
+)

--- a/docs/examples/1.8.x/server-go/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-go/examples/account/update-email-verification.md
@@ -1,0 +1,20 @@
+package main
+
+import (
+    "fmt"
+    "github.com/appwrite/sdk-for-go/client"
+    "github.com/appwrite/sdk-for-go/account"
+)
+
+client := client.New(
+    client.WithEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    client.WithProject("<YOUR_PROJECT_ID>")
+    client.WithSession("")
+)
+
+service := account.New(client)
+
+response, error := service.UpdateEmailVerification(
+    "<USER_ID>",
+    "<SECRET>",
+)

--- a/docs/examples/1.8.x/server-graphql/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-graphql/examples/account/create-email-verification.md
@@ -1,0 +1,12 @@
+mutation {
+    accountCreateEmailVerification(
+        url: "https://example.com"
+    ) {
+        _id
+        _createdAt
+        userId
+        secret
+        expire
+        phrase
+    }
+}

--- a/docs/examples/1.8.x/server-graphql/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-graphql/examples/account/update-email-verification.md
@@ -1,0 +1,13 @@
+mutation {
+    accountUpdateEmailVerification(
+        userId: "<USER_ID>",
+        secret: "<SECRET>"
+    ) {
+        _id
+        _createdAt
+        userId
+        secret
+        expire
+        phrase
+    }
+}

--- a/docs/examples/1.8.x/server-kotlin/java/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-kotlin/java/account/create-email-verification.md
@@ -1,0 +1,23 @@
+import io.appwrite.Client;
+import io.appwrite.coroutines.CoroutineCallback;
+import io.appwrite.services.Account;
+
+Client client = new Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+    .setSession(""); // The user session to authenticate with
+
+Account account = new Account(client);
+
+account.createEmailVerification(
+    "https://example.com", // url
+    new CoroutineCallback<>((result, error) -> {
+        if (error != null) {
+            error.printStackTrace();
+            return;
+        }
+
+        System.out.println(result);
+    })
+);
+

--- a/docs/examples/1.8.x/server-kotlin/java/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-kotlin/java/account/update-email-verification.md
@@ -1,0 +1,24 @@
+import io.appwrite.Client;
+import io.appwrite.coroutines.CoroutineCallback;
+import io.appwrite.services.Account;
+
+Client client = new Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+    .setSession(""); // The user session to authenticate with
+
+Account account = new Account(client);
+
+account.updateEmailVerification(
+    "<USER_ID>", // userId
+    "<SECRET>", // secret
+    new CoroutineCallback<>((result, error) -> {
+        if (error != null) {
+            error.printStackTrace();
+            return;
+        }
+
+        System.out.println(result);
+    })
+);
+

--- a/docs/examples/1.8.x/server-kotlin/kotlin/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-kotlin/kotlin/account/create-email-verification.md
@@ -1,0 +1,14 @@
+import io.appwrite.Client
+import io.appwrite.coroutines.CoroutineCallback
+import io.appwrite.services.Account
+
+val client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+    .setSession("") // The user session to authenticate with
+
+val account = Account(client)
+
+val response = account.createEmailVerification(
+    url = "https://example.com"
+)

--- a/docs/examples/1.8.x/server-kotlin/kotlin/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-kotlin/kotlin/account/update-email-verification.md
@@ -1,0 +1,15 @@
+import io.appwrite.Client
+import io.appwrite.coroutines.CoroutineCallback
+import io.appwrite.services.Account
+
+val client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+    .setSession("") // The user session to authenticate with
+
+val account = Account(client)
+
+val response = account.updateEmailVerification(
+    userId = "<USER_ID>",
+    secret = "<SECRET>"
+)

--- a/docs/examples/1.8.x/server-nodejs/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-nodejs/examples/account/create-email-verification.md
@@ -1,0 +1,12 @@
+const sdk = require('node-appwrite');
+
+const client = new sdk.Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>') // Your project ID
+    .setSession(''); // The user session to authenticate with
+
+const account = new sdk.Account(client);
+
+const result = await account.createEmailVerification({
+    url: 'https://example.com'
+});

--- a/docs/examples/1.8.x/server-nodejs/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-nodejs/examples/account/update-email-verification.md
@@ -1,0 +1,13 @@
+const sdk = require('node-appwrite');
+
+const client = new sdk.Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>') // Your project ID
+    .setSession(''); // The user session to authenticate with
+
+const account = new sdk.Account(client);
+
+const result = await account.updateEmailVerification({
+    userId: '<USER_ID>',
+    secret: '<SECRET>'
+});

--- a/docs/examples/1.8.x/server-php/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-php/examples/account/create-email-verification.md
@@ -1,0 +1,15 @@
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Account;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setSession(''); // The user session to authenticate with
+
+$account = new Account($client);
+
+$result = $account->createEmailVerification(
+    url: 'https://example.com'
+);

--- a/docs/examples/1.8.x/server-php/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-php/examples/account/update-email-verification.md
@@ -1,0 +1,16 @@
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Account;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setSession(''); // The user session to authenticate with
+
+$account = new Account($client);
+
+$result = $account->updateEmailVerification(
+    userId: '<USER_ID>',
+    secret: '<SECRET>'
+);

--- a/docs/examples/1.8.x/server-python/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-python/examples/account/create-email-verification.md
@@ -1,0 +1,13 @@
+from appwrite.client import Client
+from appwrite.services.account import Account
+
+client = Client()
+client.set_endpoint('https://<REGION>.cloud.appwrite.io/v1') # Your API Endpoint
+client.set_project('<YOUR_PROJECT_ID>') # Your project ID
+client.set_session('') # The user session to authenticate with
+
+account = Account(client)
+
+result = account.create_email_verification(
+    url = 'https://example.com'
+)

--- a/docs/examples/1.8.x/server-python/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-python/examples/account/update-email-verification.md
@@ -1,0 +1,14 @@
+from appwrite.client import Client
+from appwrite.services.account import Account
+
+client = Client()
+client.set_endpoint('https://<REGION>.cloud.appwrite.io/v1') # Your API Endpoint
+client.set_project('<YOUR_PROJECT_ID>') # Your project ID
+client.set_session('') # The user session to authenticate with
+
+account = Account(client)
+
+result = account.update_email_verification(
+    user_id = '<USER_ID>',
+    secret = '<SECRET>'
+)

--- a/docs/examples/1.8.x/server-rest/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/create-email-verification.md
@@ -1,0 +1,11 @@
+POST /v1/account/verification HTTP/1.1
+Host: cloud.appwrite.io
+Content-Type: application/json
+X-Appwrite-Response-Format: 1.8.0
+X-Appwrite-Project: <YOUR_PROJECT_ID>
+X-Appwrite-Session: 
+X-Appwrite-JWT: <YOUR_JWT>
+
+{
+  "url": "https://example.com"
+}

--- a/docs/examples/1.8.x/server-rest/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/update-email-verification.md
@@ -1,0 +1,12 @@
+PUT /v1/account/verification HTTP/1.1
+Host: cloud.appwrite.io
+Content-Type: application/json
+X-Appwrite-Response-Format: 1.8.0
+X-Appwrite-Project: <YOUR_PROJECT_ID>
+X-Appwrite-Session: 
+X-Appwrite-JWT: <YOUR_JWT>
+
+{
+  "userId": "<USER_ID>",
+  "secret": "<SECRET>"
+}

--- a/docs/examples/1.8.x/server-ruby/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-ruby/examples/account/create-email-verification.md
@@ -1,0 +1,14 @@
+require 'appwrite'
+
+include Appwrite
+
+client = Client.new
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1') # Your API Endpoint
+    .set_project('<YOUR_PROJECT_ID>') # Your project ID
+    .set_session('') # The user session to authenticate with
+
+account = Account.new(client)
+
+result = account.create_email_verification(
+    url: 'https://example.com'
+)

--- a/docs/examples/1.8.x/server-ruby/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-ruby/examples/account/update-email-verification.md
@@ -1,0 +1,15 @@
+require 'appwrite'
+
+include Appwrite
+
+client = Client.new
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1') # Your API Endpoint
+    .set_project('<YOUR_PROJECT_ID>') # Your project ID
+    .set_session('') # The user session to authenticate with
+
+account = Account.new(client)
+
+result = account.update_email_verification(
+    user_id: '<USER_ID>',
+    secret: '<SECRET>'
+)

--- a/docs/examples/1.8.x/server-swift/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-swift/examples/account/create-email-verification.md
@@ -1,0 +1,13 @@
+import Appwrite
+
+let client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+    .setSession("") // The user session to authenticate with
+
+let account = Account(client)
+
+let token = try await account.createEmailVerification(
+    url: "https://example.com"
+)
+

--- a/docs/examples/1.8.x/server-swift/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-swift/examples/account/update-email-verification.md
@@ -1,0 +1,14 @@
+import Appwrite
+
+let client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .setProject("<YOUR_PROJECT_ID>") // Your project ID
+    .setSession("") // The user session to authenticate with
+
+let account = Account(client)
+
+let token = try await account.updateEmailVerification(
+    userId: "<USER_ID>",
+    secret: "<SECRET>"
+)
+


### PR DESCRIPTION
## Summary
- Renames `createVerification` to `createEmailVerification`
- Renames `updateVerification` to `updateEmailVerification`
- Maintains backwards compatibility by keeping old method names as deprecated (since 1.8.0)
- Updates SDK method definitions to use array syntax with both new and deprecated methods

## Changes
The verification SDK methods have been updated to better reflect their purpose as email verification methods:

### Create Email Verification
- **New method**: `account.createEmailVerification`
- **Deprecated method**: `account.createVerification` (deprecated since 1.8.0)

### Update Email Verification
- **New method**: `account.updateEmailVerification`
- **Deprecated method**: `account.updateVerification` (deprecated since 1.8.0)

## Implementation Details
- Both endpoints now use an array of Method objects in their SDK label
- The first method in each array is the new, preferred method name
- The second method is the deprecated old name with a `Deprecated` object indicating replacement
- All OpenAPI/Swagger specs have been automatically updated to reflect these changes

## Test plan
- [ ] Verify SDK generation includes both new and deprecated methods
- [ ] Confirm deprecated methods show proper deprecation warnings
- [ ] Test that both old and new method names work correctly
- [ ] Validate OpenAPI/Swagger spec changes are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)