### PR TITLE
Split TablesDB e2e tests into a separate CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,7 @@ jobs:
           Avatars,
           Console,
           Databases,
+          TablesDB,
           Functions,
           FunctionsSchedule,
           GraphQL,
@@ -420,7 +421,7 @@ jobs:
             # Services that rely on sequential test method execution (shared static state)
             FUNCTIONAL_FLAG="--functional"
             case "${{ matrix.service }}" in
-              Databases|Functions|Realtime) FUNCTIONAL_FLAG="" ;;
+              Databases|TablesDB|Functions|Realtime) FUNCTIONAL_FLAG="" ;;
             esac
 
             docker compose exec -T \

--- a/tests/e2e/Services/TablesDB/DatabasesStringTypesTest.php
+++ b/tests/e2e/Services/TablesDB/DatabasesStringTypesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\TablesDB;
+namespace Tests\E2E\Services\TablesDB;
 
 use Tests\E2E\Client;
 use Tests\E2E\Scopes\ApiTablesDB;

--- a/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsGuestTest.php
+++ b/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsGuestTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Permissions;
+namespace Tests\E2E\Services\TablesDB\Permissions;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\E2E\Client;
+use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SchemaPolling;

--- a/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsGuestTest.php
+++ b/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsGuestTest.php
@@ -4,12 +4,12 @@ namespace Tests\E2E\Services\TablesDB\Permissions;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\E2E\Client;
-use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SchemaPolling;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;

--- a/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsMemberTest.php
+++ b/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsMemberTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Permissions;
+namespace Tests\E2E\Services\TablesDB\Permissions;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\E2E\Client;
+use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SchemaPolling;

--- a/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsMemberTest.php
+++ b/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsMemberTest.php
@@ -4,12 +4,12 @@ namespace Tests\E2E\Services\TablesDB\Permissions;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\E2E\Client;
-use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SchemaPolling;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;

--- a/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsTeamTest.php
+++ b/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsTeamTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Permissions;
+namespace Tests\E2E\Services\TablesDB\Permissions;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\E2E\Client;
+use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SchemaPolling;

--- a/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsTeamTest.php
+++ b/tests/e2e/Services/TablesDB/Permissions/TablesDBPermissionsTeamTest.php
@@ -4,12 +4,12 @@ namespace Tests\E2E\Services\TablesDB\Permissions;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\E2E\Client;
-use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\SchemaPolling;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\Permissions\DatabasesPermissionsBase;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;

--- a/tests/e2e/Services/TablesDB/TablesDBConsoleClientTest.php
+++ b/tests/e2e/Services/TablesDB/TablesDBConsoleClientTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E\Services\Databases;
+namespace Tests\E2E\Services\TablesDB;
 
+use Tests\E2E\Services\Databases\DatabasesBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;

--- a/tests/e2e/Services/TablesDB/TablesDBConsoleClientTest.php
+++ b/tests/e2e/Services/TablesDB/TablesDBConsoleClientTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB;
 
-use Tests\E2E\Services\Databases\DatabasesBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideConsole;
+use Tests\E2E\Services\Databases\DatabasesBase;
 
 class TablesDBConsoleClientTest extends Scope
 {

--- a/tests/e2e/Services/TablesDB/TablesDBCustomClientTest.php
+++ b/tests/e2e/Services/TablesDB/TablesDBCustomClientTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB;
 
-use Tests\E2E\Services\Databases\DatabasesBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\DatabasesBase;
 
 class TablesDBCustomClientTest extends Scope
 {

--- a/tests/e2e/Services/TablesDB/TablesDBCustomClientTest.php
+++ b/tests/e2e/Services/TablesDB/TablesDBCustomClientTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E\Services\Databases;
+namespace Tests\E2E\Services\TablesDB;
 
+use Tests\E2E\Services\Databases\DatabasesBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;

--- a/tests/e2e/Services/TablesDB/TablesDBCustomServerTest.php
+++ b/tests/e2e/Services/TablesDB/TablesDBCustomServerTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB;
 
-use Tests\E2E\Services\Databases\DatabasesBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideServer;
+use Tests\E2E\Services\Databases\DatabasesBase;
 
 class TablesDBCustomServerTest extends Scope
 {

--- a/tests/e2e/Services/TablesDB/TablesDBCustomServerTest.php
+++ b/tests/e2e/Services/TablesDB/TablesDBCustomServerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E\Services\Databases;
+namespace Tests\E2E\Services\TablesDB;
 
+use Tests\E2E\Services\Databases\DatabasesBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBACIDTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBACIDTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB\Transactions;
 
-use Tests\E2E\Services\Databases\Transactions\ACIDBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\Transactions\ACIDBase;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
 class TablesDBACIDTest extends Scope

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBACIDTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBACIDTest.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Transactions;
+namespace Tests\E2E\Services\TablesDB\Transactions;
 
+use Tests\E2E\Services\Databases\Transactions\ACIDBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
-use Tests\E2E\Scopes\SideServer;
+use Tests\E2E\Scopes\SideClient;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
-class TablesDBTransactionsCustomServerTest extends Scope
+class TablesDBACIDTest extends Scope
 {
-    use TransactionsBase;
+    use ACIDBase;
     use DatabasesUrlHelpers;
     use ProjectCustom;
-    use SideServer;
+    use SideClient;
     use ApiTablesDB;
 }

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionPermissionsCustomClientTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionPermissionsCustomClientTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Transactions;
+namespace Tests\E2E\Services\TablesDB\Transactions;
 
+use Tests\E2E\Services\Databases\Transactions\TransactionPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionPermissionsCustomClientTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionPermissionsCustomClientTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB\Transactions;
 
-use Tests\E2E\Services\Databases\Transactions\TransactionPermissionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\Transactions\TransactionPermissionsBase;
 
 class TablesDBTransactionPermissionsCustomClientTest extends Scope
 {

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsConsoleClientTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsConsoleClientTest.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Transactions;
+namespace Tests\E2E\Services\TablesDB\Transactions;
 
+use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
-use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Scopes\SideConsole;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
-class TablesDBTransactionsCustomClientTest extends Scope
+class TablesDBTransactionsConsoleClientTest extends Scope
 {
     use TransactionsBase;
     use DatabasesUrlHelpers;
     use ProjectCustom;
-    use SideClient;
+    use SideConsole;
     use ApiTablesDB;
 }

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsConsoleClientTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsConsoleClientTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB\Transactions;
 
-use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideConsole;
+use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
 class TablesDBTransactionsConsoleClientTest extends Scope

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomClientTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomClientTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB\Transactions;
 
-use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
+use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
 class TablesDBTransactionsCustomClientTest extends Scope

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomClientTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomClientTest.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Transactions;
+namespace Tests\E2E\Services\TablesDB\Transactions;
 
+use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
-class TablesDBACIDTest extends Scope
+class TablesDBTransactionsCustomClientTest extends Scope
 {
-    use ACIDBase;
+    use TransactionsBase;
     use DatabasesUrlHelpers;
     use ProjectCustom;
     use SideClient;

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomServerTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomServerTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\E2E\Services\TablesDB\Transactions;
 
-use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideServer;
+use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
 class TablesDBTransactionsCustomServerTest extends Scope

--- a/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomServerTest.php
+++ b/tests/e2e/Services/TablesDB/Transactions/TablesDBTransactionsCustomServerTest.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace Tests\E2E\Services\Databases\Transactions;
+namespace Tests\E2E\Services\TablesDB\Transactions;
 
+use Tests\E2E\Services\Databases\Transactions\TransactionsBase;
 use Tests\E2E\Scopes\ApiTablesDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
-use Tests\E2E\Scopes\SideConsole;
+use Tests\E2E\Scopes\SideServer;
 use Tests\E2E\Traits\DatabasesUrlHelpers;
 
-class TablesDBTransactionsConsoleClientTest extends Scope
+class TablesDBTransactionsCustomServerTest extends Scope
 {
     use TransactionsBase;
     use DatabasesUrlHelpers;
     use ProjectCustom;
-    use SideConsole;
+    use SideServer;
     use ApiTablesDB;
 }


### PR DESCRIPTION
## Summary

- Moves all `TablesDB*` test files from `tests/e2e/Services/Databases/` to a new `tests/e2e/Services/TablesDB/` directory
- Updates namespaces to `Tests\E2E\Services\TablesDB\*` and adds explicit imports for shared base traits (`DatabasesBase`, `DatabasesPermissionsBase`, `ACIDBase`, `TransactionsBase`, `TransactionPermissionsBase`) that remain in the `Databases/` directory
- Adds `TablesDB` as a separate service entry in the CI matrix so `/v1/databases` (Legacy) and `/v1/tables` (TablesDB) tests run as independent parallel jobs

## Test plan

- [ ] Verify `Tests / E2E / ... / Databases` job runs only Legacy tests
- [ ] Verify `Tests / E2E / ... / TablesDB` job runs only TablesDB tests
- [ ] Confirm both jobs pass across all database/mode matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)