### PR TITLE
fix(10781): resolve VCS webhook authorization error in cleanup operations

### DIFF
--- a/app/controllers/api/vcs.php
+++ b/app/controllers/api/vcs.php
@@ -166,7 +166,7 @@ $createGitDeployments = function (GitHub $github, string $providerInstallationId
 
                             $latestCommentId = \strval($github->updateComment($owner, $repositoryName, $latestCommentId, $comment->generateComment()));
                         } finally {
-                            $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId);
+                            Authorization::skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId));
                         }
                     }
                 } else {
@@ -237,7 +237,7 @@ $createGitDeployments = function (GitHub $github, string $providerInstallationId
 
                             $latestCommentId = \strval($github->updateComment($owner, $repositoryName, $latestCommentId, $comment->generateComment()));
                         } finally {
-                            $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId);
+                            Authorization::skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId));
                         }
                     }
                 }
@@ -458,7 +458,7 @@ $createGitDeployments = function (GitHub $github, string $providerInstallationId
                             $github->updateComment($owner, $repositoryName, $latestCommentId, $comment->generateComment());
                         }
                     } finally {
-                        $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId);
+                        Authorization::skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId));
                     }
                 }
             }


### PR DESCRIPTION


## What does this PR do?

Fixes a critical authorization bug in the VCS webhook handler (/v1/vcs/github/events) that prevented GitHub webhook events (PR opened, push, etc.) from triggering builds.
The issue occurred because cleanup operations attempted to delete vcsCommentLocks documents without bypassing authorization, causing "No permissions provided for action 'delete'" errors.

This PR wraps all affected deleteDocument('vcsCommentLocks', …) calls in Authorization::skip() to ensure cleanup runs in an elevated context, consistent with other administrative operations in the same controller.

## Test Plan

Setup:

Deploy Appwrite v1.8.0+ with GitHub App integration enabled.

Connect a GitHub repository to an Appwrite Site.

Before fix:

Opening or updating a PR causes webhooks to fail.
Docker logs show: No permissions provided for action 'delete'
Preview builds remain stuck in "Waiting for build to start..."

After Fix

Apply this patch and restart the Appwrite container.
Trigger a webhook event (open PR or push).

Verify:
Webhook processes successfully.
vcsCommentLocks documents are deleted correctly.
Build job is queued.
Preview deployment starts as expected.

## Related PRs and Issues

Fixes: #10781
Component: Sites / VCS Integration
File: app/controllers/api/vcs.php

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes I have
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
No metadata or schema changes.
