### PR TITLE
chore: bump utopia-php/migration to 1.6.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4517,16 +4517,16 @@
         },
         {
             "name": "utopia-php/migration",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "037bf4b3813d44f1b0990bc124e35b501ed27fca"
+                "reference": "c2d016944cb029fa5ff822ceee704785a06ef289"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/037bf4b3813d44f1b0990bc124e35b501ed27fca",
-                "reference": "037bf4b3813d44f1b0990bc124e35b501ed27fca",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/c2d016944cb029fa5ff822ceee704785a06ef289",
+                "reference": "c2d016944cb029fa5ff822ceee704785a06ef289",
                 "shasum": ""
             },
             "require": {
@@ -4566,9 +4566,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/1.6.2"
+                "source": "https://github.com/utopia-php/migration/tree/1.6.3"
             },
-            "time": "2026-02-25T12:00:11+00:00"
+            "time": "2026-03-04T07:08:22+00:00"
         },
         {
             "name": "utopia-php/mongo",


### PR DESCRIPTION
## Summary
- Bumps `utopia-php/migration` from 1.6.2 to 1.6.3
- Includes fixes for deployment imports: respect inactive deployments option, fix chunked deployment activate param, skip child resource import when parent already exists in destination
