### PR TITLE
Add public visibility control for deprecated methods

### DIFF
--- a/app/config/specs/open-api3-1.8.x-client.json
+++ b/app/config/specs/open-api3-1.8.x-client.json
@@ -62,6 +62,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -111,6 +112,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -196,6 +198,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -272,6 +275,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -342,6 +346,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -405,6 +410,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -454,6 +460,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -531,6 +538,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -601,6 +609,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -627,6 +636,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -652,7 +662,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -721,6 +732,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -749,6 +761,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -776,7 +789,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -857,6 +871,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -882,6 +897,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -906,7 +922,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -977,6 +994,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1003,6 +1021,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1028,7 +1047,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1105,6 +1125,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1133,6 +1154,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1160,7 +1182,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1239,6 +1262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1261,6 +1285,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1282,7 +1307,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1336,6 +1362,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1358,6 +1385,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1379,7 +1407,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1431,6 +1460,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1453,6 +1483,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1474,7 +1505,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1526,6 +1558,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1548,6 +1581,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1569,7 +1603,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1623,6 +1658,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1693,6 +1729,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1768,6 +1805,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1844,6 +1882,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1893,6 +1932,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1966,6 +2006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2040,6 +2081,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2122,6 +2164,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2164,6 +2207,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2215,6 +2259,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2264,6 +2309,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2338,6 +2384,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2409,6 +2456,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2551,6 +2599,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2629,6 +2678,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2703,6 +2753,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2764,6 +2815,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2818,6 +2870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2881,6 +2934,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2931,6 +2985,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3010,6 +3065,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3081,6 +3137,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3146,6 +3203,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3228,6 +3286,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3305,6 +3364,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3450,6 +3510,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3524,6 +3585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3545,7 +3607,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3568,6 +3631,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3642,6 +3706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3665,7 +3730,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3690,6 +3756,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3775,6 +3842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3824,6 +3892,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3894,6 +3963,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4020,6 +4090,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4152,6 +4223,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4210,6 +4282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4698,6 +4771,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4780,6 +4854,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4872,6 +4947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4964,6 +5040,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5715,6 +5792,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5780,6 +5858,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5848,6 +5927,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5910,6 +5990,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5986,6 +6067,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6050,6 +6132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6133,6 +6216,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -6243,6 +6327,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -6277,6 +6362,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -6401,6 +6487,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -6510,6 +6597,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -6544,6 +6632,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -6666,6 +6755,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -6776,6 +6866,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -6882,6 +6973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -7008,6 +7100,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -7133,6 +7226,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7219,6 +7313,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7336,6 +7431,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7410,6 +7506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7462,6 +7559,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7514,6 +7612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7566,6 +7665,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7618,6 +7718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7670,6 +7771,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7722,6 +7824,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7774,6 +7877,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7826,6 +7930,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7878,6 +7983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7931,6 +8037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8014,6 +8121,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8088,6 +8196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8185,6 +8294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8284,6 +8394,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8356,6 +8467,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8447,6 +8559,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8514,6 +8627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8592,6 +8706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8820,6 +8935,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8908,6 +9024,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8976,6 +9093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9047,6 +9165,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9112,6 +9231,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9191,6 +9311,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9258,6 +9379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9344,6 +9466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9453,6 +9576,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -9482,7 +9606,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9606,6 +9731,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9714,6 +9840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -9742,7 +9869,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9861,6 +9989,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9970,6 +10099,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10075,6 +10205,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10200,6 +10331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10321,6 +10453,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10408,6 +10541,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10493,6 +10627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10555,6 +10690,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10629,6 +10765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10693,6 +10830,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10790,6 +10928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10908,6 +11047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10980,6 +11120,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11074,6 +11215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11147,6 +11289,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11245,6 +11388,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11306,6 +11450,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-1.8.x-console.json
+++ b/app/config/specs/open-api3-1.8.x-console.json
@@ -62,6 +62,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -110,6 +111,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -185,6 +187,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -234,6 +237,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -309,6 +313,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -378,6 +383,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -440,6 +446,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -489,6 +496,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -565,6 +573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -634,6 +643,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -660,6 +670,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -685,7 +696,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -753,6 +765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -781,6 +794,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -808,7 +822,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -888,6 +903,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -913,6 +929,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -937,7 +954,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1007,6 +1025,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1033,6 +1052,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1058,7 +1078,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1135,6 +1156,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1163,6 +1185,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1190,7 +1213,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1268,6 +1292,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1290,6 +1315,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1311,7 +1337,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1364,6 +1391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1386,6 +1414,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1407,7 +1436,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1458,6 +1488,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1480,6 +1511,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1501,7 +1533,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1552,6 +1585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1574,6 +1608,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1595,7 +1630,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1648,6 +1684,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1717,6 +1754,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1791,6 +1829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1866,6 +1905,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1914,6 +1954,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1986,6 +2027,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2059,6 +2101,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2140,6 +2183,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2181,6 +2225,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2231,6 +2276,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2280,6 +2326,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2354,6 +2401,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2425,6 +2473,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2567,6 +2616,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2645,6 +2695,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2719,6 +2770,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2779,6 +2831,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2832,6 +2885,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2894,6 +2948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2943,6 +2998,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3021,6 +3077,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3091,6 +3148,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3155,6 +3213,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3237,6 +3296,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3314,6 +3374,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3459,6 +3520,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3533,6 +3595,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3554,7 +3617,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3577,6 +3641,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3650,6 +3715,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3673,7 +3739,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3698,6 +3765,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3782,6 +3850,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3830,6 +3899,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3899,6 +3969,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4025,6 +4096,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4157,6 +4229,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4215,6 +4288,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4703,6 +4777,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4785,6 +4860,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4877,6 +4953,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4969,6 +5046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5711,6 +5789,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5771,6 +5850,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5846,6 +5926,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5894,6 +5975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -5920,6 +6002,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -6010,6 +6093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -6039,6 +6123,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -6126,6 +6211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6191,6 +6277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6259,6 +6346,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6321,6 +6409,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6397,6 +6486,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6461,6 +6551,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6542,6 +6633,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listUsage"
@@ -6566,6 +6658,7 @@
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/list-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listUsage"
@@ -6644,6 +6737,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6670,6 +6764,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6735,6 +6830,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6764,6 +6860,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6846,6 +6943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6871,6 +6969,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -6938,6 +7037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -7036,6 +7136,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -7161,6 +7262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -7234,6 +7336,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -7338,6 +7441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -7413,6 +7517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -7512,6 +7617,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7623,6 +7729,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7739,6 +7846,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7850,6 +7958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -7966,6 +8075,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -8077,6 +8187,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -8193,6 +8304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -8313,6 +8425,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -8438,6 +8551,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8561,6 +8675,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8689,6 +8804,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8812,6 +8928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -8940,6 +9057,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -9051,6 +9169,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -9167,6 +9286,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -9280,6 +9400,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -9402,6 +9523,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -9515,6 +9637,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9637,6 +9760,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9750,6 +9874,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9872,6 +9997,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -10009,6 +10135,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -10131,6 +10258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -10253,6 +10381,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -10364,6 +10493,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10511,6 +10641,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10586,6 +10717,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10670,6 +10802,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10786,6 +10919,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10896,6 +11030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10930,6 +11065,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10961,6 +11097,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -11082,6 +11219,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -11113,6 +11251,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -11217,6 +11356,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -11321,6 +11461,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -11423,6 +11564,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11532,6 +11674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11566,6 +11709,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11688,6 +11832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11798,6 +11943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11901,6 +12047,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRowLogs"
@@ -12001,6 +12148,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -12127,6 +12275,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -12250,6 +12399,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -12347,6 +12497,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -12486,6 +12637,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -12561,6 +12713,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12645,6 +12798,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTableLogs"
@@ -12732,6 +12886,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTableUsage"
@@ -12828,6 +12983,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12855,6 +13011,7 @@
                             ],
                             "description": "Get the database activity logs list by its unique ID.",
                             "demo": "databases\/list-logs.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12934,6 +13091,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getUsage"
@@ -12961,6 +13119,7 @@
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/get-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.getUsage"
@@ -13049,6 +13208,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13133,6 +13293,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13427,6 +13588,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13477,6 +13639,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13526,6 +13689,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13718,6 +13882,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13778,6 +13943,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13850,6 +14016,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13909,6 +14076,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14200,6 +14368,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14261,6 +14430,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14341,6 +14511,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14435,6 +14606,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14533,6 +14705,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14618,6 +14791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14734,6 +14908,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14831,6 +15006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14893,6 +15069,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14958,6 +15135,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15047,6 +15225,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15120,6 +15299,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15206,6 +15386,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15323,6 +15504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15386,6 +15568,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15457,6 +15640,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15539,6 +15723,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15598,6 +15783,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15689,6 +15875,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15758,6 +15945,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15851,6 +16039,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15924,6 +16113,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15976,6 +16166,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16026,6 +16217,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16075,6 +16267,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16124,6 +16317,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16173,6 +16367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16233,6 +16428,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16282,6 +16478,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16331,6 +16528,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16393,6 +16591,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16455,6 +16654,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16528,6 +16728,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16590,6 +16791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16678,6 +16880,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16740,6 +16943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16802,6 +17006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16864,6 +17069,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16926,6 +17132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16988,6 +17195,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17050,6 +17258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17112,6 +17321,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17174,6 +17384,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17223,6 +17434,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17272,6 +17484,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17323,6 +17536,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17375,6 +17589,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17427,6 +17642,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17479,6 +17695,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17531,6 +17748,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17583,6 +17801,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17635,6 +17854,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17687,6 +17907,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17738,6 +17959,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17825,6 +18047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17970,6 +18193,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18127,6 +18351,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18303,6 +18528,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18499,6 +18725,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -18532,6 +18759,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -18564,7 +18792,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18677,6 +18906,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -18709,6 +18939,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -18740,7 +18971,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18861,6 +19093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18914,6 +19147,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18976,6 +19210,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19062,6 +19297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19148,6 +19384,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19235,6 +19472,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -19269,6 +19507,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -19302,7 +19541,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19411,6 +19651,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -19444,6 +19685,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -19476,7 +19718,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19589,6 +19832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -19619,6 +19863,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -19648,7 +19893,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19738,6 +19984,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -19767,6 +20014,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -19795,7 +20043,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19888,6 +20137,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20005,6 +20255,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20125,6 +20376,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20221,6 +20473,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20320,6 +20573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20426,6 +20680,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20535,6 +20790,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20641,6 +20897,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20750,6 +21007,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -20791,6 +21049,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -20831,7 +21090,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -20978,6 +21238,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -21017,6 +21278,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -21055,7 +21317,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -21206,6 +21469,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21302,6 +21566,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21401,6 +21666,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21497,6 +21763,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21596,6 +21863,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21692,6 +21960,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21791,6 +22060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21887,6 +22157,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21986,6 +22257,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22039,6 +22311,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22101,6 +22374,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22187,6 +22461,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22273,6 +22548,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22358,6 +22634,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22441,6 +22718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22501,6 +22779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22580,6 +22859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22642,6 +22922,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22728,6 +23009,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22825,6 +23107,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22913,6 +23196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22978,6 +23262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23050,6 +23335,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23135,6 +23421,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23243,6 +23530,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23356,6 +23644,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23470,6 +23759,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23554,6 +23844,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23644,6 +23935,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23730,6 +24022,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23856,6 +24149,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24004,6 +24298,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24124,6 +24419,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24263,6 +24559,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24321,6 +24618,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24372,6 +24670,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24432,6 +24731,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24520,6 +24820,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24566,6 +24867,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24644,6 +24946,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24702,6 +25005,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24784,6 +25088,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24844,6 +25149,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24927,6 +25233,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25061,6 +25368,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25119,6 +25427,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25234,6 +25543,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25294,6 +25604,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatus"
@@ -25324,6 +25635,7 @@
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
                             "demo": "projects\/update-api-status.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatus"
@@ -25353,7 +25665,8 @@
                                 }
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
-                            "demo": "projects\/update-api-status.md"
+                            "demo": "projects\/update-api-status.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25448,6 +25761,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatusAll"
@@ -25476,6 +25790,7 @@
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
                             "demo": "projects\/update-api-status-all.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatusAll"
@@ -25503,7 +25818,8 @@
                                 }
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
-                            "demo": "projects\/update-api-status-all.md"
+                            "demo": "projects\/update-api-status-all.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25585,6 +25901,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25664,6 +25981,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25743,6 +26061,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25822,6 +26141,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25913,6 +26233,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25995,6 +26316,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26074,6 +26396,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26153,6 +26476,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26232,6 +26556,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26311,6 +26636,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26390,6 +26716,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26490,6 +26817,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26561,6 +26889,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26646,6 +26975,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26714,6 +27044,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26800,6 +27131,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26870,6 +27202,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27016,6 +27349,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27085,6 +27419,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27239,6 +27574,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27307,6 +27643,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27462,6 +27799,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27532,6 +27870,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27673,6 +28012,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27742,6 +28082,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27861,6 +28202,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27929,6 +28271,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28024,6 +28367,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28094,6 +28438,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28196,6 +28541,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28275,6 +28621,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMTP"
@@ -28311,6 +28658,7 @@
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
                             "demo": "projects\/update-smtp.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMTP"
@@ -28346,7 +28694,8 @@
                                 }
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
-                            "demo": "projects\/update-smtp.md"
+                            "demo": "projects\/update-smtp.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28467,6 +28816,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.createSMTPTest"
@@ -28505,6 +28855,7 @@
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
                             "demo": "projects\/create-smtp-test.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.createSMTPTest"
@@ -28542,7 +28893,8 @@
                                 }
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
-                            "demo": "projects\/create-smtp-test.md"
+                            "demo": "projects\/create-smtp-test.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28676,6 +29028,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28755,6 +29108,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28979,6 +29333,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29243,6 +29598,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29469,6 +29825,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.getSMSTemplate"
@@ -29499,6 +29856,7 @@
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
                             "demo": "projects\/get-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.getSMSTemplate"
@@ -29528,7 +29886,8 @@
                                 }
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
-                            "demo": "projects\/get-sms-template.md"
+                            "demo": "projects\/get-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -29752,6 +30111,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMSTemplate"
@@ -29784,6 +30144,7 @@
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
                             "demo": "projects\/update-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMSTemplate"
@@ -29815,7 +30176,8 @@
                                 }
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
-                            "demo": "projects\/update-sms-template.md"
+                            "demo": "projects\/update-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30058,6 +30420,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.deleteSMSTemplate"
@@ -30088,6 +30451,7 @@
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
                             "demo": "projects\/delete-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.deleteSMSTemplate"
@@ -30117,7 +30481,8 @@
                                 }
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
-                            "demo": "projects\/delete-sms-template.md"
+                            "demo": "projects\/delete-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30343,6 +30708,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30412,6 +30778,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30527,6 +30894,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30595,6 +30963,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30711,6 +31080,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30781,6 +31151,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30851,6 +31222,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30936,6 +31308,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31003,6 +31376,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31081,6 +31455,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31194,6 +31569,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31272,6 +31648,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31323,6 +31700,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31383,6 +31761,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31443,6 +31822,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31527,6 +31907,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31779,6 +32160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31829,6 +32211,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31878,6 +32261,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32007,6 +32391,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32067,6 +32452,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32139,6 +32525,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32198,6 +32585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32446,6 +32834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32507,6 +32896,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32587,6 +32977,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32681,6 +33072,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32785,6 +33177,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32865,6 +33258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32981,6 +33375,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33079,6 +33474,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33141,6 +33537,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33206,6 +33603,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33295,6 +33693,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33366,6 +33765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33451,6 +33851,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33513,6 +33914,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33584,6 +33986,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33666,6 +34069,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33725,6 +34129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33816,6 +34221,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33885,6 +34291,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33978,6 +34385,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34049,6 +34457,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34133,6 +34542,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34266,6 +34676,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34325,6 +34736,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34455,6 +34867,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34518,6 +34931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34615,6 +35029,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34714,6 +35129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34786,6 +35202,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34877,6 +35294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34944,6 +35362,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35022,6 +35441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35250,6 +35670,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35333,6 +35754,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35405,6 +35827,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35487,6 +35910,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35571,6 +35995,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35655,6 +36080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35723,6 +36149,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35794,6 +36221,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35859,6 +36287,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35938,6 +36367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36005,6 +36435,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36089,6 +36520,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "listUsage",
@@ -36108,7 +36540,8 @@
                                 }
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/list-usage.md"
+                            "demo": "tablesdb\/list-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -36183,6 +36616,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36242,6 +36676,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36318,6 +36753,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36382,6 +36818,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36479,6 +36916,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36603,6 +37041,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36675,6 +37114,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36778,6 +37218,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36852,6 +37293,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36950,6 +37392,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37060,6 +37503,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37175,6 +37619,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37285,6 +37730,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37400,6 +37846,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37510,6 +37957,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37625,6 +38073,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37744,6 +38193,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37868,6 +38318,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37990,6 +38441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38117,6 +38569,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38239,6 +38692,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38366,6 +38820,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38476,6 +38931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38591,6 +39047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38703,6 +39160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38824,6 +39282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38936,6 +39395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39057,6 +39517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39169,6 +39630,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39290,6 +39752,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39426,6 +39889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39547,6 +40011,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39668,6 +40133,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39778,6 +40244,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39924,6 +40391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39998,6 +40466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40081,6 +40550,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40194,6 +40664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40290,6 +40761,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40428,6 +40900,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40502,6 +40975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40585,6 +41059,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40673,6 +41148,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40782,6 +41258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -40811,7 +41288,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -40838,7 +41316,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -40959,6 +41438,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -40985,7 +41465,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41089,6 +41570,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41192,6 +41674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41293,6 +41776,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41401,6 +41885,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -41429,7 +41914,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41548,6 +42034,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41657,6 +42144,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41759,6 +42247,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41858,6 +42347,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41983,6 +42473,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42105,6 +42596,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42200,6 +42692,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "getUsage",
@@ -42222,7 +42715,8 @@
                                 }
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/get-usage.md"
+                            "demo": "tablesdb\/get-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -42309,6 +42803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42396,6 +42891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42481,6 +42977,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42543,6 +43040,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42617,6 +43115,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42679,6 +43178,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42765,6 +43265,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42862,6 +43363,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42980,6 +43482,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43052,6 +43555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43146,6 +43650,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43219,6 +43724,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43316,6 +43822,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43376,6 +43883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43457,6 +43965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43551,6 +44060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43640,6 +44150,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43700,6 +44211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43770,6 +44282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43831,6 +44344,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43915,6 +44429,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44005,6 +44520,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44090,6 +44606,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44175,6 +44692,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44254,6 +44772,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44315,6 +44834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44400,6 +44920,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44485,6 +45006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44600,6 +45122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44703,6 +45226,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44808,6 +45332,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44880,6 +45405,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44932,6 +45458,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44993,6 +45520,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45073,6 +45601,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45155,6 +45684,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45238,6 +45768,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45323,6 +45854,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45419,6 +45951,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -45447,6 +45980,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -45474,7 +46008,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45550,6 +46085,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -45577,6 +46113,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -45603,7 +46140,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45682,6 +46220,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -45708,6 +46247,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -45733,7 +46273,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45797,6 +46338,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -45823,6 +46365,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -45848,7 +46391,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45910,6 +46454,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -45936,6 +46481,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -45961,7 +46507,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -46023,6 +46570,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -46049,6 +46597,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -46074,7 +46623,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -46138,6 +46688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46218,6 +46769,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46298,6 +46850,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46378,6 +46931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46437,6 +46991,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46517,6 +47072,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46587,6 +47143,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46639,6 +47196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46693,6 +47251,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46764,6 +47323,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46845,6 +47405,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46929,6 +47490,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47039,6 +47601,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47109,6 +47672,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47198,6 +47762,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47269,6 +47834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47351,6 +47917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47431,6 +47998,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47511,6 +48079,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47607,6 +48176,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47705,6 +48275,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47790,6 +48361,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47860,6 +48432,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47930,6 +48503,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48015,6 +48589,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48104,6 +48679,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48189,6 +48765,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48240,6 +48817,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-1.8.x-server.json
+++ b/app/config/specs/open-api3-1.8.x-server.json
@@ -62,6 +62,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -112,6 +113,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -197,6 +199,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -274,6 +277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -345,6 +349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -409,6 +414,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -458,6 +464,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -536,6 +543,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -607,6 +615,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -634,6 +643,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -660,7 +670,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -730,6 +741,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -759,6 +771,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -787,7 +800,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -869,6 +883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -895,6 +910,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -920,7 +936,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -992,6 +1009,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1018,6 +1036,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1043,7 +1062,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1120,6 +1140,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1149,6 +1170,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1177,7 +1199,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1257,6 +1280,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1280,6 +1304,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1302,7 +1327,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1357,6 +1383,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1380,6 +1407,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1402,7 +1430,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1455,6 +1484,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1478,6 +1508,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1500,7 +1531,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1553,6 +1585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1576,6 +1609,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1598,7 +1632,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1653,6 +1688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1724,6 +1760,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1800,6 +1837,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1877,6 +1915,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1927,6 +1966,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2001,6 +2041,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2076,6 +2117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2159,6 +2201,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2202,6 +2245,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2254,6 +2298,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2303,6 +2348,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2377,6 +2423,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2455,6 +2502,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2533,6 +2581,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2607,6 +2656,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2669,6 +2719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2724,6 +2775,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2788,6 +2840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2843,6 +2896,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2925,6 +2979,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3002,6 +3057,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3147,6 +3203,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3221,6 +3278,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3243,7 +3301,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3267,6 +3326,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3342,6 +3402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3366,7 +3427,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3392,6 +3454,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3478,6 +3541,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3528,6 +3592,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3599,6 +3664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3727,6 +3793,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3861,6 +3928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3921,6 +3989,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4411,6 +4480,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4495,6 +4565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4589,6 +4660,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4683,6 +4755,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -5434,6 +5507,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -5461,6 +5535,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -5552,6 +5627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -5582,6 +5658,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -5670,6 +5747,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5737,6 +5815,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5807,6 +5886,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5871,6 +5951,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5949,6 +6030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6015,6 +6097,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6098,6 +6181,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6125,6 +6209,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6191,6 +6276,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6221,6 +6307,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6304,6 +6391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6330,6 +6418,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -6398,6 +6487,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -6497,6 +6587,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -6623,6 +6714,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -6697,6 +6789,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -6802,6 +6895,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -6878,6 +6972,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -6978,6 +7073,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7090,6 +7186,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7207,6 +7304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7319,6 +7417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -7436,6 +7535,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -7548,6 +7648,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -7665,6 +7766,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -7786,6 +7888,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -7912,6 +8015,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8036,6 +8140,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8165,6 +8270,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8289,6 +8395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -8418,6 +8525,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -8530,6 +8638,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -8647,6 +8756,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -8761,6 +8871,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -8884,6 +8995,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -8998,6 +9110,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9121,6 +9234,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9235,6 +9349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9358,6 +9473,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -9496,6 +9612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -9619,6 +9736,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -9742,6 +9860,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -9854,6 +9973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10002,6 +10122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10078,6 +10199,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10163,6 +10285,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10280,6 +10403,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10392,6 +10516,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10427,6 +10552,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10459,6 +10585,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -10582,6 +10709,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -10614,6 +10742,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -10719,6 +10848,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -10824,6 +10954,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -10927,6 +11058,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11038,6 +11170,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11073,6 +11206,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11197,6 +11331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11309,6 +11444,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11417,6 +11553,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -11545,6 +11682,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -11670,6 +11808,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -11768,6 +11907,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -11908,6 +12048,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -11984,6 +12125,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12069,6 +12211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12154,6 +12297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12449,6 +12593,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12500,6 +12645,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12550,6 +12696,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12610,6 +12757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12902,6 +13050,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12964,6 +13113,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13045,6 +13195,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13140,6 +13291,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13239,6 +13391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13325,6 +13478,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13442,6 +13596,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13540,6 +13695,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13603,6 +13759,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13669,6 +13826,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13759,6 +13917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13833,6 +13992,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -13921,6 +14081,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14040,6 +14201,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14105,6 +14267,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14177,6 +14340,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14237,6 +14401,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14329,6 +14494,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14399,6 +14565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14493,6 +14660,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14567,6 +14735,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14621,6 +14790,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14673,6 +14843,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14723,6 +14894,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14773,6 +14945,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14823,6 +14996,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14884,6 +15058,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14934,6 +15109,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14984,6 +15160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15047,6 +15224,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15110,6 +15288,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15184,6 +15363,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15247,6 +15427,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15336,6 +15517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15399,6 +15581,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15462,6 +15645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15525,6 +15709,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15588,6 +15773,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15651,6 +15837,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15714,6 +15901,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15777,6 +15965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15840,6 +16029,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15890,6 +16080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15940,6 +16131,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15992,6 +16184,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16046,6 +16239,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16100,6 +16294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16154,6 +16349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16208,6 +16404,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16262,6 +16459,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16316,6 +16514,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16370,6 +16569,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16423,6 +16623,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16511,6 +16712,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16657,6 +16859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16815,6 +17018,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16992,6 +17196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17189,6 +17394,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -17223,6 +17429,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -17256,7 +17463,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17370,6 +17578,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -17403,6 +17612,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -17435,7 +17645,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17557,6 +17768,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17611,6 +17823,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17674,6 +17887,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17761,6 +17975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17848,6 +18063,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17936,6 +18152,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -17971,6 +18188,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -18005,7 +18223,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18115,6 +18334,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -18149,6 +18369,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -18182,7 +18403,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18296,6 +18518,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -18327,6 +18550,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -18357,7 +18581,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18448,6 +18673,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -18478,6 +18704,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -18507,7 +18734,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18601,6 +18829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18719,6 +18948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18840,6 +19070,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18937,6 +19168,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19037,6 +19269,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19144,6 +19377,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19254,6 +19488,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19361,6 +19596,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19471,6 +19707,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -19513,6 +19750,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -19554,7 +19792,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19702,6 +19941,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -19742,6 +19982,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -19781,7 +20022,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19933,6 +20175,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20030,6 +20273,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20130,6 +20374,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20227,6 +20472,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20327,6 +20573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20424,6 +20671,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20524,6 +20772,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20621,6 +20870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20721,6 +20971,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20775,6 +21026,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20838,6 +21090,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20925,6 +21178,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21012,6 +21266,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21098,6 +21353,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21182,6 +21438,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21243,6 +21500,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21323,6 +21581,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21386,6 +21645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21473,6 +21733,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21571,6 +21832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21661,6 +21923,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21727,6 +21990,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21801,6 +22065,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21886,6 +22151,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22139,6 +22405,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22190,6 +22457,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22240,6 +22508,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22300,6 +22569,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22549,6 +22819,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22611,6 +22882,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22692,6 +22964,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22787,6 +23060,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22892,6 +23166,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22973,6 +23248,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23090,6 +23366,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23189,6 +23466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23252,6 +23530,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23318,6 +23597,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23408,6 +23688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23480,6 +23761,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23566,6 +23848,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23629,6 +23912,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23701,6 +23985,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23761,6 +24046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23853,6 +24139,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23923,6 +24210,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24017,6 +24305,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24089,6 +24378,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24174,6 +24464,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24308,6 +24599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24368,6 +24660,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24499,6 +24792,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24563,6 +24857,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24662,6 +24957,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24763,6 +25059,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24837,6 +25134,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24930,6 +25228,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24999,6 +25298,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25079,6 +25379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25309,6 +25610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25394,6 +25696,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25479,6 +25782,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25564,6 +25868,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25634,6 +25939,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25707,6 +26013,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25774,6 +26081,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25855,6 +26163,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25924,6 +26233,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26007,6 +26317,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26067,6 +26378,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26144,6 +26456,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26209,6 +26522,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26307,6 +26621,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26432,6 +26747,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26505,6 +26821,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26609,6 +26926,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26684,6 +27002,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26783,6 +27102,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26894,6 +27214,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27010,6 +27331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27121,6 +27443,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27237,6 +27560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27348,6 +27672,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27464,6 +27789,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27584,6 +27910,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27709,6 +28036,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27832,6 +28160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27960,6 +28289,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28083,6 +28413,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28211,6 +28542,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28322,6 +28654,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28438,6 +28771,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28551,6 +28885,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28673,6 +29008,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28786,6 +29122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28908,6 +29245,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29021,6 +29359,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29143,6 +29482,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29280,6 +29620,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29402,6 +29743,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29524,6 +29866,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29635,6 +29978,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29782,6 +30126,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29857,6 +30202,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29941,6 +30287,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30055,6 +30402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30152,6 +30500,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30291,6 +30640,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30366,6 +30716,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30452,6 +30803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -30563,6 +30915,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -30593,7 +30946,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -30621,7 +30975,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30744,6 +31099,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -30771,7 +31127,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30876,6 +31233,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30980,6 +31338,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -31082,6 +31441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31192,6 +31552,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -31221,7 +31582,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -31342,6 +31704,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31453,6 +31816,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31560,6 +31924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31687,6 +32052,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31810,6 +32176,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31899,6 +32266,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31986,6 +32354,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32050,6 +32419,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32126,6 +32496,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32192,6 +32563,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32291,6 +32663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32411,6 +32784,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32485,6 +32859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32581,6 +32956,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32656,6 +33032,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32755,6 +33132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32817,6 +33195,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32900,6 +33279,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -32995,6 +33375,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33085,6 +33466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33146,6 +33528,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33217,6 +33600,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33279,6 +33663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33364,6 +33749,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33455,6 +33841,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33541,6 +33928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33627,6 +34015,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33707,6 +34096,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33769,6 +34159,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33855,6 +34246,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33941,6 +34333,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34057,6 +34450,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34161,6 +34555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34267,6 +34662,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34320,6 +34716,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34382,6 +34779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34463,6 +34861,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34546,6 +34945,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34630,6 +35030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34716,6 +35117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34813,6 +35215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -34842,6 +35245,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -34870,7 +35274,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -34947,6 +35352,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -34975,6 +35381,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -35002,7 +35409,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35082,6 +35490,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -35109,6 +35518,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -35135,7 +35545,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35200,6 +35611,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -35227,6 +35639,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -35253,7 +35666,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35316,6 +35730,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -35343,6 +35758,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -35369,7 +35785,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -35432,6 +35849,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -35459,6 +35877,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -35485,7 +35904,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35550,6 +35970,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35631,6 +36052,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35712,6 +36134,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35793,6 +36216,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35853,6 +36277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35934,6 +36359,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36005,6 +36431,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36058,6 +36485,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36113,6 +36541,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36185,6 +36614,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36267,6 +36697,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36352,6 +36783,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36463,6 +36895,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36534,6 +36967,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36624,6 +37058,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36696,6 +37131,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36779,6 +37215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36860,6 +37297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []

--- a/app/config/specs/open-api3-latest-client.json
+++ b/app/config/specs/open-api3-latest-client.json
@@ -62,6 +62,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -111,6 +112,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -196,6 +198,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -272,6 +275,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -342,6 +346,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -405,6 +410,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -454,6 +460,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -531,6 +538,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -601,6 +609,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -627,6 +636,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -652,7 +662,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -721,6 +732,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -749,6 +761,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -776,7 +789,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -857,6 +871,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -882,6 +897,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -906,7 +922,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -977,6 +994,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1003,6 +1021,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1028,7 +1047,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1105,6 +1125,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1133,6 +1154,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1160,7 +1182,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1239,6 +1262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1261,6 +1285,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1282,7 +1307,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1336,6 +1362,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1358,6 +1385,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1379,7 +1407,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1431,6 +1460,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1453,6 +1483,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1474,7 +1505,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1526,6 +1558,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1548,6 +1581,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1569,7 +1603,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1623,6 +1658,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1693,6 +1729,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1768,6 +1805,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1844,6 +1882,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1893,6 +1932,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1966,6 +2006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2040,6 +2081,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2122,6 +2164,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2164,6 +2207,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2215,6 +2259,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2264,6 +2309,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2338,6 +2384,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2409,6 +2456,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2551,6 +2599,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2629,6 +2678,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2703,6 +2753,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2764,6 +2815,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2818,6 +2870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2881,6 +2934,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2931,6 +2985,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3010,6 +3065,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3081,6 +3137,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3146,6 +3203,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3228,6 +3286,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3305,6 +3364,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3450,6 +3510,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3524,6 +3585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3545,7 +3607,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3568,6 +3631,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3642,6 +3706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3665,7 +3730,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3690,6 +3756,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3775,6 +3842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3824,6 +3892,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3894,6 +3963,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4020,6 +4090,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4152,6 +4223,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4210,6 +4282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4698,6 +4771,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4780,6 +4854,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4872,6 +4947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4964,6 +5040,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5715,6 +5792,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5780,6 +5858,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5848,6 +5927,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5910,6 +5990,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5986,6 +6067,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6050,6 +6132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6133,6 +6216,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -6243,6 +6327,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -6277,6 +6362,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -6401,6 +6487,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -6510,6 +6597,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -6544,6 +6632,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -6666,6 +6755,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -6776,6 +6866,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -6882,6 +6973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -7008,6 +7100,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -7133,6 +7226,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7219,6 +7313,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7336,6 +7431,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7410,6 +7506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7462,6 +7559,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7514,6 +7612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7566,6 +7665,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7618,6 +7718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7670,6 +7771,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7722,6 +7824,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7774,6 +7877,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7826,6 +7930,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7878,6 +7983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7931,6 +8037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8014,6 +8121,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8088,6 +8196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8185,6 +8294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8284,6 +8394,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8356,6 +8467,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8447,6 +8559,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8514,6 +8627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8592,6 +8706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8820,6 +8935,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8908,6 +9024,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8976,6 +9093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9047,6 +9165,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9112,6 +9231,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9191,6 +9311,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9258,6 +9379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9344,6 +9466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9453,6 +9576,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -9482,7 +9606,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9606,6 +9731,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9714,6 +9840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -9742,7 +9869,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9861,6 +9989,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9970,6 +10099,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10075,6 +10205,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10200,6 +10331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10321,6 +10453,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10408,6 +10541,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10493,6 +10627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10555,6 +10690,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10629,6 +10765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10693,6 +10830,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10790,6 +10928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10908,6 +11047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10980,6 +11120,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11074,6 +11215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11147,6 +11289,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11245,6 +11388,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11306,6 +11450,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-latest-console.json
+++ b/app/config/specs/open-api3-latest-console.json
@@ -62,6 +62,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -110,6 +111,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -185,6 +187,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -234,6 +237,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -309,6 +313,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -378,6 +383,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -440,6 +446,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -489,6 +496,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -565,6 +573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -634,6 +643,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -660,6 +670,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -685,7 +696,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -753,6 +765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -781,6 +794,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -808,7 +822,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -888,6 +903,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -913,6 +929,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -937,7 +954,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1007,6 +1025,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1033,6 +1052,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1058,7 +1078,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1135,6 +1156,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1163,6 +1185,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1190,7 +1213,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1268,6 +1292,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1290,6 +1315,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1311,7 +1337,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1364,6 +1391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1386,6 +1414,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1407,7 +1436,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1458,6 +1488,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1480,6 +1511,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1501,7 +1533,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1552,6 +1585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1574,6 +1608,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1595,7 +1630,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1648,6 +1684,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1717,6 +1754,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1791,6 +1829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1866,6 +1905,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1914,6 +1954,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1986,6 +2027,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2059,6 +2101,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2140,6 +2183,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2181,6 +2225,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2231,6 +2276,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2280,6 +2326,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2354,6 +2401,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2425,6 +2473,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2567,6 +2616,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2645,6 +2695,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2719,6 +2770,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2779,6 +2831,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2832,6 +2885,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2894,6 +2948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2943,6 +2998,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3021,6 +3077,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3091,6 +3148,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3155,6 +3213,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3237,6 +3296,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3314,6 +3374,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3459,6 +3520,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3533,6 +3595,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3554,7 +3617,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3577,6 +3641,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3650,6 +3715,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3673,7 +3739,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3698,6 +3765,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3782,6 +3850,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3830,6 +3899,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3899,6 +3969,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4025,6 +4096,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4157,6 +4229,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4215,6 +4288,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4703,6 +4777,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4785,6 +4860,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4877,6 +4953,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4969,6 +5046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5711,6 +5789,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5771,6 +5850,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5846,6 +5926,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5894,6 +5975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -5920,6 +6002,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -6010,6 +6093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -6039,6 +6123,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -6126,6 +6211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6191,6 +6277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6259,6 +6346,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6321,6 +6409,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6397,6 +6486,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6461,6 +6551,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6542,6 +6633,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listUsage"
@@ -6566,6 +6658,7 @@
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/list-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listUsage"
@@ -6644,6 +6737,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6670,6 +6764,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6735,6 +6830,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6764,6 +6860,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6846,6 +6943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6871,6 +6969,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -6938,6 +7037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -7036,6 +7136,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -7161,6 +7262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -7234,6 +7336,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -7338,6 +7441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -7413,6 +7517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -7512,6 +7617,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7623,6 +7729,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7739,6 +7846,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7850,6 +7958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -7966,6 +8075,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -8077,6 +8187,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -8193,6 +8304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -8313,6 +8425,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -8438,6 +8551,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8561,6 +8675,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8689,6 +8804,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8812,6 +8928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -8940,6 +9057,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -9051,6 +9169,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -9167,6 +9286,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -9280,6 +9400,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -9402,6 +9523,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -9515,6 +9637,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9637,6 +9760,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9750,6 +9874,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9872,6 +9997,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -10009,6 +10135,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -10131,6 +10258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -10253,6 +10381,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -10364,6 +10493,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10511,6 +10641,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10586,6 +10717,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10670,6 +10802,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10786,6 +10919,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10896,6 +11030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10930,6 +11065,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10961,6 +11097,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -11082,6 +11219,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -11113,6 +11251,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -11217,6 +11356,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -11321,6 +11461,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -11423,6 +11564,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11532,6 +11674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11566,6 +11709,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11688,6 +11832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11798,6 +11943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11901,6 +12047,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRowLogs"
@@ -12001,6 +12148,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -12127,6 +12275,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -12250,6 +12399,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -12347,6 +12497,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -12486,6 +12637,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -12561,6 +12713,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12645,6 +12798,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTableLogs"
@@ -12732,6 +12886,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTableUsage"
@@ -12828,6 +12983,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12855,6 +13011,7 @@
                             ],
                             "description": "Get the database activity logs list by its unique ID.",
                             "demo": "databases\/list-logs.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12934,6 +13091,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getUsage"
@@ -12961,6 +13119,7 @@
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/get-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.getUsage"
@@ -13049,6 +13208,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13133,6 +13293,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13427,6 +13588,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13477,6 +13639,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13526,6 +13689,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13718,6 +13882,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13778,6 +13943,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13850,6 +14016,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13909,6 +14076,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14200,6 +14368,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14261,6 +14430,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14341,6 +14511,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14435,6 +14606,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14533,6 +14705,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14618,6 +14791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14734,6 +14908,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14831,6 +15006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14893,6 +15069,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14958,6 +15135,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15047,6 +15225,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15120,6 +15299,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15206,6 +15386,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15323,6 +15504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15386,6 +15568,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15457,6 +15640,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15539,6 +15723,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15598,6 +15783,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15689,6 +15875,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15758,6 +15945,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15851,6 +16039,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15924,6 +16113,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15976,6 +16166,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16026,6 +16217,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16075,6 +16267,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16124,6 +16317,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16173,6 +16367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16233,6 +16428,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16282,6 +16478,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16331,6 +16528,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16393,6 +16591,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16455,6 +16654,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16528,6 +16728,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16590,6 +16791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16678,6 +16880,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16740,6 +16943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16802,6 +17006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16864,6 +17069,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16926,6 +17132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16988,6 +17195,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17050,6 +17258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17112,6 +17321,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17174,6 +17384,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17223,6 +17434,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17272,6 +17484,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17323,6 +17536,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17375,6 +17589,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17427,6 +17642,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17479,6 +17695,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17531,6 +17748,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17583,6 +17801,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17635,6 +17854,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17687,6 +17907,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17738,6 +17959,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17825,6 +18047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17970,6 +18193,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18127,6 +18351,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18303,6 +18528,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18499,6 +18725,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -18532,6 +18759,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -18564,7 +18792,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18677,6 +18906,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -18709,6 +18939,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -18740,7 +18971,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18861,6 +19093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18914,6 +19147,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18976,6 +19210,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19062,6 +19297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19148,6 +19384,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19235,6 +19472,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -19269,6 +19507,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -19302,7 +19541,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19411,6 +19651,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -19444,6 +19685,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -19476,7 +19718,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19589,6 +19832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -19619,6 +19863,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -19648,7 +19893,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19738,6 +19984,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -19767,6 +20014,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -19795,7 +20043,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19888,6 +20137,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20005,6 +20255,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20125,6 +20376,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20221,6 +20473,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20320,6 +20573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20426,6 +20680,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20535,6 +20790,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20641,6 +20897,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20750,6 +21007,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -20791,6 +21049,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -20831,7 +21090,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -20978,6 +21238,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -21017,6 +21278,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -21055,7 +21317,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -21206,6 +21469,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21302,6 +21566,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21401,6 +21666,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21497,6 +21763,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21596,6 +21863,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21692,6 +21960,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21791,6 +22060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21887,6 +22157,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21986,6 +22257,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22039,6 +22311,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22101,6 +22374,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22187,6 +22461,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22273,6 +22548,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22358,6 +22634,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22441,6 +22718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22501,6 +22779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22580,6 +22859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22642,6 +22922,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22728,6 +23009,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22825,6 +23107,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22913,6 +23196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22978,6 +23262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23050,6 +23335,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23135,6 +23421,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23243,6 +23530,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23356,6 +23644,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23470,6 +23759,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23554,6 +23844,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23644,6 +23935,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23730,6 +24022,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23856,6 +24149,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24004,6 +24298,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24124,6 +24419,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24263,6 +24559,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24321,6 +24618,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24372,6 +24670,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24432,6 +24731,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24520,6 +24820,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24566,6 +24867,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24644,6 +24946,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24702,6 +25005,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24784,6 +25088,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24844,6 +25149,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24927,6 +25233,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25061,6 +25368,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25119,6 +25427,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25234,6 +25543,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25294,6 +25604,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatus"
@@ -25324,6 +25635,7 @@
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
                             "demo": "projects\/update-api-status.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatus"
@@ -25353,7 +25665,8 @@
                                 }
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
-                            "demo": "projects\/update-api-status.md"
+                            "demo": "projects\/update-api-status.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25448,6 +25761,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatusAll"
@@ -25476,6 +25790,7 @@
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
                             "demo": "projects\/update-api-status-all.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatusAll"
@@ -25503,7 +25818,8 @@
                                 }
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
-                            "demo": "projects\/update-api-status-all.md"
+                            "demo": "projects\/update-api-status-all.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25585,6 +25901,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25664,6 +25981,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25743,6 +26061,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25822,6 +26141,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25913,6 +26233,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25995,6 +26316,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26074,6 +26396,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26153,6 +26476,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26232,6 +26556,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26311,6 +26636,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26390,6 +26716,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26490,6 +26817,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26561,6 +26889,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26646,6 +26975,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26714,6 +27044,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26800,6 +27131,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26870,6 +27202,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27016,6 +27349,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27085,6 +27419,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27239,6 +27574,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27307,6 +27643,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27462,6 +27799,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27532,6 +27870,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27673,6 +28012,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27742,6 +28082,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27861,6 +28202,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27929,6 +28271,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28024,6 +28367,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28094,6 +28438,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28196,6 +28541,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28275,6 +28621,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMTP"
@@ -28311,6 +28658,7 @@
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
                             "demo": "projects\/update-smtp.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMTP"
@@ -28346,7 +28694,8 @@
                                 }
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
-                            "demo": "projects\/update-smtp.md"
+                            "demo": "projects\/update-smtp.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28467,6 +28816,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.createSMTPTest"
@@ -28505,6 +28855,7 @@
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
                             "demo": "projects\/create-smtp-test.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.createSMTPTest"
@@ -28542,7 +28893,8 @@
                                 }
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
-                            "demo": "projects\/create-smtp-test.md"
+                            "demo": "projects\/create-smtp-test.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28676,6 +29028,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28755,6 +29108,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28979,6 +29333,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29243,6 +29598,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29469,6 +29825,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.getSMSTemplate"
@@ -29499,6 +29856,7 @@
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
                             "demo": "projects\/get-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.getSMSTemplate"
@@ -29528,7 +29886,8 @@
                                 }
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
-                            "demo": "projects\/get-sms-template.md"
+                            "demo": "projects\/get-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -29752,6 +30111,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMSTemplate"
@@ -29784,6 +30144,7 @@
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
                             "demo": "projects\/update-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMSTemplate"
@@ -29815,7 +30176,8 @@
                                 }
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
-                            "demo": "projects\/update-sms-template.md"
+                            "demo": "projects\/update-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30058,6 +30420,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.deleteSMSTemplate"
@@ -30088,6 +30451,7 @@
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
                             "demo": "projects\/delete-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.deleteSMSTemplate"
@@ -30117,7 +30481,8 @@
                                 }
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
-                            "demo": "projects\/delete-sms-template.md"
+                            "demo": "projects\/delete-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30343,6 +30708,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30412,6 +30778,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30527,6 +30894,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30595,6 +30963,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30711,6 +31080,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30781,6 +31151,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30851,6 +31222,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30936,6 +31308,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31003,6 +31376,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31081,6 +31455,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31194,6 +31569,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31272,6 +31648,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31323,6 +31700,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31383,6 +31761,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31443,6 +31822,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31527,6 +31907,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31779,6 +32160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31829,6 +32211,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31878,6 +32261,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32007,6 +32391,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32067,6 +32452,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32139,6 +32525,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32198,6 +32585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32446,6 +32834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32507,6 +32896,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32587,6 +32977,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32681,6 +33072,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32785,6 +33177,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32865,6 +33258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32981,6 +33375,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33079,6 +33474,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33141,6 +33537,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33206,6 +33603,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33295,6 +33693,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33366,6 +33765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33451,6 +33851,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33513,6 +33914,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33584,6 +33986,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33666,6 +34069,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33725,6 +34129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33816,6 +34221,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33885,6 +34291,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33978,6 +34385,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34049,6 +34457,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34133,6 +34542,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34266,6 +34676,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34325,6 +34736,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34455,6 +34867,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34518,6 +34931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34615,6 +35029,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34714,6 +35129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34786,6 +35202,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34877,6 +35294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34944,6 +35362,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35022,6 +35441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35250,6 +35670,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35333,6 +35754,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35405,6 +35827,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35487,6 +35910,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35571,6 +35995,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35655,6 +36080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35723,6 +36149,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35794,6 +36221,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35859,6 +36287,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35938,6 +36367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36005,6 +36435,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36089,6 +36520,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "listUsage",
@@ -36108,7 +36540,8 @@
                                 }
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/list-usage.md"
+                            "demo": "tablesdb\/list-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -36183,6 +36616,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36242,6 +36676,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36318,6 +36753,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36382,6 +36818,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36479,6 +36916,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36603,6 +37041,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36675,6 +37114,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36778,6 +37218,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36852,6 +37293,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36950,6 +37392,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37060,6 +37503,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37175,6 +37619,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37285,6 +37730,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37400,6 +37846,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37510,6 +37957,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37625,6 +38073,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37744,6 +38193,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37868,6 +38318,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37990,6 +38441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38117,6 +38569,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38239,6 +38692,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38366,6 +38820,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38476,6 +38931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38591,6 +39047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38703,6 +39160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38824,6 +39282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38936,6 +39395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39057,6 +39517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39169,6 +39630,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39290,6 +39752,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39426,6 +39889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39547,6 +40011,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39668,6 +40133,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39778,6 +40244,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39924,6 +40391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39998,6 +40466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40081,6 +40550,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40194,6 +40664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40290,6 +40761,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40428,6 +40900,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40502,6 +40975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40585,6 +41059,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40673,6 +41148,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40782,6 +41258,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -40811,7 +41288,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -40838,7 +41316,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -40959,6 +41438,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -40985,7 +41465,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41089,6 +41570,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41192,6 +41674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41293,6 +41776,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41401,6 +41885,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -41429,7 +41914,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41548,6 +42034,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41657,6 +42144,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41759,6 +42247,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41858,6 +42347,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41983,6 +42473,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42105,6 +42596,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42200,6 +42692,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "getUsage",
@@ -42222,7 +42715,8 @@
                                 }
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/get-usage.md"
+                            "demo": "tablesdb\/get-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -42309,6 +42803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42396,6 +42891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42481,6 +42977,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42543,6 +43040,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42617,6 +43115,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42679,6 +43178,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42765,6 +43265,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42862,6 +43363,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42980,6 +43482,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43052,6 +43555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43146,6 +43650,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43219,6 +43724,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43316,6 +43822,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43376,6 +43883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43457,6 +43965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43551,6 +44060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43640,6 +44150,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43700,6 +44211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43770,6 +44282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43831,6 +44344,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43915,6 +44429,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44005,6 +44520,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44090,6 +44606,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44175,6 +44692,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44254,6 +44772,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44315,6 +44834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44400,6 +44920,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44485,6 +45006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44600,6 +45122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44703,6 +45226,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44808,6 +45332,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44880,6 +45405,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44932,6 +45458,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44993,6 +45520,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45073,6 +45601,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45155,6 +45684,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45238,6 +45768,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45323,6 +45854,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45419,6 +45951,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -45447,6 +45980,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -45474,7 +46008,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45550,6 +46085,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -45577,6 +46113,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -45603,7 +46140,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45682,6 +46220,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -45708,6 +46247,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -45733,7 +46273,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45797,6 +46338,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -45823,6 +46365,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -45848,7 +46391,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45910,6 +46454,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -45936,6 +46481,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -45961,7 +46507,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -46023,6 +46570,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -46049,6 +46597,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -46074,7 +46623,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -46138,6 +46688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46218,6 +46769,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46298,6 +46850,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46378,6 +46931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46437,6 +46991,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46517,6 +47072,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46587,6 +47143,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46639,6 +47196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46693,6 +47251,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46764,6 +47323,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46845,6 +47405,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46929,6 +47490,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47039,6 +47601,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47109,6 +47672,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47198,6 +47762,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47269,6 +47834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47351,6 +47917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47431,6 +47998,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47511,6 +48079,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47607,6 +48176,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47705,6 +48275,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47790,6 +48361,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47860,6 +48432,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47930,6 +48503,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48015,6 +48589,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48104,6 +48679,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48189,6 +48765,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48240,6 +48817,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/open-api3-latest-server.json
+++ b/app/config/specs/open-api3-latest-server.json
@@ -62,6 +62,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -112,6 +113,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -197,6 +199,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -274,6 +277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -345,6 +349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -409,6 +414,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -458,6 +464,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -536,6 +543,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -607,6 +615,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -634,6 +643,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -660,7 +670,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -730,6 +741,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -759,6 +771,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -787,7 +800,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -869,6 +883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -895,6 +910,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -920,7 +936,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -992,6 +1009,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1018,6 +1036,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1043,7 +1062,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1120,6 +1140,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1149,6 +1170,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1177,7 +1199,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1257,6 +1280,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1280,6 +1304,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1302,7 +1327,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1357,6 +1383,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1380,6 +1407,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1402,7 +1430,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1455,6 +1484,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1478,6 +1508,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1500,7 +1531,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1553,6 +1585,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1576,6 +1609,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1598,7 +1632,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1653,6 +1688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1724,6 +1760,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1800,6 +1837,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1877,6 +1915,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1927,6 +1966,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2001,6 +2041,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2076,6 +2117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2159,6 +2201,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2202,6 +2245,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2254,6 +2298,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2303,6 +2348,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2377,6 +2423,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2455,6 +2502,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2533,6 +2581,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2607,6 +2656,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2669,6 +2719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2724,6 +2775,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2788,6 +2840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2843,6 +2896,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2925,6 +2979,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3002,6 +3057,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3147,6 +3203,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3221,6 +3278,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3243,7 +3301,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3267,6 +3326,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3342,6 +3402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3366,7 +3427,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3392,6 +3454,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3478,6 +3541,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3528,6 +3592,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3599,6 +3664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3727,6 +3793,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3861,6 +3928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3921,6 +3989,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4411,6 +4480,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4495,6 +4565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4589,6 +4660,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4683,6 +4755,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -5434,6 +5507,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -5461,6 +5535,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -5552,6 +5627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -5582,6 +5658,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -5670,6 +5747,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5737,6 +5815,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5807,6 +5886,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5871,6 +5951,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5949,6 +6030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6015,6 +6097,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6098,6 +6181,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6125,6 +6209,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6191,6 +6276,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6221,6 +6307,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6304,6 +6391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6330,6 +6418,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -6398,6 +6487,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -6497,6 +6587,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -6623,6 +6714,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -6697,6 +6789,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -6802,6 +6895,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -6878,6 +6972,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -6978,6 +7073,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7090,6 +7186,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7207,6 +7304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7319,6 +7417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -7436,6 +7535,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -7548,6 +7648,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -7665,6 +7766,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -7786,6 +7888,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -7912,6 +8015,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8036,6 +8140,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8165,6 +8270,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8289,6 +8395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -8418,6 +8525,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -8530,6 +8638,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -8647,6 +8756,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -8761,6 +8871,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -8884,6 +8995,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -8998,6 +9110,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9121,6 +9234,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9235,6 +9349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9358,6 +9473,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -9496,6 +9612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -9619,6 +9736,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -9742,6 +9860,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -9854,6 +9973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10002,6 +10122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10078,6 +10199,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10163,6 +10285,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10280,6 +10403,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10392,6 +10516,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10427,6 +10552,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10459,6 +10585,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -10582,6 +10709,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -10614,6 +10742,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -10719,6 +10848,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -10824,6 +10954,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -10927,6 +11058,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11038,6 +11170,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11073,6 +11206,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11197,6 +11331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11309,6 +11444,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11417,6 +11553,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -11545,6 +11682,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -11670,6 +11808,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -11768,6 +11907,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -11908,6 +12048,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -11984,6 +12125,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12069,6 +12211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12154,6 +12297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12449,6 +12593,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12500,6 +12645,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12550,6 +12696,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12610,6 +12757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12902,6 +13050,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12964,6 +13113,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13045,6 +13195,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13140,6 +13291,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13239,6 +13391,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13325,6 +13478,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13442,6 +13596,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13540,6 +13695,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13603,6 +13759,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13669,6 +13826,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13759,6 +13917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13833,6 +13992,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -13921,6 +14081,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14040,6 +14201,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14105,6 +14267,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14177,6 +14340,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14237,6 +14401,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14329,6 +14494,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14399,6 +14565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14493,6 +14660,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14567,6 +14735,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14621,6 +14790,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14673,6 +14843,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14723,6 +14894,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14773,6 +14945,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14823,6 +14996,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14884,6 +15058,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14934,6 +15109,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14984,6 +15160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15047,6 +15224,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15110,6 +15288,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15184,6 +15363,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15247,6 +15427,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15336,6 +15517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15399,6 +15581,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15462,6 +15645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15525,6 +15709,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15588,6 +15773,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15651,6 +15837,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15714,6 +15901,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15777,6 +15965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15840,6 +16029,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15890,6 +16080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15940,6 +16131,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15992,6 +16184,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16046,6 +16239,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16100,6 +16294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16154,6 +16349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16208,6 +16404,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16262,6 +16459,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16316,6 +16514,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16370,6 +16569,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16423,6 +16623,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16511,6 +16712,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16657,6 +16859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16815,6 +17018,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16992,6 +17196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17189,6 +17394,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -17223,6 +17429,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -17256,7 +17463,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17370,6 +17578,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -17403,6 +17612,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -17435,7 +17645,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17557,6 +17768,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17611,6 +17823,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17674,6 +17887,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17761,6 +17975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17848,6 +18063,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17936,6 +18152,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -17971,6 +18188,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -18005,7 +18223,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18115,6 +18334,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -18149,6 +18369,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -18182,7 +18403,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18296,6 +18518,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -18327,6 +18550,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -18357,7 +18581,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18448,6 +18673,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -18478,6 +18704,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -18507,7 +18734,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18601,6 +18829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18719,6 +18948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18840,6 +19070,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18937,6 +19168,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19037,6 +19269,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19144,6 +19377,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19254,6 +19488,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19361,6 +19596,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19471,6 +19707,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -19513,6 +19750,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -19554,7 +19792,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19702,6 +19941,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -19742,6 +19982,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -19781,7 +20022,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19933,6 +20175,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20030,6 +20273,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20130,6 +20374,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20227,6 +20472,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20327,6 +20573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20424,6 +20671,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20524,6 +20772,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20621,6 +20870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20721,6 +20971,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20775,6 +21026,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20838,6 +21090,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20925,6 +21178,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21012,6 +21266,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21098,6 +21353,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21182,6 +21438,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21243,6 +21500,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21323,6 +21581,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21386,6 +21645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21473,6 +21733,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21571,6 +21832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21661,6 +21923,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21727,6 +21990,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21801,6 +22065,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21886,6 +22151,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22139,6 +22405,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22190,6 +22457,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22240,6 +22508,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22300,6 +22569,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22549,6 +22819,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22611,6 +22882,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22692,6 +22964,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22787,6 +23060,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22892,6 +23166,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22973,6 +23248,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23090,6 +23366,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23189,6 +23466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23252,6 +23530,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23318,6 +23597,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23408,6 +23688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23480,6 +23761,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23566,6 +23848,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23629,6 +23912,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23701,6 +23985,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23761,6 +24046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23853,6 +24139,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23923,6 +24210,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24017,6 +24305,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24089,6 +24378,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24174,6 +24464,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24308,6 +24599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24368,6 +24660,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24499,6 +24792,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24563,6 +24857,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24662,6 +24957,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24763,6 +25059,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24837,6 +25134,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24930,6 +25228,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24999,6 +25298,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25079,6 +25379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25309,6 +25610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25394,6 +25696,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25479,6 +25782,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25564,6 +25868,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25634,6 +25939,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25707,6 +26013,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25774,6 +26081,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25855,6 +26163,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25924,6 +26233,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26007,6 +26317,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26067,6 +26378,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26144,6 +26456,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26209,6 +26522,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26307,6 +26621,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26432,6 +26747,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26505,6 +26821,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26609,6 +26926,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26684,6 +27002,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26783,6 +27102,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26894,6 +27214,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27010,6 +27331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27121,6 +27443,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27237,6 +27560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27348,6 +27672,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27464,6 +27789,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27584,6 +27910,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27709,6 +28036,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27832,6 +28160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27960,6 +28289,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28083,6 +28413,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28211,6 +28542,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28322,6 +28654,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28438,6 +28771,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28551,6 +28885,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28673,6 +29008,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28786,6 +29122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28908,6 +29245,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29021,6 +29359,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29143,6 +29482,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29280,6 +29620,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29402,6 +29743,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29524,6 +29866,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29635,6 +29978,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29782,6 +30126,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29857,6 +30202,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29941,6 +30287,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30055,6 +30402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30152,6 +30500,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30291,6 +30640,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30366,6 +30716,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30452,6 +30803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -30563,6 +30915,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -30593,7 +30946,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -30621,7 +30975,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30744,6 +31099,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -30771,7 +31127,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30876,6 +31233,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30980,6 +31338,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -31082,6 +31441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31192,6 +31552,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -31221,7 +31582,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -31342,6 +31704,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31453,6 +31816,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31560,6 +31924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31687,6 +32052,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31810,6 +32176,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31899,6 +32266,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31986,6 +32354,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32050,6 +32419,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32126,6 +32496,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32192,6 +32563,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32291,6 +32663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32411,6 +32784,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32485,6 +32859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32581,6 +32956,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32656,6 +33032,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32755,6 +33132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32817,6 +33195,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32900,6 +33279,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -32995,6 +33375,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33085,6 +33466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33146,6 +33528,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33217,6 +33600,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33279,6 +33663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33364,6 +33749,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33455,6 +33841,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33541,6 +33928,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33627,6 +34015,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33707,6 +34096,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33769,6 +34159,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33855,6 +34246,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33941,6 +34333,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34057,6 +34450,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34161,6 +34555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34267,6 +34662,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34320,6 +34716,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34382,6 +34779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34463,6 +34861,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34546,6 +34945,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34630,6 +35030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34716,6 +35117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34813,6 +35215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -34842,6 +35245,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -34870,7 +35274,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -34947,6 +35352,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -34975,6 +35381,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -35002,7 +35409,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35082,6 +35490,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -35109,6 +35518,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -35135,7 +35545,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35200,6 +35611,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -35227,6 +35639,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -35253,7 +35666,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35316,6 +35730,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -35343,6 +35758,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -35369,7 +35785,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -35432,6 +35849,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -35459,6 +35877,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -35485,7 +35904,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35550,6 +35970,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35631,6 +36052,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35712,6 +36134,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35793,6 +36216,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35853,6 +36277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35934,6 +36359,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36005,6 +36431,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36058,6 +36485,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36113,6 +36541,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36185,6 +36614,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36267,6 +36697,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36352,6 +36783,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36463,6 +36895,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36534,6 +36967,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36624,6 +37058,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36696,6 +37131,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36779,6 +37215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36860,6 +37297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []

--- a/app/config/specs/swagger2-1.8.x-client.json
+++ b/app/config/specs/swagger2-1.8.x-client.json
@@ -108,6 +108,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -159,6 +160,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -250,6 +252,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -328,6 +331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -399,6 +403,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -462,6 +467,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -511,6 +517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -587,6 +594,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -660,6 +668,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -686,6 +695,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -711,7 +721,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -780,6 +791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -808,6 +820,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -835,7 +848,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -917,6 +931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -942,6 +957,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -966,7 +982,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1037,6 +1054,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1063,6 +1081,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1088,7 +1107,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1168,6 +1188,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1196,6 +1217,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1223,7 +1245,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1304,6 +1327,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1326,6 +1350,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1347,7 +1372,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1401,6 +1427,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1423,6 +1450,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1444,7 +1472,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1498,6 +1527,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1520,6 +1550,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1541,7 +1572,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1595,6 +1627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1617,6 +1650,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1638,7 +1672,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1694,6 +1729,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1767,6 +1803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1846,6 +1883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1924,6 +1962,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1975,6 +2014,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2051,6 +2091,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2129,6 +2170,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2214,6 +2256,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2260,6 +2303,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2313,6 +2357,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2364,6 +2409,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2442,6 +2488,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2519,6 +2566,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2656,6 +2704,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2738,6 +2787,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2814,6 +2864,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2875,6 +2926,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2931,6 +2983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2994,6 +3047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3046,6 +3100,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3130,6 +3185,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3202,6 +3258,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3267,6 +3324,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3354,6 +3412,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3439,6 +3498,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3579,6 +3639,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3657,6 +3718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3678,7 +3740,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3701,6 +3764,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3778,6 +3842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3801,7 +3866,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3826,6 +3892,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3915,6 +3982,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3966,6 +4034,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4044,6 +4113,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4168,6 +4238,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4298,6 +4369,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4360,6 +4432,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4846,6 +4919,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4928,6 +5002,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5018,6 +5093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5108,6 +5184,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5819,6 +5896,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5884,6 +5962,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5952,6 +6031,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6013,6 +6093,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6090,6 +6171,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6153,6 +6235,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6232,6 +6315,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -6334,6 +6418,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -6368,6 +6453,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -6490,6 +6576,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -6591,6 +6678,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -6625,6 +6713,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -6743,6 +6832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -6851,6 +6941,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -6951,6 +7042,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -7071,6 +7163,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -7188,6 +7281,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7270,6 +7364,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7388,6 +7483,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7459,6 +7555,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7532,6 +7629,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7603,6 +7701,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7654,6 +7753,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7705,6 +7805,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7756,6 +7857,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7807,6 +7909,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7858,6 +7961,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7909,6 +8013,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7960,6 +8065,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8014,6 +8120,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8098,6 +8205,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8167,6 +8275,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8258,6 +8367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8347,6 +8457,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8416,6 +8527,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8506,6 +8618,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8575,6 +8688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8653,6 +8767,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8859,6 +8974,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8940,6 +9056,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9008,6 +9125,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9079,6 +9197,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9143,6 +9262,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9223,6 +9343,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9289,6 +9410,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9371,6 +9493,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9472,6 +9595,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -9501,7 +9625,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9623,6 +9748,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9723,6 +9849,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -9751,7 +9878,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9866,6 +9994,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9973,6 +10102,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10072,6 +10202,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10191,6 +10322,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10304,6 +10436,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10387,6 +10520,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10476,6 +10610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10537,6 +10672,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10611,6 +10747,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10672,6 +10809,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10763,6 +10901,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10882,6 +11021,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10951,6 +11091,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11043,6 +11184,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11114,6 +11256,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11208,6 +11351,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11269,6 +11413,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-1.8.x-console.json
+++ b/app/config/specs/swagger2-1.8.x-console.json
@@ -114,6 +114,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -164,6 +165,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -247,6 +249,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -298,6 +301,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -375,6 +379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -445,6 +450,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -507,6 +513,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -556,6 +563,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -631,6 +639,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -703,6 +712,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -729,6 +739,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -754,7 +765,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -822,6 +834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -850,6 +863,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -877,7 +891,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -958,6 +973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -983,6 +999,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -1007,7 +1024,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1077,6 +1095,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1103,6 +1122,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1128,7 +1148,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1208,6 +1229,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1236,6 +1258,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1263,7 +1286,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1343,6 +1367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1365,6 +1390,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1386,7 +1412,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1439,6 +1466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1461,6 +1489,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1482,7 +1511,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1535,6 +1565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1557,6 +1588,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1578,7 +1610,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1631,6 +1664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1653,6 +1687,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1674,7 +1709,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1729,6 +1765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1801,6 +1838,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1879,6 +1917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1956,6 +1995,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2006,6 +2046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2081,6 +2122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2158,6 +2200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2242,6 +2285,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2287,6 +2331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2339,6 +2384,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2390,6 +2436,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2468,6 +2515,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2545,6 +2593,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2682,6 +2731,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2764,6 +2814,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2840,6 +2891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2900,6 +2952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2955,6 +3008,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3017,6 +3071,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3068,6 +3123,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3151,6 +3207,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3222,6 +3279,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3286,6 +3344,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3373,6 +3432,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3458,6 +3518,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3598,6 +3659,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3676,6 +3738,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3697,7 +3760,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3720,6 +3784,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3796,6 +3861,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3819,7 +3885,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3844,6 +3911,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3932,6 +4000,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3982,6 +4051,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4059,6 +4129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4183,6 +4254,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4313,6 +4385,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4375,6 +4448,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4861,6 +4935,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4943,6 +5018,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5033,6 +5109,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5123,6 +5200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5835,6 +5913,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5898,6 +5977,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5969,6 +6049,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6017,6 +6098,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -6043,6 +6125,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -6130,6 +6213,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -6159,6 +6243,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -6248,6 +6333,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6313,6 +6399,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6381,6 +6468,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6442,6 +6530,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6519,6 +6608,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6582,6 +6672,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6660,6 +6751,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listUsage"
@@ -6684,6 +6776,7 @@
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/list-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listUsage"
@@ -6760,6 +6853,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6786,6 +6880,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6851,6 +6946,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6880,6 +6976,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6964,6 +7061,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6989,6 +7087,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -7054,6 +7153,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -7147,6 +7247,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -7275,6 +7376,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -7346,6 +7448,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -7452,6 +7555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -7523,6 +7627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -7617,6 +7722,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7728,6 +7834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7841,6 +7948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7952,6 +8060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -8065,6 +8174,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -8176,6 +8286,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -8289,6 +8400,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -8410,6 +8522,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -8533,6 +8646,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8658,6 +8772,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8785,6 +8900,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8910,6 +9026,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -9037,6 +9154,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -9148,6 +9266,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -9261,6 +9380,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -9366,6 +9486,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -9478,6 +9599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -9583,6 +9705,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9695,6 +9818,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9800,6 +9924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9912,6 +10037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -10051,6 +10177,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -10175,6 +10302,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -10295,6 +10423,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -10406,6 +10535,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10548,6 +10678,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10621,6 +10752,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10701,6 +10833,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10810,6 +10943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10912,6 +11046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10946,6 +11081,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10977,6 +11113,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -11099,6 +11236,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -11130,6 +11268,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -11232,6 +11371,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -11335,6 +11475,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -11432,6 +11573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11533,6 +11675,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11567,6 +11710,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11685,6 +11829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11793,6 +11938,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11889,6 +12035,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRowLogs"
@@ -11983,6 +12130,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -12103,6 +12251,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -12219,6 +12368,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -12311,6 +12461,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -12449,6 +12600,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -12522,6 +12674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12600,6 +12753,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTableLogs"
@@ -12682,6 +12836,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTableUsage"
@@ -12772,6 +12927,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12799,6 +12955,7 @@
                             ],
                             "description": "Get the database activity logs list by its unique ID.",
                             "demo": "databases\/list-logs.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12875,6 +13032,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getUsage"
@@ -12902,6 +13060,7 @@
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/get-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.getUsage"
@@ -12986,6 +13145,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13067,6 +13227,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13379,6 +13540,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13429,6 +13591,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13478,6 +13641,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13662,6 +13826,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13720,6 +13885,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13790,6 +13956,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13849,6 +14016,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14157,6 +14325,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14218,6 +14387,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14295,6 +14465,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14384,6 +14555,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14476,6 +14648,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14561,6 +14734,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14681,6 +14855,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14777,6 +14952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14839,6 +15015,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14906,6 +15083,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14991,6 +15169,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15059,6 +15238,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15141,6 +15321,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15259,6 +15440,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15322,6 +15504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15389,6 +15572,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15467,6 +15651,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15526,6 +15711,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15616,6 +15802,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15683,6 +15870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15777,6 +15965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15847,6 +16036,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15920,6 +16110,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15990,6 +16181,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16039,6 +16231,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16088,6 +16281,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16137,6 +16331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16195,6 +16390,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16244,6 +16440,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16293,6 +16490,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16353,6 +16551,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16413,6 +16612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16482,6 +16682,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16542,6 +16743,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16626,6 +16828,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16686,6 +16889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16746,6 +16950,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16806,6 +17011,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16866,6 +17072,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16926,6 +17133,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16986,6 +17194,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17046,6 +17255,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17106,6 +17316,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17155,6 +17366,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17204,6 +17416,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17254,6 +17467,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17305,6 +17519,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17356,6 +17571,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17407,6 +17623,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17458,6 +17675,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17509,6 +17727,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17560,6 +17779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17611,6 +17831,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17662,6 +17883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17746,6 +17968,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17905,6 +18128,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18071,6 +18295,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18268,6 +18493,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18480,6 +18706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -18513,6 +18740,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -18545,7 +18773,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18667,6 +18896,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -18699,6 +18929,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -18730,7 +18961,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18853,6 +19085,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18908,6 +19141,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18968,6 +19202,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19049,6 +19284,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19130,6 +19366,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19214,6 +19451,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -19248,6 +19486,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -19281,7 +19520,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19400,6 +19640,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -19433,6 +19674,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -19465,7 +19707,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19583,6 +19826,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -19613,6 +19857,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -19642,7 +19887,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19738,6 +19984,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -19767,6 +20014,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -19795,7 +20043,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19889,6 +20138,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20018,6 +20268,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20145,6 +20396,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20249,6 +20501,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20351,6 +20604,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20467,6 +20721,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20581,6 +20836,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20697,6 +20953,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20811,6 +21068,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -20852,6 +21110,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -20892,7 +21151,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -21055,6 +21315,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -21094,6 +21355,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -21132,7 +21394,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -21294,6 +21557,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21398,6 +21662,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21500,6 +21765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21604,6 +21870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21706,6 +21973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21810,6 +22078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21912,6 +22181,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22016,6 +22286,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22116,6 +22387,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22171,6 +22443,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22231,6 +22504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22312,6 +22586,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22393,6 +22668,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22475,6 +22751,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22563,6 +22840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22623,6 +22901,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22704,6 +22983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22764,6 +23044,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22845,6 +23126,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22936,6 +23218,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23022,6 +23305,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23086,6 +23370,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23154,6 +23439,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23236,6 +23522,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23348,6 +23635,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23456,6 +23744,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23581,6 +23870,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23671,6 +23961,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23763,6 +24054,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23848,6 +24140,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23982,6 +24275,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24117,6 +24411,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24244,6 +24539,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24370,6 +24666,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24428,6 +24725,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24481,6 +24779,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24539,6 +24838,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24621,6 +24921,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24669,6 +24970,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24750,6 +25052,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24808,6 +25111,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24893,6 +25197,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24951,6 +25256,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25031,6 +25337,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25178,6 +25485,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25236,6 +25544,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25361,6 +25670,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25421,6 +25731,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatus"
@@ -25451,6 +25762,7 @@
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
                             "demo": "projects\/update-api-status.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatus"
@@ -25480,7 +25792,8 @@
                                 }
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
-                            "demo": "projects\/update-api-status.md"
+                            "demo": "projects\/update-api-status.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25575,6 +25888,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatusAll"
@@ -25603,6 +25917,7 @@
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
                             "demo": "projects\/update-api-status-all.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatusAll"
@@ -25630,7 +25945,8 @@
                                 }
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
-                            "demo": "projects\/update-api-status-all.md"
+                            "demo": "projects\/update-api-status-all.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25711,6 +26027,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25789,6 +26106,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25867,6 +26185,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25945,6 +26264,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26037,6 +26357,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26118,6 +26439,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26196,6 +26518,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26274,6 +26597,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26352,6 +26676,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26430,6 +26755,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26508,6 +26834,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26603,6 +26930,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26673,6 +27001,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26756,6 +27085,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26822,6 +27152,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26908,6 +27239,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26976,6 +27308,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27120,6 +27453,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27187,6 +27521,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27340,6 +27675,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27406,6 +27742,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27562,6 +27899,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27630,6 +27968,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27771,6 +28110,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27838,6 +28178,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27958,6 +28299,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28024,6 +28366,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28121,6 +28464,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28189,6 +28533,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28291,6 +28636,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28369,6 +28715,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMTP"
@@ -28405,6 +28752,7 @@
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
                             "demo": "projects\/update-smtp.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMTP"
@@ -28440,7 +28788,8 @@
                                 }
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
-                            "demo": "projects\/update-smtp.md"
+                            "demo": "projects\/update-smtp.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28572,6 +28921,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.createSMTPTest"
@@ -28610,6 +28960,7 @@
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
                             "demo": "projects\/create-smtp-test.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.createSMTPTest"
@@ -28647,7 +28998,8 @@
                                 }
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
-                            "demo": "projects\/create-smtp-test.md"
+                            "demo": "projects\/create-smtp-test.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28788,6 +29140,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28864,6 +29217,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29084,6 +29438,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29347,6 +29702,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29567,6 +29923,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.getSMSTemplate"
@@ -29597,6 +29954,7 @@
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
                             "demo": "projects\/get-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.getSMSTemplate"
@@ -29626,7 +29984,8 @@
                                 }
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
-                            "demo": "projects\/get-sms-template.md"
+                            "demo": "projects\/get-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -29846,6 +30205,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMSTemplate"
@@ -29878,6 +30238,7 @@
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
                             "demo": "projects\/update-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMSTemplate"
@@ -29909,7 +30270,8 @@
                                 }
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
-                            "demo": "projects\/update-sms-template.md"
+                            "demo": "projects\/update-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30147,6 +30509,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.deleteSMSTemplate"
@@ -30177,6 +30540,7 @@
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
                             "demo": "projects\/delete-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.deleteSMSTemplate"
@@ -30206,7 +30570,8 @@
                                 }
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
-                            "demo": "projects\/delete-sms-template.md"
+                            "demo": "projects\/delete-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30426,6 +30791,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30493,6 +30859,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30611,6 +30978,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30677,6 +31045,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30798,6 +31167,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30866,6 +31236,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30932,6 +31303,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31014,6 +31386,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31084,6 +31457,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31167,6 +31541,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31287,6 +31662,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31368,6 +31744,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31421,6 +31798,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31481,6 +31859,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31539,6 +31918,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31620,6 +32000,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31890,6 +32271,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31940,6 +32322,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31989,6 +32372,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32112,6 +32496,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32170,6 +32555,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32240,6 +32626,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32299,6 +32686,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32564,6 +32952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32625,6 +33014,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32702,6 +33092,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32791,6 +33182,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32891,6 +33283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32970,6 +33363,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33090,6 +33484,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33187,6 +33582,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33249,6 +33645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33316,6 +33713,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33401,6 +33799,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33468,6 +33867,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33548,6 +33948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33612,6 +34013,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33679,6 +34081,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33757,6 +34160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33816,6 +34220,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33906,6 +34311,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33973,6 +34379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34067,6 +34474,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34134,6 +34542,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34215,6 +34624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34359,6 +34769,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34418,6 +34829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34558,6 +34970,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34618,6 +35031,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34709,6 +35123,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34798,6 +35213,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34867,6 +35283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34957,6 +35374,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35026,6 +35444,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35104,6 +35523,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35310,6 +35730,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35387,6 +35808,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35457,6 +35879,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35535,6 +35958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35616,6 +36040,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35702,6 +36127,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35770,6 +36196,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35841,6 +36268,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35905,6 +36333,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35985,6 +36414,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36051,6 +36481,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36132,6 +36563,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "listUsage",
@@ -36151,7 +36583,8 @@
                                 }
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/list-usage.md"
+                            "demo": "tablesdb\/list-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -36224,6 +36657,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36283,6 +36717,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36361,6 +36796,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36423,6 +36859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36515,6 +36952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36642,6 +37080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36712,6 +37151,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36817,6 +37257,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36887,6 +37328,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36980,6 +37422,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37090,6 +37533,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37202,6 +37646,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37312,6 +37757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37424,6 +37870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37534,6 +37981,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37646,6 +38094,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37766,6 +38215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37888,6 +38338,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38012,6 +38463,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38138,6 +38590,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38262,6 +38715,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38388,6 +38842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38498,6 +38953,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38610,6 +39066,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38714,6 +39171,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38825,6 +39283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38929,6 +39388,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39040,6 +39500,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39144,6 +39605,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39255,6 +39717,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39393,6 +39856,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39516,6 +39980,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39635,6 +40100,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39745,6 +40211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39886,6 +40353,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39958,6 +40426,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40037,6 +40506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40144,6 +40614,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40235,6 +40706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40372,6 +40844,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40444,6 +40917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40521,6 +40995,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40603,6 +41078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40704,6 +41180,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -40733,7 +41210,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -40760,7 +41238,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -40882,6 +41361,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -40908,7 +41388,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41010,6 +41491,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41112,6 +41594,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41208,6 +41691,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41308,6 +41792,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -41336,7 +41821,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41451,6 +41937,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41558,6 +42045,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41653,6 +42141,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41746,6 +42235,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41865,6 +42355,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41980,6 +42471,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42069,6 +42561,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "getUsage",
@@ -42091,7 +42584,8 @@
                                 }
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/get-usage.md"
+                            "demo": "tablesdb\/get-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -42173,6 +42667,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42256,6 +42751,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42345,6 +42841,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42406,6 +42903,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42480,6 +42978,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42540,6 +43039,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42620,6 +43120,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42711,6 +43212,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42830,6 +43332,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42899,6 +43402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42991,6 +43495,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43062,6 +43567,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43155,6 +43661,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43215,6 +43722,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43293,6 +43801,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43382,6 +43891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43466,6 +43976,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43526,6 +44037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43597,6 +44109,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43656,6 +44169,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43737,6 +44251,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43834,6 +44349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43925,6 +44441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44014,6 +44531,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44092,6 +44610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44153,6 +44672,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44244,6 +44764,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44335,6 +44856,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44461,6 +44983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44573,6 +45096,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44683,6 +45207,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44753,6 +45278,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44807,6 +45333,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44868,6 +45395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44947,6 +45475,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45029,6 +45558,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45109,6 +45639,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45189,6 +45720,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45280,6 +45812,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -45308,6 +45841,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -45335,7 +45869,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45412,6 +45947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -45439,6 +45975,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -45465,7 +46002,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45540,6 +46078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -45566,6 +46105,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -45591,7 +46131,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45653,6 +46194,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -45679,6 +46221,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -45704,7 +46247,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45766,6 +46310,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -45792,6 +46337,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -45817,7 +46363,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -45879,6 +46426,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -45905,6 +46453,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -45930,7 +46479,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45994,6 +46544,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46073,6 +46624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46152,6 +46704,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46229,6 +46782,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46288,6 +46842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46365,6 +46920,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46433,6 +46989,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46487,6 +47044,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46543,6 +47101,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46612,6 +47171,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46690,6 +47250,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46771,6 +47332,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46882,6 +47444,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46950,6 +47513,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47040,6 +47604,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47109,6 +47674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47191,6 +47757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47270,6 +47837,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47349,6 +47917,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47444,6 +48013,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47537,6 +48107,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47620,6 +48191,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47686,6 +48258,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47752,6 +48325,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47835,6 +48409,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47919,6 +48494,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47999,6 +48575,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48052,6 +48629,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-1.8.x-server.json
+++ b/app/config/specs/swagger2-1.8.x-server.json
@@ -117,6 +117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -169,6 +170,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -260,6 +262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -339,6 +342,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -411,6 +415,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -475,6 +480,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -524,6 +530,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -601,6 +608,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -675,6 +683,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -702,6 +711,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -728,7 +738,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -798,6 +809,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -827,6 +839,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -855,7 +868,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -938,6 +952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -964,6 +979,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -989,7 +1005,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1061,6 +1078,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1087,6 +1105,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1112,7 +1131,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1192,6 +1212,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1221,6 +1242,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1249,7 +1271,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1331,6 +1354,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1354,6 +1378,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1376,7 +1401,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1431,6 +1457,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1454,6 +1481,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1476,7 +1504,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1531,6 +1560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1554,6 +1584,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1576,7 +1607,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1631,6 +1663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1654,6 +1687,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1676,7 +1710,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1733,6 +1768,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1807,6 +1843,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1887,6 +1924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1966,6 +2004,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2018,6 +2057,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2095,6 +2135,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2174,6 +2215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2260,6 +2302,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2307,6 +2350,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2361,6 +2405,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2412,6 +2457,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2490,6 +2536,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2572,6 +2619,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2654,6 +2702,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2730,6 +2779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2792,6 +2842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2849,6 +2900,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2913,6 +2965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2970,6 +3023,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3057,6 +3111,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3142,6 +3197,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3282,6 +3338,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3360,6 +3417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3382,7 +3440,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3406,6 +3465,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3484,6 +3544,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3508,7 +3569,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3534,6 +3596,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3624,6 +3687,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3676,6 +3740,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3755,6 +3820,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3881,6 +3947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4013,6 +4080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4077,6 +4145,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4565,6 +4634,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4649,6 +4719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4741,6 +4812,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4833,6 +4905,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -5545,6 +5618,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -5572,6 +5646,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -5660,6 +5735,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -5690,6 +5766,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -5780,6 +5857,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5847,6 +5925,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5917,6 +5996,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5980,6 +6060,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6059,6 +6140,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6124,6 +6206,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6204,6 +6287,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6231,6 +6315,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6297,6 +6382,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6327,6 +6413,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6412,6 +6499,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6438,6 +6526,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -6504,6 +6593,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -6598,6 +6688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -6727,6 +6818,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -6799,6 +6891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -6906,6 +6999,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -6978,6 +7072,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -7073,6 +7168,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7185,6 +7281,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7299,6 +7396,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7411,6 +7509,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -7525,6 +7624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -7637,6 +7737,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -7751,6 +7852,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -7873,6 +7975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -7997,6 +8100,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8123,6 +8227,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8251,6 +8356,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8377,6 +8483,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -8505,6 +8612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -8617,6 +8725,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -8731,6 +8840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -8837,6 +8947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -8950,6 +9061,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -9056,6 +9168,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9169,6 +9282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9275,6 +9389,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9388,6 +9503,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -9528,6 +9644,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -9653,6 +9770,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -9774,6 +9892,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -9886,6 +10005,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10029,6 +10149,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10103,6 +10224,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10184,6 +10306,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10294,6 +10417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10398,6 +10522,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10433,6 +10558,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10465,6 +10591,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -10589,6 +10716,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -10621,6 +10749,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -10724,6 +10853,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -10828,6 +10958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -10926,6 +11057,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11029,6 +11161,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11064,6 +11197,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11184,6 +11318,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11294,6 +11429,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11396,6 +11532,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -11518,6 +11655,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -11636,6 +11774,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -11729,6 +11868,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -11868,6 +12008,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -11942,6 +12083,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12021,6 +12163,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12103,6 +12246,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12416,6 +12560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12467,6 +12612,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12517,6 +12663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12577,6 +12724,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12886,6 +13034,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12948,6 +13097,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13026,6 +13176,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13116,6 +13267,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13209,6 +13361,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13295,6 +13448,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13416,6 +13570,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13513,6 +13668,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13576,6 +13732,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13644,6 +13801,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13730,6 +13888,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13799,6 +13958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -13883,6 +14043,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14003,6 +14164,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14068,6 +14230,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14136,6 +14299,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14196,6 +14360,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14287,6 +14452,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14355,6 +14521,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14450,6 +14617,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14521,6 +14689,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14596,6 +14765,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14668,6 +14838,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14718,6 +14889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14768,6 +14940,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14818,6 +14991,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14877,6 +15051,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14927,6 +15102,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14977,6 +15153,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15038,6 +15215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15099,6 +15277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15169,6 +15348,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15230,6 +15410,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15315,6 +15496,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15376,6 +15558,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15437,6 +15620,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15498,6 +15682,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15559,6 +15744,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15620,6 +15806,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15681,6 +15868,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15742,6 +15930,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15803,6 +15992,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15853,6 +16043,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15903,6 +16094,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15954,6 +16146,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16007,6 +16200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16060,6 +16254,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16113,6 +16308,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16166,6 +16362,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16219,6 +16416,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16272,6 +16470,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16325,6 +16524,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16378,6 +16578,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16463,6 +16664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16623,6 +16825,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16790,6 +16993,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16988,6 +17192,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17201,6 +17406,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -17235,6 +17441,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -17268,7 +17475,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17391,6 +17599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -17424,6 +17633,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -17456,7 +17666,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17580,6 +17791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17636,6 +17848,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17697,6 +17910,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17779,6 +17993,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17861,6 +18076,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17946,6 +18162,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -17981,6 +18198,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -18015,7 +18233,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18135,6 +18354,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -18169,6 +18389,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -18202,7 +18423,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18321,6 +18543,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -18352,6 +18575,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -18382,7 +18606,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18479,6 +18704,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -18509,6 +18735,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -18538,7 +18765,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18633,6 +18861,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18763,6 +18992,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18891,6 +19121,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18996,6 +19227,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19099,6 +19331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19216,6 +19449,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19331,6 +19565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19448,6 +19683,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19563,6 +19799,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -19605,6 +19842,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -19646,7 +19884,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19810,6 +20049,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -19850,6 +20090,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -19889,7 +20130,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -20052,6 +20294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20157,6 +20400,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20260,6 +20504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20365,6 +20610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20468,6 +20714,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20573,6 +20820,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20676,6 +20924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20781,6 +21030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20882,6 +21132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20938,6 +21189,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20999,6 +21251,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21081,6 +21334,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21163,6 +21417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21246,6 +21501,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21335,6 +21591,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21396,6 +21653,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21478,6 +21736,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21539,6 +21798,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21621,6 +21881,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21713,6 +21974,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21801,6 +22063,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21866,6 +22129,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21936,6 +22200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22018,6 +22283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22289,6 +22555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22340,6 +22607,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22390,6 +22658,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22450,6 +22719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22716,6 +22986,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22778,6 +23049,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22856,6 +23128,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22946,6 +23219,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23047,6 +23321,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23127,6 +23402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23248,6 +23524,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23346,6 +23623,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23409,6 +23687,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23477,6 +23756,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23563,6 +23843,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23631,6 +23912,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23712,6 +23994,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23777,6 +24060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23845,6 +24129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23905,6 +24190,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23996,6 +24282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24064,6 +24351,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24159,6 +24447,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24227,6 +24516,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24309,6 +24599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24454,6 +24745,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24514,6 +24806,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24655,6 +24948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24716,6 +25010,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24809,6 +25104,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24900,6 +25196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24971,6 +25268,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25063,6 +25361,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25134,6 +25433,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25214,6 +25514,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25422,6 +25723,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25501,6 +25803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25583,6 +25886,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25670,6 +25974,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25740,6 +26045,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25813,6 +26119,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25879,6 +26186,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25961,6 +26269,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26029,6 +26338,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26109,6 +26419,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26169,6 +26480,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26248,6 +26560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26311,6 +26624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26404,6 +26718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26532,6 +26847,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26603,6 +26919,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26709,6 +27026,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26780,6 +27098,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26874,6 +27193,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26985,6 +27305,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27098,6 +27419,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27209,6 +27531,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27322,6 +27645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27433,6 +27757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27546,6 +27871,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27667,6 +27993,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27790,6 +28117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27915,6 +28243,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28042,6 +28371,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28167,6 +28497,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28294,6 +28625,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28405,6 +28737,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28518,6 +28851,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28623,6 +28957,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28735,6 +29070,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28840,6 +29176,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28952,6 +29289,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29057,6 +29395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29169,6 +29508,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29308,6 +29648,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29432,6 +29773,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29552,6 +29894,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29663,6 +30006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29805,6 +30149,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29878,6 +30223,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29958,6 +30304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30066,6 +30413,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30158,6 +30506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30296,6 +30645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30369,6 +30719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30448,6 +30799,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -30551,6 +30903,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -30581,7 +30934,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -30609,7 +30963,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30733,6 +31088,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -30760,7 +31116,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30863,6 +31220,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30966,6 +31324,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -31063,6 +31422,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31165,6 +31525,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -31194,7 +31555,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -31311,6 +31673,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31420,6 +31783,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31521,6 +31885,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31642,6 +32007,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31757,6 +32123,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31842,6 +32209,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31933,6 +32301,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31996,6 +32365,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32072,6 +32442,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32135,6 +32506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32228,6 +32600,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32349,6 +32722,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32420,6 +32794,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32514,6 +32889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32587,6 +32963,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32682,6 +33059,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32744,6 +33122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32824,6 +33203,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -32914,6 +33294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -32999,6 +33380,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33060,6 +33442,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33132,6 +33515,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33192,6 +33576,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33274,6 +33659,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33372,6 +33758,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33464,6 +33851,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33554,6 +33942,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33633,6 +34022,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33695,6 +34085,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33787,6 +34178,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33879,6 +34271,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34006,6 +34399,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34119,6 +34513,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34230,6 +34625,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34285,6 +34681,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34347,6 +34744,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34427,6 +34825,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34510,6 +34909,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34591,6 +34991,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34672,6 +35073,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34764,6 +35166,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -34793,6 +35196,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -34821,7 +35225,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -34899,6 +35304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -34927,6 +35333,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -34954,7 +35361,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35030,6 +35438,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -35057,6 +35466,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -35083,7 +35493,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35146,6 +35557,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -35173,6 +35585,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -35199,7 +35612,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35262,6 +35676,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -35289,6 +35704,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -35315,7 +35731,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -35378,6 +35795,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -35405,6 +35823,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -35431,7 +35850,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35496,6 +35916,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35576,6 +35997,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35656,6 +36078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35734,6 +36157,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35794,6 +36218,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35872,6 +36297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35941,6 +36367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35996,6 +36423,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36053,6 +36481,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36123,6 +36552,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36202,6 +36632,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36284,6 +36715,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36396,6 +36828,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36465,6 +36898,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36556,6 +36990,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36626,6 +37061,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36709,6 +37145,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36789,6 +37226,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []

--- a/app/config/specs/swagger2-latest-client.json
+++ b/app/config/specs/swagger2-latest-client.json
@@ -108,6 +108,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -159,6 +160,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -250,6 +252,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -328,6 +331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -399,6 +403,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -462,6 +467,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -511,6 +517,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -587,6 +594,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -660,6 +668,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -686,6 +695,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -711,7 +721,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -780,6 +791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -808,6 +820,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -835,7 +848,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -917,6 +931,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -942,6 +957,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -966,7 +982,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1037,6 +1054,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1063,6 +1081,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1088,7 +1107,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1168,6 +1188,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1196,6 +1217,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1223,7 +1245,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1304,6 +1327,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1326,6 +1350,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1347,7 +1372,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1401,6 +1427,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1423,6 +1450,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1444,7 +1472,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1498,6 +1527,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1520,6 +1550,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1541,7 +1572,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1595,6 +1627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1617,6 +1650,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1638,7 +1672,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1694,6 +1729,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1767,6 +1803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1846,6 +1883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1924,6 +1962,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1975,6 +2014,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2051,6 +2091,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2129,6 +2170,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2214,6 +2256,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2260,6 +2303,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2313,6 +2357,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2364,6 +2409,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2442,6 +2488,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2519,6 +2566,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2656,6 +2704,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2738,6 +2787,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2814,6 +2864,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2875,6 +2926,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2931,6 +2983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2994,6 +3047,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3046,6 +3100,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3130,6 +3185,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3202,6 +3258,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3267,6 +3324,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3354,6 +3412,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3439,6 +3498,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3579,6 +3639,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3657,6 +3718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3678,7 +3740,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3701,6 +3764,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3778,6 +3842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3801,7 +3866,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3826,6 +3892,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3915,6 +3982,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3966,6 +4034,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4044,6 +4113,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4168,6 +4238,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4298,6 +4369,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4360,6 +4432,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4846,6 +4919,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4928,6 +5002,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5018,6 +5093,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5108,6 +5184,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5819,6 +5896,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5884,6 +5962,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5952,6 +6031,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6013,6 +6093,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6090,6 +6171,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6153,6 +6235,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6232,6 +6315,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -6334,6 +6418,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -6368,6 +6453,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -6490,6 +6576,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -6591,6 +6678,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -6625,6 +6713,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -6743,6 +6832,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -6851,6 +6941,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -6951,6 +7042,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -7071,6 +7163,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -7188,6 +7281,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7270,6 +7364,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7388,6 +7483,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7459,6 +7555,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7532,6 +7629,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7603,6 +7701,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7654,6 +7753,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7705,6 +7805,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7756,6 +7857,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7807,6 +7909,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7858,6 +7961,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7909,6 +8013,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -7960,6 +8065,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8014,6 +8120,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8098,6 +8205,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8167,6 +8275,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8258,6 +8367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8347,6 +8457,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8416,6 +8527,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8506,6 +8618,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8575,6 +8688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8653,6 +8767,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8859,6 +8974,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -8940,6 +9056,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9008,6 +9125,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9079,6 +9197,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9143,6 +9262,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9223,6 +9343,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9289,6 +9410,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9371,6 +9493,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9472,6 +9595,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -9501,7 +9625,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9623,6 +9748,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9723,6 +9849,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -9751,7 +9878,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -9866,6 +9994,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -9973,6 +10102,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10072,6 +10202,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10191,6 +10322,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10304,6 +10436,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10387,6 +10520,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10476,6 +10610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10537,6 +10672,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10611,6 +10747,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10672,6 +10809,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10763,6 +10901,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10882,6 +11021,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -10951,6 +11091,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11043,6 +11184,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11114,6 +11256,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11208,6 +11351,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -11269,6 +11413,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-latest-console.json
+++ b/app/config/specs/swagger2-latest-console.json
@@ -114,6 +114,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -164,6 +165,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -247,6 +249,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -298,6 +301,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -375,6 +379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -445,6 +450,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -507,6 +513,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -556,6 +563,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -631,6 +639,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -703,6 +712,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -729,6 +739,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -754,7 +765,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -822,6 +834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -850,6 +863,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -877,7 +891,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -958,6 +973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -983,6 +999,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -1007,7 +1024,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1077,6 +1095,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1103,6 +1122,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1128,7 +1148,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1208,6 +1229,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1236,6 +1258,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1263,7 +1286,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1343,6 +1367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1365,6 +1390,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1386,7 +1412,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1439,6 +1466,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1461,6 +1489,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1482,7 +1511,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1535,6 +1565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1557,6 +1588,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1578,7 +1610,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1631,6 +1664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1653,6 +1687,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1674,7 +1709,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1729,6 +1765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1801,6 +1838,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1879,6 +1917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -1956,6 +1995,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2006,6 +2046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2081,6 +2122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2158,6 +2200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2242,6 +2285,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2287,6 +2331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2339,6 +2384,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2390,6 +2436,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2468,6 +2515,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2545,6 +2593,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2682,6 +2731,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2764,6 +2814,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2840,6 +2891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2900,6 +2952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2955,6 +3008,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3017,6 +3071,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3068,6 +3123,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3151,6 +3207,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3222,6 +3279,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3286,6 +3344,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3373,6 +3432,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3458,6 +3518,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3598,6 +3659,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3676,6 +3738,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3697,7 +3760,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3720,6 +3784,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3796,6 +3861,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3819,7 +3885,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3844,6 +3911,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3932,6 +4000,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3982,6 +4051,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4059,6 +4129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4183,6 +4254,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4313,6 +4385,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4375,6 +4448,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4861,6 +4935,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -4943,6 +5018,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5033,6 +5109,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5123,6 +5200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5835,6 +5913,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5898,6 +5977,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -5969,6 +6049,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6017,6 +6098,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -6043,6 +6125,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -6130,6 +6213,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -6159,6 +6243,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -6248,6 +6333,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6313,6 +6399,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6381,6 +6468,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6442,6 +6530,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6519,6 +6608,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6582,6 +6672,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -6660,6 +6751,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listUsage"
@@ -6684,6 +6776,7 @@
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/list-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listUsage"
@@ -6760,6 +6853,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6786,6 +6880,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6851,6 +6946,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6880,6 +6976,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6964,6 +7061,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6989,6 +7087,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -7054,6 +7153,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -7147,6 +7247,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -7275,6 +7376,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -7346,6 +7448,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -7452,6 +7555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -7523,6 +7627,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -7617,6 +7722,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7728,6 +7834,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7841,6 +7948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7952,6 +8060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -8065,6 +8174,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -8176,6 +8286,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -8289,6 +8400,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -8410,6 +8522,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -8533,6 +8646,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8658,6 +8772,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8785,6 +8900,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8910,6 +9026,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -9037,6 +9154,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -9148,6 +9266,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -9261,6 +9380,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -9366,6 +9486,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -9478,6 +9599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -9583,6 +9705,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9695,6 +9818,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9800,6 +9924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9912,6 +10037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -10051,6 +10177,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -10175,6 +10302,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -10295,6 +10423,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -10406,6 +10535,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10548,6 +10678,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10621,6 +10752,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10701,6 +10833,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10810,6 +10943,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10912,6 +11046,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10946,6 +11081,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10977,6 +11113,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -11099,6 +11236,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -11130,6 +11268,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -11232,6 +11371,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -11335,6 +11475,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -11432,6 +11573,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11533,6 +11675,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11567,6 +11710,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11685,6 +11829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11793,6 +11938,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11889,6 +12035,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRowLogs"
@@ -11983,6 +12130,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -12103,6 +12251,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -12219,6 +12368,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -12311,6 +12461,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -12449,6 +12600,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -12522,6 +12674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12600,6 +12753,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTableLogs"
@@ -12682,6 +12836,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTableUsage"
@@ -12772,6 +12927,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12799,6 +12955,7 @@
                             ],
                             "description": "Get the database activity logs list by its unique ID.",
                             "demo": "databases\/list-logs.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.listDatabaseLogs"
@@ -12875,6 +13032,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getUsage"
@@ -12902,6 +13060,7 @@
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of collections, documents, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
                             "demo": "databases\/get-usage.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.getUsage"
@@ -12986,6 +13145,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13067,6 +13227,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13379,6 +13540,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13429,6 +13591,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13478,6 +13641,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13662,6 +13826,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13720,6 +13885,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13790,6 +13956,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -13849,6 +14016,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14157,6 +14325,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14218,6 +14387,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14295,6 +14465,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14384,6 +14555,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14476,6 +14648,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14561,6 +14734,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14681,6 +14855,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14777,6 +14952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14839,6 +15015,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14906,6 +15083,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -14991,6 +15169,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15059,6 +15238,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15141,6 +15321,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15259,6 +15440,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15322,6 +15504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15389,6 +15572,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15467,6 +15651,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15526,6 +15711,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15616,6 +15802,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15683,6 +15870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15777,6 +15965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15847,6 +16036,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15920,6 +16110,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -15990,6 +16181,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16039,6 +16231,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16088,6 +16281,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16137,6 +16331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16195,6 +16390,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16244,6 +16440,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16293,6 +16490,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16353,6 +16551,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16413,6 +16612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16482,6 +16682,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16542,6 +16743,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16626,6 +16828,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16686,6 +16889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16746,6 +16950,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16806,6 +17011,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16866,6 +17072,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16926,6 +17133,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -16986,6 +17194,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17046,6 +17255,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17106,6 +17316,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17155,6 +17366,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17204,6 +17416,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17254,6 +17467,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17305,6 +17519,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17356,6 +17571,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17407,6 +17623,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17458,6 +17675,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17509,6 +17727,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17560,6 +17779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17611,6 +17831,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17662,6 +17883,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17746,6 +17968,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -17905,6 +18128,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18071,6 +18295,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18268,6 +18493,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18480,6 +18706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -18513,6 +18740,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -18545,7 +18773,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18667,6 +18896,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -18699,6 +18929,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -18730,7 +18961,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18853,6 +19085,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18908,6 +19141,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -18968,6 +19202,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19049,6 +19284,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19130,6 +19366,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -19214,6 +19451,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -19248,6 +19486,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -19281,7 +19520,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19400,6 +19640,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -19433,6 +19674,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -19465,7 +19707,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19583,6 +19826,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -19613,6 +19857,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -19642,7 +19887,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19738,6 +19984,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -19767,6 +20014,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -19795,7 +20043,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19889,6 +20138,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20018,6 +20268,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20145,6 +20396,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20249,6 +20501,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20351,6 +20604,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20467,6 +20721,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20581,6 +20836,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20697,6 +20953,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -20811,6 +21068,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -20852,6 +21110,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -20892,7 +21151,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -21055,6 +21315,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -21094,6 +21355,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -21132,7 +21394,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -21294,6 +21557,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21398,6 +21662,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21500,6 +21765,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21604,6 +21870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21706,6 +21973,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21810,6 +22078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -21912,6 +22181,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22016,6 +22286,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22116,6 +22387,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22171,6 +22443,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22231,6 +22504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22312,6 +22586,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22393,6 +22668,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22475,6 +22751,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22563,6 +22840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22623,6 +22901,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22704,6 +22983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22764,6 +23044,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22845,6 +23126,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -22936,6 +23218,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23022,6 +23305,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23086,6 +23370,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23154,6 +23439,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23236,6 +23522,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23348,6 +23635,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23456,6 +23744,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23581,6 +23870,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23671,6 +23961,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23763,6 +24054,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23848,6 +24140,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -23982,6 +24275,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24117,6 +24411,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24244,6 +24539,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24370,6 +24666,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24428,6 +24725,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24481,6 +24779,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24539,6 +24838,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24621,6 +24921,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24669,6 +24970,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24750,6 +25052,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24808,6 +25111,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24893,6 +25197,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -24951,6 +25256,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25031,6 +25337,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25178,6 +25485,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25236,6 +25544,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25361,6 +25670,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25421,6 +25731,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatus"
@@ -25451,6 +25762,7 @@
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
                             "demo": "projects\/update-api-status.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatus"
@@ -25480,7 +25792,8 @@
                                 }
                             ],
                             "description": "Update the status of a specific API type. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime.",
-                            "demo": "projects\/update-api-status.md"
+                            "demo": "projects\/update-api-status.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25575,6 +25888,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateAPIStatusAll"
@@ -25603,6 +25917,7 @@
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
                             "demo": "projects\/update-api-status-all.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateAPIStatusAll"
@@ -25630,7 +25945,8 @@
                                 }
                             ],
                             "description": "Update the status of all API types. Use this endpoint to enable or disable API types such as REST, GraphQL and Realtime all at once.",
-                            "demo": "projects\/update-api-status-all.md"
+                            "demo": "projects\/update-api-status-all.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -25711,6 +26027,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25789,6 +26106,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25867,6 +26185,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -25945,6 +26264,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26037,6 +26357,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26118,6 +26439,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26196,6 +26518,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26274,6 +26597,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26352,6 +26676,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26430,6 +26755,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26508,6 +26834,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26603,6 +26930,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26673,6 +27001,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26756,6 +27085,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26822,6 +27152,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26908,6 +27239,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -26976,6 +27308,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27120,6 +27453,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27187,6 +27521,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27340,6 +27675,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27406,6 +27742,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27562,6 +27899,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27630,6 +27968,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27771,6 +28110,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27838,6 +28178,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -27958,6 +28299,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28024,6 +28366,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28121,6 +28464,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28189,6 +28533,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28291,6 +28636,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28369,6 +28715,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMTP"
@@ -28405,6 +28752,7 @@
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
                             "demo": "projects\/update-smtp.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMTP"
@@ -28440,7 +28788,8 @@
                                 }
                             ],
                             "description": "Update the SMTP configuration for your project. Use this endpoint to configure your project's SMTP provider with your custom settings for sending transactional emails. ",
-                            "demo": "projects\/update-smtp.md"
+                            "demo": "projects\/update-smtp.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28572,6 +28921,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.createSMTPTest"
@@ -28610,6 +28960,7 @@
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
                             "demo": "projects\/create-smtp-test.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.createSMTPTest"
@@ -28647,7 +28998,8 @@
                                 }
                             ],
                             "description": "Send a test email to verify SMTP configuration. ",
-                            "demo": "projects\/create-smtp-test.md"
+                            "demo": "projects\/create-smtp-test.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -28788,6 +29140,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -28864,6 +29217,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29084,6 +29438,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29347,6 +29702,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -29567,6 +29923,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.getSMSTemplate"
@@ -29597,6 +29954,7 @@
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
                             "demo": "projects\/get-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.getSMSTemplate"
@@ -29626,7 +29984,8 @@
                                 }
                             ],
                             "description": "Get a custom SMS template for the specified locale and type returning it's contents.",
-                            "demo": "projects\/get-sms-template.md"
+                            "demo": "projects\/get-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -29846,6 +30205,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.updateSMSTemplate"
@@ -29878,6 +30238,7 @@
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
                             "demo": "projects\/update-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.updateSMSTemplate"
@@ -29909,7 +30270,8 @@
                                 }
                             ],
                             "description": "Update a custom SMS template for the specified locale and type. Use this endpoint to modify the content of your SMS templates. ",
-                            "demo": "projects\/update-sms-template.md"
+                            "demo": "projects\/update-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30147,6 +30509,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "projects.deleteSMSTemplate"
@@ -30177,6 +30540,7 @@
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
                             "demo": "projects\/delete-sms-template.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "projects.deleteSMSTemplate"
@@ -30206,7 +30570,8 @@
                                 }
                             ],
                             "description": "Reset a custom SMS template to its default value. This endpoint removes any custom message and restores the template to its original state. ",
-                            "demo": "projects\/delete-sms-template.md"
+                            "demo": "projects\/delete-sms-template.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30426,6 +30791,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30493,6 +30859,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30611,6 +30978,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30677,6 +31045,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30798,6 +31167,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30866,6 +31236,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -30932,6 +31303,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31014,6 +31386,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31084,6 +31457,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31167,6 +31541,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31287,6 +31662,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31368,6 +31744,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31421,6 +31798,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31481,6 +31859,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31539,6 +31918,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31620,6 +32000,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31890,6 +32271,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31940,6 +32322,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -31989,6 +32372,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32112,6 +32496,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32170,6 +32555,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32240,6 +32626,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32299,6 +32686,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32564,6 +32952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32625,6 +33014,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32702,6 +33092,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32791,6 +33182,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32891,6 +33283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -32970,6 +33363,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33090,6 +33484,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33187,6 +33582,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33249,6 +33645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33316,6 +33713,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33401,6 +33799,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33468,6 +33867,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33548,6 +33948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33612,6 +34013,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33679,6 +34081,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33757,6 +34160,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33816,6 +34220,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33906,6 +34311,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -33973,6 +34379,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34067,6 +34474,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34134,6 +34542,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34215,6 +34624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34359,6 +34769,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34418,6 +34829,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34558,6 +34970,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34618,6 +35031,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34709,6 +35123,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34798,6 +35213,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34867,6 +35283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -34957,6 +35374,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35026,6 +35444,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35104,6 +35523,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35310,6 +35730,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35387,6 +35808,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35457,6 +35879,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35535,6 +35958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35616,6 +36040,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35702,6 +36127,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35770,6 +36196,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35841,6 +36268,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35905,6 +36333,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -35985,6 +36414,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36051,6 +36481,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36132,6 +36563,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "listUsage",
@@ -36151,7 +36583,8 @@
                                 }
                             ],
                             "description": "List usage metrics and statistics for all databases in the project. You can view the total number of databases, tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/list-usage.md"
+                            "demo": "tablesdb\/list-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -36224,6 +36657,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36283,6 +36717,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36361,6 +36796,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36423,6 +36859,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36515,6 +36952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36642,6 +37080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36712,6 +37151,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36817,6 +37257,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36887,6 +37328,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -36980,6 +37422,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37090,6 +37533,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37202,6 +37646,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37312,6 +37757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37424,6 +37870,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37534,6 +37981,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37646,6 +38094,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37766,6 +38215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -37888,6 +38338,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38012,6 +38463,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38138,6 +38590,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38262,6 +38715,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38388,6 +38842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38498,6 +38953,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38610,6 +39066,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38714,6 +39171,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38825,6 +39283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -38929,6 +39388,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39040,6 +39500,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39144,6 +39605,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39255,6 +39717,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39393,6 +39856,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39516,6 +39980,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39635,6 +40100,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39745,6 +40211,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39886,6 +40353,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -39958,6 +40426,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40037,6 +40506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40144,6 +40614,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40235,6 +40706,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40372,6 +40844,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40444,6 +40917,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40521,6 +40995,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40603,6 +41078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -40704,6 +41180,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -40733,7 +41210,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -40760,7 +41238,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -40882,6 +41361,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -40908,7 +41388,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41010,6 +41491,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41112,6 +41594,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41208,6 +41691,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41308,6 +41792,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -41336,7 +41821,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -41451,6 +41937,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41558,6 +42045,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41653,6 +42141,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41746,6 +42235,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41865,6 +42355,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -41980,6 +42471,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42069,6 +42561,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "getUsage",
@@ -42091,7 +42584,8 @@
                                 }
                             ],
                             "description": "Get usage metrics and statistics for a database. You can view the total number of tables, rows, and storage usage. The response includes both current totals and historical data over time. Use the optional range parameter to specify the time window for historical data: 24h (last 24 hours), 30d (last 30 days), or 90d (last 90 days). If not specified, range defaults to 30 days.",
-                            "demo": "tablesdb\/get-usage.md"
+                            "demo": "tablesdb\/get-usage.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -42173,6 +42667,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42256,6 +42751,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42345,6 +42841,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42406,6 +42903,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42480,6 +42978,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42540,6 +43039,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42620,6 +43120,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42711,6 +43212,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42830,6 +43332,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42899,6 +43402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -42991,6 +43495,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43062,6 +43567,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43155,6 +43661,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43215,6 +43722,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43293,6 +43801,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43382,6 +43891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43466,6 +43976,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43526,6 +44037,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43597,6 +44109,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43656,6 +44169,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43737,6 +44251,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43834,6 +44349,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -43925,6 +44441,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44014,6 +44531,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44092,6 +44610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44153,6 +44672,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44244,6 +44764,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44335,6 +44856,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44461,6 +44983,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44573,6 +45096,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44683,6 +45207,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44753,6 +45278,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44807,6 +45333,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44868,6 +45395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -44947,6 +45475,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45029,6 +45558,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45109,6 +45639,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45189,6 +45720,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -45280,6 +45812,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -45308,6 +45841,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -45335,7 +45869,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45412,6 +45947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -45439,6 +45975,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -45465,7 +46002,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45540,6 +46078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -45566,6 +46105,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -45591,7 +46131,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45653,6 +46194,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -45679,6 +46221,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -45704,7 +46247,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45766,6 +46310,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -45792,6 +46337,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -45817,7 +46363,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -45879,6 +46426,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -45905,6 +46453,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -45930,7 +46479,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -45994,6 +46544,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46073,6 +46624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46152,6 +46704,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46229,6 +46782,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46288,6 +46842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46365,6 +46920,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46433,6 +46989,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46487,6 +47044,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46543,6 +47101,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46612,6 +47171,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46690,6 +47250,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46771,6 +47332,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46882,6 +47444,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -46950,6 +47513,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47040,6 +47604,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47109,6 +47674,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47191,6 +47757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47270,6 +47837,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47349,6 +47917,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47444,6 +48013,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47537,6 +48107,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47620,6 +48191,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47686,6 +48258,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47752,6 +48325,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47835,6 +48409,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47919,6 +48494,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -47999,6 +48575,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -48052,6 +48629,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }

--- a/app/config/specs/swagger2-latest-server.json
+++ b/app/config/specs/swagger2-latest-server.json
@@ -117,6 +117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -169,6 +170,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -260,6 +262,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -339,6 +342,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -411,6 +415,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -475,6 +480,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -524,6 +530,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -601,6 +608,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -675,6 +683,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAAuthenticator"
@@ -702,6 +711,7 @@
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
                             "demo": "account\/create-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAAuthenticator"
@@ -728,7 +738,8 @@
                                 }
                             ],
                             "description": "Add an authenticator app to be used as an MFA factor. Verify the authenticator using the [verify authenticator](\/docs\/references\/cloud\/client-web\/account#updateMfaAuthenticator) method.",
-                            "demo": "account\/create-mfa-authenticator.md"
+                            "demo": "account\/create-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -798,6 +809,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAAuthenticator"
@@ -827,6 +839,7 @@
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
                             "demo": "account\/update-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAAuthenticator"
@@ -855,7 +868,8 @@
                                 }
                             ],
                             "description": "Verify an authenticator app after adding it using the [add authenticator](\/docs\/references\/cloud\/client-web\/account#createMfaAuthenticator) method.",
-                            "demo": "account\/update-mfa-authenticator.md"
+                            "demo": "account\/update-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -938,6 +952,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.deleteMFAAuthenticator"
@@ -964,6 +979,7 @@
                             ],
                             "description": "Delete an authenticator for a user by ID.",
                             "demo": "account\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.deleteMFAAuthenticator"
@@ -989,7 +1005,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator for a user by ID.",
-                            "demo": "account\/delete-mfa-authenticator.md"
+                            "demo": "account\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1061,6 +1078,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFAChallenge"
@@ -1087,6 +1105,7 @@
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
                             "demo": "account\/create-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFAChallenge"
@@ -1112,7 +1131,8 @@
                                 }
                             ],
                             "description": "Begin the process of MFA verification after sign-in. Finish the flow with [updateMfaChallenge](\/docs\/references\/cloud\/client-web\/account#updateMfaChallenge) method.",
-                            "demo": "account\/create-mfa-challenge.md"
+                            "demo": "account\/create-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1192,6 +1212,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFAChallenge"
@@ -1221,6 +1242,7 @@
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/update-mfa-challenge.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFAChallenge"
@@ -1249,7 +1271,8 @@
                                 }
                             ],
                             "description": "Complete the MFA challenge by providing the one-time password. Finish the process of MFA verification by providing the one-time password. To begin the flow, use [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/update-mfa-challenge.md"
+                            "demo": "account\/update-mfa-challenge.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1331,6 +1354,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.listMFAFactors"
@@ -1354,6 +1378,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "account\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.listMFAFactors"
@@ -1376,7 +1401,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "account\/list-mfa-factors.md"
+                            "demo": "account\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1431,6 +1457,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.getMFARecoveryCodes"
@@ -1454,6 +1481,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
                             "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.getMFARecoveryCodes"
@@ -1476,7 +1504,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to read recovery codes.",
-                            "demo": "account\/get-mfa-recovery-codes.md"
+                            "demo": "account\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1531,6 +1560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.createMFARecoveryCodes"
@@ -1554,6 +1584,7 @@
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
                             "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createMFARecoveryCodes"
@@ -1576,7 +1607,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes as backup for MFA flow. It's recommended to generate and show then immediately after user successfully adds their authehticator. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method.",
-                            "demo": "account\/create-mfa-recovery-codes.md"
+                            "demo": "account\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1631,6 +1663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "account.updateMFARecoveryCodes"
@@ -1654,6 +1687,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
                             "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateMFARecoveryCodes"
@@ -1676,7 +1710,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method. An OTP challenge is required to regenreate recovery codes.",
-                            "demo": "account\/update-mfa-recovery-codes.md"
+                            "demo": "account\/update-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -1733,6 +1768,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1807,6 +1843,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1887,6 +1924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -1966,6 +2004,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2018,6 +2057,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2095,6 +2135,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2174,6 +2215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2260,6 +2302,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2307,6 +2350,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2361,6 +2405,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2412,6 +2457,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2490,6 +2536,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2572,6 +2619,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.6.0",
                         "replaceWith": "account.createSession"
@@ -2654,6 +2702,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -2730,6 +2779,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2792,6 +2842,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2849,6 +2900,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2913,6 +2965,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -2970,6 +3023,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3057,6 +3111,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3142,6 +3197,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3282,6 +3338,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": []
                     }
@@ -3360,6 +3417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createEmailVerification",
@@ -3382,7 +3440,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
-                            "demo": "account\/create-email-verification.md"
+                            "demo": "account\/create-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "createVerification",
@@ -3406,6 +3465,7 @@
                             ],
                             "description": "Use this endpoint to send a verification message to your user email address to confirm they are the valid owners of that address. Both the **userId** and **secret** arguments will be passed as query parameters to the URL you have provided to be attached to the verification email. The provided URL should redirect the user back to your app and allow you to complete the verification process by verifying both the **userId** and **secret** parameters. Learn more about how to [complete the verification process](https:\/\/appwrite.io\/docs\/references\/cloud\/client-web\/account#updateVerification). The verification link sent to the user's email address is valid for 7 days.\n\nPlease note that in order to avoid a [Redirect Attack](https:\/\/github.com\/OWASP\/CheatSheetSeries\/blob\/master\/cheatsheets\/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md), the only valid redirect URLs are the ones from domains you have set when adding your platforms in the console interface.\n",
                             "demo": "account\/create-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.createEmailVerification"
@@ -3484,6 +3544,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "updateEmailVerification",
@@ -3508,7 +3569,8 @@
                                 }
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
-                            "demo": "account\/update-email-verification.md"
+                            "demo": "account\/update-email-verification.md",
+                            "public": true
                         },
                         {
                             "name": "updateVerification",
@@ -3534,6 +3596,7 @@
                             ],
                             "description": "Use this endpoint to complete the user email verification process. Use both the **userId** and **secret** parameters that were attached to your app URL to verify the user email ownership. If confirmed this route will return a 200 status code.",
                             "demo": "account\/update-verification.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "account.updateEmailVerification"
@@ -3624,6 +3687,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3676,6 +3740,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3755,6 +3820,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -3881,6 +3947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4013,6 +4080,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4077,6 +4145,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4565,6 +4634,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4649,6 +4719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4741,6 +4812,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -4833,6 +4905,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -5545,6 +5618,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.list"
@@ -5572,6 +5646,7 @@
                             ],
                             "description": "Get a list of all databases from the current Appwrite project. You can use the search parameter to filter your results.",
                             "demo": "databases\/list.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.list"
@@ -5660,6 +5735,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.create"
@@ -5690,6 +5766,7 @@
                             ],
                             "description": "Create a new Database.\n",
                             "demo": "databases\/create.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.create"
@@ -5780,6 +5857,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5847,6 +5925,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5917,6 +5996,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -5980,6 +6060,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6059,6 +6140,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6124,6 +6206,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -6204,6 +6287,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.get"
@@ -6231,6 +6315,7 @@
                             ],
                             "description": "Get a database by its unique ID. This endpoint response returns a JSON object with the database metadata.",
                             "demo": "databases\/get.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.get"
@@ -6297,6 +6382,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.update"
@@ -6327,6 +6413,7 @@
                             ],
                             "description": "Update a database by its unique ID.",
                             "demo": "databases\/update.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.update"
@@ -6412,6 +6499,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.delete"
@@ -6438,6 +6526,7 @@
                             ],
                             "description": "Delete a database by its unique ID. Only API keys with with databases.write scope can delete a database.",
                             "demo": "databases\/delete.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.delete"
@@ -6504,6 +6593,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listTables"
@@ -6598,6 +6688,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createTable"
@@ -6727,6 +6818,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getTable"
@@ -6799,6 +6891,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateTable"
@@ -6906,6 +6999,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteTable"
@@ -6978,6 +7072,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listColumns"
@@ -7073,6 +7168,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createBooleanColumn"
@@ -7185,6 +7281,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateBooleanColumn"
@@ -7299,6 +7396,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createDatetimeColumn"
@@ -7411,6 +7509,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateDatetimeColumn"
@@ -7525,6 +7624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEmailColumn"
@@ -7637,6 +7737,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEmailColumn"
@@ -7751,6 +7852,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createEnumColumn"
@@ -7873,6 +7975,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateEnumColumn"
@@ -7997,6 +8100,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createFloatColumn"
@@ -8123,6 +8227,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateFloatColumn"
@@ -8251,6 +8356,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIntegerColumn"
@@ -8377,6 +8483,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIntegerColumn"
@@ -8505,6 +8612,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIpColumn"
@@ -8617,6 +8725,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateIpColumn"
@@ -8731,6 +8840,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createLineColumn"
@@ -8837,6 +8947,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateLineColumn"
@@ -8950,6 +9061,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPointColumn"
@@ -9056,6 +9168,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePointColumn"
@@ -9169,6 +9282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createPolygonColumn"
@@ -9275,6 +9389,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updatePolygonColumn"
@@ -9388,6 +9503,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRelationshipColumn"
@@ -9528,6 +9644,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createStringColumn"
@@ -9653,6 +9770,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateStringColumn"
@@ -9774,6 +9892,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createUrlColumn"
@@ -9886,6 +10005,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateUrlColumn"
@@ -10029,6 +10149,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getColumn"
@@ -10103,6 +10224,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteColumn"
@@ -10184,6 +10306,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRelationshipColumn"
@@ -10294,6 +10417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listRows"
@@ -10398,6 +10522,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createRow"
@@ -10433,6 +10558,7 @@
                             ],
                             "description": "Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRow"
@@ -10465,6 +10591,7 @@
                             ],
                             "description": "Create new Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/create-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.createRows"
@@ -10589,6 +10716,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRows"
@@ -10621,6 +10749,7 @@
                             ],
                             "description": "Create or update Documents. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.\n",
                             "demo": "databases\/upsert-documents.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRows"
@@ -10724,6 +10853,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRows"
@@ -10828,6 +10958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRows"
@@ -10926,6 +11057,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getRow"
@@ -11029,6 +11161,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.upsertRow"
@@ -11064,6 +11197,7 @@
                             ],
                             "description": "Create or update a Document. Before using this route, you should create a new collection resource using either a [server integration](https:\/\/appwrite.io\/docs\/server\/databases#databasesCreateCollection) API or directly from your database console.",
                             "demo": "databases\/upsert-document.md",
+                            "public": true,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "tablesDB.upsertRow"
@@ -11184,6 +11318,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.updateRow"
@@ -11294,6 +11429,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteRow"
@@ -11396,6 +11532,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.decrementRowColumn"
@@ -11518,6 +11655,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.incrementRowColumn"
@@ -11636,6 +11774,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.listIndexes"
@@ -11729,6 +11868,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.createIndex"
@@ -11868,6 +12008,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.getIndex"
@@ -11942,6 +12083,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "tablesDB.deleteIndex"
@@ -12021,6 +12163,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12103,6 +12246,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12416,6 +12560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12467,6 +12612,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12517,6 +12663,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12577,6 +12724,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12886,6 +13034,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -12948,6 +13097,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13026,6 +13176,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13116,6 +13267,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13209,6 +13361,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13295,6 +13448,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13416,6 +13570,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13513,6 +13668,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13576,6 +13732,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13644,6 +13801,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13730,6 +13888,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -13799,6 +13958,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -13883,6 +14043,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14003,6 +14164,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -14068,6 +14230,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14136,6 +14299,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14196,6 +14360,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14287,6 +14452,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14355,6 +14521,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14450,6 +14617,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14521,6 +14689,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14596,6 +14765,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14668,6 +14838,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14718,6 +14889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14768,6 +14940,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14818,6 +14991,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14877,6 +15051,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14927,6 +15102,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -14977,6 +15153,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15038,6 +15215,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15099,6 +15277,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15169,6 +15348,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15230,6 +15410,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15315,6 +15496,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15376,6 +15558,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15437,6 +15620,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15498,6 +15682,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15559,6 +15744,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15620,6 +15806,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15681,6 +15868,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15742,6 +15930,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15803,6 +15992,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15853,6 +16043,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15903,6 +16094,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -15954,6 +16146,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16007,6 +16200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16060,6 +16254,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16113,6 +16308,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16166,6 +16362,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16219,6 +16416,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16272,6 +16470,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16325,6 +16524,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -16378,6 +16578,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16463,6 +16664,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16623,6 +16825,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16790,6 +16993,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -16988,6 +17192,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17201,6 +17406,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMS"
@@ -17235,6 +17441,7 @@
                             ],
                             "description": "Create a new SMS message.",
                             "demo": "messaging\/create-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMS"
@@ -17268,7 +17475,8 @@
                                 }
                             ],
                             "description": "Create a new SMS message.",
-                            "demo": "messaging\/create-sms.md"
+                            "demo": "messaging\/create-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17391,6 +17599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMS"
@@ -17424,6 +17633,7 @@
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
                             "demo": "messaging\/update-sms.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMS"
@@ -17456,7 +17666,8 @@
                                 }
                             ],
                             "description": "Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.\n",
-                            "demo": "messaging\/update-sms.md"
+                            "demo": "messaging\/update-sms.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -17580,6 +17791,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17636,6 +17848,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17697,6 +17910,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17779,6 +17993,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17861,6 +18076,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -17946,6 +18162,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createAPNSProvider"
@@ -17981,6 +18198,7 @@
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
                             "demo": "messaging\/create-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createAPNSProvider"
@@ -18015,7 +18233,8 @@
                                 }
                             ],
                             "description": "Create a new Apple Push Notification service provider.",
-                            "demo": "messaging\/create-apns-provider.md"
+                            "demo": "messaging\/create-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18135,6 +18354,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateAPNSProvider"
@@ -18169,6 +18389,7 @@
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
                             "demo": "messaging\/update-apns-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateAPNSProvider"
@@ -18202,7 +18423,8 @@
                                 }
                             ],
                             "description": "Update a Apple Push Notification service provider by its unique ID.",
-                            "demo": "messaging\/update-apns-provider.md"
+                            "demo": "messaging\/update-apns-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18321,6 +18543,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createFCMProvider"
@@ -18352,6 +18575,7 @@
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
                             "demo": "messaging\/create-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createFCMProvider"
@@ -18382,7 +18606,8 @@
                                 }
                             ],
                             "description": "Create a new Firebase Cloud Messaging provider.",
-                            "demo": "messaging\/create-fcm-provider.md"
+                            "demo": "messaging\/create-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18479,6 +18704,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateFCMProvider"
@@ -18509,6 +18735,7 @@
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
                             "demo": "messaging\/update-fcm-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateFCMProvider"
@@ -18538,7 +18765,8 @@
                                 }
                             ],
                             "description": "Update a Firebase Cloud Messaging provider by its unique ID.",
-                            "demo": "messaging\/update-fcm-provider.md"
+                            "demo": "messaging\/update-fcm-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -18633,6 +18861,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18763,6 +18992,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18891,6 +19121,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -18996,6 +19227,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19099,6 +19331,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19216,6 +19449,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19331,6 +19565,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19448,6 +19683,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -19563,6 +19799,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.createSMTPProvider"
@@ -19605,6 +19842,7 @@
                             ],
                             "description": "Create a new SMTP provider.",
                             "demo": "messaging\/create-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.createSMTPProvider"
@@ -19646,7 +19884,8 @@
                                 }
                             ],
                             "description": "Create a new SMTP provider.",
-                            "demo": "messaging\/create-smtp-provider.md"
+                            "demo": "messaging\/create-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -19810,6 +20049,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "messaging.updateSMTPProvider"
@@ -19850,6 +20090,7 @@
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
                             "demo": "messaging\/update-smtp-provider.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "messaging.updateSMTPProvider"
@@ -19889,7 +20130,8 @@
                                 }
                             ],
                             "description": "Update a SMTP provider by its unique ID.",
-                            "demo": "messaging\/update-smtp-provider.md"
+                            "demo": "messaging\/update-smtp-provider.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -20052,6 +20294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20157,6 +20400,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20260,6 +20504,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20365,6 +20610,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20468,6 +20714,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20573,6 +20820,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20676,6 +20924,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20781,6 +21030,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20882,6 +21132,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20938,6 +21189,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -20999,6 +21251,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21081,6 +21334,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21163,6 +21417,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21246,6 +21501,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21335,6 +21591,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21396,6 +21653,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21478,6 +21736,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21539,6 +21798,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21621,6 +21881,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21713,6 +21974,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21801,6 +22063,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -21866,6 +22129,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "JWT": []
@@ -21936,6 +22200,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22018,6 +22283,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22289,6 +22555,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22340,6 +22607,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22390,6 +22658,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22450,6 +22719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22716,6 +22986,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22778,6 +23049,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22856,6 +23128,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -22946,6 +23219,7 @@
                         "server"
                     ],
                     "packaging": true,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23047,6 +23321,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23127,6 +23402,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23248,6 +23524,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23346,6 +23623,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23409,6 +23687,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23477,6 +23756,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23563,6 +23843,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23631,6 +23912,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23712,6 +23994,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23777,6 +24060,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23845,6 +24129,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23905,6 +24190,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -23996,6 +24282,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24064,6 +24351,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24159,6 +24447,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24227,6 +24516,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24309,6 +24599,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24454,6 +24745,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24514,6 +24806,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24655,6 +24948,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -24716,6 +25010,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24809,6 +25104,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24900,6 +25196,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -24971,6 +25268,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25063,6 +25361,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25134,6 +25433,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25214,6 +25514,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25422,6 +25723,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -25501,6 +25803,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25583,6 +25886,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25670,6 +25974,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25740,6 +26045,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25813,6 +26119,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25879,6 +26186,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -25961,6 +26269,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26029,6 +26338,7 @@
                         "client"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26109,6 +26419,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26169,6 +26480,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26248,6 +26560,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26311,6 +26624,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26404,6 +26718,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26532,6 +26847,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26603,6 +26919,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26709,6 +27026,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26780,6 +27098,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26874,6 +27193,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -26985,6 +27305,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27098,6 +27419,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27209,6 +27531,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27322,6 +27645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27433,6 +27757,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27546,6 +27871,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27667,6 +27993,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27790,6 +28117,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -27915,6 +28243,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28042,6 +28371,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28167,6 +28497,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28294,6 +28625,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28405,6 +28737,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28518,6 +28851,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28623,6 +28957,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28735,6 +29070,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28840,6 +29176,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -28952,6 +29289,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29057,6 +29395,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29169,6 +29508,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29308,6 +29648,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29432,6 +29773,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29552,6 +29894,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29663,6 +30006,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29805,6 +30149,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29878,6 +30223,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -29958,6 +30304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30066,6 +30413,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30158,6 +30506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30296,6 +30645,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30369,6 +30719,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30448,6 +30799,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -30551,6 +30903,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "createRow",
@@ -30581,7 +30934,8 @@
                                 }
                             ],
                             "description": "Create a new Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-row.md"
+                            "demo": "tablesdb\/create-row.md",
+                            "public": true
                         },
                         {
                             "name": "createRows",
@@ -30609,7 +30963,8 @@
                                 }
                             ],
                             "description": "Create new Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/create-rows.md"
+                            "demo": "tablesdb\/create-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30733,6 +31088,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRows",
@@ -30760,7 +31116,8 @@
                                 }
                             ],
                             "description": "Create or update Rows. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.\n",
-                            "demo": "tablesdb\/upsert-rows.md"
+                            "demo": "tablesdb\/upsert-rows.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -30863,6 +31220,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -30966,6 +31324,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -31063,6 +31422,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31165,6 +31525,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "methods": [
                         {
                             "name": "upsertRow",
@@ -31194,7 +31555,8 @@
                                 }
                             ],
                             "description": "Create or update a Row. Before using this route, you should create a new table resource using either a [server integration](https:\/\/appwrite.io\/docs\/references\/cloud\/server-dart\/tablesDB#createTable) API or directly from your database console.",
-                            "demo": "tablesdb\/upsert-row.md"
+                            "demo": "tablesdb\/upsert-row.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -31311,6 +31673,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31420,6 +31783,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31521,6 +31885,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31642,6 +32007,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31757,6 +32123,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31842,6 +32209,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31933,6 +32301,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -31996,6 +32365,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32072,6 +32442,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32135,6 +32506,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32228,6 +32600,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32349,6 +32722,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32420,6 +32794,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32514,6 +32889,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32587,6 +32963,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32682,6 +33059,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32744,6 +33122,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Session": []
@@ -32824,6 +33203,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -32914,6 +33294,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -32999,6 +33380,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33060,6 +33442,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33132,6 +33515,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33192,6 +33576,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33274,6 +33659,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33372,6 +33758,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33464,6 +33851,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33554,6 +33942,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33633,6 +34022,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33695,6 +34085,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33787,6 +34178,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -33879,6 +34271,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34006,6 +34399,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34119,6 +34513,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34230,6 +34625,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34285,6 +34681,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34347,6 +34744,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34427,6 +34825,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34510,6 +34909,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34591,6 +34991,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34672,6 +35073,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -34764,6 +35166,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFA"
@@ -34793,6 +35196,7 @@
                             ],
                             "description": "Enable or disable MFA on a user account.",
                             "demo": "users\/update-mfa.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFA"
@@ -34821,7 +35225,8 @@
                                 }
                             ],
                             "description": "Enable or disable MFA on a user account.",
-                            "demo": "users\/update-mfa.md"
+                            "demo": "users\/update-mfa.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -34899,6 +35304,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.deleteMFAAuthenticator"
@@ -34927,6 +35333,7 @@
                             ],
                             "description": "Delete an authenticator app.",
                             "demo": "users\/delete-mfa-authenticator.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.deleteMFAAuthenticator"
@@ -34954,7 +35361,8 @@
                                 }
                             ],
                             "description": "Delete an authenticator app.",
-                            "demo": "users\/delete-mfa-authenticator.md"
+                            "demo": "users\/delete-mfa-authenticator.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35030,6 +35438,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.listMFAFactors"
@@ -35057,6 +35466,7 @@
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
                             "demo": "users\/list-mfa-factors.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.listMFAFactors"
@@ -35083,7 +35493,8 @@
                                 }
                             ],
                             "description": "List the factors available on the account to be used as a MFA challange.",
-                            "demo": "users\/list-mfa-factors.md"
+                            "demo": "users\/list-mfa-factors.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35146,6 +35557,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.getMFARecoveryCodes"
@@ -35173,6 +35585,7 @@
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.getMFARecoveryCodes"
@@ -35199,7 +35612,8 @@
                                 }
                             ],
                             "description": "Get recovery codes that can be used as backup for MFA flow by User ID. Before getting codes, they must be generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/get-mfa-recovery-codes.md"
+                            "demo": "users\/get-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35262,6 +35676,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.updateMFARecoveryCodes"
@@ -35289,6 +35704,7 @@
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
                             "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.updateMFARecoveryCodes"
@@ -35315,7 +35731,8 @@
                                 }
                             ],
                             "description": "Regenerate recovery codes that can be used as backup for MFA flow by User ID. Before regenerating codes, they must be first generated using [createMfaRecoveryCodes](\/docs\/references\/cloud\/client-web\/account#createMfaRecoveryCodes) method.",
-                            "demo": "users\/update-mfa-recovery-codes.md"
+                            "demo": "users\/update-mfa-recovery-codes.md",
+                            "public": false
                         }
                     ],
                     "auth": {
@@ -35378,6 +35795,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": false,
                     "deprecated": {
                         "since": "1.8.0",
                         "replaceWith": "users.createMFARecoveryCodes"
@@ -35405,6 +35823,7 @@
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
                             "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": false,
                             "deprecated": {
                                 "since": "1.8.0",
                                 "replaceWith": "users.createMFARecoveryCodes"
@@ -35431,7 +35850,8 @@
                                 }
                             ],
                             "description": "Generate recovery codes used as backup for MFA flow for User ID. Recovery codes can be used as a MFA verification type in [createMfaChallenge](\/docs\/references\/cloud\/client-web\/account#createMfaChallenge) method by client SDK.",
-                            "demo": "users\/create-mfa-recovery-codes.md"
+                            "demo": "users\/create-mfa-recovery-codes.md",
+                            "public": true
                         }
                     ],
                     "auth": {
@@ -35496,6 +35916,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35576,6 +35997,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35656,6 +36078,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35734,6 +36157,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35794,6 +36218,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35872,6 +36297,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35941,6 +36367,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -35996,6 +36423,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36053,6 +36481,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36123,6 +36552,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36202,6 +36632,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36284,6 +36715,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36396,6 +36828,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36465,6 +36898,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36556,6 +36990,7 @@
                         "console"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36626,6 +37061,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36709,6 +37145,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []
@@ -36789,6 +37226,7 @@
                         "server"
                     ],
                     "packaging": false,
+                    "public": true,
                     "auth": {
                         "Project": [],
                         "Key": []

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3754,6 +3754,7 @@ App::post('/v1/account/verifications/email')
                 since: '1.8.0',
                 replaceWith: 'account.createEmailVerification'
             ),
+            public: false,
         )
     ])
     ->label('abuse-limit', 10)
@@ -3970,6 +3971,7 @@ App::put('/v1/account/verifications/email')
                 since: '1.8.0',
                 replaceWith: 'account.updateEmailVerification'
             ),
+            public: false,
         )
     ])
     ->label('abuse-limit', 10)

--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -339,6 +339,7 @@ App::post('/v1/messaging/providers/smtp')
                 since: '1.8.0',
                 replaceWith: 'messaging.createSMTPProvider',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -872,6 +873,7 @@ App::post('/v1/messaging/providers/fcm')
                 since: '1.8.0',
                 replaceWith: 'messaging.createFCMProvider',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -961,6 +963,7 @@ App::post('/v1/messaging/providers/apns')
                 since: '1.8.0',
                 replaceWith: 'messaging.createAPNSProvider',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -1574,6 +1577,7 @@ App::patch('/v1/messaging/providers/smtp/:providerId')
                 since: '1.8.0',
                 replaceWith: 'messaging.updateSMTPProvider',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -2165,6 +2169,7 @@ App::patch('/v1/messaging/providers/fcm/:providerId')
                 since: '1.8.0',
                 replaceWith: 'messaging.updateFCMProvider',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -2260,6 +2265,7 @@ App::patch('/v1/messaging/providers/apns/:providerId')
                 since: '1.8.0',
                 replaceWith: 'messaging.updateAPNSProvider',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -3325,6 +3331,7 @@ App::post('/v1/messaging/messages/sms')
                 since: '1.8.0',
                 replaceWith: 'messaging.createSMS',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',
@@ -4168,6 +4175,7 @@ App::patch('/v1/messaging/messages/sms/:messageId')
                 since: '1.8.0',
                 replaceWith: 'messaging.updateSMS',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'messaging',

--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -563,6 +563,7 @@ App::patch('/v1/projects/:projectId/api')
                 since: '1.8.0',
                 replaceWith: 'projects.updateAPIStatus',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',
@@ -620,6 +621,7 @@ App::patch('/v1/projects/:projectId/api/all')
                 since: '1.8.0',
                 replaceWith: 'projects.updateAPIStatusAll',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',
@@ -2024,6 +2026,7 @@ App::patch('/v1/projects/:projectId/smtp')
                 since: '1.8.0',
                 replaceWith: 'projects.updateSMTP',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',
@@ -2140,6 +2143,7 @@ App::post('/v1/projects/:projectId/smtp/tests')
                 since: '1.8.0',
                 replaceWith: 'projects.createSMTPTest',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',
@@ -2234,6 +2238,7 @@ App::get('/v1/projects/:projectId/templates/sms/:type/:locale')
                 since: '1.8.0',
                 replaceWith: 'projects.getSMSTemplate',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',
@@ -2400,6 +2405,7 @@ App::patch('/v1/projects/:projectId/templates/sms/:type/:locale')
                 since: '1.8.0',
                 replaceWith: 'projects.updateSMSTemplate',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',
@@ -2524,6 +2530,7 @@ App::delete('/v1/projects/:projectId/templates/sms/:type/:locale')
                 since: '1.8.0',
                 replaceWith: 'projects.deleteSMSTemplate',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'projects',

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1813,6 +1813,7 @@ App::patch('/v1/users/:userId/mfa')
                 since: '1.8.0',
                 replaceWith: 'users.updateMFA',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'users',
@@ -1872,6 +1873,7 @@ App::get('/v1/users/:userId/mfa/factors')
                 since: '1.8.0',
                 replaceWith: 'users.listMFAFactors',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'users',
@@ -1930,6 +1932,7 @@ App::get('/v1/users/:userId/mfa/recovery-codes')
                 since: '1.8.0',
                 replaceWith: 'users.getMFARecoveryCodes',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'users',
@@ -1994,6 +1997,7 @@ App::patch('/v1/users/:userId/mfa/recovery-codes')
                 since: '1.8.0',
                 replaceWith: 'users.createMFARecoveryCodes',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'users',
@@ -2065,6 +2069,7 @@ App::put('/v1/users/:userId/mfa/recovery-codes')
                 since: '1.8.0',
                 replaceWith: 'users.updateMFARecoveryCodes',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'users',
@@ -2077,7 +2082,8 @@ App::put('/v1/users/:userId/mfa/recovery-codes')
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_MFA_RECOVERY_CODES,
                 )
-            ]
+            ],
+            public: false,
         )
     ])
     ->param('userId', '', new UID(), 'User ID.')
@@ -2136,6 +2142,7 @@ App::delete('/v1/users/:userId/mfa/authenticators/:type')
                 since: '1.8.0',
                 replaceWith: 'users.deleteMFAAuthenticator',
             ),
+            public: false,
         ),
         new Method(
             namespace: 'users',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Create.php
@@ -60,6 +60,7 @@ class Create extends Action
                         since: '1.8.0',
                         replaceWith: 'account.createMFAAuthenticator',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Delete.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Delete.php
@@ -57,6 +57,7 @@ class Delete extends Action
                         since: '1.8.0',
                         replaceWith: 'account.deleteMFAAuthenticator',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Update.php
@@ -59,6 +59,7 @@ class Update extends Action
                         since: '1.8.0',
                         replaceWith: 'account.updateMFAAuthenticator',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
@@ -72,6 +72,7 @@ class Create extends Action
                         since: '1.8.0',
                         replaceWith: 'account.createMFAChallenge',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -59,6 +59,7 @@ class Update extends Action
                         since: '1.8.0',
                         replaceWith: 'account.updateMFAChallenge',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Factors/XList.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Factors/XList.php
@@ -49,6 +49,7 @@ class XList extends Action
                         since: '1.8.0',
                         replaceWith: 'account.listMFAFactors',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Create.php
@@ -55,6 +55,7 @@ class Create extends Action
                         since: '1.8.0',
                         replaceWith: 'account.createMFARecoveryCodes',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Get.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Get.php
@@ -48,6 +48,7 @@ class Get extends Action
                         since: '1.8.0',
                         replaceWith: 'account.getMFARecoveryCodes',
                     ),
+                    public: false,
                 ),
                 new Method(
                     namespace: 'account',

--- a/src/Appwrite/SDK/Method.php
+++ b/src/Appwrite/SDK/Method.php
@@ -31,6 +31,7 @@ class Method
      * @param array<Parameter> $parameters
      * @param array $additionalParameters
      * @param string $desc
+     * @param bool $public Whether this method should be rendered on the website/documentation
      */
     public function __construct(
         protected string $namespace,
@@ -47,7 +48,8 @@ class Method
         protected ContentType $requestType = ContentType::JSON,
         protected array $parameters = [],
         protected array $additionalParameters = [],
-        protected string $desc = ''
+        protected string $desc = '',
+        protected bool $public = true
     ) {
         $this->validateMethod($name, $namespace);
         $this->validateAuthTypes($auth);
@@ -304,6 +306,17 @@ class Method
     public function setParameters(array $parameters): self
     {
         $this->parameters = $parameters;
+        return $this;
+    }
+
+    public function isPublic(): bool
+    {
+        return $this->public;
+    }
+
+    public function setPublic(bool $public): self
+    {
+        $this->public = $public;
         return $this;
     }
 

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -165,7 +165,8 @@ class OpenAPI3 extends Format
                     'rate-key' => $route->getLabel('abuse-key', 'url:{url},ip:{ip}'),
                     'scope' => $route->getLabel('scope', ''),
                     'platforms' => $sdkPlatforms,
-                    'packaging' => $sdk->isPackaging()
+                    'packaging' => $sdk->isPackaging(),
+                    'public' => $sdk->isPublic(),
                 ],
             ];
 
@@ -225,6 +226,7 @@ class OpenAPI3 extends Format
                         'responses' => [],
                         'description' => ($desc) ? \file_get_contents($desc) : '',
                         'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodObj->getMethodName()) . '.md',
+                        'public' => $methodObj->isPublic(),
                     ];
 
                     // add deprecation only if method has it!

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -170,6 +170,7 @@ class Swagger2 extends Format
                     'scope' => $route->getLabel('scope', ''),
                     'platforms' => $sdkPlatforms,
                     'packaging' => $sdk->isPackaging(),
+                    'public' => $sdk->isPublic(),
                 ],
             ];
 
@@ -234,6 +235,7 @@ class Swagger2 extends Format
                         'responses' => [],
                         'description' => ($desc) ? \file_get_contents($desc) : '',
                         'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodObj->getMethodName()) . '.md',
+                        'public' => $methodObj->isPublic(),
                     ];
 
                     // add deprecation only if method has it!


### PR DESCRIPTION
## Summary
This PR adds a visibility control mechanism for deprecated methods to prevent them from appearing in public documentation while maintaining backward compatibility in the API.

## Changes
- Added `public` parameter to the `Method` class to control documentation visibility
- Added `isPublic()` and `setPublic()` methods to the Method class
- Marked deprecated methods as non-public (`public: false`) across:
  - Account verification endpoints
  - Messaging provider endpoints (SMTP, FCM, APNS)
  - Messaging SMS endpoints
  - Account MFA authenticators, challenges, factors, and recovery codes
- Updated OpenAPI 3 and Swagger 2 specs (both 1.8.x and latest versions) to reflect visibility changes

## Test plan
- [ ] Verify deprecated methods still function correctly in the API
- [ ] Confirm deprecated methods are hidden from public documentation
- [ ] Ensure non-deprecated methods remain visible in documentation
- [ ] Check that SDK generation works correctly with the new public parameter