### PR TITLE
Enable SMTP keep-alive in mail worker

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -420,6 +420,7 @@ $register->set('smtp', function () {
     $mail->Password = $password;
     $mail->SMTPSecure = System::getEnv('_APP_SMTP_SECURE', '');
     $mail->SMTPAutoTLS = false;
+    $mail->SMTPKeepAlive = true;
     $mail->CharSet = 'UTF-8';
     $mail->Timeout = 10; /* Connection timeout */
     $mail->getSMTPInstance()->Timelimit = 30; /* Timeout for each individual SMTP command (e.g. HELO, EHLO, etc.) */

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -214,6 +214,7 @@ class Mails extends Action
         $mail->Password = $password;
         $mail->SMTPSecure = $smtp['secure'];
         $mail->SMTPAutoTLS = false;
+        $mail->SMTPKeepAlive = true;
         $mail->CharSet = 'UTF-8';
         $mail->Timeout = 10; /* Connection timeout */
         $mail->getSMTPInstance()->Timelimit = 30; /* Timeout for each individual SMTP command (e.g. HELO, EHLO, etc.) */


### PR DESCRIPTION
## Summary
- Enable `SMTPKeepAlive` on PHPMailer instances in both the default SMTP registry and custom SMTP path
- Reuses SMTP connections across mail jobs, avoiding repeated TCP connect + TLS handshake + AUTH per email
- Should significantly reduce job processing duration (~1.5s → maybe ~300ms for subsequent jobs)

## Test plan
- [ ] Deploy to staging and monitor mail worker job duration metrics
- [ ] Verify emails are still delivered correctly after extended idle periods (connection recovery)
- [ ] Test with both default SMTP and custom project SMTP configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)