### PR TITLE
fix: task subprocesses

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php doctor $@
+exec php /usr/src/code/app/cli.php doctor "$@"

--- a/bin/install
+++ b/bin/install
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php install $@
+exec php /usr/src/code/app/cli.php install "$@"

--- a/bin/interval
+++ b/bin/interval
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php interval $@
+exec php /usr/src/code/app/cli.php interval "$@"

--- a/bin/maintenance
+++ b/bin/maintenance
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php maintenance $@
+exec php /usr/src/code/app/cli.php maintenance "$@"

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php migrate $@
+exec php /usr/src/code/app/cli.php migrate "$@"

--- a/bin/queue-count-failed
+++ b/bin/queue-count-failed
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php queue-count --type=failed $@
+exec php /usr/src/code/app/cli.php queue-count --type=failed "$@"

--- a/bin/queue-count-processing
+++ b/bin/queue-count-processing
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php queue-count --type=processing $@
+exec php /usr/src/code/app/cli.php queue-count --type=processing "$@"

--- a/bin/queue-count-success
+++ b/bin/queue-count-success
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php queue-count --type=success $@
+exec php /usr/src/code/app/cli.php queue-count --type=success "$@"

--- a/bin/queue-retry
+++ b/bin/queue-retry
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php queue-retry $@
+exec php /usr/src/code/app/cli.php queue-retry "$@"

--- a/bin/realtime
+++ b/bin/realtime
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/realtime.php $@
+exec php /usr/src/code/app/realtime.php "$@"

--- a/bin/schedule-executions
+++ b/bin/schedule-executions
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php schedule-executions $@
+exec php /usr/src/code/app/cli.php schedule-executions "$@"

--- a/bin/schedule-functions
+++ b/bin/schedule-functions
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php schedule-functions $@
+exec php /usr/src/code/app/cli.php schedule-functions "$@"

--- a/bin/schedule-messages
+++ b/bin/schedule-messages
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php schedule-messages $@
+exec php /usr/src/code/app/cli.php schedule-messages "$@"

--- a/bin/screenshot
+++ b/bin/screenshot
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php screenshot $@
+exec php /usr/src/code/app/cli.php screenshot "$@"

--- a/bin/sdks
+++ b/bin/sdks
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php sdks $@
+exec php /usr/src/code/app/cli.php sdks "$@"

--- a/bin/specs
+++ b/bin/specs
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php specs $@
+exec php /usr/src/code/app/cli.php specs "$@"

--- a/bin/ssl
+++ b/bin/ssl
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php ssl $@
+exec php /usr/src/code/app/cli.php ssl "$@"

--- a/bin/stats-resources
+++ b/bin/stats-resources
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php stats-resources $@
+exec php /usr/src/code/app/cli.php stats-resources "$@"

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/src/code/vendor/bin/phpunit --configuration /usr/src/code/phpunit.xml $@
+exec /usr/src/code/vendor/bin/phpunit --configuration /usr/src/code/phpunit.xml "$@"

--- a/bin/upgrade
+++ b/bin/upgrade
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php upgrade $@
+exec php /usr/src/code/app/cli.php upgrade "$@"

--- a/bin/vars
+++ b/bin/vars
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/cli.php vars $@
+exec php /usr/src/code/app/cli.php vars "$@"

--- a/bin/worker-audits
+++ b/bin/worker-audits
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php audits $@
+exec php /usr/src/code/app/worker.php audits "$@"

--- a/bin/worker-builds
+++ b/bin/worker-builds
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php builds $@
+exec php /usr/src/code/app/worker.php builds "$@"

--- a/bin/worker-certificates
+++ b/bin/worker-certificates
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php certificates $@
+exec php /usr/src/code/app/worker.php certificates "$@"

--- a/bin/worker-databases
+++ b/bin/worker-databases
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php databases $@
+exec php /usr/src/code/app/worker.php databases "$@"

--- a/bin/worker-deletes
+++ b/bin/worker-deletes
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php deletes $@
+exec php /usr/src/code/app/worker.php deletes "$@"

--- a/bin/worker-functions
+++ b/bin/worker-functions
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php functions $@
+exec php /usr/src/code/app/worker.php functions "$@"

--- a/bin/worker-mails
+++ b/bin/worker-mails
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php mails $@
+exec php /usr/src/code/app/worker.php mails "$@"

--- a/bin/worker-messaging
+++ b/bin/worker-messaging
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php messaging $@
+exec php /usr/src/code/app/worker.php messaging "$@"

--- a/bin/worker-migrations
+++ b/bin/worker-migrations
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php migrations $@
+exec php /usr/src/code/app/worker.php migrations "$@"

--- a/bin/worker-stats-resources
+++ b/bin/worker-stats-resources
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php stats-resources $@
+exec php /usr/src/code/app/worker.php stats-resources "$@"

--- a/bin/worker-stats-usage
+++ b/bin/worker-stats-usage
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php stats-usage $@
+exec php /usr/src/code/app/worker.php stats-usage "$@"

--- a/bin/worker-webhooks
+++ b/bin/worker-webhooks
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/app/worker.php webhooks $@
+exec php /usr/src/code/app/worker.php webhooks "$@"


### PR DESCRIPTION
Use exec to replace the shell process with PHP, ensuring signals (SIGTERM, SIGINT, etc.) are delivered directly to the PHP process instead of the wrapper shell. Also quote $@ properly for argument handling.

Before:
`php /usr/src/code/app/cli.php doctor $@`

After:
`exec php /usr/src/code/app/cli.php doctor "$@"`