### PR TITLE
Improve SMTP error logging in development

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -315,6 +315,11 @@ $register->set('smtp', function () {
     $mail->SMTPAutoTLS = false;
     $mail->CharSet = 'UTF-8';
 
+    // Enable SMTP debug in development environment
+    if (System::getEnv('_APP_ENV', 'development') === 'development') {
+        $mail->SMTPDebug = true;
+    }
+
     $from = \urldecode(System::getEnv('_APP_SYSTEM_EMAIL_NAME', APP_NAME . ' Server'));
     $email = System::getEnv('_APP_SYSTEM_EMAIL_ADDRESS', APP_EMAIL_TEAM);
 

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -198,6 +198,11 @@ class Mails extends Action
         $mail->SMTPAutoTLS = false;
         $mail->CharSet = 'UTF-8';
 
+        // Enable SMTP debug in development environment
+        if (System::getEnv('_APP_ENV', 'development') === 'development') {
+            $mail->SMTPDebug = true;
+        }
+
         $mail->setFrom($smtp['senderEmail'], $smtp['senderName']);
 
         $mail->isHTML();


### PR DESCRIPTION
## What does this PR do?

This PR improves the debugging experience for SMTP email delivery in the Mails worker by conditionally enabling PHPMailer's SMTP debug output when running in a development environment.

### Key changes:
- Conditionally set `$mail->SMTPDebug = true` when `_APP_ENV=development`
- Applied this logic in both:
  - the `getMailer()` method
  - the SMTP registration closure
- Improves troubleshooting of SMTP-related issues without affecting production logs
- Fixes **#1390**

This change helps developers quickly identify SMTP configuration or server issues during development while keeping production logs clean and secure.

---

## Test Plan

- Set `_APP_ENV=development` and triggered email sending  
  - Verified detailed PHPMailer SMTP debug output is displayed  
- Set `_APP_ENV=production`  
  - Confirmed no debug output and normal behavior  
- Ensured both `getMailer()` and the SMTP closure correctly apply the environment-based condition  
- Verified no regressions in existing email delivery functionality

---

## Related PRs and Issues

- Fixes **#1390**

---

## Checklist

-  I have read the [Contributing Guidelines](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)
-  This PR does not modify API metadata
