### PR TITLE
Replace region check with project ID check for execution logging

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -301,7 +301,7 @@ class Create extends Base
 
         if ($async) {
             if (is_null($scheduledAt)) {
-                if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                if ($project->getId() != '6862e6a6000cce69f9da') {
                     $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
                 }
                 $queueForFunctions
@@ -344,7 +344,7 @@ class Create extends Base
                     ->setAttribute('scheduleInternalId', $schedule->getSequence())
                     ->setAttribute('scheduledAt', $scheduledAt);
 
-                if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+                if ($project->getId() != '6862e6a6000cce69f9da') {
                     $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
                 }
             }
@@ -505,7 +505,7 @@ class Create extends Base
                 ->addMetric(str_replace(['{resourceType}', '{resourceInternalId}'], [RESOURCE_TYPE_FUNCTIONS, $function->getSequence()], METRIC_RESOURCE_TYPE_ID_EXECUTIONS_MB_SECONDS), (int)(($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT) * $execution->getAttribute('duration', 0) * ($spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT)))
             ;
 
-            if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+            if ($project->getId() != '6862e6a6000cce69f9da') {
                 $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
             }
         }

--- a/src/Appwrite/Platform/Workers/Executions.php
+++ b/src/Appwrite/Platform/Workers/Executions.php
@@ -7,7 +7,6 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
-use Utopia\System\System;
 
 class Executions extends Action
 {
@@ -45,7 +44,8 @@ class Executions extends Action
             throw new Exception('Missing execution');
         }
 
-        if (System::getEnv('_APP_REGION') !== 'nyc') { // TODO: Remove region check
+        $project = new Document($payload['project'] ?? []);
+        if ($project->getId() != '6862e6a6000cce69f9da') {
             $dbForProject->upsertDocument('executions', $execution);
         }
     }


### PR DESCRIPTION
## Summary
- Replace `System::getEnv('_APP_REGION') !== 'nyc'` checks with `$project->getId() != '6862e6a6000cce69f9da'` to disable execution logging for a specific project instead of an entire region
- Updated 3 occurrences in `Create.php` and 1 in `Executions.php` worker
- Removed unused `System` import from `Executions.php`

## Test plan
- [x] Verify execution logging is disabled for project `6862e6a6000cce69f9da`
- [x] Verify execution logging works normally for all other projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)