### PR TITLE
fix: show timed-out executions as failed across API endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -90,6 +90,15 @@ class Delete extends Base
         }
         $status = $execution->getAttribute('status');
 
+        // Treat timed-out executions as failed so they can be deleted.
+        if ($status === 'waiting' || $status === 'processing') {
+            $timeout = $function->getAttribute('timeout', 900);
+            $elapsed = \time() - \strtotime($execution->getCreatedAt());
+            if ($elapsed >= $timeout) {
+                $status = 'failed';
+            }
+        }
+
         if (!in_array($status, ['completed', 'failed', 'scheduled'])) {
             throw new Exception(Exception::EXECUTION_IN_PROGRESS);
         }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Get.php
@@ -82,6 +82,16 @@ class Get extends Base
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
 
+        // Override status in response if the execution is stuck in waiting/processing beyond the function timeout.
+        $status = $execution->getAttribute('status', '');
+        if ($status === 'waiting' || $status === 'processing') {
+            $timeout = $function->getAttribute('timeout', 900);
+            $elapsed = \time() - \strtotime($execution->getCreatedAt());
+            if ($elapsed >= $timeout) {
+                $execution->setAttribute('status', 'failed');
+            }
+        }
+
         $response->dynamic($execution, Response::MODEL_EXECUTION);
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/Get.php
@@ -71,6 +71,16 @@ class Get extends Base
             throw new Exception(Exception::LOG_NOT_FOUND);
         }
 
+        // Override status in response if the log is stuck in waiting/processing beyond the site timeout.
+        $status = $log->getAttribute('status', '');
+        if ($status === 'waiting' || $status === 'processing') {
+            $timeout = $site->getAttribute('timeout', 30);
+            $elapsed = \time() - \strtotime($log->getCreatedAt());
+            if ($elapsed >= $timeout) {
+                $log->setAttribute('status', 'failed');
+            }
+        }
+
         $response->dynamic($log, Response::MODEL_EXECUTION); //TODO: Change to model log, but model log already exists - decide what to do
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/XList.php
@@ -11,6 +11,7 @@ use Appwrite\Utopia\Database\Validator\Queries\Executions;
 use Appwrite\Utopia\Database\Validator\Queries\Logs;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
+use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Order as OrderException;
 use Utopia\Database\Exception\Query as QueryException;
@@ -99,6 +100,35 @@ class XList extends Base
             $cursor->setValue($cursorDocument);
         }
 
+        // Calculate the cutoff datetime before which a waiting/processing log is considered timed out.
+        $timeout = $site->getAttribute('timeout', 30);
+        $thresholdDate = new \DateTime("-{$timeout} seconds");
+        $threshold = DateTime::format($thresholdDate);
+
+        // Capture what statuses the caller explicitly requested, before we mutate the query.
+        $requestedStatuses = [];
+        foreach ($queries as $query) {
+            if ($query->getMethod() === Query::TYPE_EQUAL && $query->getAttribute() === 'status') {
+                $requestedStatuses = [...$requestedStatuses, ...$query->getValues()];
+            }
+        }
+
+        // If the caller is filtering by 'failed', expand the DB query to also return
+        // waiting/processing logs created before the timeout threshold, so timed-out
+        // logs that were never marked failed in the DB are included in the results.
+        foreach ($queries as $index => $query) {
+            if ($query->getMethod() === Query::TYPE_EQUAL && $query->getAttribute() === 'status' && \in_array('failed', $query->getValues())) {
+                $queries[$index] = Query::or([
+                    $query,
+                    Query::and([
+                        Query::equal('status', ['waiting', 'processing']),
+                        Query::createdBefore($threshold),
+                    ]),
+                ]);
+                break;
+            }
+        }
+
         $filterQueries = Query::groupByType($queries)['filters'];
 
         try {
@@ -106,6 +136,20 @@ class XList extends Base
             $total = $includeTotal ? $dbForProject->count('executions', $filterQueries, APP_LIMIT_COUNT) : 0;
         } catch (OrderException $e) {
             throw new Exception(Exception::DATABASE_QUERY_ORDER_NULL, "The order attribute '{$e->getAttribute()}' had a null value. Cursor pagination requires all documents order attribute values are non-null.");
+        }
+
+        // Override status in response for timed-out logs, but only when the caller
+        // did not explicitly request a non-failed status (e.g. waiting/processing).
+        if (empty(\array_diff($requestedStatuses, ['failed']))) {
+            foreach ($results as $log) {
+                $status = $log->getAttribute('status', '');
+                if ($status === 'waiting' || $status === 'processing') {
+                    $elapsed = \time() - \strtotime($log->getCreatedAt());
+                    if ($elapsed >= $timeout) {
+                        $log->setAttribute('status', 'failed');
+                    }
+                }
+            }
         }
 
         $response->dynamic(new Document([


### PR DESCRIPTION
## Summary

Executions that time out can remain stuck in `waiting` or `processing` status in the database. This mirrors the frontend workaround from appwrite/console#2788 across the relevant API endpoints for both functions and sites.

- **GET** execution/log: override status to `failed` in the response if elapsed time since creation exceeds the resource's configured timeout
- **LIST** executions/logs: same in-response override; when the caller filters by `failed`, expands the DB query with an `OR` to also fetch `waiting`/`processing` entries created before the timeout threshold so they appear in results; skips the in-response override when the caller explicitly requests a non-failed status to avoid contradicting the filter
- **DELETE** execution: allows deletion of timed-out executions still stored as `waiting`/`processing` by treating them as `failed` for the status guard

All changes are in-memory only — database records are not modified.

> [!NOTE]
> These changes should be removed once a proper database-level fix is applied.

## Test plan

- [ ] GET a timed-out execution (stuck in `waiting`/`processing`) — response should show `status: failed`
- [ ] LIST executions with `status = failed` filter — timed-out entries should appear
- [ ] LIST executions with `status = waiting` or `status = processing` filter — timed-out entries should not appear
- [ ] LIST executions with no status filter — timed-out entries should appear as `failed`
- [ ] DELETE a timed-out execution stuck in `waiting`/`processing` — should succeed
- [ ] DELETE an execution that is genuinely still in progress (within timeout) — should still be blocked