### PR TITLE
Refactor schedule base

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -195,7 +195,6 @@ abstract class ScheduleBase extends Action
         }
         if (empty($this->schedules)) {
             Console::success("No resources found");
-            return;
         }
 
         // On initial load: load all projects from all schedules


### PR DESCRIPTION
Optimizing project fetching by using a find() query instead of  getDocument() per schedule
And keeping projects in a map to prevent redundant projects.