### PR TITLE
Add minor releases for all SDKs - deprecate createVerification, add createEmailVerification

### DIFF
--- a/app/config/platforms.php
+++ b/app/config/platforms.php
@@ -11,7 +11,7 @@ return [
             [
                 'key' => 'web',
                 'name' => 'Web',
-                'version' => '21.0.0',
+                'version' => '21.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-web',
                 'package' => 'https://www.npmjs.com/package/appwrite',
                 'enabled' => true,
@@ -60,7 +60,7 @@ return [
             [
                 'key' => 'flutter',
                 'name' => 'Flutter',
-                'version' => '20.0.0',
+                'version' => '20.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-flutter',
                 'package' => 'https://pub.dev/packages/appwrite',
                 'enabled' => true,
@@ -79,7 +79,7 @@ return [
             [
                 'key' => 'apple',
                 'name' => 'Apple',
-                'version' => '13.0.0',
+                'version' => '13.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-apple',
                 'package' => 'https://github.com/appwrite/sdk-for-apple',
                 'enabled' => true,
@@ -116,7 +116,7 @@ return [
             [
                 'key' => 'android',
                 'name' => 'Android',
-                'version' => '11.0.0',
+                'version' => '11.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-android',
                 'package' => 'https://search.maven.org/artifact/io.appwrite/sdk-for-android',
                 'enabled' => true,
@@ -139,7 +139,7 @@ return [
             [
                 'key' => 'react-native',
                 'name' => 'React Native',
-                'version' => '0.15.0',
+                'version' => '0.16.0',
                 'url' => 'https://github.com/appwrite/sdk-for-react-native',
                 'package' => 'https://npmjs.com/package/react-native-appwrite',
                 'enabled' => true,
@@ -226,7 +226,7 @@ return [
             [
                 'key' => 'cli',
                 'name' => 'Command Line',
-                'version' => '10.0.1',
+                'version' => '10.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-cli',
                 'package' => 'https://www.npmjs.com/package/appwrite-cli',
                 'enabled' => true,
@@ -262,7 +262,7 @@ return [
             [
                 'key' => 'nodejs',
                 'name' => 'Node.js',
-                'version' => '20.0.0',
+                'version' => '20.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-node',
                 'package' => 'https://www.npmjs.com/package/node-appwrite',
                 'enabled' => true,
@@ -281,7 +281,7 @@ return [
             [
                 'key' => 'php',
                 'name' => 'PHP',
-                'version' => '17.2.0',
+                'version' => '17.3.0',
                 'url' => 'https://github.com/appwrite/sdk-for-php',
                 'package' => 'https://packagist.org/packages/appwrite/appwrite',
                 'enabled' => true,
@@ -300,7 +300,7 @@ return [
             [
                 'key' => 'python',
                 'name' => 'Python',
-                'version' => '13.2.0',
+                'version' => '13.3.0',
                 'url' => 'https://github.com/appwrite/sdk-for-python',
                 'package' => 'https://pypi.org/project/appwrite/',
                 'enabled' => true,
@@ -319,7 +319,7 @@ return [
             [
                 'key' => 'ruby',
                 'name' => 'Ruby',
-                'version' => '19.0.0',
+                'version' => '19.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-ruby',
                 'package' => 'https://rubygems.org/gems/appwrite',
                 'enabled' => true,
@@ -338,7 +338,7 @@ return [
             [
                 'key' => 'go',
                 'name' => 'Go',
-                'version' => '0.13.0',
+                'version' => '0.14.0',
                 'url' => 'https://github.com/appwrite/sdk-for-go',
                 'package' => 'https://github.com/appwrite/sdk-for-go',
                 'enabled' => true,
@@ -357,7 +357,7 @@ return [
             [
                 'key' => 'dotnet',
                 'name' => '.NET',
-                'version' => '0.19.0',
+                'version' => '0.20.0',
                 'url' => 'https://github.com/appwrite/sdk-for-dotnet',
                 'package' => 'https://www.nuget.org/packages/Appwrite',
                 'enabled' => true,
@@ -376,7 +376,7 @@ return [
             [
                 'key' => 'dart',
                 'name' => 'Dart',
-                'version' => '19.0.0',
+                'version' => '19.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-dart',
                 'package' => 'https://pub.dev/packages/dart_appwrite',
                 'enabled' => true,
@@ -395,7 +395,7 @@ return [
             [
                 'key' => 'kotlin',
                 'name' => 'Kotlin',
-                'version' => '12.0.0',
+                'version' => '12.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-kotlin',
                 'package' => 'https://search.maven.org/artifact/io.appwrite/sdk-for-kotlin',
                 'enabled' => true,
@@ -418,7 +418,7 @@ return [
             [
                 'key' => 'swift',
                 'name' => 'Swift',
-                'version' => '13.0.0',
+                'version' => '13.1.0',
                 'url' => 'https://github.com/appwrite/sdk-for-swift',
                 'package' => 'https://github.com/appwrite/sdk-for-swift',
                 'enabled' => true,

--- a/docs/examples/1.8.x/client-rest/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/create-email-verification.md
@@ -1,4 +1,4 @@
-POST /v1/account/verification HTTP/1.1
+POST /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/client-rest/examples/account/create-phone-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/create-phone-verification.md
@@ -1,4 +1,4 @@
-POST /v1/account/verification/phone HTTP/1.1
+POST /v1/account/verifications/phone HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/client-rest/examples/account/create-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/create-verification.md
@@ -1,4 +1,4 @@
-POST /v1/account/verification HTTP/1.1
+POST /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/client-rest/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/update-email-verification.md
@@ -1,4 +1,4 @@
-PUT /v1/account/verification HTTP/1.1
+PUT /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/client-rest/examples/account/update-phone-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/update-phone-verification.md
@@ -1,4 +1,4 @@
-PUT /v1/account/verification/phone HTTP/1.1
+PUT /v1/account/verifications/phone HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/client-rest/examples/account/update-verification.md
+++ b/docs/examples/1.8.x/client-rest/examples/account/update-verification.md
@@ -1,4 +1,4 @@
-PUT /v1/account/verification HTTP/1.1
+PUT /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/server-rest/examples/account/create-email-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/create-email-verification.md
@@ -1,4 +1,4 @@
-POST /v1/account/verification HTTP/1.1
+POST /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/server-rest/examples/account/create-phone-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/create-phone-verification.md
@@ -1,4 +1,4 @@
-POST /v1/account/verification/phone HTTP/1.1
+POST /v1/account/verifications/phone HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/server-rest/examples/account/create-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/create-verification.md
@@ -1,4 +1,4 @@
-POST /v1/account/verification HTTP/1.1
+POST /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/server-rest/examples/account/update-email-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/update-email-verification.md
@@ -1,4 +1,4 @@
-PUT /v1/account/verification HTTP/1.1
+PUT /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/server-rest/examples/account/update-phone-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/update-phone-verification.md
@@ -1,4 +1,4 @@
-PUT /v1/account/verification/phone HTTP/1.1
+PUT /v1/account/verifications/phone HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/examples/1.8.x/server-rest/examples/account/update-verification.md
+++ b/docs/examples/1.8.x/server-rest/examples/account/update-verification.md
@@ -1,4 +1,4 @@
-PUT /v1/account/verification HTTP/1.1
+PUT /v1/account/verifications/email HTTP/1.1
 Host: cloud.appwrite.io
 Content-Type: application/json
 X-Appwrite-Response-Format: 1.8.0

--- a/docs/sdks/android/CHANGELOG.md
+++ b/docs/sdks/android/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 11.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 8.2.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/apple/CHANGELOG.md
+++ b/docs/sdks/apple/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 13.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 10.2.0
 
 * Update sdk to use swift-native doc comments instead of jsdoc styled comments as per [Swift Documentation Comments](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)

--- a/docs/sdks/cli/CHANGELOG.md
+++ b/docs/sdks/cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 10.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 10.0.1
 
 * Fix CLI Dart model generation issues

--- a/docs/sdks/dart/CHANGELOG.md
+++ b/docs/sdks/dart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 19.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 18.1.0
 
 * Add `orderRandom` query support

--- a/docs/sdks/dotnet/CHANGELOG.md
+++ b/docs/sdks/dotnet/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.20.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 0.15.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/flutter/CHANGELOG.md
+++ b/docs/sdks/flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 20.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 19.1.0
 
 * Add `orderRandom` query support

--- a/docs/sdks/go/CHANGELOG.md
+++ b/docs/sdks/go/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.14.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 0.9.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/kotlin/CHANGELOG.md
+++ b/docs/sdks/kotlin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 12.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 9.1.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/nodejs/CHANGELOG.md
+++ b/docs/sdks/nodejs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 20.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 17.2.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/php/CHANGELOG.md
+++ b/docs/sdks/php/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 17.3.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 15.1.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/python/CHANGELOG.md
+++ b/docs/sdks/python/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 13.3.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 11.1.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/react-native/CHANGELOG.md
+++ b/docs/sdks/react-native/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 0.16.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 0.11.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/ruby/CHANGELOG.md
+++ b/docs/sdks/ruby/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 19.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 16.1.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service

--- a/docs/sdks/swift/CHANGELOG.md
+++ b/docs/sdks/swift/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 13.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 10.2.0
 
 * Update sdk to use swift-native doc comments instead of jsdoc styled comments as per [Swift Documentation Comments](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)

--- a/docs/sdks/web/CHANGELOG.md
+++ b/docs/sdks/web/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 21.1.0
+
+* Deprecate `createVerification` method in `Account` service
+* Add `createEmailVerification` method in `Account` service
+
 ## 18.2.0
 
 * Add `incrementDocumentAttribute` and `decrementDocumentAttribute` support to `Databases` service


### PR DESCRIPTION
## Summary

This PR adds minor version releases for all client and server SDKs to deprecate the `createVerification` method in the Account service and introduce the new `createEmailVerification` method as its replacement.

## Updated SDK Versions

### Client SDKs
- Android: 11.0.0 → 11.1.0
- Web: 21.0.0 → 21.1.0
- Flutter: 20.0.0 → 20.1.0
- Apple: 13.0.0 → 13.1.0
- React Native: 0.15.0 → 0.16.0

### Server SDKs
- Node.js: 20.0.0 → 20.1.0
- PHP: 17.2.0 → 17.3.0
- Python: 13.2.0 → 13.3.0
- Ruby: 19.0.0 → 19.1.0
- Go: 0.13.0 → 0.14.0
- .NET: 0.19.0 → 0.20.0
- Dart: 19.0.0 → 19.1.0
- Kotlin: 12.0.0 → 12.1.0
- Swift: 13.0.0 → 13.1.0

### Console SDK
- CLI: 10.0.1 → 10.1.0

## Changelog Entries

Each SDK changelog now includes:
- Deprecate `createVerification` method in `Account` service
- Add `createEmailVerification` method in `Account` service

## Files Modified
- `app/config/platforms.php` - Updated all SDK versions
- `docs/sdks/*/CHANGELOG.md` - Added new minor version entries for all SDKs