### PR TITLE
ci: use blacksmith runners for slowest e2e services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
 
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     needs: [build, matrix]
     permissions:
       contents: read
@@ -398,6 +398,19 @@ jobs:
           Messaging,
           Migrations
         ]
+        include:
+          - service: Databases
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - service: Sites
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - service: Functions
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - service: Avatars
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - service: Realtime
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - service: TablesDB
+            runner: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ concurrency:
 env:
   COMPOSE_FILE: docker-compose.yml
   IMAGE: appwrite-dev
-  CACHE_KEY: appwrite-dev-${{ github.event.pull_request.head.sha }}
 
 on:
   pull_request:
@@ -248,11 +247,12 @@ jobs:
             TESTING=true
             VERSION=dev
 
-      - name: Cache Docker Image
-        uses: actions/cache@v5
+      - name: Upload Docker Image
+        uses: actions/upload-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
+          name: ${{ env.IMAGE }}
           path: /tmp/${{ env.IMAGE }}.tar
+          retention-days: 1
 
   unit:
     name: Tests / Unit
@@ -265,12 +265,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
 
-      - name: Load Cache
-        uses: actions/cache@v5
+      - name: Download Docker Image
+        uses: actions/download-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
-          path: /tmp/${{ env.IMAGE }}.tar
-          fail-on-cache-miss: true
+          name: ${{ env.IMAGE }}
+          path: /tmp
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -313,12 +312,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
 
-      - name: Load Cache
-        uses: actions/cache@v5
+      - name: Download Docker Image
+        uses: actions/download-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
-          path: /tmp/${{ env.IMAGE }}.tar
-          fail-on-cache-miss: true
+          name: ${{ env.IMAGE }}
+          path: /tmp
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -415,12 +413,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Load Cache
-        uses: actions/cache@v5
+      - name: Download Docker Image
+        uses: actions/download-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
-          path: /tmp/${{ env.IMAGE }}.tar
-          fail-on-cache-miss: true
+          name: ${{ env.IMAGE }}
+          path: /tmp
 
       - name: Set database environment
         run: |
@@ -509,12 +506,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Load Cache
-        uses: actions/cache@v5
+      - name: Download Docker Image
+        uses: actions/download-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
-          path: /tmp/${{ env.IMAGE }}.tar
-          fail-on-cache-miss: true
+          name: ${{ env.IMAGE }}
+          path: /tmp
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -568,12 +564,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Load Cache
-        uses: actions/cache@v5
+      - name: Download Docker Image
+        uses: actions/download-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
-          path: /tmp/${{ env.IMAGE }}.tar
-          fail-on-cache-miss: true
+          name: ${{ env.IMAGE }}
+          path: /tmp
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -629,12 +624,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Load Cache
-        uses: actions/cache@v5
+      - name: Download Docker Image
+        uses: actions/download-artifact@v7
         with:
-          key: ${{ env.CACHE_KEY }}
-          path: /tmp/${{ env.IMAGE }}.tar
-          fail-on-cache-miss: true
+          name: ${{ env.IMAGE }}
+          path: /tmp
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
- Routes the 6 slowest e2e services to `blacksmith-4vcpu-ubuntu-2404` runners based on timing data from the last CI run
- All other services continue using `ubuntu-latest`

| Service | Duration | Runner |
|---|---|---|
| Databases | 7m 45s | blacksmith-4vcpu-ubuntu-2404 |
| Sites | 6m 39s | blacksmith-4vcpu-ubuntu-2404 |
| Functions | 5m 33s | blacksmith-4vcpu-ubuntu-2404 |
| Avatars | 5m 28s | blacksmith-4vcpu-ubuntu-2404 |
| Realtime | 4m 41s | blacksmith-4vcpu-ubuntu-2404 |
| TablesDB | 3m 26s | blacksmith-4vcpu-ubuntu-2404 |

## Test plan
- [ ] Verify CI jobs for the listed services pick up the blacksmith runner
- [ ] Verify all other services still use `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)