### PR TITLE
ci: declare explicit token permissions for maintenance workflows

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 0 * * *'  # 12am UTC daily runtime
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   scan-image:
     name: Scan Docker Image

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 0 * * *"  # Midnight Runtime
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add explicit `GITHUB_TOKEN` permissions to maintenance/security workflows:
- `.github/workflows/stale.yml`
- `.github/workflows/cleanup-cache.yml`
- `.github/workflows/nightly.yml`

## Permission mapping
- `stale.yml`: `issues: write`, `pull-requests: write` (required by `actions/stale`)
- `cleanup-cache.yml`: `actions: write`, `contents: read` (delete Actions cache keys + checkout)
- `nightly.yml`: `contents: read`, `security-events: write` (checkout + SARIF upload)

## Why
These workflows currently rely on implicit default token scopes. Declaring required permissions explicitly improves least-privilege security and makes access requirements auditable.
