### PR TITLE
fix: Restore _APP_CONNECTIONS_DB_CONSOLE and _APP_CONNECTIONS_DB_PROJECT env vars for MySQL 8.x support

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -412,12 +412,12 @@ return [
         ],
     ],
     [
-        'category' => 'MariaDB',
-        'description' => 'Appwrite is using a MariaDB server for managing persistent database data. The MariaDB env vars are used to allow Appwrite server to connect to the MariaDB container.',
+        'category' => 'Database',
+        'description' => 'Appwrite uses a MariaDB or MySQL server for managing persistent database data. The DB env vars are used to allow Appwrite server to connect to the database container. To use an external MySQL 8.x database, set _APP_CONNECTIONS_DB_CONSOLE and _APP_CONNECTIONS_DB_PROJECT with a mysql:// scheme DSN.',
         'variables' => [
             [
                 'name' => '_APP_DB_HOST',
-                'description' => 'MariaDB server host name address. Default value is: \'mariadb\'.',
+                'description' => 'Database server host name address. Default value is: \'mariadb\'.',
                 'introduction' => '',
                 'default' => 'mariadb',
                 'required' => false,
@@ -426,7 +426,7 @@ return [
             ],
             [
                 'name' => '_APP_DB_PORT',
-                'description' => 'MariaDB server TCP port. Default value is: \'3306\'.',
+                'description' => 'Database server TCP port. Default value is: \'3306\'.',
                 'introduction' => '',
                 'default' => '3306',
                 'required' => false,
@@ -435,7 +435,7 @@ return [
             ],
             [
                 'name' => '_APP_DB_SCHEMA',
-                'description' => 'MariaDB server database schema. Default value is: \'appwrite\'.',
+                'description' => 'Database server database schema. Default value is: \'appwrite\'.',
                 'introduction' => '',
                 'default' => 'appwrite',
                 'required' => false,
@@ -444,7 +444,7 @@ return [
             ],
             [
                 'name' => '_APP_DB_USER',
-                'description' => 'MariaDB server user name. Default value is: \'user\'.',
+                'description' => 'Database server user name. Default value is: \'user\'.',
                 'introduction' => '',
                 'default' => 'user',
                 'required' => false,
@@ -453,7 +453,7 @@ return [
             ],
             [
                 'name' => '_APP_DB_PASS',
-                'description' => 'MariaDB server user password. Default value is: \'password\'.',
+                'description' => 'Database server user password. Default value is: \'password\'.',
                 'introduction' => '',
                 'default' => 'password',
                 'required' => false,
@@ -462,12 +462,30 @@ return [
             ],
             [
                 'name' => '_APP_DB_ROOT_PASS',
-                'description' => 'MariaDB server root password. Default value is: \'rootsecretpassword\'.',
+                'description' => 'Database server root password. Default value is: \'rootsecretpassword\'.',
                 'introduction' => '',
                 'default' => 'rootsecretpassword',
                 'required' => false,
                 'question' => '',
                 'filter' => 'password'
+            ],
+            [
+                'name' => '_APP_CONNECTIONS_DB_CONSOLE',
+                'description' => 'Full DSN for the console database connection. Allows overriding the default MariaDB connection with a custom DSN including scheme selection (mariadb:// or mysql://). Format: db_main=mysql://user:password@host:port/database. When not set, falls back to the default MariaDB connection built from _APP_DB_* variables.',
+                'introduction' => '',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_CONNECTIONS_DB_PROJECT',
+                'description' => 'Full DSN for the project database connection. Allows overriding the default MariaDB connection with a custom DSN including scheme selection (mariadb:// or mysql://). Format: db_main=mysql://user:password@host:port/database. When not set, falls back to the default MariaDB connection built from _APP_DB_* variables.',
+                'introduction' => '',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
             ],
         ],
     ],

--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -165,13 +165,13 @@ $register->set('pools', function () {
     $connections = [
         'console' => [
             'type' => 'database',
-            'dsns' => $fallbackForDB,
+            'dsns' => System::getEnv('_APP_CONNECTIONS_DB_CONSOLE', $fallbackForDB),
             'multiple' => false,
             'schemes' => ['mariadb', 'mysql'],
         ],
         'database' => [
             'type' => 'database',
-            'dsns' => $fallbackForDB,
+            'dsns' => System::getEnv('_APP_CONNECTIONS_DB_PROJECT', $fallbackForDB),
             'multiple' => true,
             'schemes' => ['mariadb', 'mysql'],
         ],


### PR DESCRIPTION
## What does this PR do?

This PR restores the `_APP_CONNECTIONS_DB_CONSOLE` and `_APP_CONNECTIONS_DB_PROJECT` environment variables in `app/init/registers.php` and adds their documentation to `app/config/variables.php`.

### Motivation & Problem
Commit `195edd19ac` ("wip", 2025-03-15) inadvertently removed these environment variables from the database pool configuration. This caused a regression where users could no longer override the database connection DSN to specify the `mysql://` scheme.

The `utopia-php/database` library determines which adapter to use based on the scheme:
```php
$adapter = match ($dsn->getScheme()) {
    'mariadb' => new MariaDB($resource()),
    'mysql' => new MySQL($resource()),
    default => null
};

```

Without these environment variables, the system falls back to a hardcoded `mariadb` scheme. This forces the use of the MariaDB adapter, which utilizes `SET STATEMENT max_statement_time = N` syntax. MySQL 8.x does not support this syntax, resulting in the following error:

> SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax ... near 'max_statement_time = 15 FOR ...'

### The Fix

By restoring `System::getEnv('_APP_CONNECTIONS_DB_CONSOLE', ...)` and `_APP_CONNECTIONS_DB_PROJECT`, users can now explicitly set a DSN with the `mysql://` scheme (e.g., via `.env`). This correctly triggers the MySQL adapter, which uses optimizer hints (`/*+ max_execution_time(N) */`) supported by MySQL 8.x.

### Changes

* **app/init/registers.php**: Restored `System::getEnv()` calls for console and database pool DSNs.
* **app/config/variables.php**: Added documentation for the two restored env vars and updated the category from "MariaDB" to "Database" to reflect broader support.

## Test Plan

I have verified the fix with the following steps:

1. **Regression Test (Default MariaDB)**
* Start Appwrite without setting the restored env vars.
* **Result**: The system correctly falls back to the default MariaDB connection (constructed from `_APP_DB_*` vars). The server starts and operates normally.


2. **MySQL 8.x Connection Test**
* Set up an external MySQL 8.0 instance.
* Configure `.env` with the restored variables:
```env
_APP_CONNECTIONS_DB_CONSOLE=mysql://user:pass@mysql-8-host:3306/appwrite
_APP_CONNECTIONS_DB_PROJECT=mysql://user:pass@mysql-8-host:3306/appwrite

```


* Start Appwrite.
* **Result**: The server connects successfully. Queries run without syntax errors regarding `max_statement_time`, confirming the `MySQL` adapter is active.



## Related PRs and Issues

* Regression introduced in commit: `195edd19ac`

## Checklist

* [x] Have you read the [[Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
* [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

```

```