### PR TITLE
Add Users service to console SDK to enable user deletion from GUI

### DIFF
--- a/public/sdk-console/index.ts
+++ b/public/sdk-console/index.ts
@@ -6,6 +6,7 @@ export { Functions } from './services/functions';
 export { Locale } from './services/locale';
 export { Storage } from './services/storage';
 export { Teams } from './services/teams';
+export { Users } from './services/users';
 export type { Models, Payload, RealtimeResponseEvent, UploadProgress } from './client';
 export type { QueryTypes, QueryTypesList } from './query';
 export { Permission } from './permission';

--- a/public/sdk-console/models.ts
+++ b/public/sdk-console/models.ts
@@ -820,6 +820,18 @@ export namespace Models {
          */
         status: boolean;
         /**
+         * Hashed user password.
+         */
+        password?: string;
+        /**
+         * Password hashing algorithm.
+         */
+        hash?: string;
+        /**
+         * Password hashing algorithm configuration.
+         */
+        hashOptions?: object;
+        /**
          * Labels for the user.
          */
         labels: string[];
@@ -852,8 +864,49 @@ export namespace Models {
          */
         prefs: Preferences;
         /**
+         * A user-owned message receiver. A single user may have multiple e.g. emails, phones, and a browser. Each target is registered with a single provider.
+         */
+        targets: Target[];
+        /**
          * Most recent access date in ISO 8601 format.
          */
         accessedAt: string;
+    }
+    /**
+     * Target
+     */
+    export type Target = {
+        /**
+         * Target ID.
+         */
+        $id: string;
+        /**
+         * Target creation time in ISO 8601 format.
+         */
+        $createdAt: string;
+        /**
+         * Target update date in ISO 8601 format.
+         */
+        $updatedAt: string;
+        /**
+         * Target Name.
+         */
+        name: string;
+        /**
+         * User ID.
+         */
+        userId: string;
+        /**
+         * Provider ID.
+         */
+        providerId?: string;
+        /**
+         * The target provider type. Can be one of the following: `email`, `sms` or `push`.
+         */
+        providerType: string;
+        /**
+         * The target identifier.
+         */
+        identifier: string;
     }
 }

--- a/public/sdk-console/models.ts
+++ b/public/sdk-console/models.ts
@@ -778,4 +778,82 @@ export namespace Models {
          */
         countryName: string;
     }
+    /**
+     * Users List
+     */
+    export type UserList<Preferences extends Models.Preferences> = {
+        /**
+         * Total number of users documents that matched your query.
+         */
+        total: number;
+        /**
+         * List of users.
+         */
+        users: User<Preferences>[];
+    }
+    /**
+     * User
+     */
+    export type User<Preferences extends Models.Preferences> = {
+        /**
+         * User ID.
+         */
+        $id: string;
+        /**
+         * User creation date in ISO 8601 format.
+         */
+        $createdAt: string;
+        /**
+         * User update date in ISO 8601 format.
+         */
+        $updatedAt: string;
+        /**
+         * User name.
+         */
+        name: string;
+        /**
+         * User registration date in ISO 8601 format.
+         */
+        registration: string;
+        /**
+         * User status. Pass `true` for enabled and `false` for disabled.
+         */
+        status: boolean;
+        /**
+         * Labels for the user.
+         */
+        labels: string[];
+        /**
+         * Password update time in ISO 8601 format.
+         */
+        passwordUpdate: string;
+        /**
+         * User email address.
+         */
+        email: string;
+        /**
+         * User phone number in E.164 format.
+         */
+        phone: string;
+        /**
+         * Email verification status.
+         */
+        emailVerification: boolean;
+        /**
+         * Phone verification status.
+         */
+        phoneVerification: boolean;
+        /**
+         * Multi factor authentication status.
+         */
+        mfa: boolean;
+        /**
+         * User preferences as a key-value object
+         */
+        prefs: Preferences;
+        /**
+         * Most recent access date in ISO 8601 format.
+         */
+        accessedAt: string;
+    }
 }

--- a/public/sdk-console/services/users.ts
+++ b/public/sdk-console/services/users.ts
@@ -1,0 +1,122 @@
+import { Service } from '../service';
+import { AppwriteException, Client } from '../client';
+import type { Models } from '../models';
+import type { UploadProgress, Payload } from '../client';
+
+export class Users extends Service {
+
+     constructor(client: Client)
+     {
+        super(client);
+     }
+
+        /**
+         * List Users
+         *
+         * Get a list of all the project's users. You can use the query params to
+         * filter your results.
+         *
+         * @param {string[]} queries
+         * @param {string} search
+         * @throws {AppwriteException}
+         * @returns {Promise}
+         */
+        async list<Preferences extends Models.Preferences>(queries?: string[], search?: string): Promise<Models.UserList<Preferences>> {
+            let path = '/users';
+            let payload: Payload = {};
+
+            if (typeof queries !== 'undefined') {
+                payload['queries'] = queries;
+            }
+
+            if (typeof search !== 'undefined') {
+                payload['search'] = search;
+            }
+
+            const uri = new URL(this.client.config.endpoint + path);
+            return await this.client.call('get', uri, {
+                'content-type': 'application/json',
+            }, payload);
+        }
+
+        /**
+         * Get User
+         *
+         * Get a user by its unique ID.
+         *
+         * @param {string} userId
+         * @throws {AppwriteException}
+         * @returns {Promise}
+         */
+        async get<Preferences extends Models.Preferences>(userId: string): Promise<Models.User<Preferences>> {
+            if (typeof userId === 'undefined') {
+                throw new AppwriteException('Missing required parameter: "userId"');
+            }
+
+            let path = '/users/{userId}'.replace('{userId}', userId);
+            let payload: Payload = {};
+
+            const uri = new URL(this.client.config.endpoint + path);
+            return await this.client.call('get', uri, {
+                'content-type': 'application/json',
+            }, payload);
+        }
+
+        /**
+         * Delete User
+         *
+         * Delete a user by its unique ID, thereby releasing it from your project.
+         * All user-related resources (sessions, memberships, targets) are also
+         * deleted. Since this action is irreversible, use it with caution.
+         *
+         * @param {string} userId
+         * @throws {AppwriteException}
+         * @returns {Promise}
+         */
+        async delete(userId: string): Promise<{}> {
+            if (typeof userId === 'undefined') {
+                throw new AppwriteException('Missing required parameter: "userId"');
+            }
+
+            let path = '/users/{userId}'.replace('{userId}', userId);
+            let payload: Payload = {};
+
+            const uri = new URL(this.client.config.endpoint + path);
+            return await this.client.call('delete', uri, {
+                'content-type': 'application/json',
+            }, payload);
+        }
+
+        /**
+         * Update User Status
+         *
+         * Update the user status by its unique ID. Use this endpoint to block or
+         * unblock a user.
+         *
+         * @param {string} userId
+         * @param {boolean} status
+         * @throws {AppwriteException}
+         * @returns {Promise}
+         */
+        async updateStatus<Preferences extends Models.Preferences>(userId: string, status: boolean): Promise<Models.User<Preferences>> {
+            if (typeof userId === 'undefined') {
+                throw new AppwriteException('Missing required parameter: "userId"');
+            }
+
+            if (typeof status === 'undefined') {
+                throw new AppwriteException('Missing required parameter: "status"');
+            }
+
+            let path = '/users/{userId}/status'.replace('{userId}', userId);
+            let payload: Payload = {};
+
+            if (typeof status !== 'undefined') {
+                payload['status'] = status;
+            }
+
+            const uri = new URL(this.client.config.endpoint + path);
+            return await this.client.call('patch', uri, {
+                'content-type': 'application/json',
+            }, payload);
+        }
+};

--- a/public/sdk-console/services/users.ts
+++ b/public/sdk-console/services/users.ts
@@ -110,9 +110,7 @@ export class Users extends Service {
             let path = '/users/{userId}/status'.replace('{userId}', userId);
             let payload: Payload = {};
 
-            if (typeof status !== 'undefined') {
-                payload['status'] = status;
-            }
+            payload['status'] = status;
 
             const uri = new URL(this.client.config.endpoint + path);
             return await this.client.call('patch', uri, {


### PR DESCRIPTION
Fixes #11393
                                                                                                                                          
  ## What does this PR do?
                                                                                                                                          
  Adds a `Users` service to the console SDK (`public/sdk-console/`) so the console frontend can manage users at the system level —        
  including permanently deleting a user account.
                                                                                                                                          
  Currently, admins can only remove users from organizations but cannot delete user accounts entirely from the system via the GUI. The    
  backend API (`DELETE /v1/users/{userId}`) already supports this, and the console OpenAPI spec includes the endpoint, but the console SDK
   was missing the `Users` service to expose it.                                                                                          
                                                                                                                                        
  Changes:
  - Added `public/sdk-console/services/users.ts` with `list`, `get`, `delete`, and `updateStatus` methods
  - Added `User` and `UserList` types to `public/sdk-console/models.ts`
  - Exported the new `Users` service from `public/sdk-console/index.ts`                                                                   
   
  ## Test Plan                                                                                                                            
                                                                                                                                        
  - Verified the new `Users` service methods (`list`, `get`, `delete`, `updateStatus`) match the existing backend API endpoints and       
  parameter signatures in `app/controllers/api/users.php`
  - Confirmed the `User` model type matches the server-side response model in `src/Appwrite/Utopia/Response/Model/User.php`               
  - Confirmed the endpoints are already present in the console OpenAPI spec (`open-api3-latest-console.json`)                             
                                                                                                                                          
  ## Related PRs and Issues                                                                                                               
                                                                                                                                          
  - Fixes #11393 — No GUI method for deleting a user permanently from the Appwrite system                                                 
  
  ## Checklist                                                                                                                            
                                                                                                                                        
  - [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?          
  - [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example
  docs?                                      