### PR TITLE
feat: add getPlatformsForPR and getSdksCommand overridable methods

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -492,10 +492,10 @@ class Specs extends Action
             // Copy SDK examples for this version, filtered by PR platforms
             if (\is_dir($examplesDir)) {
                 \exec('mkdir -p ' . \escapeshellarg("{$target}/examples/{$version}"));
-                $exampleFolders = \glob($examplesDir . '/*', GLOB_ONLYDIR);
+                $exampleFolders = \glob($examplesDir . '/*', GLOB_ONLYDIR) ?: [];
                 foreach ($exampleFolders as $folder) {
                     $folderName = \basename($folder);
-                    $platform = \strstr($folderName, '-', true);
+                    $platform = \strstr($folderName, '-', true) ?: $folderName;
                     if (!\in_array($platform, $prPlatforms, true)) {
                         Console::info("Skipping SDK examples for platform '{$platform}': examples/{$version}/{$folderName}");
                         continue;


### PR DESCRIPTION
## Summary

- Adds `getPlatformsForPR()` static method that returns which platforms are included when copying spec files and creating the PR — defaults to all platforms, override in a subclass to exclude specific ones
- Adds `getSdksCommand()` protected method that builds the CLI command for SDK example regeneration — override in a subclass to customise flags like `--platform`, `--sdk`, or `--mode`
- Wires both methods into `action()` replacing the previously hardcoded logic

## Test plan

- [ ] Run `specs` task and verify all platforms are still copied by default
- [ ] Subclass `Specs`, override `getPlatformsForPR()` to exclude a platform and confirm only the remaining platforms are copied
- [ ] Subclass `Specs`, override `getSdksCommand()` and confirm the custom command is used during example regeneration