### PR TITLE
fix: retry Redis pconnect on stale persistent connection

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -4,6 +4,7 @@ use Appwrite\Extend\Exception;
 use Appwrite\GraphQL\Promises\Adapter\Swoole;
 use Appwrite\Hooks\Hooks;
 use Appwrite\PubSub\Adapter\Redis as PubSub;
+use Appwrite\Redis\RedisConnection;
 use Appwrite\URL\URL as AppwriteURL;
 use MaxMind\Db\Reader;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -274,13 +275,8 @@ $register->set('pools', function () {
                 },
                 'redis' => function () use ($dsnHost, $dsnPort, $dsnPass) {
                     $redis = new \Redis();
-                    @$redis->pconnect($dsnHost, (int)$dsnPort);
-                    if ($dsnPass) {
-                        $redis->auth($dsnPass);
-                    }
-                    $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 
-                    return $redis;
+                    return RedisConnection::create($redis, $dsnHost, (int)$dsnPort, $dsnPass);
                 },
                 default => throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Invalid scheme'),
             };

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -21,6 +21,7 @@ use Appwrite\Event\Webhook;
 use Appwrite\Extend\Exception;
 use Appwrite\GraphQL\Schema;
 use Appwrite\Network\Cors;
+use Appwrite\Redis\RedisConnection;
 use Appwrite\Network\Platform;
 use Appwrite\Network\Validator\Origin;
 use Appwrite\Network\Validator\Redirect;
@@ -672,13 +673,8 @@ App::setResource('redis', function () {
     $pass = System::getEnv('_APP_REDIS_PASS', '');
 
     $redis = new \Redis();
-    @$redis->pconnect($host, (int) $port);
-    if ($pass) {
-        $redis->auth($pass);
-    }
-    $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 
-    return $redis;
+    return RedisConnection::create($redis, $host, (int) $port, $pass);
 });
 
 App::setResource('timelimit', function (\Redis $redis) {

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -3,6 +3,7 @@
 use Appwrite\Extend\Exception;
 use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Messaging\Adapter\Realtime;
+use Appwrite\Redis\RedisConnection;
 use Appwrite\Network\Validator\Origin;
 use Appwrite\PubSub\Adapter\Pool as PubSubPool;
 use Appwrite\Utopia\Database\Documents\User;
@@ -171,13 +172,8 @@ if (!function_exists('getRedis')) {
         $pass = System::getEnv('_APP_REDIS_PASS', '');
 
         $redis = new \Redis();
-        @$redis->pconnect($host, (int)$port);
-        if ($pass) {
-            $redis->auth($pass);
-        }
-        $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 
-        return $ctx['redis'] = $redis;
+        return $ctx['redis'] = RedisConnection::create($redis, $host, (int)$port, $pass);
     }
 }
 

--- a/app/worker.php
+++ b/app/worker.php
@@ -17,6 +17,7 @@ use Appwrite\Event\Realtime;
 use Appwrite\Event\StatsUsage;
 use Appwrite\Event\Webhook;
 use Appwrite\Platform\Appwrite;
+use Appwrite\Redis\RedisConnection;
 use Appwrite\Utopia\Database\Documents\User;
 use Executor\Executor;
 use Swoole\Runtime;
@@ -243,13 +244,8 @@ Server::setResource('redis', function () {
     $pass = System::getEnv('_APP_REDIS_PASS', '');
 
     $redis = new \Redis();
-    @$redis->pconnect($host, (int)$port);
-    if ($pass) {
-        $redis->auth($pass);
-    }
-    $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
 
-    return $redis;
+    return RedisConnection::create($redis, $host, (int)$port, $pass);
 });
 
 Server::setResource('timelimit', function (\Redis $redis) {

--- a/src/Appwrite/Redis/RedisConnection.php
+++ b/src/Appwrite/Redis/RedisConnection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Appwrite\Redis;
+
+class RedisConnection
+{
+    /**
+     * Create a persistent Redis connection with automatic retry on stale connections.
+     *
+     * Persistent connections (pconnect) can become stale when the Redis server
+     * restarts or the connection is interrupted. When reused, they throw a
+     * RedisException with "read error on connection". This method catches that
+     * error, closes the stale connection, and retries once.
+     */
+    public static function create(\Redis $redis, string $host, int $port, string $pass = ''): \Redis
+    {
+        try {
+            @$redis->pconnect($host, $port);
+        } catch (\RedisException $e) {
+            $redis->close();
+            @$redis->pconnect($host, $port);
+        }
+
+        if ($pass) {
+            $redis->auth($pass);
+        }
+
+        $redis->setOption(\Redis::OPT_READ_TIMEOUT, -1);
+
+        return $redis;
+    }
+}

--- a/tests/unit/Redis/RedisConnectionTest.php
+++ b/tests/unit/Redis/RedisConnectionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Redis;
+
+use Appwrite\Redis\RedisConnection;
+use PHPUnit\Framework\TestCase;
+
+class RedisConnectionTest extends TestCase
+{
+    public function testCreateSucceedsOnFirstAttempt(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->once())
+            ->method('pconnect')
+            ->with('localhost', 6379)
+            ->willReturn(true);
+        $redis->expects($this->once())
+            ->method('setOption')
+            ->with(\Redis::OPT_READ_TIMEOUT, -1);
+        $redis->expects($this->never())
+            ->method('close');
+
+        $result = RedisConnection::create($redis, 'localhost', 6379);
+        $this->assertSame($redis, $result);
+    }
+
+    public function testCreateWithPassword(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->once())
+            ->method('pconnect')
+            ->willReturn(true);
+        $redis->expects($this->once())
+            ->method('auth')
+            ->with('secret');
+        $redis->expects($this->once())
+            ->method('setOption')
+            ->with(\Redis::OPT_READ_TIMEOUT, -1);
+
+        $result = RedisConnection::create($redis, 'localhost', 6379, 'secret');
+        $this->assertSame($redis, $result);
+    }
+
+    public function testCreateRetriesOnRedisException(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->exactly(2))
+            ->method('pconnect')
+            ->with('localhost', 6379)
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \RedisException('read error on connection to cache:6379')),
+                true
+            );
+        $redis->expects($this->once())
+            ->method('close');
+        $redis->expects($this->once())
+            ->method('setOption')
+            ->with(\Redis::OPT_READ_TIMEOUT, -1);
+
+        $result = RedisConnection::create($redis, 'localhost', 6379);
+        $this->assertSame($redis, $result);
+    }
+
+    public function testCreateThrowsAfterRetryFails(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->exactly(2))
+            ->method('pconnect')
+            ->willThrowException(new \RedisException('read error on connection to cache:6379'));
+        $redis->expects($this->once())
+            ->method('close');
+
+        $this->expectException(\RedisException::class);
+        $this->expectExceptionMessage('read error on connection to cache:6379');
+
+        RedisConnection::create($redis, 'localhost', 6379);
+    }
+
+    public function testCreateWithPasswordRetriesOnRedisException(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->exactly(2))
+            ->method('pconnect')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \RedisException('read error on connection to cache:6379')),
+                true
+            );
+        $redis->expects($this->once())
+            ->method('close');
+        $redis->expects($this->once())
+            ->method('auth')
+            ->with('secret');
+        $redis->expects($this->once())
+            ->method('setOption')
+            ->with(\Redis::OPT_READ_TIMEOUT, -1);
+
+        $result = RedisConnection::create($redis, 'localhost', 6379, 'secret');
+        $this->assertSame($redis, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes Sentry issue CLOUD-3JPN: `read error on connection to cache:6379` (1355 events)
- When Redis persistent connections (pconnect) become stale (e.g., after server restart or network interruption), reusing them throws a `RedisException`. This adds a centralized `RedisConnection::create()` helper that catches the exception, closes the broken connection, and retries once.
- Replaces duplicated raw `pconnect` logic in 4 files (`realtime.php`, `worker.php`, `resources.php`, `registers.php`) with the new helper.

## Test plan
- [x] Added unit tests for `RedisConnection::create()` covering:
  - Successful first connection
  - Connection with password
  - Retry after `RedisException` on stale connection
  - Exception propagation when retry also fails
  - Retry with password authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)