### PR TITLE
fix: prevent status code contamination in batched GraphQL queries

### DIFF
--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -258,6 +258,9 @@ class Resolvers
         ?callable $beforeResolve = null,
         ?callable $beforeReject = null,
     ): void {
+        $response->setStatusCode(Response::STATUS_CODE_OK);
+        $response->setPayload([]);
+
         // Drop json content type so post args are used directly
         if (\str_starts_with($request->getHeader('content-type'), 'application/json')) {
             $request->removeHeader('content-type');
@@ -266,7 +269,6 @@ class Resolvers
         $request = clone $request;
         $utopia->setResource('request', static fn () => $request);
         $response->setContentType(Response::CONTENT_TYPE_NULL);
-        $response->setStatusCode(Response::STATUS_CODE_OK);
 
         try {
             $route = $utopia->match($request, fresh: true);


### PR DESCRIPTION
This PR fixes an issue where batched GraphQL queries would fail or return incorrect errors if a previous query in the batch failed or modified the response object. Replaced cloning with status reset to preserve headers/cookies. Fixes #5242.