### PR TITLE
perf: reduce WebSocket timeout in realtime tests (21x faster)

### DIFF
--- a/tests/e2e/Services/Realtime/RealtimeBase.php
+++ b/tests/e2e/Services/Realtime/RealtimeBase.php
@@ -11,7 +11,8 @@ trait RealtimeBase
         array $channels = [],
         array $headers = [],
         ?string $projectId = null,
-        ?array $queries = null
+        ?array $queries = null,
+        int $timeout = 2
     ): WebSocketClient {
         if (is_null($projectId)) {
             $projectId = $this->getProject()['$id'];
@@ -63,7 +64,7 @@ trait RealtimeBase
             "ws://appwrite.test/v1/realtime?" . $queryString,
             [
                 "headers" => $headers,
-                "timeout" => 45,
+                "timeout" => $timeout,
             ]
         );
     }
@@ -74,9 +75,10 @@ trait RealtimeBase
      *
      * @param array $queryParams Custom query parameters (e.g., ['channels' => ['project'], 'project' => [...]])
      * @param array $headers HTTP headers
+     * @param int $timeout Timeout in seconds (default: 2)
      * @return WebSocketClient
      */
-    private function getWebsocketWithCustomQuery(array $queryParams, array $headers = []): WebSocketClient
+    private function getWebsocketWithCustomQuery(array $queryParams, array $headers = [], int $timeout = 2): WebSocketClient
     {
         $queryString = http_build_query($queryParams);
 
@@ -84,7 +86,7 @@ trait RealtimeBase
             "ws://appwrite.test/v1/realtime?" . $queryString,
             [
                 "headers" => $headers,
-                "timeout" => 45,
+                "timeout" => $timeout,
             ]
         );
     }

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientQueryTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientQueryTest.php
@@ -2535,29 +2535,35 @@ class RealtimeCustomClientQueryTest extends Scope
         $projectId = 'console';
 
         // Subscribe without queries - should receive all events
-        $clientNoQuery = $this->getWebsocket(['tests'], [
-            'origin' => 'http://localhost',
-        ], $projectId);
+        $clientNoQuery = $this->getWebsocket(
+            channels: ['tests'],
+            headers: ['origin' => 'http://localhost'],
+            projectId: $projectId,
+            timeout: 5
+        );
 
         $response = json_decode($clientNoQuery->receive(), true);
         $this->assertEquals('connected', $response['type']);
 
         // Subscribe with matching query - should receive events
-        $clientWithMatchingQuery = $this->getWebsocket(['tests'], [
-            'origin' => 'http://localhost',
-        ], $projectId, [
-            Query::equal('response', ['WS:/v1/realtime:passed'])->toString(),
-        ]);
+        $clientWithMatchingQuery = $this->getWebsocket(
+            channels: ['tests'],
+            headers: ['origin' => 'http://localhost'],
+            projectId: $projectId,
+            queries: [Query::equal('response', ['WS:/v1/realtime:passed'])->toString()],
+            timeout: 5
+        );
 
         $response = json_decode($clientWithMatchingQuery->receive(), true);
         $this->assertEquals('connected', $response['type']);
 
         // Subscribe with non-matching query - should NOT receive events
-        $clientWithNonMatchingQuery = $this->getWebsocket(['tests'], [
-            'origin' => 'http://localhost',
-        ], $projectId, [
-            Query::equal('response', ['failed'])->toString(),
-        ]);
+        $clientWithNonMatchingQuery = $this->getWebsocket(
+            channels: ['tests'],
+            headers: ['origin' => 'http://localhost'],
+            projectId: $projectId,
+            queries: [Query::equal('response', ['failed'])->toString()]
+        );
 
         $response = json_decode($clientWithNonMatchingQuery->receive(), true);
         $this->assertEquals('connected', $response['type']);

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -2225,10 +2225,14 @@ class RealtimeCustomClientTest extends Scope
         $session = $user['session'] ?? '';
         $projectId = $this->getProject()['$id'];
 
-        $client = $this->getWebsocket(['executions'], [
-            'origin' => 'http://localhost',
-            'cookie' => 'a_session_' . $projectId . '=' . $session
-        ]);
+        $client = $this->getWebsocket(
+            channels: ['executions'],
+            headers: [
+                'origin' => 'http://localhost',
+                'cookie' => 'a_session_' . $projectId . '=' . $session
+            ],
+            timeout: 10
+        );
 
         $response = json_decode($client->receive(), true);
 


### PR DESCRIPTION
## Summary
Improve realtime E2E test performance by reducing WebSocket timeouts from 45 seconds to 2 seconds.

## Problem
Realtime E2E tests were taking over 24 minutes to complete. The issue was that many tests verify event filtering works correctly by intentionally expecting a `TimeoutException` when events should be filtered. With the WebSocket timeout set to 45 seconds, each of these timeout cases added significant overhead.

## Solution
- Reduced default WebSocket timeout from 45s to 2s in `RealtimeBase`
- Added optional `timeout` parameter to `getWebsocket()` and `getWebsocketWithCustomQuery()` methods
- Used longer timeouts (5-10s) for specific tests that legitimately wait for slower operations:
  - `testChannelExecutions`: 10s timeout (function executions need time to start)
  - `testTestsChannelWithQueries`: 5s timeout (test channel events)
- Improved code readability using named parameters

## Performance Impact
- **Before:** 24:07 minutes (1,447 seconds)
- **After:** 1:09 minutes (69 seconds)  
- **Speedup:** ~21x faster ⚡

## Test Plan
- [x] All 55 realtime E2E tests pass
- [x] Tests complete in ~1 minute instead of 24 minutes
- [x] No changes to test behavior, only timeout optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)