### PR TITLE
Remove superfluous logs from StatsResources worker

### DIFF
--- a/src/Appwrite/Platform/Workers/StatsResources.php
+++ b/src/Appwrite/Platform/Workers/StatsResources.php
@@ -5,11 +5,11 @@ namespace Appwrite\Platform\Workers;
 use Appwrite\Platform\Action;
 use Exception;
 use Throwable;
-use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Queue\Message;
+use Utopia\Telemetry\Span;
 
 class StatsResources extends Action
 {
@@ -76,29 +76,15 @@ class StatsResources extends Action
         // Reset documents for each job
         $this->documents = [];
 
-        $startTime = microtime(true);
         $this->countForProject($dbForPlatform, $getLogsDB, $getProjectDB, $project);
-        $endTime = microtime(true);
-        $executionTime = $endTime - $startTime;
-        Console::info('Project: ' . $project->getId() . '(' . $project->getSequence() . ') aggregated in ' . $executionTime .' seconds');
     }
 
     protected function countForProject(Database $dbForPlatform, callable $getLogsDB, callable $getProjectDB, Document $project): void
     {
-        Console::info('Begining count for: ' . $project->getId());
-
-        $dbForLogs = null;
-        $dbForProject = null;
-        try {
-            /** @var \Utopia\Database\Database $dbForLogs */
-            $dbForLogs = call_user_func($getLogsDB, $project);
-            /** @var \Utopia\Database\Database $dbForProject */
-            $dbForProject = call_user_func($getProjectDB, $project);
-        } catch (Throwable $th) {
-            Console::error('Unable to get database');
-            Console::error($th->getMessage());
-            return;
-        }
+        /** @var \Utopia\Database\Database $dbForLogs */
+        $dbForLogs = call_user_func($getLogsDB, $project);
+        /** @var \Utopia\Database\Database $dbForProject */
+        $dbForProject = call_user_func($getProjectDB, $project);
 
         try {
 
@@ -209,7 +195,6 @@ class StatsResources extends Action
             call_user_func_array($this->logError, [$th, "StatsResources", "count_for_project_{$project->getId()}"]);
         }
 
-        Console::info('End of count for: ' . $project->getId());
     }
 
     protected function countForBuckets(Database $dbForProject, Database $dbForLogs, string $region)
@@ -463,7 +448,7 @@ class StatsResources extends Action
 
     protected function writeDocuments(Database $dbForLogs, Document $project): void
     {
-        $message = 'Stats writeDocuments project: ' . $project->getId() . '(' . $project->getSequence() . ')';
+        Span::add('documents.count', count($this->documents));
 
         /**
          * sort by unique index key reduce locks/deadlocks
@@ -492,16 +477,9 @@ class StatsResources extends Action
             return strcmp($a['time'], $b['time']);
         });
 
-        try {
-            $dbForLogs->upsertDocuments(
-                'stats',
-                $this->documents,
-            );
-
-            Console::success($message . ' | Documents: ' . count($this->documents));
-        } catch (\Throwable $e) {
-            Console::error('Error: ' . $message . ' | Exception: ' . $e->getMessage());
-            throw $e;
-        }
+        $dbForLogs->upsertDocuments(
+            'stats',
+            $this->documents,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Removed redundant `Console::info`/`Console::error`/`Console::success` logs from the `StatsResources` worker — project ID, sequence, region, database, and duration are already captured by the telemetry span
- Added `Span::add('documents.count', ...)` to capture the only detail not already in the span
- Simplified error handling by letting exceptions propagate to existing `logError` callbacks

## Test plan
- [x] Verify stats-resources worker processes projects without console log noise
- [x] Verify `documents.count` appears in telemetry span output
- [x] Verify exceptions still surface via `logError` callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)