### PR TITLE
fix(projects): allow select queries when listing projects

### DIFF
--- a/src/Appwrite/Utopia/Database/Validator/Queries/Projects.php
+++ b/src/Appwrite/Utopia/Database/Validator/Queries/Projects.php
@@ -17,4 +17,9 @@ class Projects extends Base
     {
         parent::__construct('projects', self::ALLOWED_ATTRIBUTES);
     }
+
+    public function isSelectQueryAllowed(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the `Invalid query method: select` error (HTTP 400) when listing projects with a `Query.select()`.

## Root Cause
The Console sends `Query.select(['$id'])` when listing projects, but the `Projects` query validator doesn't override `isSelectQueryAllowed()`, which defaults to `false` in the `Base` class.

## Fix
Override `isSelectQueryAllowed()` to return `true` in `Projects.php`, following the same pattern as `Deployments.php` (PR #10380).

## Changes
- `src/Appwrite/Utopia/Database/Validator/Queries/Projects.php` — Added `isSelectQueryAllowed()` returning `true`

## Testing
- `Query.select(['$id'])` no longer returns 400 when listing projects
- Existing project listing without `select` continues to work
- Pattern matches the approved approach from PR #10380