### PR TITLE
docs: add authentication requirements for async function execution

### DIFF
--- a/docs/references/functions/create-execution.md
+++ b/docs/references/functions/create-execution.md
@@ -1,1 +1,3 @@
 Trigger a function execution. The returned object will return you the current execution status. You can ping the `Get Execution` endpoint to get updates on the current execution status. Once this endpoint is called, your function execution process will start asynchronously.
+
+**Note**: To use `Get Execution` for polling async function status, you must be authenticated (have an active session). Guest users should use [Realtime subscriptions](https://appwrite.io/docs/realtime) or have the function write results to a database document instead.

--- a/docs/references/functions/get-execution.md
+++ b/docs/references/functions/get-execution.md
@@ -1,1 +1,11 @@
 Get a function execution log by its unique ID.
+
+**⚠️ Authentication Required**
+
+This endpoint requires an active user session (client SDK) or API key (server SDK). Guest users cannot access execution logs for security reasons.
+
+**For async executions**, if you need to check execution status:
+
+- **Client SDK (recommended)**: Use [Realtime subscriptions](https://appwrite.io/docs/realtime) to listen for execution updates instead of polling
+- **Guest users**: Have your function write results to a database document with public read permissions
+- **Server SDK**: Use an API key to poll execution status from your backend


### PR DESCRIPTION
## What does this PR do?

This PR improves documentation for the functions.getExecution() endpoint to address confusion reported in issue #8390.

Problem: Users trying to poll async function execution status receive an unclear error when using guest sessions:

AppwriteException: User (role: guests) missing scope (execution.read)
Solution: As confirmed by @stnguyen90, this is expected behavior for security (execution logs contain sensitive data). This PR adds clear warnings and alternatives to the documentation.

## Test Plan

uwu

## Related PRs and Issues

Fixes #8390

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
