### PR TITLE
Fix SDK namespace call

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1399,6 +1399,9 @@ Http::error()
             $sdk = $route?->getLabel("sdk", false);
             $action = 'UNKNOWN_NAMESPACE.UNKNOWN.METHOD';
             if (!empty($sdk)) {
+                if (\is_array($sdk)) {
+                    $sdk = $sdk[0];
+                }
                 /** @var \Appwrite\SDK\Method $sdk */
                 $action = $sdk->getNamespace() . '.' . $sdk->getMethodName();
             } elseif ($route === null) {

--- a/app/http.php
+++ b/app/http.php
@@ -581,6 +581,9 @@ $http->on(Constant::EVENT_REQUEST, function (SwooleRequest $swooleRequest, Swool
 
             $action = 'UNKNOWN_NAMESPACE.UNKNOWN.METHOD';
             if (!empty($sdk)) {
+                if (\is_array($sdk)) {
+                    $sdk = $sdk[0];
+                }
                 /** @var Appwrite\SDK\Method $sdk */
                 $action = $sdk->getNamespace() . '.' . $sdk->getMethodName();
             } elseif ($route === null) {


### PR DESCRIPTION
The Sentry error "Call to a member function getNamespace() on array" happened in the error handler when it tried to build the action name for logging (e.g. tablesDB.createRow).
For some routes, the sdk route label is an array of Method objects (one route, several methods). The code assumed it was always a single Method and called $sdk->getNamespace() and $sdk->getMethodName(). When $sdk was an array, that triggered the error. The tablesDB.createRow route is one of those that can expose this.
