### PR TITLE
feat(auth): allow sorting users by last activity (accessedAt)

### DIFF
--- a/docs/references/users/list-users.md
+++ b/docs/references/users/list-users.md
@@ -1,1 +1,7 @@
 Get a list of all the project's users. You can use the query params to filter your results.
+
+You may filter on the following attributes: `name`, `email`, `phone`, `status`, `passwordUpdate`, `registration`, `emailVerification`, `phoneVerification`, `labels`, `accessedAt`.
+
+To sort by last user activity, use:
+- `Query.orderAsc("accessedAt")` – oldest activity first
+- `Query.orderDesc("accessedAt")` – most recent activity first

--- a/docs/references/users/list-users.md
+++ b/docs/references/users/list-users.md
@@ -3,5 +3,5 @@ Get a list of all the project's users. You can use the query params to filter yo
 You may filter on the following attributes: `name`, `email`, `phone`, `status`, `passwordUpdate`, `registration`, `emailVerification`, `phoneVerification`, `labels`, `accessedAt`.
 
 To sort by last user activity, use:
-- `Query.orderAsc("accessedAt")` – oldest activity first
-- `Query.orderDesc("accessedAt")` – most recent activity first
+- `Query::orderAsc("accessedAt")` – oldest activity first
+- `Query::orderDesc("accessedAt")` – most recent activity first

--- a/src/Appwrite/Utopia/Database/Validator/Queries/Users.php
+++ b/src/Appwrite/Utopia/Database/Validator/Queries/Users.php
@@ -14,6 +14,7 @@ class Users extends Base
         'emailVerification',
         'phoneVerification',
         'labels',
+        'accessedAt',
     ];
 
     /**

--- a/tests/unit/Utopia/Database/Validator/Queries/UsersTest.php
+++ b/tests/unit/Utopia/Database/Validator/Queries/UsersTest.php
@@ -31,6 +31,9 @@ class UsersTest extends TestCase
         $this->assertEquals(true, $validator->isValid([Query::greaterThan('registration', '2020-10-15 06:38')]), $validator->getDescription());
         $this->assertEquals(true, $validator->isValid([Query::equal('emailVerification', [true])]), $validator->getDescription());
         $this->assertEquals(true, $validator->isValid([Query::equal('phoneVerification', [true])]), $validator->getDescription());
+        $this->assertEquals(true, $validator->isValid([Query::orderAsc('accessedAt')]), $validator->getDescription());
+        $this->assertEquals(true, $validator->isValid([Query::orderDesc('accessedAt')]), $validator->getDescription());
+        $this->assertEquals(true, $validator->isValid([Query::greaterThan('accessedAt', '2020-10-15 06:38')]), $validator->getDescription());
 
         /**
          * Test for Failure


### PR DESCRIPTION
## Summary

While working on the Users API, I noticed that the `accessedAt` field (which tracks
the most recent access date for each user) was already stored in the database and
indexed, but was not exposed as a filterable or sortable attribute in the Users list
endpoint. This made it impossible to sort users by last activity without custom
workarounds.

This PR fixes that by simply adding `accessedAt` to the allowed query attributes in the
Users query validator.

## Changes

- **[src/Appwrite/Utopia/Database/Validator/Queries/Users.php](cci:7://file:///d:/Open%20Source/appwrite/src/Appwrite/Utopia/Database/Validator/Queries/Users.php:0:0-0:0)** — Added `accessedAt`
  to `ALLOWED_ATTRIBUTES`, enabling order and filter queries on this field.
- **[tests/unit/Utopia/Database/Validator/Queries/UsersTest.php](cci:7://file:///d:/Open%20Source/appwrite/tests/unit/Utopia/Database/Validator/Queries/UsersTest.php:0:0-0:0)** — Added tests for
  `Query::orderAsc('accessedAt')`, `Query::orderDesc('accessedAt')`, and
  `Query::greaterThan('accessedAt', ...)`.
- **[docs/references/users/list-users.md](cci:7://file:///d:/Open%20Source/appwrite/docs/references/users/list-users.md:0:0-0:0)** — Updated endpoint docs to mention
  `accessedAt` as a sortable/filterable attribute.

## Usage

```php
// Most recently active users first
Query::orderDesc("accessedAt")

// Oldest activity first
Query::orderAsc("accessedAt")

// Users who haven't been active since a date
Query::lessThan("accessedAt", "2024-01-01T00:00:00.000+00:00")
