### PR TITLE
Fix null handling for optional Users API params

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -73,8 +73,9 @@ use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
 /** TODO: Remove function when we move to using utopia/platform */
-function createUser(Hash $hash, string $userId, ?string $email, ?string $password, ?string $phone, string $name, Document $project, Database $dbForProject, Hooks $hooks): Document
+function createUser(Hash $hash, string $userId, ?string $email, ?string $password, ?string $phone, ?string $name, Document $project, Database $dbForProject, Hooks $hooks): Document
 {
+    $name ??= '';
     $plaintextPassword = $password;
     $passwordHistory = $project->getAttribute('auths', [])['passwordHistory'] ?? 0;
 
@@ -255,7 +256,7 @@ App::post('/v1/users')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, ?string $email, ?string $phone, ?string $password, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, ?string $email, ?string $phone, ?string $password, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $plaintext = new Plaintext();
 
         $user = createUser($plaintext, $userId, $email, $password, $phone, $name, $project, $dbForProject, $hooks);
@@ -291,7 +292,7 @@ App::post('/v1/users/bcrypt')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $bcrypt = new Bcrypt();
         $bcrypt->setCost(8); // Default cost
 
@@ -329,7 +330,7 @@ App::post('/v1/users/md5')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $md5 = new MD5();
 
         $user = createUser($md5, $userId, $email, $password, null, $name, $project, $dbForProject, $hooks);
@@ -366,7 +367,7 @@ App::post('/v1/users/argon2')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $argon2 = new Argon2();
 
         $user = createUser($argon2, $userId, $email, $password, null, $name, $project, $dbForProject, $hooks);
@@ -404,7 +405,7 @@ App::post('/v1/users/sha')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $passwordVersion, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, string $passwordVersion, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $sha = new Sha();
         if (!empty($passwordVersion)) {
             $sha->setVersion($passwordVersion);
@@ -444,7 +445,7 @@ App::post('/v1/users/phpass')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $phpass = new PHPass();
 
         $user = createUser($phpass, $userId, $email, $password, null, $name, $project, $dbForProject, $hooks);
@@ -486,7 +487,7 @@ App::post('/v1/users/scrypt')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $passwordSalt, int $passwordCpu, int $passwordMemory, int $passwordParallel, int $passwordLength, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, string $passwordSalt, int $passwordCpu, int $passwordMemory, int $passwordParallel, int $passwordLength, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $scrypt = new Scrypt();
         $scrypt
             ->setSalt($passwordSalt)
@@ -532,7 +533,7 @@ App::post('/v1/users/scrypt-modified')
     ->inject('project')
     ->inject('dbForProject')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $passwordSalt, string $passwordSaltSeparator, string $passwordSignerKey, string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, string $passwordSalt, string $passwordSaltSeparator, string $passwordSignerKey, ?string $name, Response $response, Document $project, Database $dbForProject, Hooks $hooks) {
         $scryptModified = new ScryptModified();
         $scryptModified
             ->setSalt($passwordSalt)
@@ -575,10 +576,12 @@ App::post('/v1/users/:userId/targets')
     ->inject('queueForEvents')
     ->inject('response')
     ->inject('dbForProject')
-    ->action(function (string $targetId, string $userId, string $providerType, string $identifier, string $providerId, string $name, Event $queueForEvents, Response $response, Database $dbForProject) {
+    ->action(function (string $targetId, string $userId, string $providerType, string $identifier, ?string $providerId, ?string $name, Event $queueForEvents, Response $response, Database $dbForProject) {
         $targetId = $targetId == 'unique()' ? ID::unique() : $targetId;
+        $providerId ??= '';
+        $name ??= '';
 
-        $provider = $dbForProject->getDocument('providers', $providerId);
+        $provider = empty($providerId) ? new Document([]) : $dbForProject->getDocument('providers', $providerId);
 
         switch ($providerType) {
             case 'email':
@@ -1712,7 +1715,11 @@ App::patch('/v1/users/:userId/targets/:targetId')
     ->inject('queueForEvents')
     ->inject('response')
     ->inject('dbForProject')
-    ->action(function (string $userId, string $targetId, string $identifier, string $providerId, string $name, Event $queueForEvents, Response $response, Database $dbForProject) {
+    ->action(function (string $userId, string $targetId, ?string $identifier, ?string $providerId, ?string $name, Event $queueForEvents, Response $response, Database $dbForProject) {
+        $identifier ??= '';
+        $providerId ??= '';
+        $name ??= '';
+
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -2305,7 +2312,10 @@ App::post('/v1/users/:userId/tokens')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('queueForEvents')
-    ->action(function (string $userId, int $length, int $expire, Request $request, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->action(function (string $userId, ?int $length, ?int $expire, Request $request, Response $response, Database $dbForProject, Event $queueForEvents) {
+        $length ??= 6;
+        $expire ??= TOKEN_EXPIRATION_GENERIC;
+
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -188,6 +188,13 @@ trait UsersBase
         $this->assertEquals(201, $res['headers']['status-code']);
         $this->assertSame('', $res['body']['name']);
 
+        $cleanup = $this->client->call(Client::METHOD_DELETE, '/users/' . $res['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(204, $cleanup['headers']['status-code']);
+
         return ['userId' => $body['$id']];
     }
 
@@ -1654,6 +1661,7 @@ trait UsersBase
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertEquals($provider['body']['$id'], $response['body']['providerId']);
         $this->assertEquals('random-email@mail.org', $response['body']['identifier']);
+        $target = $response['body'];
 
         $response = $this->client->call(Client::METHOD_POST, '/users/' . $data['userId'] . '/targets', array_merge([
             'content-type' => 'application/json',
@@ -1669,7 +1677,15 @@ trait UsersBase
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertNull($response['body']['providerId']);
         $this->assertNull($response['body']['name']);
-        return $response['body'];
+
+        $cleanup = $this->client->call(Client::METHOD_DELETE, '/users/' . $data['userId'] . '/targets/' . $response['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(204, $cleanup['headers']['status-code']);
+
+        return $target;
     }
 
     /**

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -175,6 +175,19 @@ trait UsersBase
         $this->assertEquals($res['body']['hashOptions']['signerKey'], 'XyEKE9RcTDeLEsL/RjwPDBv/RqDl8fb3gpYEOQaPihbxf1ZAtSOHCjuAAa7Q3oHpCYhXSN9tizHgVOwn6krflQ==');
         $this->assertEquals($res['body']['hashOptions']['saltSeparator'], 'Bw==');
 
+        $res = $this->client->call(Client::METHOD_POST, '/users', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'userId' => ID::unique(),
+            'email' => 'null-name@appwrite.io',
+            'password' => 'password',
+            'name' => null,
+        ]);
+
+        $this->assertEquals(201, $res['headers']['status-code']);
+        $this->assertSame('', $res['body']['name']);
+
         return ['userId' => $body['$id']];
     }
 
@@ -261,6 +274,19 @@ trait UsersBase
         $this->assertEquals(201, $token['headers']['status-code']);
         $this->assertEquals($data['userId'], $token['body']['userId']);
         $this->assertEquals(15, strlen($token['body']['secret']));
+        $this->assertNotEmpty($token['body']['expire']);
+
+        $token = $this->client->call(Client::METHOD_POST, '/users/' . $data['userId'] . '/tokens', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'length' => null,
+            'expire' => null,
+        ]);
+
+        $this->assertEquals(201, $token['headers']['status-code']);
+        $this->assertEquals($data['userId'], $token['body']['userId']);
+        $this->assertEquals(6, strlen($token['body']['secret']));
         $this->assertNotEmpty($token['body']['expire']);
 
         /**
@@ -1628,6 +1654,21 @@ trait UsersBase
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertEquals($provider['body']['$id'], $response['body']['providerId']);
         $this->assertEquals('random-email@mail.org', $response['body']['identifier']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/users/' . $data['userId'] . '/targets', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'targetId' => ID::unique(),
+            'providerId' => null,
+            'providerType' => 'email',
+            'identifier' => 'null-target@mail.org',
+            'name' => null,
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertNull($response['body']['providerId']);
+        $this->assertNull($response['body']['name']);
         return $response['body'];
     }
 
@@ -1645,6 +1686,18 @@ trait UsersBase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('random-email1@mail.org', $response['body']['identifier']);
         $this->assertEquals(false, $response['body']['expired']);
+
+        $response = $this->client->call(Client::METHOD_PATCH, '/users/' . $data['userId'] . '/targets/' . $data['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'identifier' => null,
+            'providerId' => null,
+            'name' => null,
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('random-email1@mail.org', $response['body']['identifier']);
         return $response['body'];
     }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes vague server errors in Users API endpoints when optional parameters are explicitly sent as `null`.

Some optional Users API parameters could bypass validation when sent as `null`, but the route handlers still required non-nullable PHP types. That caused PHP type errors instead of treating those values as omitted.

This change makes the affected handler arguments nullable and normalizes them to the existing backend defaults:
- user `name` falls back to an empty string
- target `providerId`, `name`, and `identifier` fall back to existing empty/no-op handling
- token `length` and `expire` fall back to their default values

It also adds regression coverage for these null-input cases in the Users E2E tests.

## Test Plan

Verified locally:
- `php -l app/controllers/api/users.php`
- `php -l tests/e2e/Services/Users/UsersBase.php`

I also attempted to prepare local PHPUnit execution, but full dependency installation is blocked in this environment because the repo requires several native PHP extensions that are not available locally.

Added regression tests for:
- create user with `name: null`
- create token with `length: null` and `expire: null`
- create target with `providerId: null` and `name: null`
- update target with `identifier: null`, `providerId: null`, and `name: null`

## Related PRs and Issues

- Fixes #8785

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
