### PR TITLE
Fix APK file MIME type detection for mobile downloads

### DIFF
--- a/app/controllers/api/storage.php
+++ b/app/controllers/api/storage.php
@@ -82,7 +82,7 @@ App::post('/v1/storage/buckets')
     ->param('permissions', null, new Nullable(new Permissions(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of permission strings. By default, no user is granted with any permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
     ->param('fileSecurity', false, new Boolean(true), 'Enables configuring permissions for individual file. A user needs one of file or bucket level permissions to access a file. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
     ->param('enabled', true, new Boolean(true), 'Is bucket enabled? When set to \'disabled\', users cannot access the files in this bucket but Server SDKs with and API key can still access the bucket. No files are lost when this is toggled.', true)
-    ->param('maximumFileSize', fn (array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn (array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Storage::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
+    ->param('maximumFileSize', fn(array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn(array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Storage::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
     ->param('allowedFileExtensions', [], new ArrayList(new Text(64), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Allowed file extensions. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' extensions are allowed, each 64 characters long.', true)
     ->param('compression', Compression::NONE, new WhiteList([Compression::NONE, Compression::GZIP, Compression::ZSTD], true), 'Compression algorithm choosen for compression. Can be one of ' . Compression::NONE . ',  [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd), For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' compression is skipped even if it\'s enabled', true)
     ->param('encryption', true, new Boolean(true), 'Is encryption enabled? For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' encryption is skipped even if it\'s enabled', true)
@@ -297,7 +297,7 @@ App::put('/v1/storage/buckets/:bucketId')
     ->param('permissions', null, new Nullable(new Permissions(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of permission strings. By default, the current permissions are inherited. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
     ->param('fileSecurity', false, new Boolean(true), 'Enables configuring permissions for individual file. A user needs one of file or bucket level permissions to access a file. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
     ->param('enabled', true, new Boolean(true), 'Is bucket enabled? When set to \'disabled\', users cannot access the files in this bucket but Server SDKs with and API key can still access the bucket. No files are lost when this is toggled.', true)
-    ->param('maximumFileSize', fn (array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn (array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Storage::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
+    ->param('maximumFileSize', fn(array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn(array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Storage::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
     ->param('allowedFileExtensions', [], new ArrayList(new Text(64), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Allowed file extensions. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' extensions are allowed, each 64 characters long.', true)
     ->param('compression', Compression::NONE, new WhiteList([Compression::NONE, Compression::GZIP, Compression::ZSTD], true), 'Compression algorithm choosen for compression. Can be one of ' . Compression::NONE . ', [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd), For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' compression is skipped even if it\'s enabled', true)
     ->param('encryption', true, new Boolean(true), 'Is encryption enabled? For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' encryption is skipped even if it\'s enabled', true)
@@ -437,7 +437,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
     ->inject('authorization')
     ->action(function (string $bucketId, string $fileId, mixed $file, ?array $permissions, Request $request, Response $response, Database $dbForProject, Document $user, Event $queueForEvents, string $mode, Device $deviceForFiles, Device $deviceForLocal, Authorization $authorization) {
 
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -568,7 +568,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
         $fileSize ??= $deviceForLocal->getFileSize($fileTmpName);
         $path = $deviceForFiles->getPath($fileId . '.' . \pathinfo($fileName, PATHINFO_EXTENSION));
         $path = str_ireplace($deviceForFiles->getRoot(), $deviceForFiles->getRoot() . DIRECTORY_SEPARATOR . $bucket->getId(), $path); // Add bucket id to path after root
-
+    
         $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
 
         $metadata = ['content_type' => $deviceForLocal->getFileMimeType($fileTmpName)];
@@ -606,6 +606,19 @@ App::post('/v1/storage/buckets/:bucketId/files')
             }
 
             $mimeType = $deviceForFiles->getFileMimeType($path); // Get mime-type before compression and encryption
+    
+            // Override MIME type for specific extensions where file-based detection returns incorrect types
+            // APK files are ZIP archives, so they're detected as application/zip, but they need the APK MIME type
+            $extension = \strtolower(\pathinfo($fileName, PATHINFO_EXTENSION));
+            $extensionOverrides = [
+                'apk' => 'application/vnd.android.package-archive', // Android Package
+                'xapk' => 'application/vnd.android.package-archive', // Android Package Bundle
+            ];
+
+            if (isset($extensionOverrides[$extension])) {
+                $mimeType = $extensionOverrides[$extension];
+            }
+
             $fileHash = $deviceForFiles->getFileHash($path); // Get file hash before compression and encryption
             $data = '';
             // Compression
@@ -712,7 +725,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
                 if (!$authorization->isValid(new Input(Database::PERMISSION_CREATE, $bucket->getCreate()))) {
                     throw new Exception(Exception::USER_UNAUTHORIZED, $authorization->getDescription());
                 }
-                $file = $authorization->skip(fn () => $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file));
+                $file = $authorization->skip(fn() => $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file));
             }
         } else {
             if ($file->isEmpty()) {
@@ -758,7 +771,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
                 }
 
                 try {
-                    $file = $authorization->skip(fn () => $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file));
+                    $file = $authorization->skip(fn() => $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file));
                 } catch (NotFoundException) {
                     throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
                 }
@@ -771,7 +784,7 @@ App::post('/v1/storage/buckets/:bucketId/files')
             ->setContext('bucket', $bucket);
 
         $metadata = null; // was causing leaks as it was passed by reference
-
+    
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($file, Response::MODEL_FILE);
@@ -805,7 +818,7 @@ App::get('/v1/storage/buckets/:bucketId/files')
     ->inject('authorization')
     ->inject('mode')
     ->action(function (string $bucketId, array $queries, string $search, bool $includeTotal, Response $response, Database $dbForProject, Authorization $authorization, string $mode) {
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -846,7 +859,7 @@ App::get('/v1/storage/buckets/:bucketId/files')
             if ($fileSecurity && !$valid) {
                 $cursorDocument = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
             } else {
-                $cursorDocument = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+                $cursorDocument = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
             }
 
             if ($cursorDocument->isEmpty()) {
@@ -861,8 +874,8 @@ App::get('/v1/storage/buckets/:bucketId/files')
                 $files = $dbForProject->find('bucket_' . $bucket->getSequence(), $queries);
                 $total = $includeTotal ? $dbForProject->count('bucket_' . $bucket->getSequence(), $queries, APP_LIMIT_COUNT) : 0;
             } else {
-                $files = $authorization->skip(fn () => $dbForProject->find('bucket_' . $bucket->getSequence(), $queries));
-                $total = $includeTotal ? $authorization->skip(fn () => $dbForProject->count('bucket_' . $bucket->getSequence(), $queries, APP_LIMIT_COUNT)) : 0;
+                $files = $authorization->skip(fn() => $dbForProject->find('bucket_' . $bucket->getSequence(), $queries));
+                $total = $includeTotal ? $authorization->skip(fn() => $dbForProject->count('bucket_' . $bucket->getSequence(), $queries, APP_LIMIT_COUNT)) : 0;
             }
         } catch (NotFoundException) {
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
@@ -904,7 +917,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId')
     ->inject('authorization')
     ->inject('mode')
     ->action(function (string $bucketId, string $fileId, Response $response, Database $dbForProject, Authorization $authorization, string $mode) {
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -922,7 +935,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId')
         if ($fileSecurity && !$valid) {
             $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
         } else {
-            $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+            $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
         }
 
         if ($file->isEmpty()) {
@@ -986,7 +999,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/preview')
         }
 
         /* @type Document $bucket */
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -1010,7 +1023,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/preview')
             $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
         } else {
             /* @type Document $file */
-            $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+            $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
         }
 
         if (!$resourceToken->isEmpty() && $resourceToken->getAttribute('fileInternalId') !== $file->getSequence()) {
@@ -1136,7 +1149,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/preview')
             $transformedAt = $file->getAttribute('transformedAt', '');
             if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $transformedAt) {
                 $file->setAttribute('transformedAt', DateTime::now());
-                $authorization->skip(fn () => $dbForProject->updateDocument('bucket_' . $file->getAttribute('bucketInternalId'), $file->getId(), $file));
+                $authorization->skip(fn() => $dbForProject->updateDocument('bucket_' . $file->getAttribute('bucketInternalId'), $file->getId(), $file));
             }
         }
 
@@ -1182,7 +1195,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/download')
     ->inject('deviceForFiles')
     ->action(function (string $bucketId, string $fileId, ?string $token, Request $request, Response $response, Database $dbForProject, Authorization $authorization, string $mode, Document $resourceToken, Device $deviceForFiles) {
         /* @type Document $bucket */
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -1202,7 +1215,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/download')
             $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
         } else {
             /* @type Document $file */
-            $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+            $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
         }
 
         if (!$resourceToken->isEmpty() && $resourceToken->getAttribute('fileInternalId') !== $file->getSequence()) {
@@ -1343,7 +1356,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/view')
     ->inject('authorization')
     ->action(function (string $bucketId, string $fileId, ?string $token, Response $response, Request $request, Database $dbForProject, string $mode, Document $resourceToken, Device $deviceForFiles, Authorization $authorization) {
         /* @type Document $bucket */
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -1363,7 +1376,7 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/view')
             $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
         } else {
             /* @type Document $file */
-            $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+            $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
         }
 
         if (!$resourceToken->isEmpty() && $resourceToken->getAttribute('fileInternalId') !== $file->getSequence()) {
@@ -1521,12 +1534,12 @@ App::get('/v1/storage/buckets/:bucketId/files/:fileId/push')
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
 
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
 
-        $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+        $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
         if ($file->isEmpty()) {
             throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
         }
@@ -1673,7 +1686,7 @@ App::put('/v1/storage/buckets/:bucketId/files/:fileId')
     ->inject('authorization')
     ->action(function (string $bucketId, string $fileId, ?string $name, ?array $permissions, Response $response, Database $dbForProject, Document $user, string $mode, Event $queueForEvents, Authorization $authorization) {
 
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -1689,7 +1702,7 @@ App::put('/v1/storage/buckets/:bucketId/files/:fileId')
         }
 
         // Read permission should not be required for update
-        $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+        $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
 
         if ($file->isEmpty()) {
             throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
@@ -1737,7 +1750,7 @@ App::put('/v1/storage/buckets/:bucketId/files/:fileId')
             if ($fileSecurity && !$valid) {
                 $file = $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file);
             } else {
-                $file = $authorization->skip(fn () => $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file));
+                $file = $authorization->skip(fn() => $dbForProject->updateDocument('bucket_' . $bucket->getSequence(), $fileId, $file));
             }
         } catch (NotFoundException) {
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
@@ -1787,7 +1800,7 @@ App::delete('/v1/storage/buckets/:bucketId/files/:fileId')
     ->inject('queueForDeletes')
     ->inject('authorization')
     ->action(function (string $bucketId, string $fileId, Response $response, Database $dbForProject, Event $queueForEvents, string $mode, Device $deviceForFiles, Delete $queueForDeletes, Authorization $authorization) {
-        $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
+        $bucket = $authorization->skip(fn() => $dbForProject->getDocument('buckets', $bucketId));
 
         $isAPIKey = User::isApp($authorization->getRoles());
         $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
@@ -1803,7 +1816,7 @@ App::delete('/v1/storage/buckets/:bucketId/files/:fileId')
         }
 
         // Read permission should not be required for delete
-        $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
+        $file = $authorization->skip(fn() => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
 
         if ($file->isEmpty()) {
             throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
@@ -1836,7 +1849,7 @@ App::delete('/v1/storage/buckets/:bucketId/files/:fileId')
                 if ($fileSecurity && !$valid) {
                     $deleted = $dbForProject->deleteDocument('bucket_' . $bucket->getSequence(), $fileId);
                 } else {
-                    $deleted = $authorization->skip(fn () => $dbForProject->deleteDocument('bucket_' . $bucket->getSequence(), $fileId));
+                    $deleted = $authorization->skip(fn() => $dbForProject->deleteDocument('bucket_' . $bucket->getSequence(), $fileId));
                 }
             } catch (NotFoundException) {
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);

--- a/tests/e2e/Services/Storage/StorageAPKMimeTypeTest.php
+++ b/tests/e2e/Services/Storage/StorageAPKMimeTypeTest.php
@@ -19,7 +19,7 @@ class StorageAPKMimeTypeTest extends Scope
 
     /**
      * Test that APK files are stored and served with correct MIME type
-     * This testaddresses GitHub issue #9418 where APK files were incorrectly
+     * This test addresses GitHub issue #9418 where APK files were incorrectly
      * detected as application/zip instead of application/vnd.android.package-archive
      *
      * @return array
@@ -178,7 +178,7 @@ class StorageAPKMimeTypeTest extends Scope
     }
 
     /**
-     * Test that XAPK files (Android Package Bundle) also get correct MIME  type
+     * Test that XAPK files (third-party APK bundle format) also get correct MIME type
      *
      * @return void
      */
@@ -212,6 +212,9 @@ class StorageAPKMimeTypeTest extends Scope
         chdir($tmpDir);
         exec('zip -r ' . escapeshellarg($xapkFile) . ' . 2>&1', $output, $returnCode);
         chdir($currentDir);
+
+        $this->assertEquals(0, $returnCode, 'Failed to create XAPK file: ' . implode("\n", $output));
+        $this->assertFileExists($xapkFile, 'XAPK file was not created');
 
         try {
             $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
@@ -278,6 +281,9 @@ class StorageAPKMimeTypeTest extends Scope
         exec('zip -r ' . escapeshellarg($zipFile) . ' . 2>&1', $output, $returnCode);
         chdir($currentDir);
 
+        $this->assertEquals(0, $returnCode, 'Failed to create ZIP file: ' . implode("\n", $output));
+        $this->assertFileExists($zipFile, 'ZIP file was not created');
+
         try {
             $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
                 'content-type' => 'multipart/form-data',
@@ -342,6 +348,9 @@ class StorageAPKMimeTypeTest extends Scope
         chdir($tmpDir);
         exec('zip -r ' . escapeshellarg($apkFile) . ' . 2>&1', $output, $returnCode);
         chdir($currentDir);
+
+        $this->assertEquals(0, $returnCode, 'Failed to create APK file: ' . implode("\n", $output));
+        $this->assertFileExists($apkFile, 'APK file was not created');
 
         try {
             $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([

--- a/tests/e2e/Services/Storage/StorageAPKMimeTypeTest.php
+++ b/tests/e2e/Services/Storage/StorageAPKMimeTypeTest.php
@@ -1,0 +1,374 @@
+<?php
+
+namespace Tests\E2E\Services\Storage;
+
+use Tests\E2E\Client;
+use Tests\E2E\Scopes\ProjectCustom;
+use Tests\E2E\Scopes\Scope;
+use Tests\E2E\Scopes\SideServer;
+use Utopia\Database\Helpers\ID;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+use Utopia\Database\Validator\Datetime as DatetimeValidator;
+
+class StorageAPKMimeTypeTest extends Scope
+{
+    use StorageBase;
+    use ProjectCustom;
+    use SideServer;
+
+    /**
+     * Test that APK files are stored and served with correct MIME type
+     * This testaddresses GitHub issue #9418 where APK files were incorrectly
+     * detected as application/zip instead of application/vnd.android.package-archive
+     *
+     * @return array
+     */
+    public function testAPKFileMimeType(): array
+    {
+        // Create a test bucket
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'APK Test Bucket',
+            'fileSecurity' => true,
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+        $this->assertNotEmpty($bucket['body']['$id']);
+        $bucketId = $bucket['body']['$id'];
+
+        // Create a minimal valid APK file using shell commands
+        $tmpDir = sys_get_temp_dir() . '/apktest_' . uniqid();
+        mkdir($tmpDir);
+
+        // APK files must contain at least AndroidManifest.xml to be valid
+        $manifestContent = '<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.test.apktest">
+    <application android:label="Test APK" />
+</manifest>';
+
+        file_put_contents($tmpDir . '/AndroidManifest.xml', $manifestContent);
+        file_put_contents($tmpDir . '/classes.dex', 'dex\n035\x00');
+
+        // Create META-INF directory
+        mkdir($tmpDir . '/META-INF');
+        file_put_contents($tmpDir . '/META-INF/MANIFEST.MF', 'Manifest-Version: 1.0');
+
+        // Create APK file using shell command
+        $apkFile = sys_get_temp_dir() . '/test-app_' . uniqid() . '.apk';
+        $currentDir = getcwd();
+        chdir($tmpDir);
+        exec('zip -r ' . escapeshellarg($apkFile) . ' . 2>&1', $output, $returnCode);
+        chdir($currentDir);
+
+        $this->assertEquals(0, $returnCode, 'Failed to create APK file: ' . implode("\n", $output));
+        $this->assertFileExists($apkFile, 'APK file was not created');
+
+        try {
+            // Upload the APK file
+            $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'fileId' => ID::unique(),
+                'file' => new \CURLFile($apkFile, 'application/vnd.android.package-archive', 'test-app.apk'),
+                'permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::delete(Role::any()),
+                ],
+            ]);
+
+            // Verify upload was successful
+            $this->assertEquals(201, $file['headers']['status-code'], 'APK file upload failed');
+            $this->assertNotEmpty($file['body']['$id']);
+            $this->assertEquals('test-app.apk', $file['body']['name']);
+
+            // CRITICAL: Verify MIME type is correctly set to APK type, not ZIP
+            $this->assertEquals(
+                'application/vnd.android.package-archive',
+                $file['body']['mimeType'],
+                'APK file MIME type should be application/vnd.android.package-archive, not application/zip'
+            );
+
+            $dateValidator = new DatetimeValidator();
+            $this->assertTrue($dateValidator->isValid($file['body']['$createdAt']));
+
+            $fileId = $file['body']['$id'];
+
+            // Test the download endpoint returns correct Content-Type header
+            $downloadResponse = $this->client->call(
+                Client::METHOD_GET,
+                '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/download',
+                array_merge([
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                ], $this->getHeaders())
+            );
+
+            $this->assertEquals(200, $downloadResponse['headers']['status-code']);
+            $this->assertStringContainsString(
+                'application/vnd.android.package-archive',
+                $downloadResponse['headers']['content-type'],
+                'Download endpoint should return APK MIME type in Content-Type header'
+            );
+            $this->assertEquals(
+                'attachment; filename="test-app.apk"',
+                $downloadResponse['headers']['content-disposition'],
+                'Content-Disposition should preserve .apk filename'
+            );
+
+            // Test the view endpoint also returns correct Content-Type
+            // Note: APK files may not be in the allowed MIME types for viewing,
+            // but we should still verify the MIME type handling
+            $viewResponse = $this->client->call(
+                Client::METHOD_GET,
+                '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/view',
+                array_merge([
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                ], $this->getHeaders())
+            );
+
+            // View endpoint may return text/plain for unsupported MIME types, but check that
+            // the file still has the correct MIME type stored
+            $this->assertEquals(200, $viewResponse['headers']['status-code']);
+
+            // Get the file metadata to verify MIME type persists
+            $fileInfo = $this->client->call(
+                Client::METHOD_GET,
+                '/storage/buckets/' . $bucketId . '/files/' . $fileId,
+                array_merge([
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                ], $this->getHeaders())
+            );
+
+            $this->assertEquals(200, $fileInfo['headers']['status-code']);
+            $this->assertEquals(
+                'application/vnd.android.package-archive',
+                $fileInfo['body']['mimeType'],
+                'File metadata should persistently store APK MIME type'
+            );
+
+            return [
+                'bucketId' => $bucketId,
+                'fileId' => $fileId,
+            ];
+        } finally {
+            // Cleanup: remove temporary files
+            if (file_exists($apkFile)) {
+                unlink($apkFile);
+            }
+            if (isset($tmpDir) && is_dir($tmpDir)) {
+                exec('rm -rf ' . escapeshellarg($tmpDir));
+            }
+        }
+    }
+
+    /**
+     * Test that XAPK files (Android Package Bundle) also get correct MIME  type
+     *
+     * @return void
+     */
+    public function testXAPKFileMimeType(): void
+    {
+        // Create a test bucket
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'XAPK Test Bucket',
+            'fileSecurity' => true,
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+        $bucketId = $bucket['body']['$id'];
+
+        // Create a minimal XAPK file using shell commands
+        $tmpDir = sys_get_temp_dir() . '/xapktest_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/manifest.json', '{"package_name":"com.test.xapk"}');
+
+        $xapkFile = sys_get_temp_dir() . '/test-app_' . uniqid() . '.xapk';
+        $currentDir = getcwd();
+        chdir($tmpDir);
+        exec('zip -r ' . escapeshellarg($xapkFile) . ' . 2>&1', $output, $returnCode);
+        chdir($currentDir);
+
+        try {
+            $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'fileId' => ID::unique(),
+                'file' => new \CURLFile($xapkFile, 'application/vnd.android.package-archive', 'test-app.xapk'),
+                'permissions' => [
+                    Permission::read(Role::any()),
+                ],
+            ]);
+
+            $this->assertEquals(201, $file['headers']['status-code']);
+            $this->assertEquals('test-app.xapk', $file['body']['name']);
+            $this->assertEquals(
+                'application/vnd.android.package-archive',
+                $file['body']['mimeType'],
+                'XAPK file should also get APK MIME type'
+            );
+        } finally {
+            if (file_exists($xapkFile)) {
+                unlink($xapkFile);
+            }
+            if (isset($tmpDir) && is_dir($tmpDir)) {
+                exec('rm -rf ' . escapeshellarg($tmpDir));
+            }
+        }
+    }
+
+    /**
+     * Test that regular ZIP files still get application/zip MIME type
+     * This ensures our fix doesn't break normal ZIP file handling
+     *
+     * @return void
+     */
+    public function testRegularZIPFileMimeType(): void
+    {
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'ZIP Test Bucket',
+            'fileSecurity' => true,
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+        $bucketId = $bucket['body']['$id'];
+
+        // Create a regular ZIP file using shell commands
+        $tmpDir = sys_get_temp_dir() . '/ziptest_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/test.txt', 'This is a regular ZIP file');
+
+        $zipFile = sys_get_temp_dir() . '/test_' . uniqid() . '.zip';
+        $currentDir = getcwd();
+        chdir($tmpDir);
+        exec('zip -r ' . escapeshellarg($zipFile) . ' . 2>&1', $output, $returnCode);
+        chdir($currentDir);
+
+        try {
+            $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'fileId' => ID::unique(),
+                'file' => new \CURLFile($zipFile, 'application/zip', 'test.zip'),
+                'permissions' => [
+                    Permission::read(Role::any()),
+                ],
+            ]);
+
+            $this->assertEquals(201, $file['headers']['status-code']);
+            $this->assertEquals('test.zip', $file['body']['name']);
+            $this->assertEquals(
+                'application/zip',
+                $file['body']['mimeType'],
+                'Regular ZIP files should still have application/zip MIME type'
+            );
+        } finally {
+            if (file_exists($zipFile)) {
+                unlink($zipFile);
+            }
+            if (isset($tmpDir) && is_dir($tmpDir)) {
+                exec('rm -rf ' . escapeshellarg($tmpDir));
+            }
+        }
+    }
+
+    /**
+     * Test case-insensitive extension matching
+     * APK files with uppercase extension should also work
+     *
+     * @return void
+     */
+    public function testAPKFileUppercaseExtension(): void
+    {
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'APK Case Test Bucket',
+            'fileSecurity' => true,
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+        $bucketId = $bucket['body']['$id'];
+
+        $tmpDir = sys_get_temp_dir() . '/apktest_' . uniqid();
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/AndroidManifest.xml', '<?xml version="1.0"?><manifest></manifest>');
+
+        // Use uppercase .APK extension
+        $apkFile = sys_get_temp_dir() . '/test-APP_' . uniqid() . '.APK';
+        $currentDir = getcwd();
+        chdir($tmpDir);
+        exec('zip -r ' . escapeshellarg($apkFile) . ' . 2>&1', $output, $returnCode);
+        chdir($currentDir);
+
+        try {
+            $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'fileId' => ID::unique(),
+                'file' => new \CURLFile($apkFile, 'application/vnd.android.package-archive', 'test-APP.APK'),
+                'permissions' => [
+                    Permission::read(Role::any()),
+                ],
+            ]);
+
+            $this->assertEquals(201, $file['headers']['status-code']);
+            $this->assertEquals('test-APP.APK', $file['body']['name']);
+            $this->assertEquals(
+                'application/vnd.android.package-archive',
+                $file['body']['mimeType'],
+                'APK files with uppercase extension should also get correct MIME type'
+            );
+        } finally {
+            if (file_exists($apkFile)) {
+                unlink($apkFile);
+            }
+            if (isset($tmpDir) && is_dir($tmpDir)) {
+                exec('rm -rf ' . escapeshellarg($tmpDir));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add extension-based MIME override for APK and XAPK files
- APK files now correctly identified as application/vnd.android.package-archive
- Prevents APK files from being downloaded as ZIP on mobile devices
- Add comprehensive E2E test suite with 4 test cases
- Tests cover APK, XAPK, ZIP regression, and case-insensitive extensions
- All existing storage tests pass (no regressions)

Fixes #9418

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes a bug where APK files were being downloaded as ZIP files on mobile devices due to incorrect MIME type detection.

The Problem: APK files are ZIP archives internally, so content-based MIME detection identifies them as application/zip. However, mobile browsers require application/vnd.android.package-archive to properly handle APK downloads and trigger installation prompts.

The Solution: Added extension-based MIME type override for APK/XAPK files after content-based detection. This maintains security (content analysis for all files) while correctly handling APK edge cases.

Changes:

Modified 
app/controllers/api/storage.php
 to check file extension after MIME detection
Override MIME type to application/vnd.android.package-archive for .apk and .xapk files
Case-insensitive extension matching (.apk, .APK, .Apk all work)
Only 13 lines of code added

## Test Plan

Automated Testing:

Created comprehensive E2E test suite: 
tests/e2e/Services/Storage/StorageAPKMimeTypeTest.php
4 new test cases covering:
APK file MIME type verification
XAPK file support
ZIP regression test (ensures regular ZIP files still work)
Case-insensitive extension matching
Test Results:

`docker-compose exec appwrite vendor/bin/phpunit tests/e2e/Services/Storage/StorageAPKMimeTypeTest.php`
✅ 14/14 tests passed
✅ 197 assertions passed
✅ 0 failures
✅ No regressions in existing storage tests

Manual Verification (if needed):

Upload an APK file to Appwrite storage
Verify file metadata shows MIME type: application/vnd.android.package-archive
Download file on Android device - should download as .apk and trigger installation prompt

## Related PRs and Issues

Fixes #9418

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
