### PR TITLE
Enhance project context validation in realtime message handling. Ensu…

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -763,7 +763,7 @@ $server->onMessage(function (int $connection, string $message) use ($server, $re
         $database = getConsoleDB();
         $database->setAuthorization($authorization);
 
-        if ($projectId !== 'console') {
+        if (!empty($projectId) && $projectId !== 'console') {
             $project = $authorization->skip(fn () => $database->getDocument('projects', $projectId));
 
             $database = getProjectDB($project);
@@ -793,6 +793,11 @@ $server->onMessage(function (int $connection, string $message) use ($server, $re
 
         if (is_null($message) || (!array_key_exists('type', $message) && !array_key_exists('data', $message))) {
             throw new Exception(Exception::REALTIME_MESSAGE_FORMAT_INVALID, 'Message format is not valid.');
+        }
+
+        // Ping does not require project context; other messages do (e.g. after unsubscribe during auth)
+        if (empty($projectId) && ($message['type'] ?? '') !== 'ping') {
+            throw new Exception(Exception::REALTIME_POLICY_VIOLATION, 'Missing project context. Reconnect to the project first.');
         }
 
         switch ($message['type']) {


### PR DESCRIPTION
## Cause of the error
The production error happened when the realtime WebSocket received a ping while the connection had no project context (projectId was null). That can occur when:
The connection was removed from $realtime->connections (e.g. by unsubscribe() during the authentication flow) and the client sends a ping before resubscribing.
A race where a message is handled before the connection is fully registered with a project.
In that situation the code still called getDocument('projects', $projectId) with $projectId === null, which triggered the TypeError.

## Changes made
Guard before fetching the project (line 766)
The project is only loaded when $projectId is non-empty and not 'console':
Before: if ($projectId !== 'console') → could run with $projectId === null.
After: if (!empty($projectId) && $projectId !== 'console') → no DB call when $projectId is null or empty.
Explicit handling when there is no project (lines 799–802)
If there is no project context and the message is not a ping, the code now throws a clear policy violation instead of later failing on missing project/DB:
Ping: Still answered with pong (no project or DB needed).
Other messages (e.g. authentication): Throw REALTIME_POLICY_VIOLATION with message: "Missing project context. Reconnect to the project first."

So:
Ping with projectId === null → respond with pong, no DB access, no error.
Any other message with projectId === null → fail fast with a clear, controlled error instead of a TypeError from getDocument('projects', null).
The linter messages you see are existing ones (undefined type Redis elsewhere in the file), not from these edits.