### PR TITLE
Pin utopia-php/servers to 0.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "utopia-php/span": "1.1.*",
         "utopia-php/preloader": "0.2.*",
         "utopia-php/queue": "0.15.*",
+        "utopia-php/servers": "0.2.5",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "1.0.*",
         "utopia-php/system": "0.10.*",


### PR DESCRIPTION
## Summary
- Pins `utopia-php/servers` to exact version `0.2.5` in `composer.json` to prevent unintended version drift

## Test plan
- [ ] Verify `composer install` resolves correctly with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)