### PR TITLE
ci: declare explicit token permissions in core automation workflows

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,6 +5,10 @@ concurrency:
   cancel-in-progress: true
 
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linter

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - cl-*
 
+permissions:
+  contents: read
+
 jobs:
   build-publish:
     name: Build and Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Release

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 0 * * *"  # Midnight Runtime
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,10 @@
 name: "Static code analysis"
 
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: CodeQL


### PR DESCRIPTION
## Summary\nAdd explicit workflow token permissions to core workflows currently relying on implicit defaults:\n\n- `.github/workflows/cleanup-cache.yml`\n- `.github/workflows/linter.yml`\n- `.github/workflows/publish.yml`\n- `.github/workflows/release.yml`\n- `.github/workflows/stale.yml`\n- `.github/workflows/static-analysis.yml`\n\n## Permission choices\n- Read-only CI/build workflows: `contents: read`\n- Stale bot workflow: `issues: write`, `pull-requests: write`\n- Cache cleanup workflow: `actions: write`, `contents: read`\n\n## Why\nThis reduces reliance on broad default token scopes and makes workflow intent explicit/auditable.\n\n## Notes\n- configuration-only change\n- intentionally did not change some workflows that appear to require additional specialized scopes (e.g. SARIF/preview publishing flows)\n