### PR TITLE
fix: add session alert email template translations for all languages

### DIFF
--- a/app/config/locale/translations/af.json
+++ b/app/config/locale/translations/af.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Hierdie aanmelding is versoek met behulp van {{agentClient}} op {{agentDevice}} {{agentOs}}. As jy nie die aanmelding versoek het nie, kan jy hierdie e-pos veilig ignoreer.",
     "emails.otpSession.securityPhrase": "Die veiligheidsfrase vir hierdie e-pos is {{phrase}}. Jy kan hierdie e-pos vertrou as hierdie frase ooreenstem met die frase wat gewys is tydens aanmelding.",
     "emails.otpSession.thanks": "Dankie,",
-    "emails.otpSession.signature": "{{project}} span"
+    "emails.otpSession.signature": "{{project}} span",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ar-ma.json
+++ b/app/config/locale/translations/ar-ma.json
@@ -235,5 +235,15 @@
     "continents.eu": "ؤروپا",
     "continents.na": "ميريكان الشمالية",
     "continents.oc": "ؤقيانوسيا",
-    "continents.sa": "ميريكان الجنوبية"
+    "continents.sa": "ميريكان الجنوبية",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ar.json
+++ b/app/config/locale/translations/ar.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "تم طلب هذا الدخول باستخدام {{agentClient}} على جهاز {{agentDevice}} {{agentOs}}. إذا لم تطلب الدخول، يمكنك تجاهل هذا البريد الإلكتروني بأمان.",
     "emails.otpSession.securityPhrase": "عبارة الأمان لهذا البريد الإلكتروني هي {{phrase}}. يمكنك الوثوق بهذا البريد الإلكتروني إذا كانت هذه العبارة تتطابق مع العبارة المعروضة أثناء تسجيل الدخول.",
     "emails.otpSession.thanks": "شكرًا،",
-    "emails.otpSession.signature": "فريق {{project}}"
+    "emails.otpSession.signature": "فريق {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/as.json
+++ b/app/config/locale/translations/as.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "আপোনাৰ পূৰ্বৰ প্ৰমাণপত্ৰটো প্ৰথম ব্ৰিফল হোৱাৰ দিনৰ পৰা ৩০ দিনলৈ বৈধ থাকিব। আমি এই ঘটনাটোৰ তদন্ত কৰিবলৈ উচ্চ পৰামৰ্শ দিয়ে, অন্যথা আপোনাৰ ডোমেইনটো অবৈধ SSL যোগাযোগ অবিহনে থাকিব।",
     "emails.certificate.thanks": "ধন্যবাদ,",
     "emails.certificate.signature": "{{project}} দল",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/az.json
+++ b/app/config/locale/translations/az.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Bu giriş {{agentClient}} vasitəsilə {{agentDevice}} {{agentOs}} istifadə edərək istənildi. Əgər siz giriş istəməmisinizsə, bu e-poçtu laqeyd qoya bilərsiniz.",
     "emails.otpSession.securityPhrase": "Bu e-poçtun təhlükəsizlik ifadəsi {{phrase}}-dir. Əgər bu ifadə daxil olarkən göstərilən ifadə ilə üst-üstə düşürsə, bu e-poçta etibar edə bilərsiniz.",
     "emails.otpSession.thanks": "Sağ olun,",
-    "emails.otpSession.signature": "{{project}} komandası"
+    "emails.otpSession.signature": "{{project}} komandası",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/be.json
+++ b/app/config/locale/translations/be.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "Ваш папярэдні сертыфікат будзе дзейнічаць 30 дзён з моманту першай няўдачы. Мы высока рэкамендуем расследаваць гэтую сітуацыю, інакш ваш дамен апынецца без дзейнага сертыфіката SSL-злучэння.",
     "emails.certificate.thanks": "Дзякуй,",
     "emails.certificate.signature": "каманда {{project}}",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/bg.json
+++ b/app/config/locale/translations/bg.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Този вход беше заявен чрез {{agentClient}} на {{agentDevice}} {{agentOs}}. Ако не сте заявили входа, можете спокойно да пренебрегнете този имейл.",
     "emails.otpSession.securityPhrase": "Фразата за сигурност за този имейл е {{phrase}}. Можете да се доверите на този имейл, ако тази фраза съвпада с фразата, показана по време на вписването.",
     "emails.otpSession.thanks": "Благодаря,",
-    "emails.otpSession.signature": "екип на {{project}}"
+    "emails.otpSession.signature": "екип на {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/bh.json
+++ b/app/config/locale/translations/bh.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "तोहार पिछलका प्रमाणपत्र पहिल असफलता से 30 दिन धरी मान्य होईत। हम बहुत जोर देके सलाह देतानी कि एह मामला के जांच करीं, नहीं त तोहार डोमेन बिना कोनो मान्य SSL संवाद के रहि जाईत।",
     "emails.certificate.thanks": "धन्यवाद,",
     "emails.certificate.signature": "{{project}} टीम",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/bn.json
+++ b/app/config/locale/translations/bn.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "এই সাইন ইনটি {{agentClient}} ব্যবহার করে {{agentDevice}} {{agentOs}}-এ অনুরোধ করা হয়েছে। আপনি যদি সাইন ইনের অনুরোধ না করে থাকেন, আপনি নিরাপদে এই ইমেলটি উপেক্ষা করতে পারেন।",
     "emails.otpSession.securityPhrase": "এই ইমেইলের জন্য সুরক্ষা বাক্য হলো {{phrase}}। যদি এই বাক্যটি সাইন ইনের সময় দেখানো বাক্যের সাথে মেলে, তাহলে আপনি এই ইমেইলটিকে বিশ্বাস করতে পারেন।",
     "emails.otpSession.thanks": "ধন্যবাদ,",
-    "emails.otpSession.signature": "{{project}} দল"
+    "emails.otpSession.signature": "{{project}} দল",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/bs.json
+++ b/app/config/locale/translations/bs.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Ovaj zahtjev za prijavom je poslan koristeći {{agentClient}} na {{agentDevice}} {{agentOs}}. Ako niste zatražili prijavu, možete sigurno ignorisati ovaj email.",
     "emails.otpSession.securityPhrase": "Sigurnosna fraza za ovaj email je {{phrase}}. Možete vjerovati ovom emailu ako se ova fraza podudara sa frazom prikazanom prilikom prijave.",
     "emails.otpSession.thanks": "Hvala,",
-    "emails.otpSession.signature": "tim {{project}}"
+    "emails.otpSession.signature": "tim {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ca.json
+++ b/app/config/locale/translations/ca.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Aquest inici de sessió s'ha sol·licitat utilitzant {{agentClient}} en {{agentDevice}} {{agentOs}}. Si no has sol·licitat l'inici de sessió, pots ignorar aquest correu electrònic sense cap problema.",
     "emails.otpSession.securityPhrase": "La frase de seguretat d'aquest correu electrònic és {{phrase}}. Podeu confiar en aquest correu electrònic si aquesta frase coincideix amb la frase mostrada durant l'inici de sessió.",
     "emails.otpSession.thanks": "Gràcies,",
-    "emails.otpSession.signature": "equip {{project}}"
+    "emails.otpSession.signature": "equip {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/cs.json
+++ b/app/config/locale/translations/cs.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Tento přihlašovací pokus byl proveden pomocí {{agentClient}} na zařízení {{agentDevice}} {{agentOs}}. Pokud jste se nepřihlašovali, tento e-mail můžete bezpečně ignorovat.",
     "emails.otpSession.securityPhrase": "Bezpečnostní fráze pro tento e-mail je {{phrase}}. Tomuto e-mailu můžete důvěřovat, pokud se tato fráze shoduje s frází zobrazenou při přihlášení.",
     "emails.otpSession.thanks": "Děkuji,",
-    "emails.otpSession.signature": "tým {{project}}"
+    "emails.otpSession.signature": "tým {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/da.json
+++ b/app/config/locale/translations/da.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Denne indlogning blev anmodet om ved hjælp af {{agentClient}} på {{agentDevice}} {{agentOs}}. Hvis du ikke har anmodet om indlogningen, kan du trygt ignorere denne e-mail.",
     "emails.otpSession.securityPhrase": "Sikkerhedsfrasen for denne e-mail er {{phrase}}. Du kan stole på denne e-mail, hvis denne frase matcher frasen vist under login.",
     "emails.otpSession.thanks": "Tak,",
-    "emails.otpSession.signature": "{{project}} team"
+    "emails.otpSession.signature": "{{project}} team",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/de.json
+++ b/app/config/locale/translations/de.json
@@ -246,5 +246,15 @@
     "emails.otpSession.securityPhrase": "Die Sicherheitsphrase für diese E-Mail lautet {{phrase}}. Sie können dieser E-Mail vertrauen, wenn diese Phrase mit der Phrase übereinstimmt, die beim Anmelden angezeigt wird.",
     "emails.otpSession.thanks": "Danke,",
     "emails.otpSession.signature": "{{project}} Team",
-    "mock": "Eine Beispielübersetzung für Testzwecke."
+    "mock": "Eine Beispielübersetzung für Testzwecke.",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/el.json
+++ b/app/config/locale/translations/el.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Αυτή η είσοδος ζητήθηκε με χρήση {{agentClient}} σε {{agentDevice}} {{agentOs}}. Εάν δεν ζητήσατε την είσοδο, μπορείτε να αγνοήσετε αυτό το email με ασφάλεια.",
     "emails.otpSession.securityPhrase": "Η φράση ασφαλείας για αυτό το email είναι {{phrase}}. Μπορείτε να εμπιστευτείτε αυτό το email αν αυτή η φράση ταιριάζει με τη φράση που εμφανίστηκε κατά την είσοδο.",
     "emails.otpSession.thanks": "Ευχαριστώ,",
-    "emails.otpSession.signature": "ομάδα {{project}}"
+    "emails.otpSession.signature": "ομάδα {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/eo.json
+++ b/app/config/locale/translations/eo.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Ĉi tiu ensaluto estis petita per {{agentClient}} en {{agentDevice}} {{agentOs}}. Se vi ne petis la ensaluton, vi povas sekure ignori ĉi tiun retpoŝton.",
     "emails.otpSession.securityPhrase": "Sekureca frazo por ĉi tiu retpoŝto estas {{phrase}}. Vi povas fidi ĉi tiun retpoŝton se tiu ĉi frazo kongruas kun la frazo montrita dum ensaluto.",
     "emails.otpSession.thanks": "Dankon,",
-    "emails.otpSession.signature": "teamo de {{project}}"
+    "emails.otpSession.signature": "teamo de {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/es.json
+++ b/app/config/locale/translations/es.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Este inicio de sesión fue solicitado usando {{agentClient}} en {{agentDevice}} {{agentOs}}. Si no solicitaste el inicio de sesión, puedes ignorar este correo electrónico de forma segura.",
     "emails.otpSession.securityPhrase": "La frase de seguridad para este correo electrónico es {{phrase}}. Puedes confiar en este correo si esta frase coincide con la frase mostrada durante el inicio de sesión.",
     "emails.otpSession.thanks": "Gracias.,",
-    "emails.otpSession.signature": "El equipo de {{project}}"
+    "emails.otpSession.signature": "El equipo de {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/fa.json
+++ b/app/config/locale/translations/fa.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "این ورود به سیستم با استفاده از {{agentClient}} در {{agentDevice}} {{agentOs}} درخواست شده است. اگر شما این ورود به سیستم را درخواست نکرده‌اید، می‌توانید به راحتی این ایمیل را نادیده بگیرید.",
     "emails.otpSession.securityPhrase": "عبارت امنیتی برای این ایمیل {{phrase}} است. اگر این عبارت با عبارت نشان داده شده هنگام ورود به سیستم مطابقت داشته باشد، می‌توانید به این ایمیل اعتماد کنید.",
     "emails.otpSession.thanks": "متشکرم،",
-    "emails.otpSession.signature": "تیم {{project}}"
+    "emails.otpSession.signature": "تیم {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/fi.json
+++ b/app/config/locale/translations/fi.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Tämä kirjautumispyyntö tehtiin käyttämällä {{agentClient}} laitteella {{agentDevice}} {{agentOs}}. Jos et pyytänyt kirjautumista, voit huoletta ohittaa tämän sähköpostin.",
     "emails.otpSession.securityPhrase": "Tämän sähköpostin turvalause on {{phrase}}. Voit luottaa tähän sähköpostiin, jos tämä lause vastaa kirjautumisen yhteydessä näytettyä lausetta.",
     "emails.otpSession.thanks": "Kiitos,",
-    "emails.otpSession.signature": "{{project}} -tiimi"
+    "emails.otpSession.signature": "{{project}} -tiimi",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/fo.json
+++ b/app/config/locale/translations/fo.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Hendan innritað varð umbidin við {{agentClient}} á {{agentDevice}} {{agentOs}}. Um tú ikki hevur umbiðið innritingina, kanst tú trygt ignorera hesa teldupostin.",
     "emails.otpSession.securityPhrase": "Trygdarorðið fyri hesa teldupostin er {{phrase}}. Tú kanst líta á hesa teldupostin um hetta orðið passar við orðið víst tá tú ritaði inn.",
     "emails.otpSession.thanks": "Takk,",
-    "emails.otpSession.signature": "{{project}} lið"
+    "emails.otpSession.signature": "{{project}} lið",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/fr.json
+++ b/app/config/locale/translations/fr.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Cette connexion a été demandée en utilisant {{agentClient}} sur {{agentDevice}} {{agentOs}}. Si vous n'avez pas demandé cette connexion, vous pouvez ignorer cet e-mail en toute sécurité.",
     "emails.otpSession.securityPhrase": "La phrase de sécurité pour cet e-mail est {{phrase}}. Vous pouvez faire confiance à cet e-mail si cette phrase correspond à celle affichée lors de la connexion.",
     "emails.otpSession.thanks": "Merci,",
-    "emails.otpSession.signature": "équipe {{project}}"
+    "emails.otpSession.signature": "équipe {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ga.json
+++ b/app/config/locale/translations/ga.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Rinneadh an iarratas seo chun síniú isteach ag baint úsáide as {{agentClient}} ar {{agentDevice}} {{agentOs}}. Mura ndearna tú an iarratas chun síniú isteach, is féidir leat an ríomhphost seo a neamhaird go sábháilte.",
     "emails.otpSession.securityPhrase": "Frása slándála don ríomhphost seo ná {{phrase}}. Is féidir muinín a bheith agat as an ríomhphost seo má mheaitseálann an frása seo leis an bhfrása a taispeántar le linn síniú isteach.",
     "emails.otpSession.thanks": "Go raibh maith agat,",
-    "emails.otpSession.signature": "foireann {{project}}"
+    "emails.otpSession.signature": "foireann {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/gu.json
+++ b/app/config/locale/translations/gu.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "આ સાઇન ઇનની વિનંતી {{agentClient}} નો ઉપયોગ કરીને {{agentDevice}} {{agentOs}} પર થઈ છે. જો તમે સાઇન ઇનની વિનંતી કરી ન હોય, તો આ ઈમેલને સુરક્ષિત રીતે અવગણી શકો છો.",
     "emails.otpSession.securityPhrase": "આ ઇમેઇલ માટેનો સુરક્ષા શબ્દ {{phrase}} છે. જો આ શબ્દ સાઇન ઇન વખતે દર્શાવેલા શબ્દ સાથે મેળ ખાતો હોય તો તમે આ ઇમેઇલ પર વિશ્વાસ કરી શકો છો.",
     "emails.otpSession.thanks": "આભાર,",
-    "emails.otpSession.signature": "{{project}} ટીમ"
+    "emails.otpSession.signature": "{{project}} ટીમ",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/he.json
+++ b/app/config/locale/translations/he.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "ההתחברות הזו בוקשה באמצעות {{agentClient}} על {{agentDevice}} {{agentOs}}. אם לא ביקשת את ההתחברות, באפשרותך להתעלם בבטחה ממייל זה.",
     "emails.otpSession.securityPhrase": "משפט האבטחה למייל זה הוא {{phrase}}. אתה יכול לסמוך על המייל הזה אם המשפט הזה תואם את המשפט שהוצג במהלך הכניסה למערכת.",
     "emails.otpSession.thanks": "תודה,",
-    "emails.otpSession.signature": "צוות {{project}}"
+    "emails.otpSession.signature": "צוות {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/hi.json
+++ b/app/config/locale/translations/hi.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "यह साइन इन {{agentClient}} का उपयोग करके {{agentDevice}} {{agentOs}} पर किया गया था। यदि आपने साइन इन का अनुरोध नहीं किया है, तो आप इस ईमेल को नजरअंदाज कर सकते हैं।",
     "emails.otpSession.securityPhrase": "इस ईमेल के लिए सुरक्षा वाक्यांश {{phrase}} है। अगर यह वाक्यांश साइन इन के दौरान दिखाए गए वाक्यांश से मेल खाता है, तो आप इस ईमेल पर भरोसा कर सकते हैं।",
     "emails.otpSession.thanks": "धन्यवाद,",
-    "emails.otpSession.signature": "{{project}} टीम"
+    "emails.otpSession.signature": "{{project}} टीम",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/hr.json
+++ b/app/config/locale/translations/hr.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Ova prijava je zatražena pomoću {{agentClient}} na {{agentDevice}} {{agentOs}}. Ako niste zatražili prijavu, ovaj e-mail možete sigurno zanemariti.",
     "emails.otpSession.securityPhrase": "Sigurnosna fraza za ovaj e-mail je {{phrase}}. Možete vjerovati ovom e-mailu ako se ova fraza podudara s frazom prikazanom prilikom prijave.",
     "emails.otpSession.thanks": "Hvala,",
-    "emails.otpSession.signature": "tim {{project}}"
+    "emails.otpSession.signature": "tim {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/hu.json
+++ b/app/config/locale/translations/hu.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Ez a bejelentkezés a(z) {{agentClient}} használatával lett kérve a(z) {{agentDevice}} {{agentOs}} eszközön. Ha Ön nem kérte a bejelentkezést, nyugodtan figyelmen kívül hagyhatja ezt az e-mailt.",
     "emails.otpSession.securityPhrase": "Az e-mailhez tartozó biztonsági kód: {{phrase}}. Ennek az e-mailnek megbízhat, ha a megjelenített kód megegyezik a bejelentkezéskor megjelenő kóddal.",
     "emails.otpSession.thanks": "Köszönöm,",
-    "emails.otpSession.signature": "{{project}} csapat"
+    "emails.otpSession.signature": "{{project}} csapat",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/hy.json
+++ b/app/config/locale/translations/hy.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Սույն մուտքը խնդրված է {{agentClient}}-ի կողմից {{agentDevice}} {{agentOs}}-ում։ Եթե Դուք չեք խնդրել մուտքը, ապա հանգիստ անտեսել այս էլփոստը։",
     "emails.otpSession.securityPhrase": "Այս էլ.փոստի անվտանգության արտահայտությունը {{phrase}} է: Կարող եք վստահել այս էլ.փոստին, եթե այս արտահայտությունը համընկնում է մուտք գործելու պահին տրված արտահայտության հետ։",
     "emails.otpSession.thanks": "Շնորհակալ եմ,",
-    "emails.otpSession.signature": "{{project}} թիմ"
+    "emails.otpSession.signature": "{{project}} թիմ",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/id.json
+++ b/app/config/locale/translations/id.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Tanda masuk ini diminta menggunakan {{agentClient}} pada {{agentDevice}} {{agentOs}}. Jika Anda tidak meminta tanda masuk, Anda dapat mengabaikan email ini dengan aman.",
     "emails.otpSession.securityPhrase": "Frasa keamanan untuk email ini adalah {{phrase}}. Anda dapat mempercayai email ini jika frasa tersebut cocok dengan frasa yang ditampilkan saat masuk.",
     "emails.otpSession.thanks": "Terima kasih,",
-    "emails.otpSession.signature": "tim {{project}}"
+    "emails.otpSession.signature": "tim {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/is.json
+++ b/app/config/locale/translations/is.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Innskráningin var óskað eftir með því að nota {{agentClient}} á {{agentDevice}} {{agentOs}}. Ef þú baðst ekki um innskráninguna getur þú hunsað þennan tölvupóst örugglega.",
     "emails.otpSession.securityPhrase": "Öryggissetning fyrir þetta tölvupóst er {{phrase}}. Þú getur treyst þessum tölvupósti ef þessi setning passar við setninguna sem birtist við innskráningu.",
     "emails.otpSession.thanks": "Takk,",
-    "emails.otpSession.signature": "{{project}} liðið"
+    "emails.otpSession.signature": "{{project}} liðið",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/it.json
+++ b/app/config/locale/translations/it.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Questa registrazione è stata richiesta tramite {{agentClient}} su {{agentDevice}} {{agentOs}}. Se non hai richiesto la registrazione, puoi ignorare tranquillamente questa email.",
     "emails.otpSession.securityPhrase": "La frase di sicurezza per questa email è {{phrase}}. Puoi fidarti di questa email se questa frase corrisponde alla frase mostrata durante l'accesso.",
     "emails.otpSession.thanks": "Grazie,",
-    "emails.otpSession.signature": "team {{project}}"
+    "emails.otpSession.signature": "team {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ja.json
+++ b/app/config/locale/translations/ja.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "このサインインは、{{agentClient}} を使い {{agentDevice}} {{agentOs}} で要求されました。サインインを要求していない場合、このメールを無視しても安全です。",
     "emails.otpSession.securityPhrase": "このメールのセキュリティフレーズは{{phrase}}です。サインイン時に表示されたフレーズと一致する場合、このメールを信頼できます。",
     "emails.otpSession.thanks": "ありがとうございます。、",
-    "emails.otpSession.signature": "{{project}} チーム"
+    "emails.otpSession.signature": "{{project}} チーム",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/jv.json
+++ b/app/config/locale/translations/jv.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Tandha mlebu iki dijaluk nganggo {{agentClient}} ing {{agentDevice}} {{agentOs}}. Yen panjenengan ora njaluk tandha mlebu, panjenengan bisa nglirwakake email iki kanthi aman.",
     "emails.otpSession.securityPhrase": "Tembung keamanan kanggo email iki yaiku {{phrase}}. Sampeyan bisa percaya email iki menawa tembung kasebut cocog karo tembung sing ditampilake nalika mlebu.",
     "emails.otpSession.thanks": "Matur nuwun,",
-    "emails.otpSession.signature": "tim {{project}}"
+    "emails.otpSession.signature": "tim {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/km.json
+++ b/app/config/locale/translations/km.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "ការចូលប្រព័ន្ធនេះត្រូវបានស្នើរបស់អ្នកប្រើប្រាស់តាមរយៈ {{agentClient}} នៅលើ {{agentDevice}} {{agentOs}}។ ប្រសិនបើអ្នកមិនបានស្នើរការចូលប្រព័ន្ធនេះទេ អ្នកអាចមិនអើពើអ៊ីម៉ែលនេះបាន។",
     "emails.otpSession.securityPhrase": "ឃ្លាសម្រាប់សុវត្ថិភាពអ៊ីមែលនេះគឺ {{phrase}}។ អ្នកអាចទុកចិត្តនូវអ៊ីមែលនេះប្រសិនបើឃ្លានេះត្រូវគ្នាជាមួយឃ្លាដែលបានបង្ហាញពេលចូលគណនី។",
     "emails.otpSession.thanks": "អរគុណ",
-    "emails.otpSession.signature": "ក្រុម {{project}}"
+    "emails.otpSession.signature": "ក្រុម {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/kn.json
+++ b/app/config/locale/translations/kn.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "ಈ ಸೈನ್ ಇನ್ ಅನ್ನು {{agentClient}} ಬಳಸಿ {{agentDevice}} {{agentOs}}ನಲ್ಲಿ ಕೋರಿಕೆ ಮಾಡಲಾಗಿದೆ. ನೀವು ಸೈನ್ ಇನ್ ಅನ್ನು ಕೋರಿಕೆ ಮಾಡಿರದಿದ್ದರೆ, ಈ ಇಮೇಲ್ ಅನ್ನು ನೀವು ನಿರಾಳವಾಗಿ ಅಲಕ್ಷ್ಯ ಮಾಡಬಹುದು.",
     "emails.otpSession.securityPhrase": "ಈ ಇಮೇಲ್‌ಗೆ ಭದ್ರತಾ ಪದವು {{phrase}}. ನೀವು ಸೈನ್ ಇನ್ ಮಾಡುವಾಗ ತೋರಿಸಿದ ಪದವು ಇದರೊಂದಿಗೆ ಹೊಂದಿಕೊಂಡರೆ ಈ ಇಮೇಲನ್ನು ನೀವು ನಂಬಬಹುದು.",
     "emails.otpSession.thanks": "ಧನ್ಯವಾದಗಳು,",
-    "emails.otpSession.signature": "ಪ್ರಾಜೆಕ್ಟ್ ತಂಡ"
+    "emails.otpSession.signature": "ಪ್ರಾಜೆಕ್ಟ್ ತಂಡ",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ko.json
+++ b/app/config/locale/translations/ko.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "이 로그인은 {{agentClient}}을 사용하여 {{agentDevice}} {{agentOs}}에서 요청되었습니다. 로그인을 요청하지 않았다면, 이 이메일을 안심하고 무시하셔도 됩니다.",
     "emails.otpSession.securityPhrase": "이 이메일의 보안 구절은 {{phrase}}입니다. 로그인하는 동안 표시된 구절과 이 구절이 일치하면 이 이메일을 신뢰할 수 있습니다.",
     "emails.otpSession.thanks": "감사합니다、",
-    "emails.otpSession.signature": "{{project}} 팀"
+    "emails.otpSession.signature": "{{project}} 팀",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/la.json
+++ b/app/config/locale/translations/la.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "Praeclarum tuum testificationem valet ad XXX dies a primo defectu. Magnopere suademus ut hoc casum investiges, alioquin dominium tuum sine valida SSL communicatione erit.",
     "emails.certificate.thanks": "Gratias,",
     "emails.certificate.signature": "team {{project}}",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/lb.json
+++ b/app/config/locale/translations/lb.json
@@ -244,5 +244,15 @@
     "emails.otpSession.clientInfo": "Dësen Aloggen gouf mat {{agentClient}} op {{agentDevice}} {{agentOs}} gefrot. Wann Dir d'Ufro fir d'Aloggen net gemaach hutt, kënnt Dir dësen E-Mail roueg ignoréieren.",
     "emails.otpSession.securityPhrase": "D'Sécherheetsausso fir dësen E-Mail ass {{phrase}}. Dir kënnt dësem E-Mail vertrauen, wann dës Ausso mat der Ausso iwwereneestëmmt, déi beim Umellen gewise ginn ass.",
     "emails.otpSession.thanks": "Merci,",
-    "emails.otpSession.signature": "{{project}} Equipe"
+    "emails.otpSession.signature": "{{project}} Equipe",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/lt.json
+++ b/app/config/locale/translations/lt.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Šis prisijungimas buvo užklaustas naudojant {{agentClient}} įrenginyje {{agentDevice}} {{agentOs}}. Jei neprašėte prisijungti, šį el. laišką galite drąsiai ignoruoti.",
     "emails.otpSession.securityPhrase": "Šio el. laiško saugumo frazė yra {{phrase}}. Galite pasitikėti šiuo el. laišku, jei ši frazė atitinka frazę, rodytą prisijungimo metu.",
     "emails.otpSession.thanks": "Ačiū,",
-    "emails.otpSession.signature": "{{project}} komanda"
+    "emails.otpSession.signature": "{{project}} komanda",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/lv.json
+++ b/app/config/locale/translations/lv.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Šo pierakstīšanos pieprasīja, izmantojot {{agentClient}} ierīcē {{agentDevice}} {{agentOs}}. Ja neesat pieprasījis pierakstīšanos, šo e-pastu droši var ignorēt.",
     "emails.otpSession.securityPhrase": "Drošības frāze šim e-pastam ir {{phrase}}. Šim e-pastam var uzticēties, ja šī frāze sakrīt ar frāzi, kas parādīta pieslēdzoties.",
     "emails.otpSession.thanks": "Paldies,",
-    "emails.otpSession.signature": "{{project}} komanda"
+    "emails.otpSession.signature": "{{project}} komanda",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ml.json
+++ b/app/config/locale/translations/ml.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "നിങ്ങളുടെ മുൻപത്തെ സർട്ടിഫിക്കറ്റ് ആദ്യ പരാജയത്തിനു ശേഷം 30 ദിവസം വരെ സാധുവായിരിക്കും. ഈ കേസ് അന്വേഷിച്ചു നോക്കുന്നത് ഞങ്ങൾ ശക്തമായി ശുപാർശ ചെയ്യുന്നു, അല്ലെങ്കിൽ നിങ്ങളുടെ ഡൊമെയ്‌ൻ സാധുവായ SSL കമ്മ്യൂണിക്കേഷനില്ലാത്ത ഒരു അവസ്ഥയിലാകും.",
     "emails.certificate.thanks": "നന്ദി,",
     "emails.certificate.signature": "{{project}} ടീം",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/mr.json
+++ b/app/config/locale/translations/mr.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "ही साइन इन विनंती {{agentClient}} वापरुन {{agentDevice}} {{agentOs}} वरुन करण्यात आली आहे. जर तुम्ही ही साइन इन विनंती केली नसेल, तर तुम्ही हा ईमेल सुरक्षितपणे दुर्लक्ष करू शकता.",
     "emails.otpSession.securityPhrase": "या ईमेलसाठीचे सुरक्षा वाक्यांश {{phrase}} आहे. जर हे वाक्यांश साइन इन करताना दाखवल्या गेलेल्या वाक्यांशाशी जुळत असेल तर आपण या ईमेलवर विश्वास ठेवू शकता.",
     "emails.otpSession.thanks": "धन्यवाद,",
-    "emails.otpSession.signature": "{{project}} संघ"
+    "emails.otpSession.signature": "{{project}} संघ",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ms.json
+++ b/app/config/locale/translations/ms.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Penandaan masuk ini telah diminta menggunakan {{agentClient}} pada {{agentDevice}} {{agentOs}}. Jika anda tidak meminta penandaan masuk, anda boleh mengabaikan emel ini dengan selamat.",
     "emails.otpSession.securityPhrase": "Frasa keselamatan untuk email ini adalah {{phrase}}. Anda boleh mempercayai email ini jika frasa ini sepadan dengan frasa yang ditunjukkan semasa log masuk.",
     "emails.otpSession.thanks": "Terima kasih,",
-    "emails.otpSession.signature": "pasukan {{project}}"
+    "emails.otpSession.signature": "pasukan {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/nb.json
+++ b/app/config/locale/translations/nb.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Denne innloggingen ble forespurt ved hjelp av {{agentClient}} på {{agentDevice}} {{agentOs}}. Hvis du ikke ba om innloggingen, kan du trygt ignorere denne e-posten.",
     "emails.otpSession.securityPhrase": "Sikkerhetsfrasen for denne e-posten er {{phrase}}. Du kan stole på denne e-posten hvis denne frasen stemmer overens med frasen som ble vist under pålogging.",
     "emails.otpSession.thanks": "Takk,",
-    "emails.otpSession.signature": "{{project}} team"
+    "emails.otpSession.signature": "{{project}} team",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ne.json
+++ b/app/config/locale/translations/ne.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "यो साइन इन {{agentClient}} प्रयोग गरेर {{agentDevice}} {{agentOs}} मा अनुरोध गरिएको थियो। यदि तपाईंले साइन इन अनुरोध गर्नुभएको छैन भने, तपाईंले यो इमेललाई ध्यान नदिई सुरक्षित रूपमा अनदेखा गर्न सक्नुहुन्छ।",
     "emails.otpSession.securityPhrase": "यस ईमेलको लागि सुरक्षा वाक्य {{phrase}} हो। यदि यो वाक्य साइन इन गर्दा देखाइएको वाक्यसँग मेल खान्छ भने तपाईँले यो ईमेलमा विश्वास गर्न सक्नुहुन्छ।",
     "emails.otpSession.thanks": "धन्यवाद,",
-    "emails.otpSession.signature": "{{project}} टिम"
+    "emails.otpSession.signature": "{{project}} टिम",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/nl.json
+++ b/app/config/locale/translations/nl.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Deze aanmelding is aangevraagd met {{agentClient}} op {{agentDevice}} {{agentOs}}. Als u de aanmelding niet heeft aangevraagd, kunt u deze e-mail veilig negeren.",
     "emails.otpSession.securityPhrase": "De beveiligingszin voor deze e-mail is {{phrase}}. U kunt deze e-mail vertrouwen als deze zin overeenkomt met de zin die wordt getoond tijdens het inloggen.",
     "emails.otpSession.thanks": "Bedankt,",
-    "emails.otpSession.signature": "{{project}} team"
+    "emails.otpSession.signature": "{{project}} team",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/nn.json
+++ b/app/config/locale/translations/nn.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "Førre sertifikatet ditt vil vere gyldig i 30 dagar sidan den første feilen. Vi rår sterkt til at du undersøkjer denne saka, elles vil domenet ditt ende opp utan gyldig SSL-kommunikasjon.",
     "emails.certificate.thanks": "Takk,",
     "emails.certificate.signature": "{{project}} team",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/or.json
+++ b/app/config/locale/translations/or.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "ଏହି ସାଇନ୍ ଇନ୍ ଅନୁରୋଧ କରାଯାଇଛି {{agentClient}} ଉପରେ {{agentDevice}} {{agentOs}} ବ୍ୟବହାର କରି। ଯଦି ଆପଣ ସାଇନ୍ ଇନ୍ ଅନୁରୋଧ କରି ନାହାଁନ୍ତି, ଆପଣ ସୁରକ୍ଷିତଭାବେ ଏହି ଇମେଲକୁ ଉପେକ୍ଷା କରିପାରନ୍ତି।",
     "emails.otpSession.securityPhrase": "ଏହି ଇମେଲର ସୁରକ୍ଷା ବାକ୍ୟାଂଶ ହେଉଛି {{phrase}}। ସାଇନ୍ ଇନ୍ କରିବା ସମୟରେ ଦେଖାଯାଇଥିବା ବାକ୍ୟାଂଶ ସହ ଏହା ମେଳେ ଯଦି, ଆପଣ ଏହି ଇମେଲକୁ ଆସ୍ଥା କରି ପାରିବେ।",
     "emails.otpSession.thanks": "ଧନ୍ୟବାଦ,",
-    "emails.otpSession.signature": "ପ୍ରକଳ୍ପ ଟିମ୍ବ୍"
+    "emails.otpSession.signature": "ପ୍ରକଳ୍ପ ଟିମ୍ବ୍",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/pa.json
+++ b/app/config/locale/translations/pa.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "ਇਹ ਸਾਈਨ ਇਨ ਬੇਨਤੀ {{agentClient}} 'ਤੇ {{agentDevice}} {{agentOs}} ਦਾ ਇਸਤੇਮਾਲ ਕਰਕੇ ਕੀਤੀ ਗਈ ਸੀ। ਜੇ ਤੁਸੀਂ ਇਸ ਸਾਈਨ ਇਨ ਦੀ ਬੇਨਤੀ ਨਹੀਂ ਕੀਤੀ, ਤਾਂ ਤੁਸੀਂ ਇਸ ਈਮੇਲ ਨੂੰ ਬਿਨਾਂ ਕਿਸੇ ਚਿੰਤਾ ਦੇ ਨਜ਼ਰਅੰਦਾਜ਼ ਕਰ ਸਕਦੇ ਹੋ।",
     "emails.otpSession.securityPhrase": "ਇਸ ਈਮੇਲ ਲਈ ਸੁਰੱਖਿਆ ਵਾਕ ਹੈ {{phrase}}। ਜੇ ਇਹ ਵਾਕ ਸਾਈਨ ਇਨ ਕਰਨ ਸਮੇਂ ਦਿਖਾਈ ਦੇਣ ਵਾਲੇ ਵਾਕ ਨਾਲ ਮੇਲ ਖਾਂਦਾ ਹੈ ਤਾਂ ਤੁਸੀਂ ਇਸ ਈਮੇਲ 'ਤੇ ਭਰੋਸਾ ਕਰ ਸਕਦੇ ਹੋ।",
     "emails.otpSession.thanks": "ਧੰਨਵਾਦ,",
-    "emails.otpSession.signature": "{{project}} ਟੀਮ"
+    "emails.otpSession.signature": "{{project}} ਟੀਮ",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/pl.json
+++ b/app/config/locale/translations/pl.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "To logowanie zostało zażądane przy użyciu {{agentClient}} na {{agentDevice}} {{agentOs}}. Jeśli nie zażądałeś logowania, możesz bezpiecznie zignorować tę wiadomość e-mail.",
     "emails.otpSession.securityPhrase": "Hasłem zabezpieczającym dla tego e-maila jest {{phrase}}. Możesz zaufać temu e-mailowi, jeśli hasło zgadza się z hasłem wyświetlonym podczas logowania.",
     "emails.otpSession.thanks": "Dzięki,",
-    "emails.otpSession.signature": "team {{project}}"
+    "emails.otpSession.signature": "team {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/pt-br.json
+++ b/app/config/locale/translations/pt-br.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Este acesso foi solicitado usando {{agentClient}} em {{agentDevice}} {{agentOs}}. Se você não solicitou o acesso, pode ignorar este e-mail com segurança.",
     "emails.otpSession.securityPhrase": "A frase de segurança para este e-mail é {{phrase}}. Você pode confiar neste e-mail se esta frase corresponder à frase mostrada durante o login.",
     "emails.otpSession.thanks": "Obrigado,",
-    "emails.otpSession.signature": "equipe {{project}}"
+    "emails.otpSession.signature": "equipe {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/pt-pt.json
+++ b/app/config/locale/translations/pt-pt.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Este pedido de entrada foi feito usando {{agentClient}} em {{agentDevice}} {{agentOs}}. Se você não solicitou o acesso, pode ignorar este e-mail com segurança.",
     "emails.otpSession.securityPhrase": "A frase de segurança para este email é {{phrase}}. Você pode confiar neste email se essa frase corresponder à frase mostrada durante o login.",
     "emails.otpSession.thanks": "Obrigado,",
-    "emails.otpSession.signature": "equipe {{project}}"
+    "emails.otpSession.signature": "equipe {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ro.json
+++ b/app/config/locale/translations/ro.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Această solicitare de autentificare a fost efectuată folosind {{agentClient}} pe {{agentDevice}} {{agentOs}}. Dacă nu ați cerut autentificarea, puteți ignora în siguranță acest email.",
     "emails.otpSession.securityPhrase": "Fraza de securitate pentru acest e-mail este {{phrase}}. Puteți avea încredere în acest e-mail dacă fraza se potrivește cu cea afișată în timpul autentificării.",
     "emails.otpSession.thanks": "Mulțumesc,",
-    "emails.otpSession.signature": "echipa {{project}}"
+    "emails.otpSession.signature": "echipa {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ru.json
+++ b/app/config/locale/translations/ru.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Этот вход был запрошен с использованием {{agentClient}} на {{agentDevice}} {{agentOs}}. Если вы не запрашивали вход, можете спокойно игнорировать это письмо.",
     "emails.otpSession.securityPhrase": "Фраза безопасности для этого письма {{phrase}}. Вы можете доверять этому письму, если эта фраза совпадает с фразой, показанной во время входа в систему.",
     "emails.otpSession.thanks": "Спасибо,",
-    "emails.otpSession.signature": "команда {{project}}"
+    "emails.otpSession.signature": "команда {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sa.json
+++ b/app/config/locale/translations/sa.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "एष प्रवेशनं प्रार्थितं {{agentClient}} नाम प्रतिनिधौ {{agentDevice}} {{agentOs}} इत्यस्मिन्। यदि त्वमेव प्रवेशनं न प्रार्थितवानसि, तर्हि त्वमनेन ईपत्रेण उपेक्षितुं शक्नोसि।",
     "emails.otpSession.securityPhrase": "अस्य ईमेलस्य सुरक्षा वाक्यं {{phrase}} अस्ति। यदि अयं वाक्यः प्रवेशकाले दृष्टवाक्येन साम्यं याति तर्हि अस्माकं ईमेलं विश्वसनीयम् अस्ति।",
     "emails.otpSession.thanks": "धन्यवादाः,",
-    "emails.otpSession.signature": "कार्यक्रमस्य समूहः"
+    "emails.otpSession.signature": "कार्यक्रमस्य समूहः",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sd.json
+++ b/app/config/locale/translations/sd.json
@@ -251,5 +251,15 @@
     "emails.certificate.footer": "توهان جو اڳيون سرٽيفڪيٽ اولهو فئيلر جي ݙينهن کان ٣٠ ݙينهن لاءِ ماني ويندو. اسان ان جي چھان بني جي بھرپور خواهش ڪنداسين، نہ ته توهان جو ݙومين بغير ڪوري SSL ڪميونڪيشن آڻي ويندي.",
     "emails.certificate.thanks": "شُكريا,",
     "emails.certificate.signature": "ٽيم",
-    "sms.verification.body": "{{secret}}"
+    "sms.verification.body": "{{secret}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/si.json
+++ b/app/config/locale/translations/si.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "මෙම සයින් ඉන් ඉල්ලුම ඉල්ලා ඇත්තේ {{agentClient}} මගින් {{agentDevice}} {{agentOs}} හි භාවිතයෙනි. ඔබ සයින් ඉන් ඉල්ලුම සිදු කළේ නැතහොත්, මෙම ඊමේල් පණිවුඩය නිරාපදව නොසලකා හැරිය හැකිය.",
     "emails.otpSession.securityPhrase": "මෙම ඊමේල්ට සඳහා ආරක්ෂක පාඨය {{phrase}}. පුරන්න විට පෙන්වන පාඨයට මෙම පාඨය ගැලපෙනවා නම්, ඔබට මෙම ඊමේල් විශ්වාස කළ හැකිය.",
     "emails.otpSession.thanks": "ස්තුතියි,",
-    "emails.otpSession.signature": "{{project}} කණ්ඩායම"
+    "emails.otpSession.signature": "{{project}} කණ්ඩායම",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sk.json
+++ b/app/config/locale/translations/sk.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Toto prihlásenie bolo vyžiadané pomocou {{agentClient}} na {{agentDevice}} {{agentOs}}. Ak ste prihlásenie nevyžiadali, tento e-mail môžete bezpečne ignorovať.",
     "emails.otpSession.securityPhrase": "Bezpečnostná fráza pre tento e-mail je {{phrase}}. Tento e-mail môžete dôverovať, ak táto fráza zodpovedá fráze zobrazenej počas prihlasovania.",
     "emails.otpSession.thanks": "Ďakujem,",
-    "emails.otpSession.signature": "tím {{project}}"
+    "emails.otpSession.signature": "tím {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sl.json
+++ b/app/config/locale/translations/sl.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Za to prijavo je bila uporabljena {{agentClient}} na {{agentDevice}} {{agentOs}}. Če niste zahtevali prijave, lahko to e-pošto varno prezrete.",
     "emails.otpSession.securityPhrase": "Varnostni stavek za to e-pošto je {{phrase}}. Temu e-sporočilu lahko zaupate, če se ta stavek ujema s stavkom, ki je prikazan ob prijavi.",
     "emails.otpSession.thanks": "Hvala,",
-    "emails.otpSession.signature": "ekipa {{project}}"
+    "emails.otpSession.signature": "ekipa {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sn.json
+++ b/app/config/locale/translations/sn.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Chikumbiro chekupinda ichi chakumbirwa uchishandisa {{agentClient}} pa{{agentDevice}} {{agentOs}}. Kana iwe usina kukumbira kupinda, unogona kufuratira email iyi zvakachengeteka.",
     "emails.otpSession.securityPhrase": "Chirevo chekuchengetedza cheemail iyi ndechekuti {{phrase}}. Unogona kuvimba neemail iyi kana chirevo ichi chichienderana nechirevo chakaratidzwa panguva yekupinda.",
     "emails.otpSession.thanks": "Ndatenda,",
-    "emails.otpSession.signature": "chikwata {{project}}"
+    "emails.otpSession.signature": "chikwata {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sq.json
+++ b/app/config/locale/translations/sq.json
@@ -242,5 +242,15 @@
     "emails.otpSession.clientInfo": "Ky hyrje u kërkua duke përdorur {{agentClient}} në {{agentDevice}} {{agentOs}}. Nëse nuk e keni kërkuar hyrjen, mund ta injoroni këtë email pa asnjë problem.",
     "emails.otpSession.securityPhrase": "Fjala e sigurisë për këtë email është {{phrase}}. Ju mund të besoni këtë email nëse kjo fjalë përputhet me fjalën që shfaqet gjatë kyçjes.",
     "emails.otpSession.thanks": "Faleminderit,",
-    "emails.otpSession.signature": "ekipi i {{project}}"
+    "emails.otpSession.signature": "ekipi i {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/sv.json
+++ b/app/config/locale/translations/sv.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Den här inloggningsbegäran gjordes med {{agentClient}} på {{agentDevice}} {{agentOs}}. Om du inte har begärt inloggningen kan du ignorera detta e-postmeddelande.",
     "emails.otpSession.securityPhrase": "Säkerhetsfrasen för detta e-postmeddelande är {{phrase}}. Du kan lita på detta e-postmeddelande om frasen stämmer överens med frasen som visades vid inloggningen.",
     "emails.otpSession.thanks": "Tack,",
-    "emails.otpSession.signature": "{{project}} team"
+    "emails.otpSession.signature": "{{project}} team",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ta.json
+++ b/app/config/locale/translations/ta.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "இந்த உள்நுழைவு {{agentClient}} மூலம் {{agentDevice}} {{agentOs}} இல் கோரப்பட்டுள்ளது. நீங்கள் உள்நுழைவை கோரவில்லை எனில், இந்த மின்னஞ்சலை புறக்கணிக்கலாம்.",
     "emails.otpSession.securityPhrase": "இந்த மின்னஞ்சலுக்கான பாதுகாப்பு வாசகம் {{phrase}} ஆகும். இந்த வாசகம் உள்நுழையும் போது காட்டப்பட்ட வாசகத்துடன் பொருந்துமானால், இந்த மின்னஞ்சலை நம்பலாம்.",
     "emails.otpSession.thanks": "நன்றி,",
-    "emails.otpSession.signature": "{{project}} குழு"
+    "emails.otpSession.signature": "{{project}} குழு",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/te.json
+++ b/app/config/locale/translations/te.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "ఈ సైన్ ఇన్‌ను {{agentClient}} ఉపయోగించి {{agentDevice}} {{agentOs}}పై అభ్యర్థించారు. మీరు ఈ సైన్ ఇన్‌ను అభ్యర్థించకపోతే, ఈ ఈమెయిల్‌ను సురక్షితంగా ఉపేక్షించవచ్చు.",
     "emails.otpSession.securityPhrase": "ఈ ఇమెయిల్‌కు భద్రతా పదం {{phrase}}. మీరు సైన్ ఇన్ సమయంలో చూపించబడిన పదంతో ఈ పదం సరిపోలుస్తుంటే ఈ ఇమెయిల్‌ను నమ్మవచ్చు.",
     "emails.otpSession.thanks": "ధన్యవాదాలు,",
-    "emails.otpSession.signature": "ప్రాజెక్టు బృందం"
+    "emails.otpSession.signature": "ప్రాజెక్టు బృందం",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/th.json
+++ b/app/config/locale/translations/th.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "การลงชื่อเข้าใช้งานนี้ได้รับการทำผ่าน {{agentClient}} บน {{agentDevice}} {{agentOs}} หากคุณไม่ได้ทำการขอลงชื่อเข้าใช้นี้ คุณสามารถเพิกเฉยต่ออีเมลนี้ได้เลย",
     "emails.otpSession.securityPhrase": "วลีความปลอดภัยสำหรับอีเมลนี้คือ {{phrase}} คุณสามารถเชื่อถืออีเมลนี้ได้หากวลีนี้ตรงกับวลีที่แสดงขณะลงชื่อเข้าใช้งาน.",
     "emails.otpSession.thanks": "ขอบคุณครับ/ค่ะ",
-    "emails.otpSession.signature": "ทีม {{project}}"
+    "emails.otpSession.signature": "ทีม {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/tl.json
+++ b/app/config/locale/translations/tl.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Ang pag-sign in na ito ay hiniling gamit ang {{agentClient}} sa {{agentDevice}} {{agentOs}}. Kung hindi ikaw ang humiling ng pag-sign in, maaari mong ligtas na balewalain ang email na ito.",
     "emails.otpSession.securityPhrase": "Ang security phrase para sa email na ito ay {{phrase}}. Maaari mong pagkatiwalaan ang email na ito kung ang phrase na ito ay tugma sa phrase na ipinakita noong nag-sign in.",
     "emails.otpSession.thanks": "Salamat,",
-    "emails.otpSession.signature": "team ng {{project}}"
+    "emails.otpSession.signature": "team ng {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/tr.json
+++ b/app/config/locale/translations/tr.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Bu oturum açma işlemi, {{agentDevice}} {{agentOs}} üzerinde {{agentClient}} kullanılarak talep edildi. Eğer oturum açma isteğinde bulunmadıysanız, bu e-postayı güvenle yok sayabilirsiniz.",
     "emails.otpSession.securityPhrase": "Bu e-postanın güvenlik ifadesi {{phrase}}. Giriş sırasında gösterilen ifade ile bu ifade eşleşiyorsa bu e-postaya güvenebilirsiniz.",
     "emails.otpSession.thanks": "Teşekkürler,",
-    "emails.otpSession.signature": "{{project}} takımı"
+    "emails.otpSession.signature": "{{project}} takımı",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/uk.json
+++ b/app/config/locale/translations/uk.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Цей запит на вхід було здійснено за допомогою {{agentClient}} на {{agentDevice}} {{agentOs}}. Якщо ви не запитували вхід, можете спокійно ігнорувати цей електронний лист.",
     "emails.otpSession.securityPhrase": "Фраза безпеки для цього електронного листа - {{phrase}}. Ви можете довіряти цьому електронному листу, якщо ця фраза відповідає фразі, показаній під час входу в систему.",
     "emails.otpSession.thanks": "Дякую,",
-    "emails.otpSession.signature": "команда {{project}}"
+    "emails.otpSession.signature": "команда {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/ur.json
+++ b/app/config/locale/translations/ur.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "یہ سائن ان کی درخواست {{agentClient}} استعمال کرتے ہوئے {{agentDevice}} {{agentOs}} پر کی گئی تھی۔ اگر آپ نے سائن ان کی درخواست نہیں کی تھی، تو آپ اس ای میل کو بغیر کسی فکر کے نظرانداز کر سکتے ہیں۔",
     "emails.otpSession.securityPhrase": "اس ایمیل کے لئے حفاظتی جملہ {{phrase}} ہے۔ اگر یہ جملہ سائن ان کے دوران دکھائے گئے جملے سے میل کھاتا ہے تو آپ اس ایمیل پر بھروسہ کر سکتے ہیں۔",
     "emails.otpSession.thanks": "شکریہ،",
-    "emails.otpSession.signature": "ٹیم {{project}}"
+    "emails.otpSession.signature": "ٹیم {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/vi.json
+++ b/app/config/locale/translations/vi.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Đăng nhập này được yêu cầu sử dụng {{agentClient}} trên {{agentDevice}} {{agentOs}}. Nếu bạn không yêu cầu đăng nhập, bạn có thể bỏ qua email này một cách an toàn.",
     "emails.otpSession.securityPhrase": "Cụm từ bảo mật cho email này là {{phrase}}. Bạn có thể tin tưởng email này nếu cụm từ này khớp với cụm từ hiển thị khi đăng nhập.",
     "emails.otpSession.thanks": "Cảm ơn",
-    "emails.otpSession.signature": "nhóm {{project}}"
+    "emails.otpSession.signature": "nhóm {{project}}",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/zh-cn.json
+++ b/app/config/locale/translations/zh-cn.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "此次登录是通过{{agentClient}}在{{agentDevice}} {{agentOs}}上请求的。如果您没有请求登录，可以放心忽略此电子邮件。",
     "emails.otpSession.securityPhrase": "此电子邮件的安全短语是{{phrase}}。如果此短语与登录时显示的短语一致，您可以信任此邮件。",
     "emails.otpSession.thanks": "谢谢，、",
-    "emails.otpSession.signature": "{{project}} 团队"
+    "emails.otpSession.signature": "{{project}} 团队",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }

--- a/app/config/locale/translations/zh-tw.json
+++ b/app/config/locale/translations/zh-tw.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "這次的登入是使用{{agentClient}}在{{agentDevice}} {{agentOs}}上請求的。如果您沒有請求這次的登入，您可以放心地忽略這封電子郵件。",
     "emails.otpSession.securityPhrase": "這封電子郵件的安全口令是{{phrase}}。如果這個口令與登入時顯示的口令相匹配，您可以信任這封電子郵件。",
     "emails.otpSession.thanks": "謝謝，、",
-    "emails.otpSession.signature": "{{project}} 團隊"
+    "emails.otpSession.signature": "{{project}} 團隊",
+    "emails.sessionAlert.subject": "Security alert: new session on your {{project}} account",
+    "emails.sessionAlert.preview": "New login detected on {{project}} at {{time}} UTC.",
+    "emails.sessionAlert.hello": "Hello {{user}},",
+    "emails.sessionAlert.body": "A new session has been created on your {{b}}{{project}}{{/b}} account, {{b}}on {{date}}, {{year}} at {{time}} UTC{{/b}}.\nHere are the details of the new session: ",
+    "emails.sessionAlert.listDevice": "Device: {{b}}{{device}}{{/b}}",
+    "emails.sessionAlert.listIpAddress": "IP Address: {{b}}{{ipAddress}}{{/b}}",
+    "emails.sessionAlert.listCountry": "Country: {{b}}{{country}}{{/b}}",
+    "emails.sessionAlert.footer": "If this was you, there's nothing more you need to do.\nIf you didn't initiate this session or suspect any unauthorized activity, please secure your account.",
+    "emails.sessionAlert.thanks": "Thanks,",
+    "emails.sessionAlert.signature": "{{project}} team"
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #8659 — Session alert email template was broken for all languages except English.

### Problem

The session alert email template keys (`emails.sessionAlert.*`) were only defined in `en.json`. When a user's locale was set to any non-English language (e.g., `es`, `fr`, `de`), the email displayed raw template key names like `{{emails.sessionAlert.subject}}` instead of actual readable text.

### Solution

Added the English session alert translation keys as fallback to all 72 non-English locale files. This ensures users receive readable session alert emails regardless of their locale setting.

While ideally each language would have its own native translation, having the English text as fallback is far better than showing raw template keys. Native translations can be contributed incrementally.

### Changes

- Added 10 `emails.sessionAlert.*` keys to all 72 non-English translation JSON files in `app/config/locale/translations/`

### Testing

- Verified `en.json` was not modified
- All JSON files remain valid and properly formatted
- Keys are consistent across all locale files