### PR TITLE
fix: Update in-memory project document after accessedAt update

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -59,9 +59,11 @@ abstract class ScheduleBase extends Action
         if (!$project->isEmpty() && $project->getId() !== 'console') {
             $accessedAt = $project->getAttribute('accessedAt', 0);
             if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $accessedAt) {
+                $now = DateTime::now();
                 $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-                    'accessedAt' => DateTime::now()
+                    'accessedAt' => $now
                 ]));
+                $project->setAttribute('accessedAt', $now);
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes an issue where the `updateProjectAccess` method in `ScheduleBase.php` was updating the database with a new `accessedAt` timestamp but not updating the in-memory project document. This caused the condition to constantly evaluate to true on subsequent calls, triggering unnecessary database updates.

## Changes
- Store `DateTime::now()` in a variable `$now` for consistency
- After updating the database, call `$project->setAttribute('accessedAt', $now)` to update the in-memory document

## Technical Details
The `updateProjectAccess` method is called from:
- `ScheduleFunctions.php`
- `ScheduleExecutions.php`
- `ScheduleMessages.php`

In each case, the `$schedule['project']` document is passed by reference from `$this->schedules`. Without updating the in-memory document, the next call to `updateProjectAccess()` would see the old `accessedAt` value and trigger another unnecessary database update.

## Test plan
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] No regressions