### PR TITLE
fix: Enable batch mode for issue triage safe-outputs

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -5,7 +5,7 @@
 #
 # Source: githubnext/agentics/workflows/issue-triage.md@0837fb7b24c3b84ee77fb7c8cfa8735c48be347a
 #
-# Effective stop-time: 2025-12-12 18:55:25
+# Effective stop-time: 2025-12-12 19:43:36
 #
 # Job Dependency Graph:
 # ```mermaid
@@ -2200,7 +2200,7 @@ jobs:
              - Suggest resources or links that might be helpful for resolving the issue or learning skills related to the issue or the particular area of the codebase affected by it
              - Mention any nudges or ideas that could help the team in addressing the issue
              - If appropriate break the issue down to sub-tasks and write a checklist of things to do
-             - Use collapsed-by-default sections in the GitHub markdown to keep the comment tidy. Collapse all sections except the short main summary at the top. Ensure text is bolded using markdown syntax.
+             - Use collapsed-by-default sections in the GitHub markdown to keep the comment tidy. Collapse all sections except the short main summary at the top. For bolded section titles, wrap the text with `<strong>` and `</strong>` to make it bold.
              - Do not indicate/encourage a community member to submit a PR for the issue.
           
           12. After processing all issues, provide a summary of how many issues were triaged (created or updated in the last 24 hours). If no issues matched the criteria, simply note that no issues needed triage.
@@ -5007,7 +5007,7 @@ jobs:
         id: check_stop_time
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
-          GH_AW_STOP_TIME: 2025-12-12 18:55:25
+          GH_AW_STOP_TIME: 2025-12-12 19:43:36
           GH_AW_WORKFLOW_NAME: "Agentic Triage"
         with:
           script: |

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -109,7 +109,7 @@ You're a triage assistant for GitHub issues. Your task is to analyze issues that
    - Suggest resources or links that might be helpful for resolving the issue or learning skills related to the issue or the particular area of the codebase affected by it
    - Mention any nudges or ideas that could help the team in addressing the issue
    - If appropriate break the issue down to sub-tasks and write a checklist of things to do
-   - Use collapsed-by-default sections in the GitHub markdown to keep the comment tidy. Collapse all sections except the short main summary at the top. Ensure text is bolded using markdown syntax.
+   - Use collapsed-by-default sections in the GitHub markdown to keep the comment tidy. Collapse all sections except the short main summary at the top. For bolded section titles, wrap the text with `<strong>` and `</strong>` to make it bold.
    - Do not indicate/encourage a community member to submit a PR for the issue.
 
 12. After processing all issues, provide a summary of how many issues were triaged (created or updated in the last 24 hours). If no issues matched the criteria, simply note that no issues needed triage.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The new [issue triage](https://github.com/appwrite/appwrite/blob/main/.github/workflows/issue-triage.md) workflow [ran](https://github.com/appwrite/appwrite/actions/runs/19146090321/job/54724079504), but it didn't create any issues or applied any labels:

<img width="354" height="460" alt="image" src="https://github.com/user-attachments/assets/a8c1eb78-2599-4c30-8bd5-64931ca853fb" />

To fix this: 

- Add target: "*" to safe-outputs configuration for add-labels and add-comment
- This allows the workflow to apply comments and labels to multiple issues when running in scheduled/manual trigger mode (batch processing)
- Previously, safe-outputs jobs were skipped because they required github.event.issue.number which only exists in event-triggered runs
- With target: "*", the workflow now reads issue numbers from the agent output and applies changes to each issue individually

## Test Plan

Manual

## Related PRs and Issues

None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
