### PR TITLE
Fix users.listMfaFactors() recoveryCode mismatch (#10927)

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1852,22 +1852,28 @@ App::get('/v1/users/:userId/mfa/factors')
     ->inject('response')
     ->inject('dbForProject')
     ->action(function (string $userId, Response $response, Database $dbForProject) {
-        $user = $dbForProject->getDocument('users', $userId);
+    $user = $dbForProject->getDocument('users', $userId);
 
-        if ($user->isEmpty()) {
-            throw new Exception(Exception::USER_NOT_FOUND);
-        }
+    if ($user->isEmpty()) {
+        throw new Exception(Exception::USER_NOT_FOUND);
+    }
 
-        $totp = TOTP::getAuthenticatorFromUser($user);
+    
+    $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
+    $recoveryCodeEnabled = \is_array($mfaRecoveryCodes) && \count($mfaRecoveryCodes) > 0;
+   
 
-        $factors = new Document([
-            Type::TOTP => $totp !== null && $totp->getAttribute('verified', false),
-            Type::EMAIL => $user->getAttribute('email', false) && $user->getAttribute('emailVerification', false),
-            Type::PHONE => $user->getAttribute('phone', false) && $user->getAttribute('phoneVerification', false)
-        ]);
+    $totp = TOTP::getAuthenticatorFromUser($user);
 
-        $response->dynamic($factors, Response::MODEL_MFA_FACTORS);
-    });
+    $factors = new Document([
+        Type::TOTP => $totp !== null && $totp->getAttribute('verified', false),
+        Type::EMAIL => $user->getAttribute('email', false) && $user->getAttribute('emailVerification', false),
+        Type::PHONE => $user->getAttribute('phone', false) && $user->getAttribute('phoneVerification', false),
+        Type::RECOVERY_CODE => $recoveryCodeEnabled
+    ]);
+
+    $response->dynamic($factors, Response::MODEL_MFA_FACTORS);
+});
 
 App::get('/v1/users/:userId/mfa/recovery-codes')
     ->desc('Get MFA recovery codes')


### PR DESCRIPTION
Summary
Fixes an inconsistency where GET /v1/users/:userId/mfa/factors returned recoveryCode: false even when recovery codes existed for the user. This makes the users endpoint match the behavior of account.listMfaFactors().

Root cause
The Users controller did not check the user document for the mfaRecoveryCodes attribute. The Account controller already checks that attribute and sets recoveryCode: true when recovery codes exist; the Users controller simply omitted that check and therefore always returned recoveryCode: false.

What this change does

Adds the same recovery-code presence check used by the Account handler to app/controllers/api/users.php so Type::RECOVERY_CODE is set correctly.

Ensures GET /v1/users/:userId/mfa/factors returns recoveryCode: true when recovery codes exist for the user, matching GET /v1/account/mfa/factors.

Files changed

app/controllers/api/users.php — include mfaRecoveryCodes check and set Type::RECOVERY_CODE in the factors response.

- Fixes: #10927
