### PR TITLE
fix: add global scope declaration for $register in registers.php

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -31,6 +31,7 @@ use Utopia\Queue;
 use Utopia\Registry\Registry;
 use Utopia\System\System;
 
+global $register;
 $register = new Registry();
 
 Http::setMode(System::getEnv('_APP_ENV', Http::MODE_TYPE_PRODUCTION));


### PR DESCRIPTION
## Summary
- Adds `global $register;` declaration before `$register = new Registry();` in `app/init/registers.php`
- Fixes PHPUnit bootstrap compatibility issue where `$register` was created in local scope instead of global scope

## Problem
PHPUnit's `FileLoader::load()` includes bootstrap files inside a function scope. Without the `global` declaration, `$register` is created in local scope and isn't accessible when other files (like `resources.php`) use `global $register;` to reference it.

## Test plan
- [ ] Run PHPUnit tests to verify bootstrap works correctly
- [ ] Verify `$register` is accessible in files that depend on it via `global $register`