### PR TITLE
Feat fix for missing null safety on console redirects

### DIFF
--- a/src/Appwrite/Platform/Modules/Console/Http/Redirects/Base.php
+++ b/src/Appwrite/Platform/Modules/Console/Http/Redirects/Base.php
@@ -37,7 +37,7 @@ abstract class Base extends Action
     public function action(Request $request, Response $response): void
     {
         $url = parse_url($request->getURI());
-        $target = "/console{$url['path']}";
+        $target = "/console" . ($url['path'] ?? '');
         $params = $request->getParams();
         if (!empty($params)) {
             $target .= "?" . \http_build_query($params);


### PR DESCRIPTION
This was throwing an error on the container logs: 

```
Warning: Undefined array key "path" in /usr/src/code/vendor/appwrite/server-ce/src/Appwrite/Platform/Modules/Console/Http/Redirects/Base.php on line 40
```