### PR TITLE
Fix: MFA with email-verified factor

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -2,7 +2,6 @@
 
 use Appwrite\Auth\Auth;
 use Appwrite\Auth\Key;
-use Appwrite\Auth\MFA\Type;
 use Appwrite\Auth\MFA\Type\TOTP;
 use Appwrite\Event\Audit;
 use Appwrite\Event\Build;


### PR DESCRIPTION
## What does this PR do?

1. Prevents from suggesting email/phone as 2nd factor, if already used as 1st factor (email otp, magic url, phone otp)
2. Prevents MFA from triggering if only 1 factor is enabled, and it's factor used during sign-in

-> to consider, should password be 2nd factor?
-> to consider reverting to original api.php behaviour, and throwing error in email/phone flows, when email/phone is only added facotor, and mfa is enabled

## Test Plan

Introduce tests:
- After enabling 2fa (in different scenarios), ensure current session remains active
- Ensure listFactors to behave properly when 1st factor is email/phone/passowrd
after answering problem in step 2, add tests for it too. either ensuse password is factor too, or ensure behaviour of email+email and email+password mfa flows

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
