### PR TITLE
Fix Safe namespace deprecation warnings

### DIFF
--- a/app/cli.php
+++ b/app/cli.php
@@ -44,6 +44,7 @@ Config::setParam('runtimes', (new Runtimes('v5'))->getAll(supported: false));
 // require controllers after overwriting runtimes
 require_once __DIR__ . '/controllers/general.php';
 
+global $register;
 CLI::setResource('register', fn () => $register);
 
 CLI::setResource('cache', function ($pools) {

--- a/src/Appwrite/Auth/OAuth2/Exception.php
+++ b/src/Appwrite/Auth/OAuth2/Exception.php
@@ -10,7 +10,7 @@ class Exception extends AppwriteException
     protected string $error = '';
     protected string $errorDescription = '';
 
-    public function __construct(string $response = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $response = '', int $code = 0, ?\Throwable $previous = null)
     {
         $this->response = $response;
         $this->message = $response;

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -392,9 +392,9 @@ class Exception extends \Exception
 
     public function __construct(
         string $type = Exception::GENERAL_UNKNOWN,
-        string $message = null,
-        int|string $code = null,
-        \Throwable $previous = null,
+        ?string $message = null,
+        int|string|null $code = null,
+        ?\Throwable $previous = null,
         ?string $view = null,
         array $params = []
     ) {

--- a/src/Appwrite/Messaging/Adapter/Realtime.php
+++ b/src/Appwrite/Messaging/Adapter/Realtime.php
@@ -297,7 +297,7 @@ class Realtime extends MessagingAdapter
      * @return array
      * @throws \Exception
      */
-    public static function fromPayload(string $event, Document $payload, Document $project = null, Document $database = null, Document $collection = null, Document $bucket = null): array
+    public static function fromPayload(string $event, Document $payload, ?Document $project = null, ?Document $database = null, ?Document $collection = null, ?Document $bucket = null): array
     {
         $channels = [];
         $roles = [];

--- a/src/Appwrite/Migration/Migration.php
+++ b/src/Appwrite/Migration/Migration.php
@@ -211,7 +211,7 @@ abstract class Migration
      * @return void
      * @throws \Throwable
      */
-    protected function createCollection(string $id, string $name = null): void
+    protected function createCollection(string $id, ?string $name = null): void
     {
         $name ??= $id;
 
@@ -262,7 +262,7 @@ abstract class Migration
         Database $database,
         string $collectionId,
         array $attributeIds,
-        string $from = null
+        ?string $from = null
     ): void {
         $from ??= $collectionId;
 
@@ -327,7 +327,7 @@ abstract class Migration
         Database $database,
         string $collectionId,
         string $attributeId,
-        string $from = null
+        ?string $from = null
     ): void {
         $from ??= $collectionId;
 
@@ -385,7 +385,7 @@ abstract class Migration
      * @throws Duplicate
      * @throws Limit
      */
-    public function createIndexFromCollection(Database $database, string $collectionId, string $indexId, string $from = null): void
+    public function createIndexFromCollection(Database $database, string $collectionId, string $indexId, ?string $from = null): void
     {
         $from ??= $collectionId;
 

--- a/src/Appwrite/Platform/Action.php
+++ b/src/Appwrite/Platform/Action.php
@@ -44,7 +44,7 @@ class Action extends UtopiaAction
      *
      * @return void
      */
-    protected function foreachDocument(Database $database, string $collection, array $queries = [], callable $callback = null, int $limit = 1000, bool $concurrent = false): void
+    protected function foreachDocument(Database $database, string $collection, array $queries = [], ?callable $callback = null, int $limit = 1000, bool $concurrent = false): void
     {
         $results = [];
         $sum = $limit;

--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -144,7 +144,7 @@ class Base extends Action
         return $deployment;
     }
 
-    public function redeployVcsSite(Request $request, Document $site, Document $project, Document $installation, Database $dbForProject, Database $dbForPlatform, Build $queueForBuilds, Document $template, GitHub $github, bool $activate, Authorization $authorization, string $referenceType = 'branch', string $reference = '', array $platform): Document
+    public function redeployVcsSite(Request $request, Document $site, Document $project, Document $installation, Database $dbForProject, Database $dbForPlatform, Build $queueForBuilds, Document $template, GitHub $github, bool $activate, Authorization $authorization, array $platform, string $referenceType = 'branch', string $reference = ''): Document
     {
         $deploymentId = ID::unique();
         $providerInstallationId = $installation->getAttribute('providerInstallationId', '');

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
@@ -488,7 +488,7 @@ abstract class Action extends UtopiaAction
         return $attribute;
     }
 
-    protected function updateAttribute(string $databaseId, string $collectionId, string $key, Database $dbForProject, Event $queueForEvents, Authorization $authorization, string $type, int $size = null, string $filter = null, string|bool|int|float|array $default = null, bool $required = null, int|float|null $min = null, int|float|null $max = null, array $elements = null, array $options = [], string $newKey = null): Document
+    protected function updateAttribute(string $databaseId, string $collectionId, string $key, Database $dbForProject, Event $queueForEvents, Authorization $authorization, string $type, ?int $size = null, ?string $filter = null, string|bool|int|float|array|null $default = null, ?bool $required = null, int|float|null $min = null, int|float|null $max = null, ?array $elements = null, array $options = [], ?string $newKey = null): Document
     {
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -578,7 +578,7 @@ class Databases extends Action
      * @return void
      * @throws Exception
      */
-    protected function deleteByGroup(string $collectionId, array $queries, Database $database, callable $callback = null): void
+    protected function deleteByGroup(string $collectionId, array $queries, Database $database, ?callable $callback = null): void
     {
         $start = \microtime(true);
 

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -23,6 +23,7 @@ use Utopia\Database\Exception\Conflict;
 use Utopia\Database\Exception\Restricted;
 use Utopia\Database\Exception\Structure;
 use Utopia\Database\Query;
+use Utopia\Database\Validator\Authorization;
 use Utopia\DSN\DSN;
 use Utopia\Logger\Log;
 use Utopia\Platform\Action;
@@ -335,7 +336,7 @@ class Deletes extends Action
      * @throws Authorization
      * @throws Exception
      */
-    private function deleteCacheByResource(Document $project, callable $getProjectDB, string $resource, string $resourceType = null): void
+    private function deleteCacheByResource(Document $project, callable $getProjectDB, string $resource, ?string $resourceType = null): void
     {
         $projectId = $project->getId();
         $dbForProject = $getProjectDB($project);
@@ -1316,7 +1317,7 @@ class Deletes extends Action
      * @return void
      * @throws Exception
      */
-    protected function listByGroup(string $collection, array $queries, Database $database, callable $callback = null): void
+    protected function listByGroup(string $collection, array $queries, Database $database, ?callable $callback = null): void
     {
         $count = 0;
         $limit = 1000;

--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -272,8 +272,8 @@ class Functions extends Action
         string $path,
         string $method,
         Document $user,
-        string $jwt = null,
-        string $event = null,
+        ?string $jwt = null,
+        ?string $event = null,
     ): void {
         $executionId = ID::unique();
         $headers['x-appwrite-execution-id'] = $executionId ?? '';
@@ -357,12 +357,12 @@ class Functions extends Action
         string $method,
         array $headers,
         array $platform,
-        string $data = null,
+        ?string $data = null,
         ?Document $user = null,
-        string $jwt = null,
-        string $event = null,
-        string $eventData = null,
-        string $executionId = null,
+        ?string $jwt = null,
+        ?string $event = null,
+        ?string $eventData = null,
+        ?string $executionId = null,
     ): void {
         $user ??= new Document();
         $functionId = $function->getId();

--- a/src/Appwrite/Utopia/Database/Documents/User.php
+++ b/src/Appwrite/Utopia/Database/Documents/User.php
@@ -131,7 +131,7 @@ class User extends Document
         return false;
     }
 
-    public function tokenVerify(int $type = null, string $secret, Proof $proofForToken): false|Document
+    public function tokenVerify(?int $type, string $secret, Proof $proofForToken): false|Document
     {
         $tokens = $this->getAttribute('tokens', []);
         foreach ($tokens as $token) {

--- a/src/Appwrite/Utopia/Fetch/BodyMultipart.php
+++ b/src/Appwrite/Utopia/Fetch/BodyMultipart.php
@@ -10,7 +10,7 @@ class BodyMultipart
     private array $parts = [];
     private string $boundary = "";
 
-    public function __construct(string $boundary = null)
+    public function __construct(?string $boundary = null)
     {
         if (is_null($boundary)) {
             $this->boundary = self::generateBoundary();


### PR DESCRIPTION
Summary
- updated Appwrite to address as many Safe namespace deprecation warnings as possible from the `docker compose exec appwrite sdks` output
- ensured nullable parameter typing now aligns with PHP 8.3 deprecation guidance for Safe helper wrappers

Testing
- Not run (not requested)