### PR TITLE
chore: bump base docker image version to 0.10.6 to fix vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:0.10.5 AS final
+FROM appwrite/base:0.10.6 AS final
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Our security scans reported several packages we used were out of date and required updates to patch security vulnerabilities.

This PR bumps our docker base image to fix the vulnerabilities

## Test Plan

Automated tests should pass

## Related PRs and Issues

- https://github.com/appwrite/docker-base/pull/55

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
