### PR TITLE
refactor(builds): remove queue magic

### DIFF
--- a/app/controllers/api/vcs.php
+++ b/app/controllers/api/vcs.php
@@ -499,17 +499,14 @@ $createGitDeployments = function (GitHub $github, string $providerInstallationId
                 ->setType(BUILD_TYPE_DEPLOYMENT)
                 ->setResource($resource)
                 ->setDeployment($deployment)
-                ->setProject($project); // set the project because it won't be set for git deployments
-
-            $queueForBuilds->trigger(); // must trigger here so that we create a build for each function/site
+                ->setProject($project)
+                ->trigger();
 
             //TODO: Add event?
         } catch (Throwable $e) {
             $errors[] = $e->getMessage();
         }
     }
-
-    $queueForBuilds->reset(); // prevent shutdown hook from triggering again
 
     if (!empty($errors)) {
         throw new Exception(Exception::GENERAL_UNKNOWN, \implode("\n", $errors));

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -4,7 +4,6 @@ use Appwrite\Auth\Auth;
 use Appwrite\Auth\Key;
 use Appwrite\Auth\MFA\Type\TOTP;
 use Appwrite\Event\Audit;
-use Appwrite\Event\Build;
 use Appwrite\Event\Database as EventDatabase;
 use Appwrite\Event\Delete;
 use Appwrite\Event\Event;
@@ -439,7 +438,6 @@ App::init()
     ->inject('queueForAudits')
     ->inject('queueForDeletes')
     ->inject('queueForDatabase')
-    ->inject('queueForBuilds')
     ->inject('queueForStatsUsage')
     ->inject('dbForProject')
     ->inject('timelimit')
@@ -450,7 +448,7 @@ App::init()
     ->inject('devKey')
     ->inject('telemetry')
     ->inject('authorization')
-    ->action(function (App $utopia, Request $request, Response $response, Document $project, Document $user, Publisher $publisher, Publisher $publisherFunctions, Publisher $publisherWebhooks, Event $queueForEvents, Messaging $queueForMessaging, Audit $queueForAudits, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, StatsUsage $queueForStatsUsage, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, Authorization $authorization) use ($usageDatabaseListener, $eventDatabaseListener) {
+    ->action(function (App $utopia, Request $request, Response $response, Document $project, Document $user, Publisher $publisher, Publisher $publisherFunctions, Publisher $publisherWebhooks, Event $queueForEvents, Messaging $queueForMessaging, Audit $queueForAudits, Delete $queueForDeletes, EventDatabase $queueForDatabase, StatsUsage $queueForStatsUsage, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, Authorization $authorization) use ($usageDatabaseListener, $eventDatabaseListener) {
 
         $route = $utopia->getRoute();
 
@@ -556,7 +554,6 @@ App::init()
 
         $queueForDeletes->setProject($project);
         $queueForDatabase->setProject($project);
-        $queueForBuilds->setProject($project);
         $queueForMessaging->setProject($project);
 
         // Clone the queues, to prevent events triggered by the database listener
@@ -737,14 +734,13 @@ App::shutdown()
     ->inject('queueForStatsUsage')
     ->inject('queueForDeletes')
     ->inject('queueForDatabase')
-    ->inject('queueForBuilds')
     ->inject('queueForMessaging')
     ->inject('queueForFunctions')
     ->inject('queueForWebhooks')
     ->inject('queueForRealtime')
     ->inject('dbForProject')
     ->inject('authorization')
-    ->action(function (App $utopia, Request $request, Response $response, Document $project, Document $user, Event $queueForEvents, Audit $queueForAudits, StatsUsage $queueForStatsUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization) use ($parseLabel) {
+    ->action(function (App $utopia, Request $request, Response $response, Document $project, Document $user, Event $queueForEvents, Audit $queueForAudits, StatsUsage $queueForStatsUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization) use ($parseLabel) {
 
         $responsePayload = $response->getPayload();
 
@@ -838,10 +834,6 @@ App::shutdown()
 
         if (!empty($queueForDatabase->getType())) {
             $queueForDatabase->trigger();
-        }
-
-        if (!empty($queueForBuilds->getType())) {
-            $queueForBuilds->trigger();
         }
 
         if (!empty($queueForMessaging->getType())) {

--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -137,7 +137,9 @@ class Base extends Action
             ->setType(BUILD_TYPE_DEPLOYMENT)
             ->setResource($function)
             ->setDeployment($deployment)
-            ->setTemplate($template);
+            ->setTemplate($template)
+            ->setProject($project)
+            ->trigger();
 
         return $deployment;
     }
@@ -331,7 +333,9 @@ class Base extends Action
             ->setType(BUILD_TYPE_DEPLOYMENT)
             ->setResource($site)
             ->setDeployment($deployment)
-            ->setTemplate($template);
+            ->setTemplate($template)
+            ->setProject($project)
+            ->trigger();
 
         return $deployment;
     }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -265,7 +265,9 @@ class Create extends Action
             $queueForBuilds
                 ->setType(BUILD_TYPE_DEPLOYMENT)
                 ->setResource($function)
-                ->setDeployment($deployment);
+                ->setDeployment($deployment)
+                ->setProject($project)
+                ->trigger();
         } else {
             if ($deployment->isEmpty()) {
                 $deployment = $dbForProject->createDocument('deployments', new Document([

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
@@ -57,6 +58,7 @@ class Create extends Action
             ->param('functionId', '', new UID(), 'Function ID.')
             ->param('deploymentId', '', new UID(), 'Deployment ID.')
             ->param('buildId', '', new UID(), 'Build unique ID.', true) // added as optional param for backward compatibility
+            ->inject('project')
             ->inject('response')
             ->inject('dbForProject')
             ->inject('queueForEvents')
@@ -69,6 +71,7 @@ class Create extends Action
         string $functionId,
         string $deploymentId,
         string $buildId,
+        Document $project,
         Response $response,
         Database $dbForProject,
         Event $queueForEvents,
@@ -123,7 +126,9 @@ class Create extends Action
         $queueForBuilds
             ->setType(BUILD_TYPE_DEPLOYMENT)
             ->setResource($function)
-            ->setDeployment($deployment);
+            ->setDeployment($deployment)
+            ->setProject($project)
+            ->trigger();
 
         $queueForEvents
             ->setParam('functionId', $function->getId())

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
@@ -51,7 +51,7 @@ class Create extends Base
                 name: 'createTemplateDeployment',
                 description: <<<EOT
                 Create a deployment based on a template.
-                
+
                 Use this endpoint with combination of [listTemplates](https://appwrite.io/docs/products/functions/templates) to find the template details.
                 EOT,
                 auth: [AuthType::KEY],
@@ -174,7 +174,9 @@ class Create extends Base
             ->setType(BUILD_TYPE_DEPLOYMENT)
             ->setResource($function)
             ->setDeployment($deployment)
-            ->setTemplate($template);
+            ->setTemplate($template)
+            ->setProject($project)
+            ->trigger();
 
         $queueForEvents
             ->setParam('functionId', $function->getId())

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -357,7 +357,9 @@ class Create extends Base
                     ->setType(BUILD_TYPE_DEPLOYMENT)
                     ->setResource($function)
                     ->setDeployment($deployment)
-                    ->setTemplate($template);
+                    ->setTemplate($template)
+                    ->setProject($project)
+                    ->trigger();
             }
 
             $functionsDomain = System::getEnv('_APP_DOMAIN_FUNCTIONS', '');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -305,7 +305,9 @@ class Create extends Action
             $queueForBuilds
                 ->setType(BUILD_TYPE_DEPLOYMENT)
                 ->setResource($site)
-                ->setDeployment($deployment);
+                ->setDeployment($deployment)
+                ->setProject($project)
+                ->trigger();
         } else {
             if ($deployment->isEmpty()) {
                 $deployment = $dbForProject->createDocument('deployments', new Document([

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -171,7 +171,9 @@ class Create extends Action
         $queueForBuilds
             ->setType(BUILD_TYPE_DEPLOYMENT)
             ->setResource($site)
-            ->setDeployment($deployment);
+            ->setDeployment($deployment)
+            ->setProject($project)
+            ->trigger();
 
         $queueForEvents
             ->setParam('siteId', $site->getId())

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
@@ -53,7 +53,7 @@ class Create extends Base
                 name: 'createTemplateDeployment',
                 description: <<<EOT
                 Create a deployment based on a template.
-                
+
                 Use this endpoint with combination of [listTemplates](https://appwrite.io/docs/products/sites/templates) to find the template details.
                 EOT,
                 auth: [AuthType::KEY],
@@ -215,7 +215,9 @@ class Create extends Base
             ->setType(BUILD_TYPE_DEPLOYMENT)
             ->setResource($site)
             ->setDeployment($deployment)
-            ->setTemplate($template);
+            ->setTemplate($template)
+            ->setProject($project)
+            ->trigger();
 
         $queueForEvents
             ->setParam('siteId', $site->getId())


### PR DESCRIPTION
Like others `queueForBuilds` is using some magic. In the API init hooks we do `setProject` and in the shutdown hook we automatically call `trigger`.

Trades some duplication for clarity - but I think it's worth it.
We should avoid magic, and definitely mutating objects across contexts - because it's really easy to make mistakes.

