### PR TITLE
fix: Fix TypeError in Origin validator when array is passed

### DIFF
--- a/src/Appwrite/Network/Validator/Origin.php
+++ b/src/Appwrite/Network/Validator/Origin.php
@@ -51,13 +51,13 @@ class Origin extends Validator
      */
     public function isValid($origin): bool
     {
-        $this->origin = $origin;
-        $this->scheme = null;
-        $this->host = null;
-
         if (!is_string($origin) || empty($origin)) {
             return false;
         }
+
+        $this->origin = $origin;
+        $this->scheme = null;
+        $this->host = null;
 
         $this->scheme = $this->parseScheme($origin);
         $this->host = strtolower(parse_url($origin, PHP_URL_HOST) ?? '');

--- a/tests/unit/Network/Validators/OriginTest.php
+++ b/tests/unit/Network/Validators/OriginTest.php
@@ -16,6 +16,8 @@ class OriginTest extends TestCase
 
         $this->assertEquals(false, $validator->isValid(''));
         $this->assertEquals(false, $validator->isValid('/'));
+        $this->assertEquals(false, $validator->isValid([]));
+        $this->assertEquals(false, $validator->isValid(['http://localhost']));
 
         $this->assertEquals(true, $validator->isValid('https://localhost'));
         $this->assertEquals(true, $validator->isValid('http://localhost'));


### PR DESCRIPTION
## Summary
Fixes a TypeError occurring in Origin validator when an array is passed as the origin parameter.

## Problem
In `Origin::isValid()`, the code assigned `$origin` to the typed property `$this->origin` (declared as `string`) BEFORE checking if `$origin` is a string. When an array was passed in the `url` parameter, this caused a TypeError before the validation check could return false.

## Changes
- **src/Appwrite/Network/Validator/Origin.php**: Moved the `is_string()` check to occur before the assignment to `$this->origin`
- **tests/unit/Network/Validators/OriginTest.php**: Added test cases for array input to prevent regression

## Test Plan
- [x] Added unit tests for array input validation
- [x] Code formatted with `composer format`
- [x] No breaking changes - behavior is the same, just fixes the TypeError