### PR TITLE
Fix #4952: Allow custom SMTP test email via _APP_SMTP_TEST_EMAIL

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -568,6 +568,15 @@ return [
                 'question' => '',
                 'filter' => ''
             ],
+            [
+                'name' => '_APP_SMTP_TEST_EMAIL',
+                'description' => 'Email address used by the doctor command to test SMTP connection. Default value is demo@example.com.',
+                'introduction' => '',
+                'default' => 'demo@example.com',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -214,7 +214,8 @@ class Doctor extends Action
             /* @var PHPMailer $mail */
             $mail = $register->get('smtp');
 
-            $mail->addAddress('demo@example.com', 'Example.com');
+            $testEmail = App::getEnv('_APP_SMTP_TEST_EMAIL', 'demo@example.com');
+            $mail->addAddress($testEmail, 'Appwrite Doctor');
             $mail->Subject = 'Test SMTP Connection';
             $mail->Body = 'Hello World';
             $mail->AltBody = 'Hello World';


### PR DESCRIPTION
### What does this PR do?
This PR allows users to configure a custom test email address for the `doctor` command using the `_APP_SMTP_TEST_EMAIL` environment variable.

### Why is this necessary?
The current hardcoded `demo@example.com` address is often rejected by SMTP providers (like SendGrid or AWS SES), causing the doctor command to report a "disconnected" status even when the configuration is correct.

### Which issue does it fix?
Fixes #4952

### Checklist
- [x] Logic updated in `Doctor.php` to use `App::getEnv`.
- [x] Environment variable registered in `app/config/variables.php`.