### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Set up Docker Buildx
@@ -33,7 +33,7 @@ jobs:
             TESTING=true
             VERSION=dev
       - name: Cache Docker Image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: '${{ env.CACHE_KEY }}'
           path: '/tmp/${{ env.IMAGE }}.tar'
@@ -45,9 +45,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: '${{ env.CACHE_KEY }}'
           path: '/tmp/${{ env.IMAGE }}.tar'
@@ -97,7 +97,7 @@ jobs:
           echo "| 200 | $(jq -r '.statusCodeDistribution."200"|tostring|[while(length>0;.[:-3])|.[-3:]]|reverse|join(",")' benchmark.json) | $(jq -r '.statusCodeDistribution."200"|tostring|[while(length>0;.[:-3])|.[-3:]]|reverse|join(",")' benchmark-latest.json) | "  >> benchmark.txt
           echo "| P99 | $(jq -r '.latencyPercentiles.p99' benchmark.json ) | $(jq -r '.latencyPercentiles.p99' benchmark-latest.json ) | "  >> benchmark.txt
       - name: Save results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: '${{ !cancelled() }}'
         with:
           name: benchmark.json
@@ -105,7 +105,7 @@ jobs:
           retention-days: 7
       - name: Find Comment
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: '${{ github.event.pull_request.number }}'
@@ -113,7 +113,7 @@ jobs:
           body-includes: Benchmark results
       - name: Comment on PR
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: '${{ steps.fc.outputs.comment-id }}'
           issue-number: '${{ github.event.pull_request.number }}'

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Cleanup
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build the Docker image
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run Trivy vulnerability scanner on filesystem
         uses: aquasecurity/trivy-action@0.20.0
         with:

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -11,14 +11,14 @@ jobs:
       pull-requests: write
     steps:
     - name: Check out code 
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
         submodules: 'recursive'
 
     - name: Build the Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with: 
         context: .
         push: false
@@ -44,7 +44,7 @@ jobs:
 
     - name: Process Trivy scan results
       id: process-results
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const fs = require('fs');
@@ -89,7 +89,7 @@ jobs:
           
           core.setOutput('comment-body', commentBody);
     - name: Find Comment
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@v4
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -97,7 +97,7 @@ jobs:
         body-includes: Security Scan Results for PR
 
     - name: Create or update comment
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@v5
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 2
         submodules: recursive
@@ -24,21 +24,21 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: appwrite/cloud
         tags: |
           type=ref,event=tag
 
     - name: Build & Publish to DockerHub
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -26,14 +26,14 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: appwrite/appwrite
         tags: |
@@ -42,7 +42,7 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/sdk-preview.yml
+++ b/.github/workflows/sdk-preview.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set SDK type
         id: set-sdk
@@ -42,7 +42,7 @@ jobs:
           docker compose exec appwrite sdks --platform=${{ steps.set-sdk.outputs.platform }} --sdk=${{ steps.set-sdk.outputs.sdk_type }} --version=latest --git=no
           sudo chown -R $USER:$USER ./app/sdks/${{ steps.set-sdk.outputs.platform }}-${{ steps.set-sdk.outputs.sdk_type }}
           
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "This issue has been labeled as a 'question', indicating that it requires additional information from the requestor. It has been inactive for 7 days. If no further activity occurs, this issue will be closed in 14 days."

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run CodeQL
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       database_changed: ${{ steps.check.outputs.database_changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -71,7 +71,7 @@ jobs:
             VERSION=dev
 
       - name: Cache Docker Image
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -83,10 +83,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -119,10 +119,10 @@ jobs:
     needs: setup
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -189,10 +189,10 @@ jobs:
         ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -273,10 +273,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -328,10 +328,10 @@ jobs:
     needs: setup
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -378,10 +378,10 @@ jobs:
         ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -426,10 +426,10 @@ jobs:
     needs: setup
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar
@@ -477,10 +477,10 @@ jobs:
         ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ env.CACHE_KEY }}
           path: /tmp/${{ env.IMAGE }}.tar


### PR DESCRIPTION
---

## What does this PR do?

This PR updates the versions of several GitHub Actions used in workflows across the repository. The changes include:

- `actions/upload-artifact` from `v4` to `v6`  
- `actions/stale` from `v9` to `v10`  
- `peter-evans/find-comment` from `v3` to `v4`  
- `docker/build-push-action` from `v5` to `v6`  
- `actions/github-script` from `v7` to `v8`  
- `actions/checkout` from `v4` to `v6`  
- `actions/cache` from `v4` to `v5`  
- `docker/metadata-action` from `v4` to `v5`  
- `actions/setup-node` from `v4` to `v6`  
- `docker/login-action` from `v2` to `v3`  
- `peter-evans/create-or-update-comment` from `v4` to `v5`  
- `docker/build-push-action` from `v4` to `v6`  
- `docker/metadata-action` from `v4` to `v5`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  
- `actions/checkout` from `v4` to `v6`  

These updates ensure compatibility with newer GitHub Actions and improved functionality.

---

## Test Plan

The changes will be tested in the CI pipeline of the pull request. Automated tests will run against the updated action versions to verify functionality and ensure no breaking changes.

---

## Related PRs and Issues

- (Related PR or issue) None provided

---

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?  
  - No API metadata changes were made, so this item is not applicable.