### PR TITLE
fix: enable SMTP debug logging in development mode

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -348,6 +348,10 @@ $register->set('smtp', function () {
 
     $mail->isSMTP();
 
+    if (System::getEnv('_APP_ENV') === 'development') {
+        $mail->SMTPDebug = true;
+    }
+
     $username = System::getEnv('_APP_SMTP_USERNAME');
     $password = System::getEnv('_APP_SMTP_PASSWORD');
 

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -197,6 +197,10 @@ class Mails extends Action
 
         $mail->isSMTP();
 
+        if (System::getEnv('_APP_ENV') === 'development') {
+            $mail->SMTPDebug = true;
+        }
+
         $username = $smtp['username'];
         $password = $smtp['password'];
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR improves SMTP error visibility in the Mails worker during development by conditionally enabling PHPMailer’s SMTP debug output when _APP_ENV=development

## Test Plan

- Set _APP_ENV=development

- Intentionally misconfigured SMTP (invalid port) to force a connection failure

- Triggered a password recovery email

- Verified detailed PHPMailer SMTP debug output appears in appwrite-worker-mails logs

- Restored correct SMTP configuration and confirmed successful email delivery

- Verified no SMTP debug output when _APP_ENV=production

## Related PRs and Issues

Fixes #1390 

## Checklist

- [X] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
