### PR TITLE
Fix txn API scope backwards compat

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Create.php
@@ -30,7 +30,7 @@ class Create extends TransactionsCreate
             ->setHttpPath('/v1/tablesdb/transactions')
             ->desc('Create transaction')
             ->groups(['api', 'database', 'transactions'])
-            ->label('scope', 'rows.write')
+            ->label('scope', ['documents.write', 'rows.write'])
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Delete.php
@@ -30,7 +30,7 @@ class Delete extends TransactionsDelete
             ->setHttpPath('/v1/tablesdb/transactions/:transactionId')
             ->desc('Delete transaction')
             ->groups(['api', 'database', 'transactions'])
-            ->label('scope', 'rows.write')
+            ->label('scope', ['documents.write', 'rows.write'])
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Get.php
@@ -30,7 +30,7 @@ class Get extends TransactionsGet
             ->setHttpPath('/v1/tablesdb/transactions/:transactionId')
             ->desc('Get transaction')
             ->groups(['api', 'database', 'transactions'])
-            ->label('scope', 'rows.read')
+            ->label('scope', ['documents.read', 'rows.read'])
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Operations/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Operations/Create.php
@@ -32,7 +32,7 @@ class Create extends OperationsCreate
             ->setHttpPath('/v1/tablesdb/transactions/:transactionId/operations')
             ->desc('Create operations')
             ->groups(['api', 'database', 'transactions'])
-            ->label('scope', 'rows.write')
+            ->label('scope', ['documents.write', 'rows.write'])
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Update.php
@@ -31,7 +31,7 @@ class Update extends TransactionsUpdate
             ->setHttpPath('/v1/tablesdb/transactions/:transactionId')
             ->desc('Update transaction')
             ->groups(['api', 'database', 'transactions'])
-            ->label('scope', 'rows.write')
+            ->label('scope', ['documents.write', 'rows.write'])
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/XList.php
@@ -30,7 +30,7 @@ class XList extends TransactionsList
             ->setHttpPath('/v1/tablesdb/transactions')
             ->desc('List transactions')
             ->groups(['api', 'database', 'transactions'])
-            ->label('scope', 'rows.read')
+            ->label('scope', ['documents.read', 'rows.read'])
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Allow using API keys with only `documents` scopes for TablesDB transactions

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
