### PR TITLE
chore: lazy init sms adapter + late static binding

### DIFF
--- a/src/Appwrite/Event/Database.php
+++ b/src/Appwrite/Event/Database.php
@@ -161,7 +161,7 @@ class Database extends Event
         return $this->document;
     }
 
-    public function setProject(Document $project): self
+    public function setProject(Document $project): static
     {
         $database = $project->getAttribute('database');
         if (!empty($database)) {

--- a/src/Appwrite/Event/Event.php
+++ b/src/Appwrite/Event/Event.php
@@ -92,9 +92,9 @@ class Event
      * Set queue used for this event.
      *
      * @param string $queue
-     * @return Event
+     * @return static
      */
-    public function setQueue(string $queue): self
+    public function setQueue(string $queue): static
     {
         $this->queue = $queue;
 
@@ -114,9 +114,9 @@ class Event
     /**
      * Set event name used for this event.
      * @param string $event
-     * @return Event
+     * @return static
      */
-    public function setEvent(string $event): self
+    public function setEvent(string $event): static
     {
         $this->event = $event;
 
@@ -137,9 +137,9 @@ class Event
      * Set project for this event.
      *
      * @param Document $project
-     * @return self
+     * @return static
      */
-    public function setProject(Document $project): self
+    public function setProject(Document $project): static
     {
         $this->project = $project;
         return $this;
@@ -159,9 +159,9 @@ class Event
      * Set platform for this event.
      *
      * @param array $platform
-     * @return self
+     * @return static
      */
-    public function setPlatform(array $platform): self
+    public function setPlatform(array $platform): static
     {
         $this->platform = $platform;
         return $this;
@@ -181,9 +181,9 @@ class Event
      * Set user for this event.
      *
      * @param Document $user
-     * @return self
+     * @return static
      */
-    public function setUser(Document $user): self
+    public function setUser(Document $user): static
     {
         $this->user = $user;
 
@@ -193,9 +193,9 @@ class Event
     /**
      * Set user ID for this event.
      *
-     * @return self
+     * @return static
      */
-    public function setUserId(string $userId): self
+    public function setUserId(string $userId): static
     {
         $this->userId = $userId;
 
@@ -225,9 +225,9 @@ class Event
      *
      * @param array $payload
      * @param array $sensitive
-     * @return self
+     * @return static
      */
-    public function setPayload(array $payload, array $sensitive = []): self
+    public function setPayload(array $payload, array $sensitive = []): static
     {
         $this->payload = $payload;
 

--- a/src/Appwrite/Event/Messaging.php
+++ b/src/Appwrite/Event/Messaging.php
@@ -162,19 +162,6 @@ class Messaging extends Event
     }
 
     /**
-     * Set project for this event.
-     *
-     * @param Document $project
-     * @return self
-     */
-    public function setProject(Document $project): self
-    {
-        $this->project = $project;
-
-        return $this;
-    }
-
-    /**
      * Prepare the payload for the event
      *
      * @return array

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -62,9 +62,6 @@ class Messaging extends Action
      */
     public function __construct()
     {
-
-        $this->adapter = $this->createInternalSMSAdapter();
-
         $this
             ->desc('Messaging worker')
             ->inject('message')
@@ -390,6 +387,10 @@ class Messaging extends Action
 
     private function sendInternalSMSMessage(Document $message, Document $project, array $recipients, Log $log): void
     {
+        if ($this->adapter === null) {
+            $this->adapter = $this->createInternalSMSAdapter();
+        }
+
         if ($this->adapter === null) {
             Console::warning('Skipped SMS processing. SMS adapter is not set.');
             return;


### PR DESCRIPTION
1. prevents initing of sms adapter in all workers:
<img width="845" height="205" alt="Screenshot 2025-12-16 at 10 37 14 AM" src="https://github.com/user-attachments/assets/f6d7559f-29dc-4b89-964e-7d75704711fd" />


2. late static binding helps fix type errors in queues, for eg here:
<img width="794" height="313" alt="Screenshot 2025-12-16 at 10 38 06 AM" src="https://github.com/user-attachments/assets/8d5aa822-8548-4f5c-a590-b043c19422d3" />
