### PR TITLE
feat: docker-compose maildev update, traefik localhost domains

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1161,7 +1161,11 @@ services:
       - appwrite
       - gateway
     environment:
-      - REDIS_HOSTS=redis
+      - RI_PRE_SETUP_DATABASES_PATH=/mnt/connections.json
+    configs:
+      - source: redisinsight-connections.json
+        target: /mnt/connections.json
+        mode: 0755
     labels:
       - "traefik.enable=true"
       - "traefik.constraint-label-stack=appwrite"
@@ -1202,6 +1206,41 @@ configs:
   redisinsight-connections.json:
     content: |
       [
+        {
+          "compressor": "NONE",
+          "id": "104dc90a-21ef-4d5e-8912-b30baabb152f",
+          "host": "redis",
+          "port": 6379,
+          "name": "redis:6379",
+          "db": 0,
+          "username": "default",
+          "password": null,
+          "connectionType": "STANDALONE",
+          "nameFromProvider": null,
+          "provider": "REDIS",
+          "lastConnection": "2025-10-16T09:22:02.591Z",
+          "modules": [
+            {
+              "name": "ReJSON",
+              "version": 20808,
+              "semanticVersion": "2.8.8"
+            },
+            {
+              "name": "search",
+              "version": 21015,
+              "semanticVersion": "2.10.15"
+            }
+          ],
+          "tls": false,
+          "tlsServername": null,
+          "verifyServerCert": null,
+          "caCert": null,
+          "clientCert": null,
+          "ssh": false,
+          "sshOptions": null,
+          "forceStandalone": false,
+          "tags": []
+        }
       ]
 
   adminer-index.php:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The appwrite/mailcatcher image has been updated as it wasn't updated for quite some time - i.e., 5 years, it was missing quite some features. In addition traefik configuration through labels adds the option to navigate to localhost domain names for easy access.

## Test Plan

Run the docker-compose and check whether the latest images works in addition to the `mail.localhost`, `redis.localhost`, `mysql.localhost`, e.g.: 

<img width="1176" height="403" alt="image" src="https://github.com/user-attachments/assets/d7acee05-6f91-44a6-8f50-2cffb6bddb0d" />

## Related PRs and Issues

- https://github.com/appwrite/docker-mailcatcher/pull/8

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
