### PR TITLE
Fix: users.updatePrefs returns full user object for consistency (fixes #7234)

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1659,12 +1659,12 @@ App::patch('/v1/users/:userId/prefs')
         responses: [
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
-                model: Response::MODEL_PREFERENCES,
+                model: Response::MODEL_USER,
             )
         ]
     ))
     ->param('userId', '', new UID(), 'User ID.')
-    ->param('prefs', '', new Assoc(), 'Prefs key-value JSON object.')
+    ->param('prefs', [], new Assoc(), 'Prefs key-value JSON object.')
     ->inject('response')
     ->inject('dbForProject')
     ->inject('queueForEvents')
@@ -1676,12 +1676,14 @@ App::patch('/v1/users/:userId/prefs')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
-        $user = $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('prefs', $prefs));
+        $user->setAttribute('prefs', $prefs);
+
+        $user = $dbForProject->updateDocument('users', $user->getId(), $user);
 
         $queueForEvents
             ->setParam('userId', $user->getId());
 
-        $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
+        $response->dynamic($user, Response::MODEL_USER);
     });
 
 App::patch('/v1/users/:userId/targets/:targetId')

--- a/tests/e2e/Services/GraphQL/Base.php
+++ b/tests/e2e/Services/GraphQL/Base.php
@@ -1585,7 +1585,12 @@ trait Base
             case self::UPDATE_USER_PREFS:
                 return 'mutation updateUserPrefs($userId: String!, $prefs: Assoc!){
                     usersUpdatePrefs(userId: $userId, prefs: $prefs) {
-                        data
+                        _id
+                        name
+                        email
+                        prefs {
+                            data
+                        }
                     }
                 }';
             case self::UPDATE_USER_EMAIL_VERIFICATION:

--- a/tests/e2e/Services/GraphQL/UsersTest.php
+++ b/tests/e2e/Services/GraphQL/UsersTest.php
@@ -456,7 +456,9 @@ class UsersTest extends Scope
         $this->assertIsArray($user['body']['data']);
         $this->assertArrayNotHasKey('errors', $user['body']);
         $this->assertIsArray($user['body']['data']['usersUpdatePrefs']);
-        $this->assertEquals('{"key":"value"}', $user['body']['data']['usersUpdatePrefs']['data']);
+        $this->assertArrayHasKey('_id', $user['body']['data']['usersUpdatePrefs']);
+        $this->assertArrayHasKey('prefs', $user['body']['data']['usersUpdatePrefs']);
+        $this->assertEquals('{"key":"value"}', $user['body']['data']['usersUpdatePrefs']['prefs']['data']);
     }
 
     /**

--- a/tests/e2e/Services/GraphQL/UsersTest.php
+++ b/tests/e2e/Services/GraphQL/UsersTest.php
@@ -457,8 +457,12 @@ class UsersTest extends Scope
         $this->assertArrayNotHasKey('errors', $user['body']);
         $this->assertIsArray($user['body']['data']['usersUpdatePrefs']);
         $this->assertArrayHasKey('_id', $user['body']['data']['usersUpdatePrefs']);
+        $this->assertEquals($this->getUser()['$id'], $user['body']['data']['usersUpdatePrefs']['_id']);
         $this->assertArrayHasKey('prefs', $user['body']['data']['usersUpdatePrefs']);
-        $this->assertEquals('{"key":"value"}', $user['body']['data']['usersUpdatePrefs']['prefs']['data']);
+        $this->assertEquals(
+            ['key' => 'value'],
+            json_decode($user['body']['data']['usersUpdatePrefs']['prefs']['data'], true)
+        );
     }
 
     /**

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -1260,8 +1260,10 @@ trait UsersBase
         ]);
 
         $this->assertEquals($user['headers']['status-code'], 200);
-        $this->assertEquals($user['body']['funcKey1'], 'funcValue1');
-        $this->assertEquals($user['body']['funcKey2'], 'funcValue2');
+        $this->assertArrayHasKey('$id', $user['body']);
+        $this->assertArrayHasKey('prefs', $user['body']);
+        $this->assertEquals($user['body']['prefs']['funcKey1'], 'funcValue1');
+        $this->assertEquals($user['body']['prefs']['funcKey2'], 'funcValue2');
 
         $user = $this->client->call(Client::METHOD_GET, '/users/' . $data['userId'] . '/prefs', array_merge([
             'content-type' => 'application/json',

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -1261,6 +1261,7 @@ trait UsersBase
 
         $this->assertEquals($user['headers']['status-code'], 200);
         $this->assertArrayHasKey('$id', $user['body']);
+        $this->assertEquals($data['userId'], $user['body']['$id']);
         $this->assertArrayHasKey('prefs', $user['body']);
         $this->assertEquals($user['body']['prefs']['funcKey1'], 'funcValue1');
         $this->assertEquals($user['body']['prefs']['funcKey2'], 'funcValue2');

--- a/tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php
+++ b/tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php
@@ -464,7 +464,9 @@ class WebhooksCustomServerTest extends Scope
         ]);
 
         $this->assertEquals(200, $user['headers']['status-code']);
-        $this->assertEquals('b', $user['body']['a']);
+        $this->assertArrayHasKey('$id', $user['body']);
+        $this->assertArrayHasKey('prefs', $user['body']);
+        $this->assertEquals('b', $user['body']['prefs']['a']);
 
         $webhook = $this->getLastRequest();
         $signatureExpected = self::getWebhookSignature($webhook, $this->getProject()['signatureKey']);
@@ -482,7 +484,9 @@ class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
         $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
-        $this->assertEquals('b', $webhook['data']['a']);
+        $this->assertArrayHasKey('$id', $webhook['data']);
+        $this->assertArrayHasKey('prefs', $webhook['data']);
+        $this->assertEquals('b', $webhook['data']['prefs']['a']);
 
         return $data;
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #7234.

The `PATCH /v1/users/:userId/prefs` endpoint (`users.updatePrefs`) was returning only the preferences object (`MODEL_PREFERENCES`) while every other update endpoint in the Users API—and the equivalent `account.updatePrefs` endpoint—returns the full user object (`MODEL_USER`). This caused the `users.*.update.prefs` event payload to be inconsistent with other `users.*.update.*` event payloads, which all carry the complete user document.

---

## Root Cause

In `app/controllers/api/users.php` (around line 1648), `updatePrefs` called:
```php
$response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
```
returning only the raw preferences map. All other user update actions (e.g. `updateName`, `updateEmail`, `updateStatus`) call:
```php
$response->dynamic($user, Response::MODEL_USER);
```
The Account API's `PATCH /v1/account/prefs` already correctly returns `$user` with `MODEL_ACCOUNT` (line 3453 of `account.php`).

---

## Solution

- Changed `MODEL_PREFERENCES` → `MODEL_USER` in the SDK method definition for `updatePrefs`.
- Changed the action body to set the attribute on the existing `$user` document (matching the pattern used in `account.php`) and return `$user` with `MODEL_USER`.
- Fixed the default value of the `prefs` param from `''` to `[]` (it is typed as an associative array).
- Updated four test files (`UsersBase.php`, `WebhooksCustomServerTest.php`, `GraphQL/Base.php`, `GraphQL/UsersTest.php`) to assert that the response is a full user object with prefs nested under the `prefs` key.

---

## Test Plan

- Updated `testUpdateAndGetUserPrefs` in `tests/e2e/Services/Users/UsersBase.php` to verify the response body contains `$id` and that prefs are nested under `prefs`.
- Updated `testUpdateUserPrefs` in `tests/e2e/Services/Webhooks/WebhooksCustomServerTest.php` to verify both the API response and the webhook payload are full user objects.
- Updated the GraphQL `UPDATE_USER_PREFS` query in `tests/e2e/Services/GraphQL/Base.php` to request user fields and updated the assertion in `UsersTest.php`.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?