### PR TITLE
docs: fix Docker command syntax in code autocompletion section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,9 @@ To get proper autocompletion for all the different functions and classes in the 
 
 ```bash
 docker run --rm --interactive --tty \
-  --volume $PWD:/app \
-  composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
+  --volume ${PWD}:/app \
+  composer update --ignore-platform-reqs --optimize-autoloader \
+  --no-plugins --no-scripts --prefer-dist
 ```
 
 ### User Interface


### PR DESCRIPTION
## Description
Fixed syntax errors in the Docker command provided in the Code Autocompletion section of CONTRIBUTING.md.

## Issue
Fixes #6039

## Changes Made
1. Fixed PWD variable syntax: Changed dollar-sign PWD to use braces for better cross-platform compatibility (especially Windows)
2. Added proper line continuation backslashes for multi-line command formatting
3. Split long options across multiple lines for improved readability

## Type of Change
- Documentation update
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have read the Contributing Guidelines and Code of Conduct