### PR TITLE
fix: disable execution document writes for nyc region

### DIFF
--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -80,7 +80,9 @@ class Functions extends Action
         // Short-term solution to offhand write operation from API container
         if ($type === Func::TYPE_ASYNC_WRITE) {
             $execution = new Document($payload['execution'] ?? []);
-            $dbForProject->createDocument('executions', $execution);
+            if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                $dbForProject->createDocument('executions', $execution);
+            }
             return;
         }
 
@@ -309,10 +311,12 @@ class Functions extends Action
             'duration' => 0.0,
         ]);
 
-        $execution = $dbForProject->createDocument('executions', $execution);
+        if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+            $execution = $dbForProject->createDocument('executions', $execution);
 
-        if ($execution->isEmpty()) {
-            throw new Exception('Failed to create execution');
+            if ($execution->isEmpty()) {
+                throw new Exception('Failed to create execution');
+            }
         }
     }
 
@@ -451,22 +455,26 @@ class Functions extends Action
                 'duration' => 0.0,
             ]);
 
-            $execution = $dbForProject->createDocument('executions', $execution);
+            if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                $execution = $dbForProject->createDocument('executions', $execution);
 
-            // TODO: @Meldiron Trigger executions.create event here
+                // TODO: @Meldiron Trigger executions.create event here
 
-            if ($execution->isEmpty()) {
-                throw new Exception('Failed to create or read execution');
+                if ($execution->isEmpty()) {
+                    throw new Exception('Failed to create or read execution');
+                }
             }
         }
 
         if ($execution->getAttribute('status') !== 'processing') {
             $execution->setAttribute('status', 'processing');
 
-            try {
-                $execution = $dbForProject->updateDocument('executions', $executionId, $execution);
-            } catch (\Throwable $e) {
-                $log->addExtra('updateError', $e->getMessage());
+            if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                try {
+                    $execution = $dbForProject->updateDocument('executions', $executionId, $execution);
+                } catch (\Throwable $e) {
+                    $log->addExtra('updateError', $e->getMessage());
+                }
             }
         }
 
@@ -611,10 +619,12 @@ class Functions extends Action
             $errorCode = $th->getCode();
         } finally {
             /** Update execution status */
-            try {
-                $execution = $dbForProject->updateDocument('executions', $executionId, $execution);
-            } catch (\Throwable $e) {
-                $log->addExtra('updateError', $e->getMessage());
+            if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                try {
+                    $execution = $dbForProject->updateDocument('executions', $executionId, $execution);
+                } catch (\Throwable $e) {
+                    $log->addExtra('updateError', $e->getMessage());
+                }
             }
 
             /** Trigger usage queue */


### PR DESCRIPTION
## Summary
- Temporarily skips all execution `createDocument` and `updateDocument` calls in the Functions worker when `_APP_REGION` is set to `nyc`
- Reduces database write load in the nyc region while executions still run normally
- All 5 skip points are marked with `// TODO: Remove region check` for easy cleanup

## Test plan
- [ ] Deploy to nyc region with `_APP_REGION=nyc` and verify no execution documents are written to the DB
- [ ] Deploy to another region without the env var and verify execution documents are created/updated as usual