### PR TITLE
fix: allow unsetting user phone after it was previously set

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3347,7 +3347,7 @@ App::patch('/v1/account/phone')
         ],
         contentType: ContentType::JSON
     ))
-    ->param('phone', '', new Phone(), 'Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.')
+    ->param('phone', '', new Phone(allowEmpty: true), 'Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.')
     ->param('password', '', new Password(), 'User password. Must be at least 8 chars.')
     ->inject('response')
     ->inject('user')
@@ -3355,8 +3355,8 @@ App::patch('/v1/account/phone')
     ->inject('queueForEvents')
     ->inject('project')
     ->inject('hooks')
-                ->inject('proofForPassword')
-->inject('authorization')
+    ->inject('proofForPassword')
+    ->inject('authorization')
     ->action(function (string $phone, string $password, Response $response, Document $user, Database $dbForProject, Event $queueForEvents, Document $project, Hooks $hooks, ProofsPassword $proofForPassword, Authorization $authorization) {
         // passwordUpdate will be empty if the user has never set a password
         $passwordUpdate = $user->getAttribute('passwordUpdate');
@@ -3372,15 +3372,19 @@ App::patch('/v1/account/phone')
 
         $hooks->trigger('passwordValidator', [$dbForProject, $project, $password, &$user, false]);
 
-        $target = $authorization->skip(fn () => $dbForProject->findOne('targets', [
-            Query::equal('identifier', [$phone]),
-        ]));
+        $phone = $phone === '' ? null : $phone;
 
-        if (!$target->isEmpty()) {
-            throw new Exception(Exception::USER_TARGET_ALREADY_EXISTS);
+        if (!\is_null($phone)) {
+            $target = $authorization->skip(fn () => $dbForProject->findOne('targets', [
+                Query::equal('identifier', [$phone]),
+            ]));
+
+            if (!$target->isEmpty()) {
+                throw new Exception(Exception::USER_TARGET_ALREADY_EXISTS);
+            }
         }
 
-        $oldPhone = $user->getAttribute('phone');
+        $oldPhone = $user->getAttribute('phone') ?? '';
 
         $user
             ->setAttribute('phone', $phone)
@@ -3403,7 +3407,26 @@ App::patch('/v1/account/phone')
             $oldTarget = $user->find('identifier', $oldPhone, 'targets');
 
             if ($oldTarget instanceof Document && !$oldTarget->isEmpty()) {
-                $authorization->skip(fn () => $dbForProject->updateDocument('targets', $oldTarget->getId(), $oldTarget->setAttribute('identifier', $phone)));
+                if (!\is_null($phone)) {
+                    $authorization->skip(fn () => $dbForProject->updateDocument('targets', $oldTarget->getId(), $oldTarget->setAttribute('identifier', $phone)));
+                } else {
+                    $authorization->skip(fn () => $dbForProject->deleteDocument('targets', $oldTarget->getId()));
+                }
+            } else {
+                if (!\is_null($phone)) {
+                    $target = $authorization->skip(fn () => $dbForProject->createDocument('targets', new Document([
+                        '$permissions' => [
+                            Permission::read(Role::user($user->getId())),
+                            Permission::update(Role::user($user->getId())),
+                            Permission::delete(Role::user($user->getId())),
+                        ],
+                        'userId' => $user->getId(),
+                        'userInternalId' => $user->getSequence(),
+                        'providerType' => MESSAGE_TYPE_SMS,
+                        'identifier' => $phone,
+                    ])));
+                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $target]);
+                }
             }
             $dbForProject->purgeCachedDocument('users', $user->getId());
         } catch (Duplicate $th) {

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3353,11 +3353,12 @@ App::patch('/v1/account/phone')
     ->inject('user')
     ->inject('dbForProject')
     ->inject('queueForEvents')
+    ->inject('queueForDeletes')
     ->inject('project')
     ->inject('hooks')
     ->inject('proofForPassword')
     ->inject('authorization')
-    ->action(function (string $phone, string $password, Response $response, Document $user, Database $dbForProject, Event $queueForEvents, Document $project, Hooks $hooks, ProofsPassword $proofForPassword, Authorization $authorization) {
+    ->action(function (string $phone, string $password, Response $response, Document $user, Database $dbForProject, Event $queueForEvents, Delete $queueForDeletes, Document $project, Hooks $hooks, ProofsPassword $proofForPassword, Authorization $authorization) {
         // passwordUpdate will be empty if the user has never set a password
         $passwordUpdate = $user->getAttribute('passwordUpdate');
 
@@ -3411,6 +3412,9 @@ App::patch('/v1/account/phone')
                     $authorization->skip(fn () => $dbForProject->updateDocument('targets', $oldTarget->getId(), $oldTarget->setAttribute('identifier', $phone)));
                 } else {
                     $authorization->skip(fn () => $dbForProject->deleteDocument('targets', $oldTarget->getId()));
+                    $queueForDeletes
+                        ->setType(DELETE_TYPE_TARGET)
+                        ->setDocument($oldTarget);
                 }
             } else {
                 if (!\is_null($phone)) {

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1548,14 +1548,15 @@ App::patch('/v1/users/:userId/phone')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
-        $oldPhone = $user->getAttribute('phone');
+        $oldPhone = $user->getAttribute('phone') ?? '';
+        $number = $number === '' ? null : $number;
 
         $user
             ->setAttribute('phone', $number)
             ->setAttribute('phoneVerification', false)
         ;
 
-        if (\strlen($number) !== 0) {
+        if (!\is_null($number)) {
             $target = $dbForProject->findOne('targets', [
                 Query::equal('identifier', [$number]),
             ]);
@@ -1573,13 +1574,13 @@ App::patch('/v1/users/:userId/phone')
             $oldTarget = $user->find('identifier', $oldPhone, 'targets');
 
             if ($oldTarget instanceof Document && !$oldTarget->isEmpty()) {
-                if (\strlen($number) !== 0) {
+                if (!\is_null($number)) {
                     $dbForProject->updateDocument('targets', $oldTarget->getId(), $oldTarget->setAttribute('identifier', $number));
                 } else {
                     $dbForProject->deleteDocument('targets', $oldTarget->getId());
                 }
             } else {
-                if (\strlen($number) !== 0) {
+                if (!\is_null($number)) {
                     $target = $dbForProject->createDocument('targets', new Document([
                         '$permissions' => [
                             Permission::read(Role::user($user->getId())),

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -2682,7 +2682,17 @@ class AccountCustomClientTest extends Scope
         ]);
 
         $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEmpty($response['body']['phone']);
+        $this->assertSame('', $response['body']['phone']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/account', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+        ]));
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['phone']);
 
         /**
          * Test for SUCCESS (re-set phone after unset)

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -2669,6 +2669,38 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals($response['body']['phone'], $newPhone);
 
         /**
+         * Test for SUCCESS (unset phone)
+         */
+        $response = $this->client->call(Client::METHOD_PATCH, '/account/phone', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+        ]), [
+            'phone' => '',
+            'password' => 'new-password'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEmpty($response['body']['phone']);
+
+        /**
+         * Test for SUCCESS (re-set phone after unset)
+         */
+        $response = $this->client->call(Client::METHOD_PATCH, '/account/phone', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
+        ]), [
+            'phone' => $newPhone,
+            'password' => 'new-password'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals($response['body']['phone'], $newPhone);
+
+        /**
          * Test for FAILURE
          */
         $response = $this->client->call(Client::METHOD_PATCH, '/account/phone', array_merge([

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -1342,6 +1342,28 @@ trait UsersBase
         $this->assertEquals($user['headers']['status-code'], 200);
         $this->assertEquals($user['body']['phone'], $updatedNumber);
 
+        // Regression: unsetting after assigning a phone should not conflict with other users without a phone.
+        $response = $this->client->call(Client::METHOD_PATCH, '/users/' . $data['userId'] . '/phone', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'number' => '',
+        ]);
+
+        $this->assertEquals($response['headers']['status-code'], 200);
+        $this->assertEquals($response['body']['phone'], '');
+
+        // Set number again for duplicate-number conflict assertion below.
+        $user = $this->client->call(Client::METHOD_PATCH, '/users/' . $data['userId'] . '/phone', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'number' => $updatedNumber,
+        ]);
+
+        $this->assertEquals($user['headers']['status-code'], 200);
+        $this->assertEquals($user['body']['phone'], $updatedNumber);
+
         /**
          * Test for FAILURE
          */


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in admin user phone updates where removing a previously set phone number could fail with `A user with the same phone number already exists in the current project.`

The update path now normalizes empty input to `null` for duplicate-safe writes while preserving correct target lookup behavior.

Fixes #11482.

## Test Plan

1. Brought up the Appwrite Docker dev stack from the repository.
2. Ran Users e2e tests:

```bash
docker compose exec appwrite test /usr/src/code/tests/e2e/Services/Users
```

Result:

- `OK (37 tests, 491 assertions)`

3. Added regression coverage in Users e2e:

- set phone number
- unset phone number
- set phone again
- verify no false duplicate conflict

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/11482

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
