### PR TITLE
Fix typo in Arabic password reset email template

### DIFF
--- a/app/config/locale/translations/ar.json
+++ b/app/config/locale/translations/ar.json
@@ -16,7 +16,7 @@
     "emails.magicSession.signature": "فريق {{project}}",
     "emails.recovery.subject": "تغيير كلمة السر",
     "emails.recovery.hello": "أهلا {{user}}،",
-    "emails.recovery.body": "برجاء اتباع الراط التالي لتغيير كلمة السر الخاصة بـ{{project}}",
+    "emails.recovery.body": "الرجاء اتباع الرابط التالي لتغيير كلمة السر الخاصة بـ{{project}}",
     "emails.recovery.footer": "لولم تطلب تغيير كلمة السر، يمكنك تجاهل هذه الرسالة",
     "emails.recovery.thanks": "شكرا،",
     "emails.recovery.buttonText": "إعادة تعيين كلمة المرور",


### PR DESCRIPTION
**Description:**
This PR fixes a typo in the Arabic password reset email template. The previous template contained incorrect words that do not make sense in Arabic.

**Changes made:**

* Corrected `الراط` → `الرابط`
* Corrected `برجاء` → `الرجاء`

**Affected file:**

* `ar.json` (or wherever the Arabic email template is located)

**Issue:**
Closes #11425

**How to test:**

1. Open a project in Appwrite → Auth → Templates
2. Check the “Reset password” template and switch the language to Arabic
3. Trigger a password reset email
4. Verify that the email body now displays:

```text
الرجاء اتباع الرابط التالي لتغيير كلمة السر الخاصة بـ{{project}}
```

**Notes:**

* This is a text-only fix and does not affect functionality.
