### PR TITLE
fix(users): handle null name param #8785

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -215,7 +215,8 @@ App::post('/v1/users')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, ?string $email, ?string $phone, ?string $password, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, ?string $email, ?string $phone, ?string $password, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+        $name = $name ??  '';
         $user = createUser('plaintext', '{}', $userId, $email, $password, $phone, $name, $project, $dbForProject, $hooks);
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

"v1/users" in this endpoint when we were previously sending 'name' as null, it was giving error. And as per #8785, 'name' is optional, so simply just made it optional, now even if you pass as null, it works. Thankyou

## Test Plan

In postman i passed name as null and its working fine

<img width="649" height="643" alt="Screenshot 2025-10-17 at 5 20 07 AM" src="https://github.com/user-attachments/assets/fe157700-0661-4d05-8fe2-d36acec3767e" />


## Related PRs and Issues

- Fixes #8785

## Checklist

- [x ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
