### PR TITLE
Fix warning builds worker

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -867,6 +867,7 @@ class Builds extends Action
 
             $deployment->setAttribute('buildLogs', $logs);
 
+            $adapter = null;
             if ($resource->getCollection() === 'sites' && !empty($detectionLogs)) {
                 $files = \explode("\n", $detectionLogs); // Parse output
                 $files = \array_filter($files); // Remove empty


### PR DESCRIPTION
fixes `Warning: Undefined variable $adapter in /usr/src/code/vendor/appwrite/server-ce/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php on line 905`