### PR TITLE
fix(auth): invalidate JWT if session is expired or deleted

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -424,7 +424,11 @@ App::setResource('user', function (string $mode, Document $project, Document $co
         }
         $jwtSessionId = $payload['sessionId'] ?? '';
         if (!empty($jwtSessionId)) {
-            if (empty($user->find('$id', $jwtSessionId, 'sessions'))) { // Match JWT to active token
+            $session = $user->find('$id', $jwtSessionId, 'sessions');
+            if (empty($session) || (isset($session['expire']) && DatabaseDateTime::formatTz($session['expire']) < DatabaseDateTime::formatTz(DatabaseDateTime::now()))) {
+                $user = new User([]);
+            }
+        } // Match JWT to active token
                 $user = new User([]);
             }
         }


### PR DESCRIPTION
### What does this PR do?
This PR addresses issue #8000 by adding a validation check during JWT authentication. It ensures that the session associated with the JWT is not only present but also valid (not expired).

### Why is this needed?
Currently, a JWT remains valid until its own expiration time, even if the underlying session has been deleted (logout) or has expired. This creates a security gap where a revoked session can still be accessed via a valid JWT.

### Changes
- In `app/init/resources.php`, added logic to check `$session['expire']` against the current time using the project's `DatabaseDateTime` alias.
- If the session is expired, the user context is reset to an empty User, effectively invalidating the request.

Fixes #8000