### PR TITLE
fix: disable execution document writes for nyc region in API

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -301,7 +301,9 @@ class Create extends Base
 
         if ($async) {
             if (is_null($scheduledAt)) {
-                $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
+                if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                    $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
+                }
                 $queueForFunctions
                     ->setType('http')
                     ->setExecution($execution)
@@ -342,7 +344,9 @@ class Create extends Base
                     ->setAttribute('scheduleInternalId', $schedule->getSequence())
                     ->setAttribute('scheduledAt', $scheduledAt);
 
-                $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
+                if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                    $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
+                }
             }
 
             $this->enqueueDeletes(
@@ -501,7 +505,9 @@ class Create extends Base
                 ->addMetric(str_replace(['{resourceType}', '{resourceInternalId}'], [RESOURCE_TYPE_FUNCTIONS, $function->getSequence()], METRIC_RESOURCE_TYPE_ID_EXECUTIONS_MB_SECONDS), (int)(($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT) * $execution->getAttribute('duration', 0) * ($spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT)))
             ;
 
-            $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
+            if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
+            }
         }
 
         $executionResponse['headers']['x-appwrite-execution-id'] = $execution->getId();


### PR DESCRIPTION
## Summary
- Temporarily skips execution `createDocument` calls in `Executions/Create.php` when `_APP_REGION` is set to `nyc`
- Companion to #11266 which covered the Functions worker — this covers the API/HTTP handler side
- All 3 skip points are marked with `// TODO: Remove region check` for easy cleanup

## Test plan
- [ ] Deploy to nyc region with `_APP_REGION=nyc` and verify no execution documents are written from the API handler
- [ ] Deploy to another region without the env var and verify execution documents are created as usual