### PR TITLE
Fix: add default fallback to Flutter framework

### DIFF
--- a/app/config/frameworks.php
+++ b/app/config/frameworks.php
@@ -282,6 +282,7 @@ return [
                 'installCommand' => 'flutter pub get',
                 'outputDirectory' => './build/web',
                 'startCommand' => 'bash helpers/server.sh',
+                'fallbackFile' => 'index.html'
             ],
         ],
     ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Adds default fallback file `index.html` to Flutter framework

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
