### PR TITLE
Updated CONTRIBUTING.md fixing issue #6039

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ docker compose up -d
 
 To get proper autocompletion for all the different functions and classes in the codebase, you'll need to install Appwrite dependencies on your local machine. You can easily do that with PHP's package manager, [Composer](https://getcomposer.org/). If you don't have Composer installed, you can use the Docker Hub image to get the same result:
 
-**Unix / macOS / Linux**
+## Unix / macOS / Linux
 
 ```bash
 docker run --rm --interactive --tty \
@@ -138,7 +138,7 @@ docker run --rm --interactive --tty \
   composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
 ```
 
-**Windows (PowerShell)**
+## Windows (PowerShell)
 
 ```powershell
 docker run --rm --interactive --tty `
@@ -146,7 +146,7 @@ docker run --rm --interactive --tty `
   composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
 ```
 
-**Windows (CMD)**
+## Windows (CMD)
 
 ```cmd
 docker run --rm --interactive --tty ^


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Added platform-specific Docker commands to the "Code Autocompletion" section in CONTRIBUTING.md.

Changes include:
- Separation of commands for Unix/macOS/Linux, Windows (PowerShell), and Windows (CMD).
- Corrected line continuation characters (`\` for Unix, `` ` `` for PowerShell, `^` for CMD).
- Updated current working directory variables (`$PWD`, `${PWD}`, `%cd%`) for better cross-platform compatibility.

## Test Plan

### Docker Command Verification Guide

Verify the Docker command works on your specific platform by running the updated snippet from `CONTRIBUTING.md` in your project root:

### Unix / macOS / Linux

1. Open a terminal (bash/zsh).
2. Copy and paste the command from the **Unix / macOS / Linux** section.
3. **Expectation:** Docker runs the container and `composer update` executes without syntax errors.

### Windows (PowerShell)

1. Open PowerShell.
2. Copy and paste the command from the **Windows (PowerShell)** section.
3. **Expectation:** Command executes cleanly using backticks (`` ` ``) for line breaks and `${PWD}` for the path.

###  Windows (CMD)

1. Open Command Prompt.
2. Copy and paste the command from the **Windows (CMD)** section.
3. **Expectation:** Command executes cleanly using carets (`^`) for line breaks and `%cd%` for the path.

## Related PRs and Issues

Fixes issue #6039 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
