### PR TITLE
Set project on queueForMails for span log context

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -496,6 +496,7 @@ Http::init()
         $queueForMessaging->setProject($project);
         $queueForFunctions->setProject($project);
         $queueForBuilds->setProject($project);
+        $queueForMails->setProject($project);
 
         /* Auto-set platforms */
         $queueForFunctions->setPlatform($platform);

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -6,6 +6,7 @@ use Appwrite\Template\Template;
 use Exception;
 use PHPMailer\PHPMailer\PHPMailer;
 use Swoole\Runtime;
+use Utopia\Database\Document;
 use Utopia\Logger\Log;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
@@ -32,6 +33,7 @@ class Mails extends Action
         $this
             ->desc('Mails worker')
             ->inject('message')
+            ->inject('project')
             ->inject('register')
             ->inject('log')
             ->callback($this->action(...));
@@ -53,7 +55,7 @@ class Mails extends Action
      * @return void
      * @throws Exception
      */
-    public function action(Message $message, Registry $register, Log $log): void
+    public function action(Message $message, Document $project, Registry $register, Log $log): void
     {
         Runtime::setHookFlags(SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP);
         $payload = $message->getPayload() ?? [];

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -735,6 +735,7 @@ class Migrations extends Action
         ];
 
         $queueForMails
+            ->setProject($project)
             ->setSubject($subject)
             ->setPreview($preview)
             ->setBody($emailBody)

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -253,6 +253,7 @@ class Webhooks extends Action
             ->setParam('{{year}}', date("Y"));
 
         $queueForMails
+            ->setProject($project)
             ->setSubject($subject)
             ->setPreview($preview)
             ->setBody($body->render());


### PR DESCRIPTION
## Summary
- Add `$queueForMails->setProject($project)` in the shared API controller alongside other queue auto-set project calls
- Add `setProject($project)` in Webhooks and Migrations workers before triggering mails
- Inject `project` into the Mails worker action so the framework can resolve project context from the queue payload

This fixes span logs for the Mails worker showing empty `project.id`, null `project.sequence`, and `unknown` for `project.region`/`project.database`.

## Test plan
- [ ] Trigger a mail (e.g. password recovery) and verify span logs include correct `project.id`, `project.sequence`, `project.region`, `project.database`
- [ ] Verify webhook failure alert emails still send correctly
- [ ] Verify migration CSV export notification emails still send correctly