### PR TITLE
fix: vectorsdb SDK spec and DatabaseType enum

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
@@ -68,9 +68,8 @@ class Create extends CreateDocumentAction
                     ],
                     contentType: ContentType::JSON,
                     parameters: [
-                        new Parameter('databaseId', optional: false),
-                        new Parameter('collectionId', optional: false),
-                        new Parameter('documents', optional: false),
+                        new Parameter('texts', optional: false),
+                        new Parameter('model', optional: true),
                     ]
                 )
             ])

--- a/src/Appwrite/Utopia/Response/Model/Database.php
+++ b/src/Appwrite/Utopia/Response/Model/Database.php
@@ -45,7 +45,7 @@ class Database extends Model
                 'description' => 'Database type.',
                 'default' => 'legacy',
                 'example' => 'legacy',
-                'enum' => ['legacy', 'tablesdb', 'documentsdb'],
+                'enum' => ['legacy', 'tablesdb', 'documentsdb', 'vectorsdb'],
             ]);
     }
 


### PR DESCRIPTION
## Summary
- Fix `createTextEmbeddings` SDK parameters to match actual endpoint params (`texts`, `model` instead of `databaseId`, `collectionId`, `documents`)
- Add `vectorsdb` to `DatabaseType` enum in Database response model so SDK generates correct enum values

## Test plan
- [ ] Regenerate console SDK and verify `DatabaseType` includes `Vectorsdb`
- [ ] Verify `createTextEmbeddings` SDK method accepts `texts` and `model` params after regeneration