### PR TITLE
Fix for when vcs comment is empty

### DIFF
--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -251,7 +251,7 @@ class Comment
         $json = \base64_decode($state);
 
         $builds = \json_decode($json, true);
-        $this->builds = $builds;
+        $this->builds = \is_array($builds) ? $builds : [];
 
         return $this;
     }


### PR DESCRIPTION
fallback to an empty array for type safety 