### PR TITLE
fixed api key creation with expire:never - bug

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -1498,7 +1498,7 @@ App::post('/v1/projects/:projectId/keys')
             'projectId' => $project->getId(),
             'name' => $name,
             'scopes' => $scopes,
-            'expire' => $expire,
+            'expire' => $expire ?? null,
             'sdks' => [],
             'accessedAt' => null,
             'secret' => API_KEY_STANDARD . '_' . \bin2hex(\random_bytes(128)),
@@ -1637,7 +1637,7 @@ App::put('/v1/projects/:projectId/keys/:keyId')
         $key
             ->setAttribute('name', $name)
             ->setAttribute('scopes', $scopes)
-            ->setAttribute('expire', $expire);
+            ->setAttribute('expire', $expire ?? null);
 
         $dbForPlatform->updateDocument('keys', $key->getId(), $key);
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -844,7 +844,7 @@ App::setResource('devKey', function (Request $request, Document $project, array 
 
     // check expiration
     $expire = $key->getAttribute('expire');
-    if (!empty($expire) && $expire < DatabaseDateTime::formatTz(DatabaseDateTime::now())) {
+    if ($expire !== null && !empty($expire) && $expire < DatabaseDateTime::formatTz(DatabaseDateTime::now())) {
         return new Document([]);
     }
 

--- a/src/Appwrite/Auth/Key.php
+++ b/src/Appwrite/Auth/Key.php
@@ -178,7 +178,7 @@ class Key
                 }
 
                 $expire = $key->getAttribute('expire');
-                if (!empty($expire) && $expire < DateTime::formatTz(DateTime::now())) {
+                if ($expire !== null && !empty($expire) && $expire < DateTime::formatTz(DateTime::now())) {
                     $expired = true;
                 }
 


### PR DESCRIPTION
This pull request improves how API key expiration is handled by ensuring that the `expire` attribute is consistently set to `null` when not provided, and by updating expiration checks to explicitly handle `null` values. This prevents potential issues with empty or unset expiration dates, making the codebase more robust and predictable.

**Expiration handling improvements:**

* In `app/controllers/api/projects.php`, both API key creation and update now set the `expire` attribute to `null` if not provided, ensuring consistency in the stored value. [[1]](diffhunk://#diff-d23e87a7ab11afb8b33ef1f815fb507126f0993da92c71e8a361d2a944a24dc7L1501-R1501) [[2]](diffhunk://#diff-d23e87a7ab11afb8b33ef1f815fb507126f0993da92c71e8a361d2a944a24dc7L1640-R1640)
* Expiration checks in `app/init/resources.php` and `src/Appwrite/Auth/Key.php` now explicitly verify that `expire` is not `null` before comparing dates, preventing logic errors when `expire` is unset. [[1]](diffhunk://#diff-edfae07d9d555f902e33e12d543c8993aa306def19f9cbacefcf7b0fe14ef4bcL847-R847) [[2]](diffhunk://#diff-ff6f4930f9a39f7cb97f68be7eb71b71398f0d0e730747f9bc15721d1128596fL181-R181)