### PR TITLE
OAuth provider handling fix

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -902,13 +902,13 @@ Http::patch('/v1/account/sessions/:sessionId')
         // Refresh OAuth access token
         $provider = $session->getAttribute('provider', '');
         $refreshToken = $session->getAttribute('providerRefreshToken', '');
-        $oAuthProviders = Config::getParam('oAuthProviders');
-        $className = $oAuthProviders[$provider]['class'];
-        if (!\class_exists($className)) {
+        $oAuthProviders = Config::getParam('oAuthProviders') ?? [];
+        $className = $oAuthProviders[$provider]['class'] ?? null;
+        if (!empty($provider) && ($className === null || !\class_exists($className))) {
             throw new Exception(Exception::PROJECT_PROVIDER_UNSUPPORTED);
         }
 
-        if (!empty($provider) && \class_exists($className)) {
+        if (!empty($provider) && $className !== null && \class_exists($className)) {
             $appId = $project->getAttribute('oAuthProviders', [])[$provider . 'Appid'] ?? '';
             $appSecret = $project->getAttribute('oAuthProviders', [])[$provider . 'Secret'] ?? '{}';
 
@@ -1340,9 +1340,9 @@ Http::get('/v1/account/sessions/oauth2/:provider')
             throw new Exception(Exception::PROJECT_PROVIDER_DISABLED, 'This provider is disabled. Please configure the provider app ID and app secret key from your ' . APP_NAME . ' console to continue.');
         }
 
-        $oAuthProviders = Config::getParam('oAuthProviders');
-        $className = $oAuthProviders[$provider]['class'];
-        if (!\class_exists($className)) {
+        $oAuthProviders = Config::getParam('oAuthProviders') ?? [];
+        $className = $oAuthProviders[$provider]['class'] ?? null;
+        if ($className === null || !\class_exists($className)) {
             throw new Exception(Exception::PROJECT_PROVIDER_UNSUPPORTED);
         }
 
@@ -1491,13 +1491,13 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
         $appSecret = $project->getAttribute('oAuthProviders', [])[$provider . 'Secret'] ?? '{}';
         $providerEnabled = $project->getAttribute('oAuthProviders', [])[$provider . 'Enabled'] ?? false;
 
-        $oAuthProviders = Config::getParam('oAuthProviders');
-        $className = $oAuthProviders[$provider]['class'];
-        if (!\class_exists($className)) {
+        $oAuthProviders = Config::getParam('oAuthProviders') ?? [];
+        $className = $oAuthProviders[$provider]['class'] ?? null;
+        if ($className === null || !\class_exists($className)) {
             throw new Exception(Exception::PROJECT_PROVIDER_UNSUPPORTED);
         }
 
-        $providers = Config::getParam('oAuthProviders');
+        $providers = Config::getParam('oAuthProviders') ?? [];
         $providerName = $providers[$provider]['name'] ?? '';
 
         /** @var Appwrite\Auth\OAuth2 $oauth2 */
@@ -2031,9 +2031,9 @@ Http::get('/v1/account/tokens/oauth2/:provider')
             throw new Exception(Exception::PROJECT_PROVIDER_DISABLED, 'This provider is disabled. Please configure the provider app ID and app secret key from your ' . APP_NAME . ' console to continue.');
         }
 
-        $oAuthProviders = Config::getParam('oAuthProviders');
-        $className = $oAuthProviders[$provider]['class'];
-        if (!\class_exists($className)) {
+        $oAuthProviders = Config::getParam('oAuthProviders') ?? [];
+        $className = $oAuthProviders[$provider]['class'] ?? null;
+        if ($className === null || !\class_exists($className)) {
             throw new Exception(Exception::PROJECT_PROVIDER_UNSUPPORTED);
         }
 


### PR DESCRIPTION
Fix for production error:
```
Warning: Trying to access array offset on null in /usr/src/code/vendor/appwrite/server-ce/app/controllers/api/account.php on line 906
```


This pull request improves the robustness of OAuth provider handling in the `sendSessionAlert` function within `app/controllers/api/account.php`. The main focus is to prevent errors when the configuration for OAuth providers is missing or incomplete, ensuring the code handles these cases gracefully.

Error handling and robustness improvements for OAuth provider configuration:

* Changed retrieval of `oAuthProviders` from `Config::getParam('oAuthProviders')` to use the null coalescing operator (`?? []`), ensuring it defaults to an empty array if not set. [[1]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L905-R911) [[2]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L1343-R1345) [[3]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L1494-R1500) [[4]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L2034-R2036)
* Modified access to the provider class name to use `['class'] ?? null`, preventing undefined index errors if the provider or class is missing. [[1]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L905-R911) [[2]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L1343-R1345) [[3]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L1494-R1500) [[4]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L2034-R2036)
* Updated logic to check for provider and class existence before attempting to use them, throwing appropriate exceptions if unsupported or disabled. [[1]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L905-R911) [[2]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L1343-R1345) [[3]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L1494-R1500) [[4]](diffhunk://#diff-93771e9bb8e57cbe7d0c0e91e7aea5d85238a362f51caf957049f1d2ccc4d312L2034-R2036)
* Ensured all retrievals of `oAuthProviders` for further processing also use the null coalescing operator for consistency and safety.