### PR TITLE
feat: add metric validation in StatsUsage worker

### DIFF
--- a/src/Appwrite/Platform/Workers/StatsUsage.php
+++ b/src/Appwrite/Platform/Workers/StatsUsage.php
@@ -162,9 +162,9 @@ class StatsUsage extends Action
         METRIC_MESSAGES_TYPE => '/^messages\.(email|sms|push)$/',
         METRIC_MESSAGES_TYPE_SENT => '/^messages\.(email|sms|push)\.sent$/',
         METRIC_MESSAGES_TYPE_FAILED => '/^messages\.(email|sms|push)\.failed$/',
-        METRIC_MESSAGES_TYPE_PROVIDER => '/^messages\.(email|sms|push)\..+$/',
-        METRIC_MESSAGES_TYPE_PROVIDER_SENT => '/^messages\.(email|sms|push)\..+\.sent$/',
-        METRIC_MESSAGES_TYPE_PROVIDER_FAILED => '/^messages\.(email|sms|push)\..+\.failed$/',
+        METRIC_MESSAGES_TYPE_PROVIDER => '/^messages\.(email|sms|push)\.[^.]+$/',
+        METRIC_MESSAGES_TYPE_PROVIDER_SENT => '/^messages\.(email|sms|push)\.[^.]+\.sent$/',
+        METRIC_MESSAGES_TYPE_PROVIDER_FAILED => '/^messages\.(email|sms|push)\.[^.]+\.failed$/',
         METRIC_DATABASE_ID_COLLECTIONS => '/^\d+\.collections$/',
         METRIC_DATABASE_ID_STORAGE => '/^\d+\.databases\.storage$/',
         METRIC_DATABASE_ID_DOCUMENTS => '/^\d+\.documents$/',
@@ -206,8 +206,8 @@ class StatsUsage extends Action
         METRIC_SITES_ID_INBOUND => '/^sites\.\d+\.inbound$/',
         METRIC_SITES_ID_OUTBOUND => '/^sites\.\d+\.outbound$/',
         METRIC_PROVIDER_TYPE_TARGETS => '/^(email|sms|push)\.targets$/',
-        METRIC_FUNCTIONS_RUNTIME => '/^functions\.runtimes\..+$/',
-        METRIC_SITES_FRAMEWORK => '/^sites\.frameworks\..+$/',
+        METRIC_FUNCTIONS_RUNTIME => '/^functions\.runtimes\.[^.]+$/',
+        METRIC_SITES_FRAMEWORK => '/^sites\.frameworks\.[^.]+$/',
     ];
 
     /**


### PR DESCRIPTION
## What does this PR do?

This PR adds validation to the `StatsUsage` worker to ensure only metrics defined in `constants.php` are processed and stored in the database. Previously, any metric could be added to the payload without verification, which could lead to invalid or malicious data being stored.

## Changes

- Added `$validMetrics` array containing all static metric constants from `constants.php`
- Added `$validMetricPatterns` array with regex patterns to validate dynamic metrics (those with placeholders like `{databaseInternalId}`, `{resourceType}`, etc.)
- Added `isValidMetric()` method to validate metric keys against both static and pattern-based metrics
- Updated `action()` method to skip invalid metrics with console warning messages
- Only valid metrics are now processed and counted

## Benefits

✅ **Security**: Unknown or malicious metrics are rejected  
✅ **Data Integrity**: Only metrics defined in constants are processed  
✅ **Debugging**: Console warnings alert when unknown metrics are received  
✅ **Performance**: Invalid metrics are skipped early, reducing unnecessary processing

## Test Plan

- [x] Syntax validation passed
- [ ] Test with valid metrics - should process normally
- [ ] Test with invalid metrics - should skip with warning
- [ ] Test with dynamic metrics (e.g., `123.collections`) - should validate correctly

## Related Issues

Closes #<issue_number_if_any>