### PR TITLE
fix: enable SMTPAuth validation for SMTP settings (#9067)

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -2080,6 +2080,7 @@ App::patch('/v1/projects/:projectId/smtp')
             $mail->SMTPSecure = $secure;
             $mail->SMTPAutoTLS = false;
             $mail->Timeout = 5;
+                        $mail->SMTPAuth = (!empty($username) && !empty($password));
 
             try {
                 $valid = $mail->SmtpConnect();


### PR DESCRIPTION
Previously, updating SMTP settings with invalid credentials would succeed because SMTPAuth was not set to true, preventing credential validation.

This fix sets SMTPAuth based on whether username and password are provided, ensuring that SmtpConnect() properly validates credentials before accepting the SMTP configuration.

Fixes #9067

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
