### PR TITLE
fix: add Telnyx messaging provider support

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -14,7 +14,7 @@ return [
                 'default' => 'production',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_LOCALE',
@@ -23,7 +23,7 @@ return [
                 'default' => 'en',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_OPTIONS_ABUSE',
@@ -32,7 +32,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_OPTIONS_FORCE_HTTPS',
@@ -41,7 +41,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_OPTIONS_FUNCTIONS_FORCE_HTTPS',
@@ -50,7 +50,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_OPTIONS_ROUTER_FORCE_HTTPS',
@@ -59,7 +59,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_OPTIONS_ROUTER_PROTECTION',
@@ -68,7 +68,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_OPENSSL_KEY_V1',
@@ -77,7 +77,7 @@ return [
                 'default' => 'your-secret-key',
                 'required' => true,
                 'question' => 'Choose a secret API key, make sure to make a backup of your key in a secure location',
-                'filter' => 'token'
+                'filter' => 'token',
             ],
             [
                 'name' => '_APP_DOMAIN',
@@ -86,7 +86,7 @@ return [
                 'default' => 'localhost',
                 'required' => true,
                 'question' => 'Enter your Appwrite hostname',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_CUSTOM_DOMAIN_DENY_LIST',
@@ -95,7 +95,7 @@ return [
                 'default' => 'example.com,test.com,app.example.com',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOMAIN_FUNCTIONS',
@@ -104,7 +104,7 @@ return [
                 'default' => 'functions.localhost',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOMAIN_SITES',
@@ -113,7 +113,7 @@ return [
                 'default' => 'sites.localhost',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET',
@@ -121,8 +121,8 @@ return [
                 'introduction' => '',
                 'default' => 'localhost',
                 'required' => true,
-                'question' => 'Enter a DNS A record hostname to serve as a CNAME for your custom domains.' . PHP_EOL . 'You can use the same value as used for the Appwrite hostname.',
-                'filter' => 'domainTarget'
+                'question' => 'Enter a DNS A record hostname to serve as a CNAME for your custom domains.'.PHP_EOL.'You can use the same value as used for the Appwrite hostname.',
+                'filter' => 'domainTarget',
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_CNAME',
@@ -131,7 +131,7 @@ return [
                 'default' => 'localhost',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_AAAA',
@@ -140,7 +140,7 @@ return [
                 'default' => '::1',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_A',
@@ -149,7 +149,7 @@ return [
                 'default' => '127.0.0.1',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_CAA',
@@ -158,7 +158,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DNS',
@@ -167,7 +167,7 @@ return [
                 'default' => '8.8.8.8',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_ROOT',
@@ -176,7 +176,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_EMAILS',
@@ -185,7 +185,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_IPS',
@@ -194,7 +194,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_CONSOLE_HOSTNAMES',
@@ -203,7 +203,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SYSTEM_EMAIL_NAME',
@@ -212,7 +212,7 @@ return [
                 'default' => 'Appwrite',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SYSTEM_EMAIL_ADDRESS',
@@ -221,7 +221,7 @@ return [
                 'default' => 'noreply@appwrite.io',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SYSTEM_TEAM_EMAIL',
@@ -230,7 +230,7 @@ return [
                 'default' => 'team@appwrite.io',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SYSTEM_RESPONSE_FORMAT',
@@ -239,7 +239,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SYSTEM_SECURITY_EMAIL_ADDRESS',
@@ -248,7 +248,7 @@ return [
                 'default' => 'certs@appwrite.io',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_EMAIL_SECURITY',
@@ -257,7 +257,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_EMAIL_CERTIFICATES',
@@ -266,7 +266,7 @@ return [
                 'default' => '',
                 'required' => true,
                 'question' => 'Enter an email that will be used when registering for SSL certificates',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_USAGE_STATS',
@@ -275,7 +275,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_LOGGING_PROVIDER',
@@ -284,7 +284,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_LOGGING_CONFIG',
@@ -293,7 +293,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_USAGE_AGGREGATION_INTERVAL',
@@ -302,7 +302,7 @@ return [
                 'default' => '30',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_USAGE_TIMESERIES_INTERVAL',
@@ -311,7 +311,7 @@ return [
                 'default' => '30',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_USAGE_DATABASE_INTERVAL',
@@ -320,7 +320,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_WORKER_PER_CORE',
@@ -329,7 +329,7 @@ return [
                 'default' => 6,
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_CONSOLE_SESSION_ALERTS',
@@ -338,7 +338,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPRESSION_ENABLED',
@@ -347,7 +347,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPRESSION_MIN_SIZE_BYTES',
@@ -356,7 +356,7 @@ return [
                 'default' => 1024,
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_TRUSTED_HEADERS',
@@ -365,8 +365,8 @@ return [
                 'default' => 'x-forwarded-for',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
-            ]
+                'filter' => '',
+            ],
         ],
     ],
     [
@@ -380,7 +380,7 @@ return [
                 'default' => 'mongodb',
                 'required' => true,
                 'question' => 'Choose your database (mariadb|mongodb|postgresql)',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DB_HOST',
@@ -389,7 +389,7 @@ return [
                 'default' => 'mongodb',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DB_PORT',
@@ -398,7 +398,7 @@ return [
                 'default' => '27017',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DB_SCHEMA',
@@ -407,7 +407,7 @@ return [
                 'default' => 'appwrite',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DB_USER',
@@ -416,7 +416,7 @@ return [
                 'default' => 'user',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DB_PASS',
@@ -425,7 +425,7 @@ return [
                 'default' => 'password',
                 'required' => false,
                 'question' => '',
-                'filter' => 'password'
+                'filter' => 'password',
             ],
             [
                 'name' => '_APP_DB_ROOT_PASS',
@@ -434,7 +434,7 @@ return [
                 'default' => 'rootsecretpassword',
                 'required' => false,
                 'question' => '',
-                'filter' => 'password'
+                'filter' => 'password',
             ],
         ],
     ],
@@ -449,7 +449,7 @@ return [
                 'default' => 'redis',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_REDIS_PORT',
@@ -458,7 +458,7 @@ return [
                 'default' => '6379',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_REDIS_USER',
@@ -467,7 +467,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_REDIS_PASS',
@@ -476,7 +476,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -491,7 +491,7 @@ return [
                 'default' => 'influxdb',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_INFLUXDB_PORT',
@@ -500,7 +500,7 @@ return [
                 'default' => '8086',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -515,7 +515,7 @@ return [
                 'default' => 'telegraf',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_STATSD_PORT',
@@ -524,7 +524,7 @@ return [
                 'default' => '8125',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -539,7 +539,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SMTP_PORT',
@@ -548,7 +548,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SMTP_SECURE',
@@ -557,7 +557,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SMTP_USERNAME',
@@ -566,7 +566,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SMTP_PASSWORD',
@@ -575,7 +575,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -585,12 +585,12 @@ return [
         'variables' => [
             [
                 'name' => '_APP_SMS_PROVIDER',
-                'description' => "Provider used for delivering SMS for Phone authentication. Use the following format: 'sms://[USER]:[SECRET]@[PROVIDER]'.\n\nEnsure `[USER]` and `[SECRET]` are URL encoded if they contain any non-alphanumeric characters.\n\nAvailable providers are twilio, Textmagic, telesign, msg91, and vonage.",
+                'description' => "Provider used for delivering SMS for Phone authentication. Use the following format: 'sms://[USER]:[SECRET]@[PROVIDER]'.\n\nEnsure `[USER]` and `[SECRET]` are URL encoded if they contain any non-alphanumeric characters.\n\nAvailable providers are twilio, Textmagic, telesign, msg91, vonage, and telnyx.",
                 'introduction' => '0.15.0',
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SMS_FROM',
@@ -599,7 +599,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -614,7 +614,7 @@ return [
                 'default' => '30000000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_STORAGE_PREVIEW_LIMIT',
@@ -623,7 +623,7 @@ return [
                 'default' => '20000000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_STORAGE_ANTIVIRUS',
@@ -632,7 +632,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_STORAGE_ANTIVIRUS_HOST',
@@ -641,7 +641,7 @@ return [
                 'default' => 'clamav',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_STORAGE_ANTIVIRUS_PORT',
@@ -650,7 +650,7 @@ return [
                 'default' => '3310',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_STORAGE_DEVICE',
@@ -841,7 +841,7 @@ return [
                 'default' => '30000000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_SIZE_LIMIT',
@@ -850,7 +850,7 @@ return [
                 'default' => '30000000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_BUILD_SIZE_LIMIT',
@@ -859,7 +859,7 @@ return [
                 'default' => '2000000000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_TIMEOUT',
@@ -868,7 +868,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_BUILD_TIMEOUT',
@@ -877,7 +877,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_BUILD_TIMEOUT',
@@ -886,7 +886,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_CONTAINERS',
@@ -895,7 +895,7 @@ return [
                 'default' => '10',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_CPUS',
@@ -904,7 +904,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_CPUS',
@@ -913,7 +913,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY',
@@ -922,7 +922,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_MEMORY',
@@ -931,7 +931,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY_SWAP',
@@ -940,16 +940,16 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_RUNTIMES',
-                'description' => "This option allows you to enable or disable runtime environments for cloud functions. Disable unused runtimes to save disk space.\n\nTo enable cloud function runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: " . \implode(', ', \array_keys(Config::getParam('runtimes'))),
+                'description' => "This option allows you to enable or disable runtime environments for cloud functions. Disable unused runtimes to save disk space.\n\nTo enable cloud function runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: ".\implode(', ', \array_keys(Config::getParam('runtimes'))),
                 'introduction' => '0.8.0',
                 'default' => 'node-16.0,php-8.0,python-3.9,ruby-3.0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_EXECUTOR_SECRET',
@@ -958,7 +958,7 @@ return [
                 'default' => 'your-secret-key',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_EXECUTOR_HOST',
@@ -968,7 +968,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_BROWSER_HOST',
@@ -978,7 +978,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_EXECUTOR_RUNTIME_NETWORK',
@@ -987,7 +987,7 @@ return [
                 'default' => 'appwrite_runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_ENVS',
@@ -996,7 +996,7 @@ return [
                 'default' => 'node-16.0,php-7.4,python-3.9,ruby-3.0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_INACTIVE_THRESHOLD',
@@ -1005,7 +1005,7 @@ return [
                 'default' => '60',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_INACTIVE_THRESHOLD',
@@ -1014,7 +1014,7 @@ return [
                 'default' => '60',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => 'DOCKERHUB_PULL_USERNAME',
@@ -1023,7 +1023,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => 'DOCKERHUB_PULL_PASSWORD',
@@ -1032,7 +1032,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => 'DOCKERHUB_PULL_EMAIL',
@@ -1041,7 +1041,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => 'OPEN_RUNTIMES_NETWORK',
@@ -1050,7 +1050,7 @@ return [
                 'default' => 'appwrite_runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_RUNTIMES_NETWORK',
@@ -1059,7 +1059,7 @@ return [
                 'default' => 'runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_RUNTIMES_NETWORK',
@@ -1068,7 +1068,7 @@ return [
                 'default' => 'runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOCKER_HUB_USERNAME',
@@ -1077,7 +1077,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_DOCKER_HUB_PASSWORD',
@@ -1086,7 +1086,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_FUNCTIONS_MAINTENANCE_INTERVAL',
@@ -1096,7 +1096,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_COMPUTE_MAINTENANCE_INTERVAL',
@@ -1106,7 +1106,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -1121,18 +1121,18 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_SITES_RUNTIMES',
-                'description' => "This option allows you to enable or disable runtime environments for Sites. Disable unused runtimes to save disk space.\n\nTo enable cloud site runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: " . \implode(', ', \array_keys(Config::getParam('runtimes'))),
+                'description' => "This option allows you to enable or disable runtime environments for Sites. Disable unused runtimes to save disk space.\n\nTo enable cloud site runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: ".\implode(', ', \array_keys(Config::getParam('runtimes'))),
                 'introduction' => '1.7.0',
                 'default' => 'static-1,node-22,flutter-3.29',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
-        ]
+        ],
     ],
     [
         'category' => 'VCS (Version Control System)',
@@ -1145,7 +1145,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_VCS_GITHUB_PRIVATE_KEY',
@@ -1154,7 +1154,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_VCS_GITHUB_APP_ID',
@@ -1163,7 +1163,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_VCS_GITHUB_CLIENT_ID',
@@ -1172,7 +1172,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_VCS_GITHUB_CLIENT_SECRET',
@@ -1181,7 +1181,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_VCS_GITHUB_WEBHOOK_SECRET',
@@ -1190,7 +1190,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -1205,7 +1205,7 @@ return [
                 'default' => '86400',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_DELAY',
@@ -1214,7 +1214,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_START_TIME',
@@ -1223,7 +1223,7 @@ return [
                 'default' => '00:00',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_CACHE',
@@ -1232,7 +1232,7 @@ return [
                 'default' => '2592000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_EXECUTION',
@@ -1241,7 +1241,7 @@ return [
                 'default' => '1209600',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_AUDIT',
@@ -1250,7 +1250,7 @@ return [
                 'default' => '1209600',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE',
@@ -1259,7 +1259,7 @@ return [
                 'default' => '15778800',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_ABUSE',
@@ -1268,7 +1268,7 @@ return [
                 'default' => '86400',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_USAGE_HOURLY',
@@ -1277,7 +1277,7 @@ return [
                 'default' => '8640000',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_SCHEDULES',
@@ -1286,8 +1286,8 @@ return [
                 'default' => '86400',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
-            ]
+                'filter' => '',
+            ],
         ],
     ],
     [
@@ -1301,7 +1301,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_GRAPHQL_MAX_BATCH_SIZE',
@@ -1310,7 +1310,7 @@ return [
                 'default' => '10',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_GRAPHQL_MAX_COMPLEXITY',
@@ -1319,7 +1319,7 @@ return [
                 'default' => '250',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_GRAPHQL_MAX_DEPTH',
@@ -1328,7 +1328,7 @@ return [
                 'default' => '3',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
         ],
     ],
@@ -1343,7 +1343,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
+                'filter' => '',
             ],
             [
                 'name' => '_APP_MIGRATIONS_FIREBASE_CLIENT_SECRET',
@@ -1352,9 +1352,9 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
-            ]
-        ]
+                'filter' => '',
+            ],
+        ],
     ],
     [
         'category' => 'Assistant',
@@ -1367,8 +1367,8 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => ''
-            ]
-        ]
-    ]
+                'filter' => '',
+            ],
+        ],
+    ],
 ];

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -585,7 +585,7 @@ return [
         'variables' => [
             [
                 'name' => '_APP_SMS_PROVIDER',
-                'description' => "Provider used for delivering SMS for Phone authentication. Use the following format: 'sms://[USER]:[SECRET]@[PROVIDER]'.\n\nEnsure `[USER]` and `[SECRET]` are URL encoded if they contain any non-alphanumeric characters.\n\nAvailable providers are twilio, Textmagic, telesign, msg91, vonage, and telnyx.",
+                'description' => "Provider used for delivering SMS for Phone authentication. Use the following format: 'sms://[USER]:[SECRET]@[PROVIDER]'.\n\nEnsure `[USER]` and `[SECRET]` are URL encoded if they contain any non-alphanumeric characters.\n\nSupported providers: twilio, textmagic, telesign, msg91, vonage, fast2sms, inforu, and telnyx.\n\nCredential mapping by provider: twilio (`[USER]=accountSid`, `[SECRET]=authToken`), textmagic (`[USER]=username`, `[SECRET]=apiKey`), telesign (`[USER]=customerId`, `[SECRET]=apiKey`), msg91 (`[USER]=senderId`, `[SECRET]=authKey`), vonage (`[USER]=apiKey`, `[SECRET]=apiSecret`), fast2sms (`[USER]=senderId`, `[SECRET]=apiKey`), inforu (`[USER]=senderId`, `[SECRET]=apiKey`).\n\nTelnyx uses a single API key. You can provide it as either `[SECRET]` or `[USER]` in the DSN. Example: `sms://unused:TELNYX_API_KEY@telnyx` or `sms://TELNYX_API_KEY@telnyx`.",
                 'introduction' => '0.15.0',
                 'default' => '',
                 'required' => false,

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -14,7 +14,7 @@ return [
                 'default' => 'production',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_LOCALE',
@@ -23,7 +23,7 @@ return [
                 'default' => 'en',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_OPTIONS_ABUSE',
@@ -32,7 +32,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_OPTIONS_FORCE_HTTPS',
@@ -41,7 +41,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_OPTIONS_FUNCTIONS_FORCE_HTTPS',
@@ -50,7 +50,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_OPTIONS_ROUTER_FORCE_HTTPS',
@@ -59,7 +59,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_OPTIONS_ROUTER_PROTECTION',
@@ -68,7 +68,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_OPENSSL_KEY_V1',
@@ -77,7 +77,7 @@ return [
                 'default' => 'your-secret-key',
                 'required' => true,
                 'question' => 'Choose a secret API key, make sure to make a backup of your key in a secure location',
-                'filter' => 'token',
+                'filter' => 'token'
             ],
             [
                 'name' => '_APP_DOMAIN',
@@ -86,7 +86,7 @@ return [
                 'default' => 'localhost',
                 'required' => true,
                 'question' => 'Enter your Appwrite hostname',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_CUSTOM_DOMAIN_DENY_LIST',
@@ -95,7 +95,7 @@ return [
                 'default' => 'example.com,test.com,app.example.com',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOMAIN_FUNCTIONS',
@@ -104,7 +104,7 @@ return [
                 'default' => 'functions.localhost',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOMAIN_SITES',
@@ -113,7 +113,7 @@ return [
                 'default' => 'sites.localhost',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET',
@@ -121,8 +121,8 @@ return [
                 'introduction' => '',
                 'default' => 'localhost',
                 'required' => true,
-                'question' => 'Enter a DNS A record hostname to serve as a CNAME for your custom domains.'.PHP_EOL.'You can use the same value as used for the Appwrite hostname.',
-                'filter' => 'domainTarget',
+                'question' => 'Enter a DNS A record hostname to serve as a CNAME for your custom domains.' . PHP_EOL . 'You can use the same value as used for the Appwrite hostname.',
+                'filter' => 'domainTarget'
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_CNAME',
@@ -131,7 +131,7 @@ return [
                 'default' => 'localhost',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_AAAA',
@@ -140,7 +140,7 @@ return [
                 'default' => '::1',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_A',
@@ -149,7 +149,7 @@ return [
                 'default' => '127.0.0.1',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOMAIN_TARGET_CAA',
@@ -158,7 +158,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DNS',
@@ -167,7 +167,7 @@ return [
                 'default' => '8.8.8.8',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_ROOT',
@@ -176,7 +176,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_EMAILS',
@@ -185,7 +185,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_IPS',
@@ -194,7 +194,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_CONSOLE_HOSTNAMES',
@@ -203,7 +203,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SYSTEM_EMAIL_NAME',
@@ -212,7 +212,7 @@ return [
                 'default' => 'Appwrite',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SYSTEM_EMAIL_ADDRESS',
@@ -221,7 +221,7 @@ return [
                 'default' => 'noreply@appwrite.io',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SYSTEM_TEAM_EMAIL',
@@ -230,7 +230,7 @@ return [
                 'default' => 'team@appwrite.io',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SYSTEM_RESPONSE_FORMAT',
@@ -239,7 +239,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SYSTEM_SECURITY_EMAIL_ADDRESS',
@@ -248,7 +248,7 @@ return [
                 'default' => 'certs@appwrite.io',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_EMAIL_SECURITY',
@@ -257,7 +257,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_EMAIL_CERTIFICATES',
@@ -266,7 +266,7 @@ return [
                 'default' => '',
                 'required' => true,
                 'question' => 'Enter an email that will be used when registering for SSL certificates',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_USAGE_STATS',
@@ -275,7 +275,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_LOGGING_PROVIDER',
@@ -284,7 +284,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_LOGGING_CONFIG',
@@ -293,7 +293,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_USAGE_AGGREGATION_INTERVAL',
@@ -302,7 +302,7 @@ return [
                 'default' => '30',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_USAGE_TIMESERIES_INTERVAL',
@@ -311,7 +311,7 @@ return [
                 'default' => '30',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_USAGE_DATABASE_INTERVAL',
@@ -320,7 +320,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_WORKER_PER_CORE',
@@ -329,7 +329,7 @@ return [
                 'default' => 6,
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_CONSOLE_SESSION_ALERTS',
@@ -338,7 +338,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPRESSION_ENABLED',
@@ -347,7 +347,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPRESSION_MIN_SIZE_BYTES',
@@ -356,7 +356,7 @@ return [
                 'default' => 1024,
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_TRUSTED_HEADERS',
@@ -365,8 +365,8 @@ return [
                 'default' => 'x-forwarded-for',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
-            ],
+                'filter' => ''
+            ]
         ],
     ],
     [
@@ -380,7 +380,7 @@ return [
                 'default' => 'mongodb',
                 'required' => true,
                 'question' => 'Choose your database (mariadb|mongodb|postgresql)',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DB_HOST',
@@ -389,7 +389,7 @@ return [
                 'default' => 'mongodb',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DB_PORT',
@@ -398,7 +398,7 @@ return [
                 'default' => '27017',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DB_SCHEMA',
@@ -407,7 +407,7 @@ return [
                 'default' => 'appwrite',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DB_USER',
@@ -416,7 +416,7 @@ return [
                 'default' => 'user',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DB_PASS',
@@ -425,7 +425,7 @@ return [
                 'default' => 'password',
                 'required' => false,
                 'question' => '',
-                'filter' => 'password',
+                'filter' => 'password'
             ],
             [
                 'name' => '_APP_DB_ROOT_PASS',
@@ -434,7 +434,7 @@ return [
                 'default' => 'rootsecretpassword',
                 'required' => false,
                 'question' => '',
-                'filter' => 'password',
+                'filter' => 'password'
             ],
         ],
     ],
@@ -449,7 +449,7 @@ return [
                 'default' => 'redis',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_REDIS_PORT',
@@ -458,7 +458,7 @@ return [
                 'default' => '6379',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_REDIS_USER',
@@ -467,7 +467,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_REDIS_PASS',
@@ -476,7 +476,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -491,7 +491,7 @@ return [
                 'default' => 'influxdb',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_INFLUXDB_PORT',
@@ -500,7 +500,7 @@ return [
                 'default' => '8086',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -515,7 +515,7 @@ return [
                 'default' => 'telegraf',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_STATSD_PORT',
@@ -524,7 +524,7 @@ return [
                 'default' => '8125',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -539,7 +539,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SMTP_PORT',
@@ -548,7 +548,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SMTP_SECURE',
@@ -557,7 +557,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SMTP_USERNAME',
@@ -566,7 +566,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SMTP_PASSWORD',
@@ -575,7 +575,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -585,12 +585,12 @@ return [
         'variables' => [
             [
                 'name' => '_APP_SMS_PROVIDER',
-                'description' => "Provider used for delivering SMS for Phone authentication. Use the following format: 'sms://[USER]:[SECRET]@[PROVIDER]'.\n\nEnsure `[USER]` and `[SECRET]` are URL encoded if they contain any non-alphanumeric characters.\n\nSupported providers: twilio, textmagic, telesign, msg91, vonage, fast2sms, inforu, and telnyx.\n\nCredential mapping by provider: twilio (`[USER]=accountSid`, `[SECRET]=authToken`), textmagic (`[USER]=username`, `[SECRET]=apiKey`), telesign (`[USER]=customerId`, `[SECRET]=apiKey`), msg91 (`[USER]=senderId`, `[SECRET]=authKey`), vonage (`[USER]=apiKey`, `[SECRET]=apiSecret`), fast2sms (`[USER]=senderId`, `[SECRET]=apiKey`), inforu (`[USER]=senderId`, `[SECRET]=apiKey`).\n\nTelnyx uses a single API key. You can provide it as either `[SECRET]` or `[USER]` in the DSN. Example: `sms://unused:TELNYX_API_KEY@telnyx` or `sms://TELNYX_API_KEY@telnyx`.",
+                'description' => "Provider used for delivering SMS for Phone authentication. Use the following format: 'sms://[USER]:[SECRET]@[PROVIDER]'.\n\nEnsure `[USER]` and `[SECRET]` are URL encoded if they contain any non-alphanumeric characters.\n\nSupported providers: twilio, textmagic, telesign, msg91, vonage, fast2sms, inforu, and telnyx.\n\nCredential mapping by provider: twilio (`[USER]=accountSid`, `[SECRET]=authToken`), textmagic (`[USER]=username`, `[SECRET]=apiKey`), telesign (`[USER]=customerId`, `[SECRET]=apiKey`), msg91 (`[USER]=senderId`, `[SECRET]=authKey`), vonage (`[USER]=apiKey`, `[SECRET]=apiSecret`), fast2sms (`[USER]=senderId`, `[SECRET]=apiKey`), inforu (`[USER]=senderId`, `[SECRET]=apiKey`), telnyx (`[SECRET]=apiKey`).\n\nTelnyx uses a single API key. Example: `sms://unused:TELNYX_API_KEY@telnyx`.",
                 'introduction' => '0.15.0',
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SMS_FROM',
@@ -599,7 +599,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -614,7 +614,7 @@ return [
                 'default' => '30000000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_STORAGE_PREVIEW_LIMIT',
@@ -623,7 +623,7 @@ return [
                 'default' => '20000000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_STORAGE_ANTIVIRUS',
@@ -632,7 +632,7 @@ return [
                 'default' => 'disabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_STORAGE_ANTIVIRUS_HOST',
@@ -641,7 +641,7 @@ return [
                 'default' => 'clamav',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_STORAGE_ANTIVIRUS_PORT',
@@ -650,7 +650,7 @@ return [
                 'default' => '3310',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_STORAGE_DEVICE',
@@ -841,7 +841,7 @@ return [
                 'default' => '30000000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_SIZE_LIMIT',
@@ -850,7 +850,7 @@ return [
                 'default' => '30000000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_BUILD_SIZE_LIMIT',
@@ -859,7 +859,7 @@ return [
                 'default' => '2000000000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_TIMEOUT',
@@ -868,7 +868,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_BUILD_TIMEOUT',
@@ -877,7 +877,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_BUILD_TIMEOUT',
@@ -886,7 +886,7 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_CONTAINERS',
@@ -895,7 +895,7 @@ return [
                 'default' => '10',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_CPUS',
@@ -904,7 +904,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_CPUS',
@@ -913,7 +913,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY',
@@ -922,7 +922,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_MEMORY',
@@ -931,7 +931,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_MEMORY_SWAP',
@@ -940,16 +940,16 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_RUNTIMES',
-                'description' => "This option allows you to enable or disable runtime environments for cloud functions. Disable unused runtimes to save disk space.\n\nTo enable cloud function runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: ".\implode(', ', \array_keys(Config::getParam('runtimes'))),
+                'description' => "This option allows you to enable or disable runtime environments for cloud functions. Disable unused runtimes to save disk space.\n\nTo enable cloud function runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: " . \implode(', ', \array_keys(Config::getParam('runtimes'))),
                 'introduction' => '0.8.0',
                 'default' => 'node-16.0,php-8.0,python-3.9,ruby-3.0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_EXECUTOR_SECRET',
@@ -958,7 +958,7 @@ return [
                 'default' => 'your-secret-key',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_EXECUTOR_HOST',
@@ -968,7 +968,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_BROWSER_HOST',
@@ -978,7 +978,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_EXECUTOR_RUNTIME_NETWORK',
@@ -987,7 +987,7 @@ return [
                 'default' => 'appwrite_runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_ENVS',
@@ -996,7 +996,7 @@ return [
                 'default' => 'node-16.0,php-7.4,python-3.9,ruby-3.0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_INACTIVE_THRESHOLD',
@@ -1005,7 +1005,7 @@ return [
                 'default' => '60',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_INACTIVE_THRESHOLD',
@@ -1014,7 +1014,7 @@ return [
                 'default' => '60',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => 'DOCKERHUB_PULL_USERNAME',
@@ -1023,7 +1023,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => 'DOCKERHUB_PULL_PASSWORD',
@@ -1032,7 +1032,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => 'DOCKERHUB_PULL_EMAIL',
@@ -1041,7 +1041,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => 'OPEN_RUNTIMES_NETWORK',
@@ -1050,7 +1050,7 @@ return [
                 'default' => 'appwrite_runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_RUNTIMES_NETWORK',
@@ -1059,7 +1059,7 @@ return [
                 'default' => 'runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_RUNTIMES_NETWORK',
@@ -1068,7 +1068,7 @@ return [
                 'default' => 'runtimes',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOCKER_HUB_USERNAME',
@@ -1077,7 +1077,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_DOCKER_HUB_PASSWORD',
@@ -1086,7 +1086,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_FUNCTIONS_MAINTENANCE_INTERVAL',
@@ -1096,7 +1096,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_MAINTENANCE_INTERVAL',
@@ -1106,7 +1106,7 @@ return [
                 'required' => false,
                 'overwrite' => true,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -1121,18 +1121,18 @@ return [
                 'default' => '900',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_SITES_RUNTIMES',
-                'description' => "This option allows you to enable or disable runtime environments for Sites. Disable unused runtimes to save disk space.\n\nTo enable cloud site runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: ".\implode(', ', \array_keys(Config::getParam('runtimes'))),
+                'description' => "This option allows you to enable or disable runtime environments for Sites. Disable unused runtimes to save disk space.\n\nTo enable cloud site runtimes, pass a list of enabled environments separated by a comma.\n\nCurrently, supported environments are: " . \implode(', ', \array_keys(Config::getParam('runtimes'))),
                 'introduction' => '1.7.0',
                 'default' => 'static-1,node-22,flutter-3.29',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
-        ],
+        ]
     ],
     [
         'category' => 'VCS (Version Control System)',
@@ -1145,7 +1145,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_VCS_GITHUB_PRIVATE_KEY',
@@ -1154,7 +1154,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_VCS_GITHUB_APP_ID',
@@ -1163,7 +1163,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_VCS_GITHUB_CLIENT_ID',
@@ -1172,7 +1172,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_VCS_GITHUB_CLIENT_SECRET',
@@ -1181,7 +1181,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_VCS_GITHUB_WEBHOOK_SECRET',
@@ -1190,7 +1190,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -1205,7 +1205,7 @@ return [
                 'default' => '86400',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_DELAY',
@@ -1214,7 +1214,7 @@ return [
                 'default' => '0',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_START_TIME',
@@ -1223,7 +1223,7 @@ return [
                 'default' => '00:00',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_CACHE',
@@ -1232,7 +1232,7 @@ return [
                 'default' => '2592000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_EXECUTION',
@@ -1241,7 +1241,7 @@ return [
                 'default' => '1209600',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_AUDIT',
@@ -1250,7 +1250,7 @@ return [
                 'default' => '1209600',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE',
@@ -1259,7 +1259,7 @@ return [
                 'default' => '15778800',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_ABUSE',
@@ -1268,7 +1268,7 @@ return [
                 'default' => '86400',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_USAGE_HOURLY',
@@ -1277,7 +1277,7 @@ return [
                 'default' => '8640000',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MAINTENANCE_RETENTION_SCHEDULES',
@@ -1286,8 +1286,8 @@ return [
                 'default' => '86400',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
-            ],
+                'filter' => ''
+            ]
         ],
     ],
     [
@@ -1301,7 +1301,7 @@ return [
                 'default' => 'enabled',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_GRAPHQL_MAX_BATCH_SIZE',
@@ -1310,7 +1310,7 @@ return [
                 'default' => '10',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_GRAPHQL_MAX_COMPLEXITY',
@@ -1319,7 +1319,7 @@ return [
                 'default' => '250',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_GRAPHQL_MAX_DEPTH',
@@ -1328,7 +1328,7 @@ return [
                 'default' => '3',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
         ],
     ],
@@ -1343,7 +1343,7 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
+                'filter' => ''
             ],
             [
                 'name' => '_APP_MIGRATIONS_FIREBASE_CLIENT_SECRET',
@@ -1352,9 +1352,9 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
-            ],
-        ],
+                'filter' => ''
+            ]
+        ]
     ],
     [
         'category' => 'Assistant',
@@ -1367,8 +1367,8 @@ return [
                 'default' => '',
                 'required' => false,
                 'question' => '',
-                'filter' => '',
-            ],
-        ],
-    ],
+                'filter' => ''
+            ]
+        ]
+    ]
 ];

--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -75,19 +75,19 @@ Http::post('/v1/messaging/providers/mailgun')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
     ->param('apiKey', '', new Text(0), 'Mailgun API Key.', true)
     ->param('domain', '', new Text(0), 'Mailgun Domain.', true)
-    ->param('isEuRegion', null, new Nullable(new Boolean), 'Set as EU region.', true)
+    ->param('isEuRegion', null, new Nullable(new Boolean()), 'Set as EU region.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name. Reply to name must have reply to email as well.', true)
-    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email. Reply to email must have reply to name as well.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email. Reply to email must have reply to name as well.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -96,15 +96,15 @@ Http::post('/v1/messaging/providers/mailgun')
 
         $credentials = [];
 
-        if (! \is_null($isEuRegion)) {
+        if (!\is_null($isEuRegion)) {
             $credentials['isEuRegion'] = $isEuRegion;
         }
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (! empty($domain)) {
+        if (!empty($domain)) {
             $credentials['domain'] = $domain;
         }
 
@@ -117,7 +117,7 @@ Http::post('/v1/messaging/providers/mailgun')
 
         if (
             $enabled === true
-            && ! empty($fromEmail)
+            && !empty($fromEmail)
             && \array_key_exists('isEuRegion', $credentials)
             && \array_key_exists('apiKey', $credentials)
             && \array_key_exists('domain', $credentials)
@@ -169,17 +169,17 @@ Http::post('/v1/messaging/providers/sendgrid')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
     ->param('apiKey', '', new Text(0), 'Sendgrid API key.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name.', true)
-    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -188,7 +188,7 @@ Http::post('/v1/messaging/providers/sendgrid')
 
         $credentials = [];
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -201,7 +201,7 @@ Http::post('/v1/messaging/providers/sendgrid')
 
         if (
             $enabled === true
-            && ! empty($fromEmail)
+            && !empty($fromEmail)
             && \array_key_exists('apiKey', $credentials)
         ) {
             $enabled = true;
@@ -251,17 +251,17 @@ Http::post('/v1/messaging/providers/resend')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
     ->param('apiKey', '', new Text(0), 'Resend API key.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name.', true)
-    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -270,7 +270,7 @@ Http::post('/v1/messaging/providers/resend')
 
         $credentials = [];
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -283,7 +283,7 @@ Http::post('/v1/messaging/providers/resend')
 
         if (
             $enabled === true
-            && ! empty($fromEmail)
+            && !empty($fromEmail)
             && \array_key_exists('apiKey', $credentials)
         ) {
             $enabled = true;
@@ -334,7 +334,7 @@ Http::post('/v1/messaging/providers/smtp')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -352,9 +352,9 @@ Http::post('/v1/messaging/providers/smtp')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
@@ -363,13 +363,13 @@ Http::post('/v1/messaging/providers/smtp')
     ->param('username', '', new Text(0), 'Authentication username.', true)
     ->param('password', '', new Text(0), 'Authentication password.', true)
     ->param('encryption', '', new WhiteList(['none', 'ssl', 'tls']), 'Encryption type. Can be omitted, \'ssl\', or \'tls\'', true)
-    ->param('autoTLS', true, new Boolean, 'Enable SMTP AutoTLS feature.', true)
+    ->param('autoTLS', true, new Boolean(), 'Enable SMTP AutoTLS feature.', true)
     ->param('mailer', '', new Text(0), 'The value to use for the X-Mailer header.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name.', true)
-    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -382,7 +382,7 @@ Http::post('/v1/messaging/providers/smtp')
             'password' => $password,
         ];
 
-        if (! empty($host)) {
+        if (!empty($host)) {
             $credentials['host'] = $host;
         }
 
@@ -398,7 +398,7 @@ Http::post('/v1/messaging/providers/smtp')
 
         if (
             $enabled === true
-            && ! empty($fromEmail)
+            && !empty($fromEmail)
             && \array_key_exists('host', $credentials)
         ) {
             $enabled = true;
@@ -448,7 +448,7 @@ Http::post('/v1/messaging/providers/msg91')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
@@ -456,7 +456,7 @@ Http::post('/v1/messaging/providers/msg91')
     ->param('templateId', '', new Text(0), 'Msg91 template ID', true)
     ->param('senderId', '', new Text(0), 'Msg91 sender ID.', true)
     ->param('authKey', '', new Text(0), 'Msg91 auth key.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -466,15 +466,15 @@ Http::post('/v1/messaging/providers/msg91')
         $options = [];
         $credentials = [];
 
-        if (! empty($templateId)) {
+        if (!empty($templateId)) {
             $credentials['templateId'] = $templateId;
         }
 
-        if (! empty($senderId)) {
+        if (!empty($senderId)) {
             $credentials['senderId'] = $senderId;
         }
 
-        if (! empty($authKey)) {
+        if (!empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
@@ -531,15 +531,15 @@ Http::post('/v1/messaging/providers/telesign')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('customerId', '', new Text(0), 'Telesign customer ID.', true)
     ->param('apiKey', '', new Text(0), 'Telesign API key.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -548,17 +548,17 @@ Http::post('/v1/messaging/providers/telesign')
 
         $options = [];
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (! empty($customerId)) {
+        if (!empty($customerId)) {
             $credentials['customerId'] = $customerId;
         }
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -615,15 +615,15 @@ Http::post('/v1/messaging/providers/textmagic')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('username', '', new Text(0), 'Textmagic username.', true)
     ->param('apiKey', '', new Text(0), 'Textmagic apiKey.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -632,17 +632,17 @@ Http::post('/v1/messaging/providers/textmagic')
 
         $options = [];
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (! empty($username)) {
+        if (!empty($username)) {
             $credentials['username'] = $username;
         }
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -699,15 +699,15 @@ Http::post('/v1/messaging/providers/twilio')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('accountSid', '', new Text(0), 'Twilio account secret ID.', true)
     ->param('authToken', '', new Text(0), 'Twilio authentication token.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -716,17 +716,17 @@ Http::post('/v1/messaging/providers/twilio')
 
         $options = [];
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (! empty($accountSid)) {
+        if (!empty($accountSid)) {
             $credentials['accountSid'] = $accountSid;
         }
 
-        if (! empty($authToken)) {
+        if (!empty($authToken)) {
             $credentials['authToken'] = $authToken;
         }
 
@@ -783,15 +783,15 @@ Http::post('/v1/messaging/providers/vonage')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('apiKey', '', new Text(0), 'Vonage API key.', true)
     ->param('apiSecret', '', new Text(0), 'Vonage API secret.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -800,17 +800,17 @@ Http::post('/v1/messaging/providers/vonage')
 
         $options = [];
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (! empty($apiSecret)) {
+        if (!empty($apiSecret)) {
             $credentials['apiSecret'] = $apiSecret;
         }
 
@@ -867,14 +867,14 @@ Http::post('/v1/messaging/providers/telnyx')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('apiKey', '', new Text(0), 'Telnyx API key.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -883,13 +883,13 @@ Http::post('/v1/messaging/providers/telnyx')
 
         $options = [];
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -946,7 +946,7 @@ Http::post('/v1/messaging/providers/fcm')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -964,14 +964,14 @@ Http::post('/v1/messaging/providers/fcm')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('serviceAccountJSON', null, new Nullable(new JSON), 'FCM service account JSON.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('serviceAccountJSON', null, new Nullable(new JSON()), 'FCM service account JSON.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -984,7 +984,7 @@ Http::post('/v1/messaging/providers/fcm')
 
         $credentials = [];
 
-        if (! \is_null($serviceAccountJSON)) {
+        if (!\is_null($serviceAccountJSON)) {
             $credentials['serviceAccountJSON'] = $serviceAccountJSON;
         }
 
@@ -1000,7 +1000,7 @@ Http::post('/v1/messaging/providers/fcm')
             'provider' => 'fcm',
             'type' => MESSAGE_TYPE_PUSH,
             'enabled' => $enabled,
-            'credentials' => $credentials,
+            'credentials' => $credentials
         ]);
 
         try {
@@ -1036,7 +1036,7 @@ Http::post('/v1/messaging/providers/apns')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -1054,9 +1054,9 @@ Http::post('/v1/messaging/providers/apns')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
@@ -1064,8 +1064,8 @@ Http::post('/v1/messaging/providers/apns')
     ->param('authKeyId', '', new Text(0), 'APNS authentication key ID.', true)
     ->param('teamId', '', new Text(0), 'APNS team ID.', true)
     ->param('bundleId', '', new Text(0), 'APNS bundle ID.', true)
-    ->param('sandbox', false, new Boolean, 'Use APNS sandbox environment.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('sandbox', false, new Boolean(), 'Use APNS sandbox environment.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -1074,19 +1074,19 @@ Http::post('/v1/messaging/providers/apns')
 
         $credentials = [];
 
-        if (! empty($authKey)) {
+        if (!empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
-        if (! empty($authKeyId)) {
+        if (!empty($authKeyId)) {
             $credentials['authKeyId'] = $authKeyId;
         }
 
-        if (! empty($teamId)) {
+        if (!empty($teamId)) {
             $credentials['teamId'] = $teamId;
         }
 
-        if (! empty($bundleId)) {
+        if (!empty($bundleId)) {
             $credentials['bundleId'] = $bundleId;
         }
 
@@ -1103,7 +1103,7 @@ Http::post('/v1/messaging/providers/apns')
         }
 
         $options = [
-            'sandbox' => $sandbox,
+            'sandbox' => $sandbox
         ];
 
         $provider = new Document([
@@ -1113,7 +1113,7 @@ Http::post('/v1/messaging/providers/apns')
             'type' => MESSAGE_TYPE_PUSH,
             'enabled' => $enabled,
             'credentials' => $credentials,
-            'options' => $options,
+            'options' => $options
         ]);
 
         try {
@@ -1145,10 +1145,10 @@ Http::get('/v1/messaging/providers')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER_LIST,
-            ),
+            )
         ]
     ))
-    ->param('queries', [], new Providers, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Providers::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Providers(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Providers::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -1161,7 +1161,7 @@ Http::get('/v1/messaging/providers')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (! empty($search)) {
+        if (!empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -1169,8 +1169,8 @@ Http::get('/v1/messaging/providers')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor;
-            if (! $validator->isValid($cursor)) {
+            $validator = new Cursor();
+            if (!$validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -1210,11 +1210,11 @@ Http::get('/v1/messaging/providers/:providerId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -1238,12 +1238,12 @@ Http::get('/v1/messaging/providers/:providerId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'provider/'.$providerId;
+        $resource = 'provider/' . $providerId;
         $logs = $audit->getLogsByResource($resource, offset: $offset, limit: $limit);
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -1271,14 +1271,14 @@ Http::get('/v1/messaging/providers/:providerId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel'],
+                'deviceModel' => $device['deviceModel']
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -1306,7 +1306,7 @@ Http::get('/v1/messaging/providers/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
@@ -1340,17 +1340,17 @@ Http::patch('/v1/messaging/providers/mailgun/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
     ->param('apiKey', '', new Text(0), 'Mailgun API Key.', true)
     ->param('domain', '', new Text(0), 'Mailgun Domain.', true)
-    ->param('isEuRegion', null, new Nullable(new Boolean), 'Set as EU region.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('isEuRegion', null, new Nullable(new Boolean()), 'Set as EU region.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the reply to field for the mail. Default value is sender name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the reply to field for the mail. Default value is sender email.', true)
     ->inject('queueForEvents')
@@ -1369,25 +1369,25 @@ Http::patch('/v1/messaging/providers/mailgun/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (! empty($fromName)) {
+        if (!empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (! empty($fromEmail)) {
+        if (!empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (! empty($replyToName)) {
+        if (!empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (! empty($replyToEmail)) {
+        if (!empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
@@ -1395,21 +1395,21 @@ Http::patch('/v1/messaging/providers/mailgun/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! \is_null($isEuRegion)) {
+        if (!\is_null($isEuRegion)) {
             $credentials['isEuRegion'] = $isEuRegion;
         }
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (! empty($domain)) {
+        if (!empty($domain)) {
             $credentials['domain'] = $domain;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('isEuRegion', $credentials) &&
@@ -1453,15 +1453,15 @@ Http::patch('/v1/messaging/providers/sendgrid/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Sendgrid API key.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the Reply To field for the mail. Default value is Sender Name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the Reply To field for the mail. Default value is Sender Email.', true)
     ->inject('queueForEvents')
@@ -1479,37 +1479,37 @@ Http::patch('/v1/messaging/providers/sendgrid/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (! empty($fromName)) {
+        if (!empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (! empty($fromEmail)) {
+        if (!empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (! empty($replyToName)) {
+        if (!empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (! empty($replyToEmail)) {
+        if (!empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
         $provider->setAttribute('options', $options);
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $provider->setAttribute('credentials', [
                 'apiKey' => $apiKey,
             ]);
         }
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $provider->getAttribute('credentials')) &&
@@ -1551,15 +1551,15 @@ Http::patch('/v1/messaging/providers/resend/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Resend API key.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the Reply To field for the mail. Default value is Sender Name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the Reply To field for the mail. Default value is Sender Email.', true)
     ->inject('queueForEvents')
@@ -1577,37 +1577,37 @@ Http::patch('/v1/messaging/providers/resend/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (! empty($fromName)) {
+        if (!empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (! empty($fromEmail)) {
+        if (!empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (! empty($replyToName)) {
+        if (!empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (! empty($replyToEmail)) {
+        if (!empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
         $provider->setAttribute('options', $options);
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $provider->setAttribute('credentials', [
                 'apiKey' => $apiKey,
             ]);
         }
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $provider->getAttribute('credentials')) &&
@@ -1650,7 +1650,7 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -1668,9 +1668,9 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
@@ -1679,13 +1679,13 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
     ->param('username', '', new Text(0), 'Authentication username.', true)
     ->param('password', '', new Text(0), 'Authentication password.', true)
     ->param('encryption', '', new WhiteList(['none', 'ssl', 'tls']), 'Encryption type. Can be \'ssl\' or \'tls\'', true)
-    ->param('autoTLS', null, new Nullable(new Boolean), 'Enable SMTP AutoTLS feature.', true)
+    ->param('autoTLS', null, new Nullable(new Boolean()), 'Enable SMTP AutoTLS feature.', true)
     ->param('mailer', '', new Text(0), 'The value to use for the X-Mailer header.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email, 'Sender email address.', true)
+    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the Reply To field for the mail. Default value is Sender Name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the Reply To field for the mail. Default value is Sender Email.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -1700,37 +1700,37 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (! empty($encryption)) {
+        if (!empty($encryption)) {
             $options['encryption'] = $encryption === 'none' ? '' : $encryption;
         }
 
-        if (! \is_null($autoTLS)) {
+        if (!\is_null($autoTLS)) {
             $options['autoTLS'] = $autoTLS;
         }
 
-        if (! empty($mailer)) {
+        if (!empty($mailer)) {
             $options['mailer'] = $mailer;
         }
 
-        if (! empty($fromName)) {
+        if (!empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (! empty($fromEmail)) {
+        if (!empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (! empty($replyToName)) {
+        if (!empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (! empty($replyToEmail)) {
+        if (!empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
@@ -1738,28 +1738,28 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($host)) {
+        if (!empty($host)) {
             $credentials['host'] = $host;
         }
 
-        if (! \is_null($port)) {
+        if (!\is_null($port)) {
             $credentials['port'] = $port;
         }
 
-        if (! empty($username)) {
+        if (!empty($username)) {
             $credentials['username'] = $username;
         }
 
-        if (! empty($password)) {
+        if (!empty($password)) {
             $credentials['password'] = $password;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
-                    ! empty($options['fromEmail'])
+                    !empty($options['fromEmail'])
                     && \array_key_exists('host', $credentials)
                 ) {
                     $provider->setAttribute('enabled', true);
@@ -1798,12 +1798,12 @@ Http::patch('/v1/messaging/providers/msg91/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('templateId', '', new Text(0), 'Msg91 template ID.', true)
     ->param('senderId', '', new Text(0), 'Msg91 sender ID.', true)
     ->param('authKey', '', new Text(0), 'Msg91 auth key.', true)
@@ -1822,27 +1822,27 @@ Http::patch('/v1/messaging/providers/msg91/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($templateId)) {
+        if (!empty($templateId)) {
             $credentials['templateId'] = $templateId;
         }
 
-        if (! empty($senderId)) {
+        if (!empty($senderId)) {
             $credentials['senderId'] = $senderId;
         }
 
-        if (! empty($authKey)) {
+        if (!empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('senderId', $credentials) &&
@@ -1885,12 +1885,12 @@ Http::patch('/v1/messaging/providers/telesign/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('customerId', '', new Text(0), 'Telesign customer ID.', true)
     ->param('apiKey', '', new Text(0), 'Telesign API key.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -1909,11 +1909,11 @@ Http::patch('/v1/messaging/providers/telesign/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -1921,17 +1921,17 @@ Http::patch('/v1/messaging/providers/telesign/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($customerId)) {
+        if (!empty($customerId)) {
             $credentials['customerId'] = $customerId;
         }
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('customerId', $credentials) &&
@@ -1974,12 +1974,12 @@ Http::patch('/v1/messaging/providers/textmagic/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('username', '', new Text(0), 'Textmagic username.', true)
     ->param('apiKey', '', new Text(0), 'Textmagic apiKey.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -1998,11 +1998,11 @@ Http::patch('/v1/messaging/providers/textmagic/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -2010,17 +2010,17 @@ Http::patch('/v1/messaging/providers/textmagic/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($username)) {
+        if (!empty($username)) {
             $credentials['username'] = $username;
         }
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('username', $credentials) &&
@@ -2063,12 +2063,12 @@ Http::patch('/v1/messaging/providers/twilio/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('accountSid', '', new Text(0), 'Twilio account secret ID.', true)
     ->param('authToken', '', new Text(0), 'Twilio authentication token.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -2087,11 +2087,11 @@ Http::patch('/v1/messaging/providers/twilio/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -2099,17 +2099,17 @@ Http::patch('/v1/messaging/providers/twilio/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($accountSid)) {
+        if (!empty($accountSid)) {
             $credentials['accountSid'] = $accountSid;
         }
 
-        if (! empty($authToken)) {
+        if (!empty($authToken)) {
             $credentials['authToken'] = $authToken;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('accountSid', $credentials) &&
@@ -2152,12 +2152,12 @@ Http::patch('/v1/messaging/providers/vonage/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Vonage API key.', true)
     ->param('apiSecret', '', new Text(0), 'Vonage API secret.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -2176,11 +2176,11 @@ Http::patch('/v1/messaging/providers/vonage/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -2188,17 +2188,17 @@ Http::patch('/v1/messaging/providers/vonage/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (! empty($apiSecret)) {
+        if (!empty($apiSecret)) {
             $credentials['apiSecret'] = $apiSecret;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $credentials) &&
@@ -2241,12 +2241,12 @@ Http::patch('/v1/messaging/providers/telnyx/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            ),
+            )
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Telnyx API key.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
     ->inject('queueForEvents')
@@ -2264,11 +2264,11 @@ Http::patch('/v1/messaging/providers/telnyx/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (! empty($from)) {
+        if (!empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -2276,13 +2276,13 @@ Http::patch('/v1/messaging/providers/telnyx/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($apiKey)) {
+        if (!empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $credentials) &&
@@ -2325,7 +2325,7 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -2343,14 +2343,14 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
-    ->param('serviceAccountJSON', null, new Nullable(new JSON), 'FCM service account JSON.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('serviceAccountJSON', null, new Nullable(new JSON()), 'FCM service account JSON.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2366,21 +2366,21 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (! \is_null($serviceAccountJSON)) {
+        if (!\is_null($serviceAccountJSON)) {
             $serviceAccountJSON = \is_string($serviceAccountJSON)
                 ? \json_decode($serviceAccountJSON, true)
                 : $serviceAccountJSON;
 
             $provider->setAttribute('credentials', [
-                'serviceAccountJSON' => $serviceAccountJSON,
+                'serviceAccountJSON' => $serviceAccountJSON
             ]);
         }
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (\array_key_exists('serviceAccountJSON', $provider->getAttribute('credentials'))) {
                     $provider->setAttribute('enabled', true);
@@ -2401,6 +2401,7 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
             ->dynamic($provider, Response::MODEL_PROVIDER);
     });
 
+
 Http::patch('/v1/messaging/providers/apns/:providerId')
     ->desc('Update APNS provider')
     ->groups(['api', 'messaging'])
@@ -2420,7 +2421,7 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -2438,18 +2439,18 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
     ->param('authKey', '', new Text(0), 'APNS authentication key.', true)
     ->param('authKeyId', '', new Text(0), 'APNS authentication key ID.', true)
     ->param('teamId', '', new Text(0), 'APNS team ID.', true)
     ->param('bundleId', '', new Text(0), 'APNS bundle ID.', true)
-    ->param('sandbox', null, new Nullable(new Boolean), 'Use APNS sandbox environment.', true)
+    ->param('sandbox', null, new Nullable(new Boolean()), 'Use APNS sandbox environment.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2465,25 +2466,25 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (! empty($name)) {
+        if (!empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (! empty($authKey)) {
+        if (!empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
-        if (! empty($authKeyId)) {
+        if (!empty($authKeyId)) {
             $credentials['authKeyId'] = $authKeyId;
         }
 
-        if (! empty($teamId)) {
+        if (!empty($teamId)) {
             $credentials['teamId'] = $teamId;
         }
 
-        if (! empty($bundleId)) {
+        if (!empty($bundleId)) {
             $credentials['bundle'] = $bundleId;
         }
 
@@ -2491,13 +2492,13 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
 
         $options = $provider->getAttribute('options');
 
-        if (! \is_null($sandbox)) {
+        if (!\is_null($sandbox)) {
             $options['sandbox'] = $sandbox;
         }
 
         $provider->setAttribute('options', $options);
 
-        if (! \is_null($enabled)) {
+        if (!\is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('authKey', $credentials) &&
@@ -2541,7 +2542,7 @@ Http::delete('/v1/messaging/providers/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            ),
+            )
         ],
         contentType: ContentType::NONE
     ))
@@ -2584,12 +2585,12 @@ Http::post('/v1/messaging/topics')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_TOPIC,
-            ),
+            )
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID. Choose a custom Topic ID or a new Topic ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Topic Name.')
-    ->param('subscribe', [Role::users()], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' roles are allowed, each 64 characters long.', true)
+    ->param('subscribe', [Role::users()], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2631,10 +2632,10 @@ Http::get('/v1/messaging/topics')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TOPIC_LIST,
-            ),
+            )
         ]
     ))
-    ->param('queries', [], new Topics, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Topics::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Topics(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Topics::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -2647,7 +2648,7 @@ Http::get('/v1/messaging/topics')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (! empty($search)) {
+        if (!empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -2655,8 +2656,8 @@ Http::get('/v1/messaging/topics')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor;
-            if (! $validator->isValid($cursor)) {
+            $validator = new Cursor();
+            if (!$validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -2696,11 +2697,11 @@ Http::get('/v1/messaging/topics/:topicId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            ),
+            )
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -2724,13 +2725,13 @@ Http::get('/v1/messaging/topics/:topicId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'topic/'.$topicId;
+        $resource = 'topic/' . $topicId;
         $logs = $audit->getLogsByResource($resource, offset: $offset, limit: $limit);
 
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -2758,14 +2759,14 @@ Http::get('/v1/messaging/topics/:topicId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel'],
+                'deviceModel' => $device['deviceModel']
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -2793,7 +2794,7 @@ Http::get('/v1/messaging/topics/:topicId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TOPIC,
-            ),
+            )
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID.', false, ['dbForProject'])
@@ -2828,12 +2829,12 @@ Http::patch('/v1/messaging/topics/:topicId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TOPIC,
-            ),
+            )
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID.', false, ['dbForProject'])
     ->param('name', null, new Nullable(new Text(128)), 'Topic Name.', true)
-    ->param('subscribe', null, new Nullable(new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' roles are allowed, each 64 characters long.', true)
+    ->param('subscribe', null, new Nullable(new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2844,11 +2845,11 @@ Http::patch('/v1/messaging/topics/:topicId')
             throw new Exception(Exception::TOPIC_NOT_FOUND);
         }
 
-        if (! \is_null($name)) {
+        if (!\is_null($name)) {
             $topic->setAttribute('name', $name);
         }
 
-        if (! \is_null($subscribe)) {
+        if (!\is_null($subscribe)) {
             $topic->setAttribute('subscribe', $subscribe);
         }
 
@@ -2879,7 +2880,7 @@ Http::delete('/v1/messaging/topics/:topicId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            ),
+            )
         ],
         contentType: ContentType::NONE
     ))
@@ -2927,7 +2928,7 @@ Http::post('/v1/messaging/topics/:topicId/subscribers')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_SUBSCRIBER,
-            ),
+            )
         ]
     ))
     ->param('subscriberId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Subscriber ID. Choose a custom Subscriber ID or a new Subscriber ID.', false, ['dbForProject'])
@@ -2945,7 +2946,7 @@ Http::post('/v1/messaging/topics/:topicId/subscribers')
         if ($topic->isEmpty()) {
             throw new Exception(Exception::TOPIC_NOT_FOUND);
         }
-        if (! $authorization->isValid(new Input('subscribe', $topic->getAttribute('subscribe')))) {
+        if (!$authorization->isValid(new Input('subscribe', $topic->getAttribute('subscribe')))) {
             throw new Exception(Exception::USER_UNAUTHORIZED, $authorization->getDescription());
         }
 
@@ -3025,11 +3026,11 @@ Http::get('/v1/messaging/topics/:topicId/subscribers')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_SUBSCRIBER_LIST,
-            ),
+            )
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID. The topic ID subscribed to.', false, ['dbForProject'])
-    ->param('queries', [], new Subscribers, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Subscribers::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Subscribers(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Subscribers::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -3042,7 +3043,7 @@ Http::get('/v1/messaging/topics/:topicId/subscribers')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (! empty($search)) {
+        if (!empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -3058,8 +3059,8 @@ Http::get('/v1/messaging/topics/:topicId/subscribers')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor;
-            if (! $validator->isValid($cursor)) {
+            $validator = new Cursor();
+            if (!$validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -3111,11 +3112,11 @@ Http::get('/v1/messaging/subscribers/:subscriberId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            ),
+            )
         ]
     ))
     ->param('subscriberId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Subscriber ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -3139,13 +3140,13 @@ Http::get('/v1/messaging/subscribers/:subscriberId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'subscriber/'.$subscriberId;
+        $resource = 'subscriber/' . $subscriberId;
         $logs = $audit->getLogsByResource($resource, limit: $limit, offset: $offset);
 
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -3173,14 +3174,14 @@ Http::get('/v1/messaging/subscribers/:subscriberId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel'],
+                'deviceModel' => $device['deviceModel']
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -3208,7 +3209,7 @@ Http::get('/v1/messaging/topics/:topicId/subscribers/:subscriberId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_SUBSCRIBER,
-            ),
+            )
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID. The topic ID subscribed to.', false, ['dbForProject'])
@@ -3258,7 +3259,7 @@ Http::delete('/v1/messaging/topics/:topicId/subscribers/:subscriberId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            ),
+            )
         ],
         contentType: ContentType::NONE
     ))
@@ -3326,7 +3327,7 @@ Http::post('/v1/messaging/messages/email')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_MESSAGE,
-            ),
+            )
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
@@ -3337,9 +3338,9 @@ Http::post('/v1/messaging/messages/email')
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('cc', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Array of target IDs to be added as CC.', true, ['dbForProject'])
     ->param('bcc', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Array of target IDs to be added as BCC.', true, ['dbForProject'])
-    ->param('attachments', [], new ArrayList(new CompoundUID), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
-    ->param('draft', false, new Boolean, 'Is message a draft', true)
-    ->param('html', false, new Boolean, 'Is content of type HTML', true)
+    ->param('attachments', [], new ArrayList(new CompoundUID()), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('draft', false, new Boolean(), 'Is message a draft', true)
+    ->param('html', false, new Boolean(), 'Is content of type HTML', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -3370,7 +3371,7 @@ Http::post('/v1/messaging/messages/email')
 
         $mergedTargets = \array_merge($targets, $cc, $bcc);
 
-        if (! empty($mergedTargets)) {
+        if (!empty($mergedTargets)) {
             $foundTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $mergedTargets),
                 Query::equal('providerType', [MESSAGE_TYPE_EMAIL]),
@@ -3388,7 +3389,7 @@ Http::post('/v1/messaging/messages/email')
             }
         }
 
-        if (! empty($attachments)) {
+        if (!empty($attachments)) {
             foreach ($attachments as &$attachment) {
                 [$bucketId, $fileId] = CompoundUID::parse($attachment);
 
@@ -3398,7 +3399,7 @@ Http::post('/v1/messaging/messages/email')
                     throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
                 }
 
-                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
 
                 if ($file->isEmpty()) {
                     throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
@@ -3491,7 +3492,7 @@ Http::post('/v1/messaging/messages/sms')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_MESSAGE,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -3509,16 +3510,16 @@ Http::post('/v1/messaging/messages/sms')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_MESSAGE,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('messageId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('content', '', new Text(64230), 'SMS Content.')
     ->param('topics', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
-    ->param('draft', false, new Boolean, 'Is message a draft', true)
+    ->param('draft', false, new Boolean(), 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -3547,7 +3548,7 @@ Http::post('/v1/messaging/messages/sms')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (! empty($targets)) {
+        if (!empty($targets)) {
             $foundTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $targets),
                 Query::equal('providerType', [MESSAGE_TYPE_SMS]),
@@ -3638,7 +3639,7 @@ Http::post('/v1/messaging/messages/push')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_MESSAGE,
-            ),
+            )
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
@@ -3647,18 +3648,18 @@ Http::post('/v1/messaging/messages/push')
     ->param('topics', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
-    ->param('data', null, new Nullable(new JSON), 'Additional key-value pair data for push notification.', true)
+    ->param('data', null, new Nullable(new JSON()), 'Additional key-value pair data for push notification.', true)
     ->param('action', '', new Text(256), 'Action for push notification.', true)
-    ->param('image', '', new CompoundUID, 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('image', '', new CompoundUID(), 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
     ->param('icon', '', new Text(256), 'Icon for push notification. Available only for Android and Web Platform.', true)
     ->param('sound', '', new Text(256), 'Sound for push notification. Available only for Android and iOS Platform.', true)
     ->param('color', '', new Text(256), 'Color for push notification. Available only for Android Platform.', true)
     ->param('tag', '', new Text(256), 'Tag for push notification. Available only for Android Platform.', true)
-    ->param('badge', -1, new Integer, 'Badge for push notification. Available only for iOS Platform.', true)
-    ->param('draft', false, new Boolean, 'Is message a draft', true)
+    ->param('badge', -1, new Integer(), 'Badge for push notification. Available only for iOS Platform.', true)
+    ->param('draft', false, new Boolean(), 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
-    ->param('contentAvailable', false, new Boolean, 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
-    ->param('critical', false, new Boolean, 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
+    ->param('contentAvailable', false, new Boolean(), 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
+    ->param('critical', false, new Boolean(), 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
     ->param('priority', 'high', new WhiteList(['normal', 'high']), 'Set the notification priority. "normal" will consider device state and may not deliver notifications immediately. "high" will always attempt to immediately deliver the notification.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -3688,7 +3689,7 @@ Http::post('/v1/messaging/messages/push')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (! empty($targets)) {
+        if (!empty($targets)) {
             $foundTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $targets),
                 Query::equal('providerType', [MESSAGE_TYPE_PUSH]),
@@ -3706,7 +3707,7 @@ Http::post('/v1/messaging/messages/push')
             }
         }
 
-        if (! empty($image)) {
+        if (!empty($image)) {
             [$bucketId, $fileId] = CompoundUID::parse($image);
 
             $bucket = $dbForProject->getDocument('buckets', $bucketId);
@@ -3714,12 +3715,12 @@ Http::post('/v1/messaging/messages/push')
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
+            $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
             if ($file->isEmpty()) {
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            if (! \in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
+            if (!\in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
                 throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
             }
 
@@ -3727,10 +3728,10 @@ Http::post('/v1/messaging/messages/push')
             $endpoint = "$protocol://{$platform['apiHostname']}/v1";
 
             $scheduleTime = $currentScheduledAt ?? $scheduledAt;
-            if (! \is_null($scheduleTime)) {
-                $expiry = (new \DateTime($scheduleTime))->add(new DateInterval('P15D'))->format('U');
+            if (!\is_null($scheduleTime)) {
+                $expiry = (new \DateTime($scheduleTime))->add(new \DateInterval('P15D'))->format('U');
             } else {
-                $expiry = (new \DateTime)->add(new DateInterval('P15D'))->format('U');
+                $expiry = (new \DateTime())->add(new \DateInterval('P15D'))->format('U');
             }
 
             $encoder = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', \intval($expiry), 0);
@@ -3750,31 +3751,31 @@ Http::post('/v1/messaging/messages/push')
 
         $pushData = [];
 
-        if (! empty($title)) {
+        if (!empty($title)) {
             $pushData['title'] = $title;
         }
-        if (! empty($body)) {
+        if (!empty($body)) {
             $pushData['body'] = $body;
         }
-        if (! empty($data)) {
+        if (!empty($data)) {
             $pushData['data'] = $data;
         }
-        if (! empty($action)) {
+        if (!empty($action)) {
             $pushData['action'] = $action;
         }
-        if (! empty($image)) {
+        if (!empty($image)) {
             $pushData['image'] = $image;
         }
-        if (! empty($icon)) {
+        if (!empty($icon)) {
             $pushData['icon'] = $icon;
         }
-        if (! empty($sound)) {
+        if (!empty($sound)) {
             $pushData['sound'] = $sound;
         }
-        if (! empty($color)) {
+        if (!empty($color)) {
             $pushData['color'] = $color;
         }
-        if (! empty($tag)) {
+        if (!empty($tag)) {
             $pushData['tag'] = $tag;
         }
         if ($badge >= 0) {
@@ -3786,7 +3787,7 @@ Http::post('/v1/messaging/messages/push')
         if ($critical) {
             $pushData['critical'] = true;
         }
-        if (! empty($priority)) {
+        if (!empty($priority)) {
             $pushData['priority'] = $priority;
         }
 
@@ -3859,10 +3860,10 @@ Http::get('/v1/messaging/messages')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE_LIST,
-            ),
+            )
         ],
     ))
-    ->param('queries', [], new Messages, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Messages::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Messages(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Messages::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -3875,7 +3876,7 @@ Http::get('/v1/messaging/messages')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (! empty($search)) {
+        if (!empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -3883,8 +3884,8 @@ Http::get('/v1/messaging/messages')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor;
-            if (! $validator->isValid($cursor)) {
+            $validator = new Cursor();
+            if (!$validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -3924,11 +3925,11 @@ Http::get('/v1/messaging/messages/:messageId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            ),
+            )
         ],
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -3952,13 +3953,13 @@ Http::get('/v1/messaging/messages/:messageId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'message/'.$messageId;
+        $resource = 'message/' . $messageId;
         $logs = $audit->getLogsByResource($resource, limit: $limit, offset: $offset);
 
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -3986,14 +3987,14 @@ Http::get('/v1/messaging/messages/:messageId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel'],
+                'deviceModel' => $device['deviceModel']
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -4021,11 +4022,11 @@ Http::get('/v1/messaging/messages/:messageId/targets')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TARGET_LIST,
-            ),
+            )
         ],
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
-    ->param('queries', [], new Targets, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Targets::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Targets(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Targets::ALLOWED_ATTRIBUTES), true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -4043,7 +4044,6 @@ Http::get('/v1/messaging/messages/:messageId/targets')
                 'targets' => [],
                 'total' => 0,
             ]), Response::MODEL_TARGET_LIST);
-
             return;
         }
 
@@ -4059,8 +4059,8 @@ Http::get('/v1/messaging/messages/:messageId/targets')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor;
-            if (! $validator->isValid($cursor)) {
+            $validator = new Cursor();
+            if (!$validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -4100,7 +4100,7 @@ Http::get('/v1/messaging/messages/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE,
-            ),
+            )
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
@@ -4134,7 +4134,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE,
-            ),
+            )
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
@@ -4143,12 +4143,12 @@ Http::patch('/v1/messaging/messages/email/:messageId')
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('subject', null, new Nullable(new Text(998)), 'Email Subject.', true)
     ->param('content', null, new Nullable(new Text(64230)), 'Email Content.', true)
-    ->param('draft', null, new Nullable(new Boolean), 'Is message a draft', true)
-    ->param('html', null, new Nullable(new Boolean), 'Is content of type HTML', true)
+    ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
+    ->param('html', null, new Nullable(new Boolean()), 'Is content of type HTML', true)
     ->param('cc', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'Array of target IDs to be added as CC.', true, ['dbForProject'])
     ->param('bcc', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'Array of target IDs to be added as BCC.', true, ['dbForProject'])
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
-    ->param('attachments', null, new Nullable(new ArrayList(new CompoundUID)), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('attachments', null, new Nullable(new ArrayList(new CompoundUID())), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('dbForPlatform')
@@ -4162,7 +4162,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             throw new Exception(Exception::MESSAGE_NOT_FOUND);
         }
 
-        if (! \is_null($draft) || ! \is_null($scheduledAt)) {
+        if (!\is_null($draft) || !\is_null($scheduledAt)) {
             if ($draft) {
                 $status = MessageStatus::DRAFT;
             } else {
@@ -4202,11 +4202,11 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (! \is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime) {
+        if (!\is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime()) {
             throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
         }
 
-        if (\is_null($currentScheduledAt) && ! \is_null($scheduledAt)) {
+        if (\is_null($currentScheduledAt) && !\is_null($scheduledAt)) {
             $schedule = $dbForPlatform->createDocument('schedules', new Document([
                 'region' => $project->getAttribute('region'),
                 'resourceType' => SCHEDULE_RESOURCE_TYPE_MESSAGE,
@@ -4221,7 +4221,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             $message->setAttribute('scheduleId', $schedule->getId());
         }
 
-        if (! \is_null($currentScheduledAt)) {
+        if (!\is_null($currentScheduledAt)) {
             $schedule = $dbForPlatform->getDocument('schedules', $message->getAttribute('scheduleId'));
             $scheduledStatus = ($status ?? $message->getAttribute('status')) === MessageStatus::SCHEDULED;
 
@@ -4233,40 +4233,40 @@ Http::patch('/v1/messaging/messages/email/:messageId')
                 ->setAttribute('resourceUpdatedAt', DateTime::now())
                 ->setAttribute('active', $scheduledStatus);
 
-            if (! \is_null($scheduledAt)) {
+            if (!\is_null($scheduledAt)) {
                 $schedule->setAttribute('schedule', $scheduledAt);
             }
 
             $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule);
         }
 
-        if (! \is_null($scheduledAt)) {
+        if (!\is_null($scheduledAt)) {
             $message->setAttribute('scheduledAt', $scheduledAt);
         }
 
-        if (! \is_null($topics)) {
+        if (!\is_null($topics)) {
             $message->setAttribute('topics', $topics);
         }
 
-        if (! \is_null($users)) {
+        if (!\is_null($users)) {
             $message->setAttribute('users', $users);
         }
 
-        if (! \is_null($targets)) {
+        if (!\is_null($targets)) {
             $message->setAttribute('targets', $targets);
         }
 
         $data = $message->getAttribute('data');
 
-        if (! \is_null($subject)) {
+        if (!\is_null($subject)) {
             $data['subject'] = $subject;
         }
 
-        if (! \is_null($content)) {
+        if (!\is_null($content)) {
             $data['content'] = $content;
         }
 
-        if (! is_null($attachments)) {
+        if (!is_null($attachments)) {
             foreach ($attachments as &$attachment) {
                 [$bucketId, $fileId] = CompoundUID::parse($attachment);
 
@@ -4276,7 +4276,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
                     throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
                 }
 
-                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
 
                 if ($file->isEmpty()) {
                     throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
@@ -4290,21 +4290,21 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             $data['attachments'] = $attachments;
         }
 
-        if (! \is_null($html)) {
+        if (!\is_null($html)) {
             $data['html'] = $html;
         }
 
-        if (! \is_null($cc)) {
+        if (!\is_null($cc)) {
             $data['cc'] = $cc;
         }
 
-        if (! \is_null($bcc)) {
+        if (!\is_null($bcc)) {
             $data['bcc'] = $bcc;
         }
 
         $message->setAttribute('data', $data);
 
-        if (! \is_null($status)) {
+        if (!\is_null($status)) {
             $message->setAttribute('status', $status);
         }
 
@@ -4342,7 +4342,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_MESSAGE,
-                ),
+                )
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -4360,16 +4360,16 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_MESSAGE,
-                ),
+                )
             ]
-        ),
+        )
     ])
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
     ->param('topics', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('content', null, new Nullable(new Text(64230)), 'Email Content.', true)
-    ->param('draft', null, new Nullable(new Boolean), 'Is message a draft', true)
+    ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -4384,7 +4384,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
             throw new Exception(Exception::MESSAGE_NOT_FOUND);
         }
 
-        if (! \is_null($draft) || ! \is_null($scheduledAt)) {
+        if (!\is_null($draft) || !\is_null($scheduledAt)) {
             if ($draft) {
                 $status = MessageStatus::DRAFT;
             } else {
@@ -4424,11 +4424,11 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (! \is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime) {
+        if (!\is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime()) {
             throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
         }
 
-        if (\is_null($currentScheduledAt) && ! \is_null($scheduledAt)) {
+        if (\is_null($currentScheduledAt) && !\is_null($scheduledAt)) {
             $schedule = $dbForPlatform->createDocument('schedules', new Document([
                 'region' => $project->getAttribute('region'),
                 'resourceType' => SCHEDULE_RESOURCE_TYPE_MESSAGE,
@@ -4443,7 +4443,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
             $message->setAttribute('scheduleId', $schedule->getId());
         }
 
-        if (! \is_null($currentScheduledAt)) {
+        if (!\is_null($currentScheduledAt)) {
             $schedule = $dbForPlatform->getDocument('schedules', $message->getAttribute('scheduleId'));
             $scheduledStatus = ($status ?? $message->getAttribute('status')) === MessageStatus::SCHEDULED;
 
@@ -4455,38 +4455,38 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
                 ->setAttribute('resourceUpdatedAt', DateTime::now())
                 ->setAttribute('active', $scheduledStatus);
 
-            if (! \is_null($scheduledAt)) {
+            if (!\is_null($scheduledAt)) {
                 $schedule->setAttribute('schedule', $scheduledAt);
             }
 
             $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule);
         }
 
-        if (! \is_null($scheduledAt)) {
+        if (!\is_null($scheduledAt)) {
             $message->setAttribute('scheduledAt', $scheduledAt);
         }
 
-        if (! \is_null($topics)) {
+        if (!\is_null($topics)) {
             $message->setAttribute('topics', $topics);
         }
 
-        if (! \is_null($users)) {
+        if (!\is_null($users)) {
             $message->setAttribute('users', $users);
         }
 
-        if (! \is_null($targets)) {
+        if (!\is_null($targets)) {
             $message->setAttribute('targets', $targets);
         }
 
         $data = $message->getAttribute('data');
 
-        if (! \is_null($content)) {
+        if (!\is_null($content)) {
             $data['content'] = $content;
         }
 
         $message->setAttribute('data', $data);
 
-        if (! \is_null($status)) {
+        if (!\is_null($status)) {
             $message->setAttribute('status', $status);
         }
 
@@ -4523,7 +4523,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE,
-            ),
+            )
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
@@ -4532,18 +4532,18 @@ Http::patch('/v1/messaging/messages/push/:messageId')
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('title', null, new Nullable(new Text(256)), 'Title for push notification.', true)
     ->param('body', null, new Nullable(new Text(64230)), 'Body for push notification.', true)
-    ->param('data', null, new Nullable(new JSON), 'Additional Data for push notification.', true)
+    ->param('data', null, new Nullable(new JSON()), 'Additional Data for push notification.', true)
     ->param('action', null, new Nullable(new Text(256)), 'Action for push notification.', true)
-    ->param('image', null, new Nullable(new CompoundUID), 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('image', null, new Nullable(new CompoundUID()), 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
     ->param('icon', null, new Nullable(new Text(256)), 'Icon for push notification. Available only for Android and Web platforms.', true)
     ->param('sound', null, new Nullable(new Text(256)), 'Sound for push notification. Available only for Android and iOS platforms.', true)
     ->param('color', null, new Nullable(new Text(256)), 'Color for push notification. Available only for Android platforms.', true)
     ->param('tag', null, new Nullable(new Text(256)), 'Tag for push notification. Available only for Android platforms.', true)
-    ->param('badge', null, new Nullable(new Integer), 'Badge for push notification. Available only for iOS platforms.', true)
-    ->param('draft', null, new Nullable(new Boolean), 'Is message a draft', true)
+    ->param('badge', null, new Nullable(new Integer()), 'Badge for push notification. Available only for iOS platforms.', true)
+    ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
-    ->param('contentAvailable', null, new Nullable(new Boolean), 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
-    ->param('critical', null, new Nullable(new Boolean), 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
+    ->param('contentAvailable', null, new Nullable(new Boolean()), 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
+    ->param('critical', null, new Nullable(new Boolean()), 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
     ->param('priority', null, new Nullable(new WhiteList(['normal', 'high'])), 'Set the notification priority. "normal" will consider device battery state and may send notifications later. "high" will always attempt to immediately deliver the notification.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -4559,7 +4559,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             throw new Exception(Exception::MESSAGE_NOT_FOUND);
         }
 
-        if (! \is_null($draft) || ! \is_null($scheduledAt)) {
+        if (!\is_null($draft) || !\is_null($scheduledAt)) {
             if ($draft) {
                 $status = MessageStatus::DRAFT;
             } else {
@@ -4599,11 +4599,11 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (! \is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime) {
+        if (!\is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime()) {
             throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
         }
 
-        if (\is_null($currentScheduledAt) && ! \is_null($scheduledAt)) {
+        if (\is_null($currentScheduledAt) && !\is_null($scheduledAt)) {
             $schedule = $dbForPlatform->createDocument('schedules', new Document([
                 'region' => $project->getAttribute('region'),
                 'resourceType' => SCHEDULE_RESOURCE_TYPE_MESSAGE,
@@ -4618,7 +4618,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             $message->setAttribute('scheduleId', $schedule->getId());
         }
 
-        if (! \is_null($currentScheduledAt)) {
+        if (!\is_null($currentScheduledAt)) {
             $schedule = $dbForPlatform->getDocument('schedules', $message->getAttribute('scheduleId'));
             $scheduledStatus = ($status ?? $message->getAttribute('status')) === MessageStatus::SCHEDULED;
 
@@ -4630,80 +4630,80 @@ Http::patch('/v1/messaging/messages/push/:messageId')
                 ->setAttribute('resourceUpdatedAt', DateTime::now())
                 ->setAttribute('active', $scheduledStatus);
 
-            if (! \is_null($scheduledAt)) {
+            if (!\is_null($scheduledAt)) {
                 $schedule->setAttribute('schedule', $scheduledAt);
             }
 
             $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule);
         }
 
-        if (! \is_null($scheduledAt)) {
+        if (!\is_null($scheduledAt)) {
             $message->setAttribute('scheduledAt', $scheduledAt);
         }
 
-        if (! \is_null($topics)) {
+        if (!\is_null($topics)) {
             $message->setAttribute('topics', $topics);
         }
 
-        if (! \is_null($users)) {
+        if (!\is_null($users)) {
             $message->setAttribute('users', $users);
         }
 
-        if (! \is_null($targets)) {
+        if (!\is_null($targets)) {
             $message->setAttribute('targets', $targets);
         }
 
         $pushData = $message->getAttribute('data');
 
-        if (! \is_null($title)) {
+        if (!\is_null($title)) {
             $pushData['title'] = $title;
         }
 
-        if (! \is_null($body)) {
+        if (!\is_null($body)) {
             $pushData['body'] = $body;
         }
 
-        if (! \is_null($data)) {
+        if (!\is_null($data)) {
             $pushData['data'] = $data;
         }
 
-        if (! \is_null($action)) {
+        if (!\is_null($action)) {
             $pushData['action'] = $action;
         }
 
-        if (! \is_null($icon)) {
+        if (!\is_null($icon)) {
             $pushData['icon'] = $icon;
         }
 
-        if (! \is_null($sound)) {
+        if (!\is_null($sound)) {
             $pushData['sound'] = $sound;
         }
 
-        if (! \is_null($color)) {
+        if (!\is_null($color)) {
             $pushData['color'] = $color;
         }
 
-        if (! \is_null($tag)) {
+        if (!\is_null($tag)) {
             $pushData['tag'] = $tag;
         }
 
-        if (! \is_null($badge)) {
+        if (!\is_null($badge)) {
             $pushData['badge'] = $badge;
         }
 
-        if (! \is_null($contentAvailable)) {
+        if (!\is_null($contentAvailable)) {
             $pushData['contentAvailable'] = $contentAvailable;
         }
 
-        if (! \is_null($critical)) {
+        if (!\is_null($critical)) {
             $pushData['critical'] = $critical;
         }
 
-        if (! \is_null($priority)) {
+        if (!\is_null($priority)) {
             $pushData['priority'] = $priority;
         }
 
-        if (! \is_null($image)) {
+        if (!\is_null($image)) {
             [$bucketId, $fileId] = CompoundUID::parse($image);
 
             $bucket = $dbForProject->getDocument('buckets', $bucketId);
@@ -4711,20 +4711,20 @@ Http::patch('/v1/messaging/messages/push/:messageId')
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
+            $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
             if ($file->isEmpty()) {
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            if (! \in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
+            if (!\in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
                 throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
             }
 
             $scheduleTime = $currentScheduledAt ?? $scheduledAt;
-            if (! \is_null($scheduleTime)) {
-                $expiry = (new \DateTime($scheduleTime))->add(new DateInterval('P15D'))->format('U');
+            if (!\is_null($scheduleTime)) {
+                $expiry = (new \DateTime($scheduleTime))->add(new \DateInterval('P15D'))->format('U');
             } else {
-                $expiry = (new \DateTime)->add(new DateInterval('P15D'))->format('U');
+                $expiry = (new \DateTime())->add(new \DateInterval('P15D'))->format('U');
             }
 
             $encoder = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', \intval($expiry), 0);
@@ -4747,7 +4747,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
 
         $message->setAttribute('data', $pushData);
 
-        if (! \is_null($status)) {
+        if (!\is_null($status)) {
             $message->setAttribute('status', $status);
         }
 
@@ -4784,7 +4784,7 @@ Http::delete('/v1/messaging/messages/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            ),
+            )
         ],
         contentType: ContentType::NONE
     ))
@@ -4814,7 +4814,7 @@ Http::delete('/v1/messaging/messages/:messageId')
                     throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
                 }
 
-                if (! empty($scheduleId)) {
+                if (!empty($scheduleId)) {
                     try {
                         $dbForPlatform->deleteDocument('schedules', $scheduleId);
                     } catch (Exception) {

--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -75,19 +75,19 @@ Http::post('/v1/messaging/providers/mailgun')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
     ->param('apiKey', '', new Text(0), 'Mailgun API Key.', true)
     ->param('domain', '', new Text(0), 'Mailgun Domain.', true)
-    ->param('isEuRegion', null, new Nullable(new Boolean()), 'Set as EU region.', true)
+    ->param('isEuRegion', null, new Nullable(new Boolean), 'Set as EU region.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name. Reply to name must have reply to email as well.', true)
-    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email. Reply to email must have reply to name as well.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email. Reply to email must have reply to name as well.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -96,15 +96,15 @@ Http::post('/v1/messaging/providers/mailgun')
 
         $credentials = [];
 
-        if (!\is_null($isEuRegion)) {
+        if (! \is_null($isEuRegion)) {
             $credentials['isEuRegion'] = $isEuRegion;
         }
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (!empty($domain)) {
+        if (! empty($domain)) {
             $credentials['domain'] = $domain;
         }
 
@@ -117,7 +117,7 @@ Http::post('/v1/messaging/providers/mailgun')
 
         if (
             $enabled === true
-            && !empty($fromEmail)
+            && ! empty($fromEmail)
             && \array_key_exists('isEuRegion', $credentials)
             && \array_key_exists('apiKey', $credentials)
             && \array_key_exists('domain', $credentials)
@@ -169,17 +169,17 @@ Http::post('/v1/messaging/providers/sendgrid')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
     ->param('apiKey', '', new Text(0), 'Sendgrid API key.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name.', true)
-    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -188,7 +188,7 @@ Http::post('/v1/messaging/providers/sendgrid')
 
         $credentials = [];
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -201,7 +201,7 @@ Http::post('/v1/messaging/providers/sendgrid')
 
         if (
             $enabled === true
-            && !empty($fromEmail)
+            && ! empty($fromEmail)
             && \array_key_exists('apiKey', $credentials)
         ) {
             $enabled = true;
@@ -251,17 +251,17 @@ Http::post('/v1/messaging/providers/resend')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
     ->param('apiKey', '', new Text(0), 'Resend API key.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name.', true)
-    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -270,7 +270,7 @@ Http::post('/v1/messaging/providers/resend')
 
         $credentials = [];
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -283,7 +283,7 @@ Http::post('/v1/messaging/providers/resend')
 
         if (
             $enabled === true
-            && !empty($fromEmail)
+            && ! empty($fromEmail)
             && \array_key_exists('apiKey', $credentials)
         ) {
             $enabled = true;
@@ -334,7 +334,7 @@ Http::post('/v1/messaging/providers/smtp')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -352,9 +352,9 @@ Http::post('/v1/messaging/providers/smtp')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
@@ -363,13 +363,13 @@ Http::post('/v1/messaging/providers/smtp')
     ->param('username', '', new Text(0), 'Authentication username.', true)
     ->param('password', '', new Text(0), 'Authentication password.', true)
     ->param('encryption', '', new WhiteList(['none', 'ssl', 'tls']), 'Encryption type. Can be omitted, \'ssl\', or \'tls\'', true)
-    ->param('autoTLS', true, new Boolean(), 'Enable SMTP AutoTLS feature.', true)
+    ->param('autoTLS', true, new Boolean, 'Enable SMTP AutoTLS feature.', true)
     ->param('mailer', '', new Text(0), 'The value to use for the X-Mailer header.', true)
     ->param('fromName', '', new Text(128, 0), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128, 0), 'Name set in the reply to field for the mail. Default value is sender name.', true)
-    ->param('replyToEmail', '', new Email(), 'Email set in the reply to field for the mail. Default value is sender email.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('replyToEmail', '', new Email, 'Email set in the reply to field for the mail. Default value is sender email.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -382,7 +382,7 @@ Http::post('/v1/messaging/providers/smtp')
             'password' => $password,
         ];
 
-        if (!empty($host)) {
+        if (! empty($host)) {
             $credentials['host'] = $host;
         }
 
@@ -398,7 +398,7 @@ Http::post('/v1/messaging/providers/smtp')
 
         if (
             $enabled === true
-            && !empty($fromEmail)
+            && ! empty($fromEmail)
             && \array_key_exists('host', $credentials)
         ) {
             $enabled = true;
@@ -448,7 +448,7 @@ Http::post('/v1/messaging/providers/msg91')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
@@ -456,7 +456,7 @@ Http::post('/v1/messaging/providers/msg91')
     ->param('templateId', '', new Text(0), 'Msg91 template ID', true)
     ->param('senderId', '', new Text(0), 'Msg91 sender ID.', true)
     ->param('authKey', '', new Text(0), 'Msg91 auth key.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -466,15 +466,15 @@ Http::post('/v1/messaging/providers/msg91')
         $options = [];
         $credentials = [];
 
-        if (!empty($templateId)) {
+        if (! empty($templateId)) {
             $credentials['templateId'] = $templateId;
         }
 
-        if (!empty($senderId)) {
+        if (! empty($senderId)) {
             $credentials['senderId'] = $senderId;
         }
 
-        if (!empty($authKey)) {
+        if (! empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
@@ -531,15 +531,15 @@ Http::post('/v1/messaging/providers/telesign')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('customerId', '', new Text(0), 'Telesign customer ID.', true)
     ->param('apiKey', '', new Text(0), 'Telesign API key.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -548,17 +548,17 @@ Http::post('/v1/messaging/providers/telesign')
 
         $options = [];
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (!empty($customerId)) {
+        if (! empty($customerId)) {
             $credentials['customerId'] = $customerId;
         }
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -615,15 +615,15 @@ Http::post('/v1/messaging/providers/textmagic')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('username', '', new Text(0), 'Textmagic username.', true)
     ->param('apiKey', '', new Text(0), 'Textmagic apiKey.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -632,17 +632,17 @@ Http::post('/v1/messaging/providers/textmagic')
 
         $options = [];
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (!empty($username)) {
+        if (! empty($username)) {
             $credentials['username'] = $username;
         }
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
@@ -699,15 +699,15 @@ Http::post('/v1/messaging/providers/twilio')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('accountSid', '', new Text(0), 'Twilio account secret ID.', true)
     ->param('authToken', '', new Text(0), 'Twilio authentication token.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -716,17 +716,17 @@ Http::post('/v1/messaging/providers/twilio')
 
         $options = [];
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (!empty($accountSid)) {
+        if (! empty($accountSid)) {
             $credentials['accountSid'] = $accountSid;
         }
 
-        if (!empty($authToken)) {
+        if (! empty($authToken)) {
             $credentials['authToken'] = $authToken;
         }
 
@@ -783,15 +783,15 @@ Http::post('/v1/messaging/providers/vonage')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('from', '', new Phone(), 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
     ->param('apiKey', '', new Text(0), 'Vonage API key.', true)
     ->param('apiSecret', '', new Text(0), 'Vonage API secret.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -800,17 +800,17 @@ Http::post('/v1/messaging/providers/vonage')
 
         $options = [];
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $options['from'] = $from;
         }
 
         $credentials = [];
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (!empty($apiSecret)) {
+        if (! empty($apiSecret)) {
             $credentials['apiSecret'] = $apiSecret;
         }
 
@@ -829,6 +829,84 @@ Http::post('/v1/messaging/providers/vonage')
             '$id' => $providerId,
             'name' => $name,
             'provider' => 'vonage',
+            'type' => MESSAGE_TYPE_SMS,
+            'enabled' => $enabled,
+            'credentials' => $credentials,
+            'options' => $options,
+        ]);
+
+        try {
+            $provider = $dbForProject->createDocument('providers', $provider);
+        } catch (DuplicateException) {
+            throw new Exception(Exception::PROVIDER_ALREADY_EXISTS);
+        }
+
+        $queueForEvents
+            ->setParam('providerId', $provider->getId());
+
+        $response
+            ->setStatusCode(Response::STATUS_CODE_CREATED)
+            ->dynamic($provider, Response::MODEL_PROVIDER);
+    });
+
+Http::post('/v1/messaging/providers/telnyx')
+    ->desc('Create Telnyx provider')
+    ->groups(['api', 'messaging'])
+    ->label('audits.event', 'provider.create')
+    ->label('audits.resource', 'provider/{response.$id}')
+    ->label('event', 'providers.[providerId].create')
+    ->label('scope', 'providers.write')
+    ->label('resourceType', RESOURCE_TYPE_PROVIDERS)
+    ->label('sdk', new Method(
+        namespace: 'messaging',
+        group: 'providers',
+        name: 'createTelnyxProvider',
+        description: '/docs/references/messaging/create-telnyx-provider.md',
+        auth: [AuthType::ADMIN, AuthType::KEY],
+        responses: [
+            new SDKResponse(
+                code: Response::STATUS_CODE_CREATED,
+                model: Response::MODEL_PROVIDER,
+            ),
+        ]
+    ))
+    ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
+    ->param('name', '', new Text(128), 'Provider name.')
+    ->param('from', '', new Phone, 'Sender Phone number. Format this number with a leading \'+\' and a country code, e.g., +16175551212.', true)
+    ->param('apiKey', '', new Text(0), 'Telnyx API key.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->inject('queueForEvents')
+    ->inject('dbForProject')
+    ->inject('response')
+    ->action(function (string $providerId, string $name, string $from, string $apiKey, ?bool $enabled, Event $queueForEvents, Database $dbForProject, Response $response) {
+        $providerId = $providerId == 'unique()' ? ID::unique() : $providerId;
+
+        $options = [];
+
+        if (! empty($from)) {
+            $options['from'] = $from;
+        }
+
+        $credentials = [];
+
+        if (! empty($apiKey)) {
+            $credentials['apiKey'] = $apiKey;
+        }
+
+        if (
+            $enabled === true
+            && \array_key_exists('apiKey', $credentials)
+            && \array_key_exists('from', $options)
+        ) {
+            $enabled = true;
+        } else {
+            $enabled = false;
+        }
+
+        $provider = new Document([
+            '$id' => $providerId,
+            'name' => $name,
+            'provider' => 'telnyx',
             'type' => MESSAGE_TYPE_SMS,
             'enabled' => $enabled,
             'credentials' => $credentials,
@@ -868,7 +946,7 @@ Http::post('/v1/messaging/providers/fcm')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -886,14 +964,14 @@ Http::post('/v1/messaging/providers/fcm')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
-    ->param('serviceAccountJSON', null, new Nullable(new JSON()), 'FCM service account JSON.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('serviceAccountJSON', null, new Nullable(new JSON), 'FCM service account JSON.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -906,7 +984,7 @@ Http::post('/v1/messaging/providers/fcm')
 
         $credentials = [];
 
-        if (!\is_null($serviceAccountJSON)) {
+        if (! \is_null($serviceAccountJSON)) {
             $credentials['serviceAccountJSON'] = $serviceAccountJSON;
         }
 
@@ -922,7 +1000,7 @@ Http::post('/v1/messaging/providers/fcm')
             'provider' => 'fcm',
             'type' => MESSAGE_TYPE_PUSH,
             'enabled' => $enabled,
-            'credentials' => $credentials
+            'credentials' => $credentials,
         ]);
 
         try {
@@ -958,7 +1036,7 @@ Http::post('/v1/messaging/providers/apns')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -976,9 +1054,9 @@ Http::post('/v1/messaging/providers/apns')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.')
@@ -986,8 +1064,8 @@ Http::post('/v1/messaging/providers/apns')
     ->param('authKeyId', '', new Text(0), 'APNS authentication key ID.', true)
     ->param('teamId', '', new Text(0), 'APNS team ID.', true)
     ->param('bundleId', '', new Text(0), 'APNS bundle ID.', true)
-    ->param('sandbox', false, new Boolean(), 'Use APNS sandbox environment.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('sandbox', false, new Boolean, 'Use APNS sandbox environment.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -996,19 +1074,19 @@ Http::post('/v1/messaging/providers/apns')
 
         $credentials = [];
 
-        if (!empty($authKey)) {
+        if (! empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
-        if (!empty($authKeyId)) {
+        if (! empty($authKeyId)) {
             $credentials['authKeyId'] = $authKeyId;
         }
 
-        if (!empty($teamId)) {
+        if (! empty($teamId)) {
             $credentials['teamId'] = $teamId;
         }
 
-        if (!empty($bundleId)) {
+        if (! empty($bundleId)) {
             $credentials['bundleId'] = $bundleId;
         }
 
@@ -1025,7 +1103,7 @@ Http::post('/v1/messaging/providers/apns')
         }
 
         $options = [
-            'sandbox' => $sandbox
+            'sandbox' => $sandbox,
         ];
 
         $provider = new Document([
@@ -1035,7 +1113,7 @@ Http::post('/v1/messaging/providers/apns')
             'type' => MESSAGE_TYPE_PUSH,
             'enabled' => $enabled,
             'credentials' => $credentials,
-            'options' => $options
+            'options' => $options,
         ]);
 
         try {
@@ -1067,10 +1145,10 @@ Http::get('/v1/messaging/providers')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER_LIST,
-            )
+            ),
         ]
     ))
-    ->param('queries', [], new Providers(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Providers::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Providers, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Providers::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -1083,7 +1161,7 @@ Http::get('/v1/messaging/providers')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (!empty($search)) {
+        if (! empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -1091,8 +1169,8 @@ Http::get('/v1/messaging/providers')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor();
-            if (!$validator->isValid($cursor)) {
+            $validator = new Cursor;
+            if (! $validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -1132,11 +1210,11 @@ Http::get('/v1/messaging/providers/:providerId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -1160,12 +1238,12 @@ Http::get('/v1/messaging/providers/:providerId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'provider/' . $providerId;
+        $resource = 'provider/'.$providerId;
         $logs = $audit->getLogsByResource($resource, offset: $offset, limit: $limit);
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -1193,14 +1271,14 @@ Http::get('/v1/messaging/providers/:providerId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel']
+                'deviceModel' => $device['deviceModel'],
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -1228,7 +1306,7 @@ Http::get('/v1/messaging/providers/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
@@ -1262,17 +1340,17 @@ Http::patch('/v1/messaging/providers/mailgun/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
     ->param('apiKey', '', new Text(0), 'Mailgun API Key.', true)
     ->param('domain', '', new Text(0), 'Mailgun Domain.', true)
-    ->param('isEuRegion', null, new Nullable(new Boolean()), 'Set as EU region.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('isEuRegion', null, new Nullable(new Boolean), 'Set as EU region.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the reply to field for the mail. Default value is sender name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the reply to field for the mail. Default value is sender email.', true)
     ->inject('queueForEvents')
@@ -1291,25 +1369,25 @@ Http::patch('/v1/messaging/providers/mailgun/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (!empty($fromName)) {
+        if (! empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (!empty($fromEmail)) {
+        if (! empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (!empty($replyToName)) {
+        if (! empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (!empty($replyToEmail)) {
+        if (! empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
@@ -1317,21 +1395,21 @@ Http::patch('/v1/messaging/providers/mailgun/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!\is_null($isEuRegion)) {
+        if (! \is_null($isEuRegion)) {
             $credentials['isEuRegion'] = $isEuRegion;
         }
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (!empty($domain)) {
+        if (! empty($domain)) {
             $credentials['domain'] = $domain;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('isEuRegion', $credentials) &&
@@ -1375,15 +1453,15 @@ Http::patch('/v1/messaging/providers/sendgrid/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Sendgrid API key.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the Reply To field for the mail. Default value is Sender Name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the Reply To field for the mail. Default value is Sender Email.', true)
     ->inject('queueForEvents')
@@ -1401,37 +1479,37 @@ Http::patch('/v1/messaging/providers/sendgrid/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (!empty($fromName)) {
+        if (! empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (!empty($fromEmail)) {
+        if (! empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (!empty($replyToName)) {
+        if (! empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (!empty($replyToEmail)) {
+        if (! empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
         $provider->setAttribute('options', $options);
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $provider->setAttribute('credentials', [
                 'apiKey' => $apiKey,
             ]);
         }
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $provider->getAttribute('credentials')) &&
@@ -1473,15 +1551,15 @@ Http::patch('/v1/messaging/providers/resend/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Resend API key.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the Reply To field for the mail. Default value is Sender Name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the Reply To field for the mail. Default value is Sender Email.', true)
     ->inject('queueForEvents')
@@ -1499,37 +1577,37 @@ Http::patch('/v1/messaging/providers/resend/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (!empty($fromName)) {
+        if (! empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (!empty($fromEmail)) {
+        if (! empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (!empty($replyToName)) {
+        if (! empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (!empty($replyToEmail)) {
+        if (! empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
         $provider->setAttribute('options', $options);
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $provider->setAttribute('credentials', [
                 'apiKey' => $apiKey,
             ]);
         }
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $provider->getAttribute('credentials')) &&
@@ -1572,7 +1650,7 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -1590,9 +1668,9 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
@@ -1601,13 +1679,13 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
     ->param('username', '', new Text(0), 'Authentication username.', true)
     ->param('password', '', new Text(0), 'Authentication password.', true)
     ->param('encryption', '', new WhiteList(['none', 'ssl', 'tls']), 'Encryption type. Can be \'ssl\' or \'tls\'', true)
-    ->param('autoTLS', null, new Nullable(new Boolean()), 'Enable SMTP AutoTLS feature.', true)
+    ->param('autoTLS', null, new Nullable(new Boolean), 'Enable SMTP AutoTLS feature.', true)
     ->param('mailer', '', new Text(0), 'The value to use for the X-Mailer header.', true)
     ->param('fromName', '', new Text(128), 'Sender Name.', true)
-    ->param('fromEmail', '', new Email(), 'Sender email address.', true)
+    ->param('fromEmail', '', new Email, 'Sender email address.', true)
     ->param('replyToName', '', new Text(128), 'Name set in the Reply To field for the mail. Default value is Sender Name.', true)
     ->param('replyToEmail', '', new Text(128), 'Email set in the Reply To field for the mail. Default value is Sender Email.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -1622,37 +1700,37 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $options = $provider->getAttribute('options');
 
-        if (!empty($encryption)) {
+        if (! empty($encryption)) {
             $options['encryption'] = $encryption === 'none' ? '' : $encryption;
         }
 
-        if (!\is_null($autoTLS)) {
+        if (! \is_null($autoTLS)) {
             $options['autoTLS'] = $autoTLS;
         }
 
-        if (!empty($mailer)) {
+        if (! empty($mailer)) {
             $options['mailer'] = $mailer;
         }
 
-        if (!empty($fromName)) {
+        if (! empty($fromName)) {
             $options['fromName'] = $fromName;
         }
 
-        if (!empty($fromEmail)) {
+        if (! empty($fromEmail)) {
             $options['fromEmail'] = $fromEmail;
         }
 
-        if (!empty($replyToName)) {
+        if (! empty($replyToName)) {
             $options['replyToName'] = $replyToName;
         }
 
-        if (!empty($replyToEmail)) {
+        if (! empty($replyToEmail)) {
             $options['replyToEmail'] = $replyToEmail;
         }
 
@@ -1660,28 +1738,28 @@ Http::patch('/v1/messaging/providers/smtp/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($host)) {
+        if (! empty($host)) {
             $credentials['host'] = $host;
         }
 
-        if (!\is_null($port)) {
+        if (! \is_null($port)) {
             $credentials['port'] = $port;
         }
 
-        if (!empty($username)) {
+        if (! empty($username)) {
             $credentials['username'] = $username;
         }
 
-        if (!empty($password)) {
+        if (! empty($password)) {
             $credentials['password'] = $password;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
-                    !empty($options['fromEmail'])
+                    ! empty($options['fromEmail'])
                     && \array_key_exists('host', $credentials)
                 ) {
                     $provider->setAttribute('enabled', true);
@@ -1720,12 +1798,12 @@ Http::patch('/v1/messaging/providers/msg91/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('templateId', '', new Text(0), 'Msg91 template ID.', true)
     ->param('senderId', '', new Text(0), 'Msg91 sender ID.', true)
     ->param('authKey', '', new Text(0), 'Msg91 auth key.', true)
@@ -1744,27 +1822,27 @@ Http::patch('/v1/messaging/providers/msg91/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($templateId)) {
+        if (! empty($templateId)) {
             $credentials['templateId'] = $templateId;
         }
 
-        if (!empty($senderId)) {
+        if (! empty($senderId)) {
             $credentials['senderId'] = $senderId;
         }
 
-        if (!empty($authKey)) {
+        if (! empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('senderId', $credentials) &&
@@ -1807,12 +1885,12 @@ Http::patch('/v1/messaging/providers/telesign/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('customerId', '', new Text(0), 'Telesign customer ID.', true)
     ->param('apiKey', '', new Text(0), 'Telesign API key.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -1831,11 +1909,11 @@ Http::patch('/v1/messaging/providers/telesign/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -1843,17 +1921,17 @@ Http::patch('/v1/messaging/providers/telesign/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($customerId)) {
+        if (! empty($customerId)) {
             $credentials['customerId'] = $customerId;
         }
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('customerId', $credentials) &&
@@ -1896,12 +1974,12 @@ Http::patch('/v1/messaging/providers/textmagic/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('username', '', new Text(0), 'Textmagic username.', true)
     ->param('apiKey', '', new Text(0), 'Textmagic apiKey.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -1920,11 +1998,11 @@ Http::patch('/v1/messaging/providers/textmagic/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -1932,17 +2010,17 @@ Http::patch('/v1/messaging/providers/textmagic/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($username)) {
+        if (! empty($username)) {
             $credentials['username'] = $username;
         }
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('username', $credentials) &&
@@ -1985,12 +2063,12 @@ Http::patch('/v1/messaging/providers/twilio/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('accountSid', '', new Text(0), 'Twilio account secret ID.', true)
     ->param('authToken', '', new Text(0), 'Twilio authentication token.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -2009,11 +2087,11 @@ Http::patch('/v1/messaging/providers/twilio/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -2021,17 +2099,17 @@ Http::patch('/v1/messaging/providers/twilio/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($accountSid)) {
+        if (! empty($accountSid)) {
             $credentials['accountSid'] = $accountSid;
         }
 
-        if (!empty($authToken)) {
+        if (! empty($authToken)) {
             $credentials['authToken'] = $authToken;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('accountSid', $credentials) &&
@@ -2074,12 +2152,12 @@ Http::patch('/v1/messaging/providers/vonage/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_PROVIDER,
-            )
+            ),
         ]
     ))
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('apiKey', '', new Text(0), 'Vonage API key.', true)
     ->param('apiSecret', '', new Text(0), 'Vonage API secret.', true)
     ->param('from', '', new Text(256), 'Sender number.', true)
@@ -2098,11 +2176,11 @@ Http::patch('/v1/messaging/providers/vonage/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (!empty($from)) {
+        if (! empty($from)) {
             $provider->setAttribute('options', [
                 'from' => $from,
             ]);
@@ -2110,21 +2188,104 @@ Http::patch('/v1/messaging/providers/vonage/:providerId')
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($apiKey)) {
+        if (! empty($apiKey)) {
             $credentials['apiKey'] = $apiKey;
         }
 
-        if (!empty($apiSecret)) {
+        if (! empty($apiSecret)) {
             $credentials['apiSecret'] = $apiSecret;
         }
 
         $provider->setAttribute('credentials', $credentials);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('apiKey', $credentials) &&
                     \array_key_exists('apiSecret', $credentials) &&
+                    \array_key_exists('from', $provider->getAttribute('options'))
+                ) {
+                    $provider->setAttribute('enabled', true);
+                } else {
+                    throw new Exception(Exception::PROVIDER_MISSING_CREDENTIALS);
+                }
+            } else {
+                $provider->setAttribute('enabled', false);
+            }
+        }
+
+        $provider = $dbForProject->updateDocument('providers', $provider->getId(), $provider);
+
+        $queueForEvents
+            ->setParam('providerId', $provider->getId());
+
+        $response
+            ->dynamic($provider, Response::MODEL_PROVIDER);
+    });
+
+Http::patch('/v1/messaging/providers/telnyx/:providerId')
+    ->desc('Update Telnyx provider')
+    ->groups(['api', 'messaging'])
+    ->label('audits.event', 'provider.update')
+    ->label('audits.resource', 'provider/{response.$id}')
+    ->label('event', 'providers.[providerId].update')
+    ->label('scope', 'providers.write')
+    ->label('resourceType', RESOURCE_TYPE_PROVIDERS)
+    ->label('sdk', new Method(
+        namespace: 'messaging',
+        group: 'providers',
+        name: 'updateTelnyxProvider',
+        description: '/docs/references/messaging/update-telnyx-provider.md',
+        auth: [AuthType::ADMIN, AuthType::KEY],
+        responses: [
+            new SDKResponse(
+                code: Response::STATUS_CODE_OK,
+                model: Response::MODEL_PROVIDER,
+            ),
+        ]
+    ))
+    ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
+    ->param('name', '', new Text(128), 'Provider name.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('apiKey', '', new Text(0), 'Telnyx API key.', true)
+    ->param('from', '', new Text(256), 'Sender number.', true)
+    ->inject('queueForEvents')
+    ->inject('dbForProject')
+    ->inject('response')
+    ->action(function (string $providerId, string $name, ?bool $enabled, string $apiKey, string $from, Event $queueForEvents, Database $dbForProject, Response $response) {
+        $provider = $dbForProject->getDocument('providers', $providerId);
+
+        if ($provider->isEmpty()) {
+            throw new Exception(Exception::PROVIDER_NOT_FOUND);
+        }
+        $providerAttr = $provider->getAttribute('provider');
+
+        if ($providerAttr !== 'telnyx') {
+            throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
+        }
+
+        if (! empty($name)) {
+            $provider->setAttribute('name', $name);
+        }
+
+        if (! empty($from)) {
+            $provider->setAttribute('options', [
+                'from' => $from,
+            ]);
+        }
+
+        $credentials = $provider->getAttribute('credentials');
+
+        if (! empty($apiKey)) {
+            $credentials['apiKey'] = $apiKey;
+        }
+
+        $provider->setAttribute('credentials', $credentials);
+
+        if (! \is_null($enabled)) {
+            if ($enabled) {
+                if (
+                    \array_key_exists('apiKey', $credentials) &&
                     \array_key_exists('from', $provider->getAttribute('options'))
                 ) {
                     $provider->setAttribute('enabled', true);
@@ -2164,7 +2325,7 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -2182,14 +2343,14 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
-    ->param('serviceAccountJSON', null, new Nullable(new JSON()), 'FCM service account JSON.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
+    ->param('serviceAccountJSON', null, new Nullable(new JSON), 'FCM service account JSON.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2205,21 +2366,21 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
-        if (!\is_null($serviceAccountJSON)) {
+        if (! \is_null($serviceAccountJSON)) {
             $serviceAccountJSON = \is_string($serviceAccountJSON)
                 ? \json_decode($serviceAccountJSON, true)
                 : $serviceAccountJSON;
 
             $provider->setAttribute('credentials', [
-                'serviceAccountJSON' => $serviceAccountJSON
+                'serviceAccountJSON' => $serviceAccountJSON,
             ]);
         }
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (\array_key_exists('serviceAccountJSON', $provider->getAttribute('credentials'))) {
                     $provider->setAttribute('enabled', true);
@@ -2240,7 +2401,6 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
             ->dynamic($provider, Response::MODEL_PROVIDER);
     });
 
-
 Http::patch('/v1/messaging/providers/apns/:providerId')
     ->desc('Update APNS provider')
     ->groups(['api', 'messaging'])
@@ -2260,7 +2420,7 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -2278,18 +2438,18 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_PROVIDER,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Provider name.', true)
-    ->param('enabled', null, new Nullable(new Boolean()), 'Set as enabled.', true)
+    ->param('enabled', null, new Nullable(new Boolean), 'Set as enabled.', true)
     ->param('authKey', '', new Text(0), 'APNS authentication key.', true)
     ->param('authKeyId', '', new Text(0), 'APNS authentication key ID.', true)
     ->param('teamId', '', new Text(0), 'APNS team ID.', true)
     ->param('bundleId', '', new Text(0), 'APNS bundle ID.', true)
-    ->param('sandbox', null, new Nullable(new Boolean()), 'Use APNS sandbox environment.', true)
+    ->param('sandbox', null, new Nullable(new Boolean), 'Use APNS sandbox environment.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2305,25 +2465,25 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
             throw new Exception(Exception::PROVIDER_INCORRECT_TYPE);
         }
 
-        if (!empty($name)) {
+        if (! empty($name)) {
             $provider->setAttribute('name', $name);
         }
 
         $credentials = $provider->getAttribute('credentials');
 
-        if (!empty($authKey)) {
+        if (! empty($authKey)) {
             $credentials['authKey'] = $authKey;
         }
 
-        if (!empty($authKeyId)) {
+        if (! empty($authKeyId)) {
             $credentials['authKeyId'] = $authKeyId;
         }
 
-        if (!empty($teamId)) {
+        if (! empty($teamId)) {
             $credentials['teamId'] = $teamId;
         }
 
-        if (!empty($bundleId)) {
+        if (! empty($bundleId)) {
             $credentials['bundle'] = $bundleId;
         }
 
@@ -2331,13 +2491,13 @@ Http::patch('/v1/messaging/providers/apns/:providerId')
 
         $options = $provider->getAttribute('options');
 
-        if (!\is_null($sandbox)) {
+        if (! \is_null($sandbox)) {
             $options['sandbox'] = $sandbox;
         }
 
         $provider->setAttribute('options', $options);
 
-        if (!\is_null($enabled)) {
+        if (! \is_null($enabled)) {
             if ($enabled) {
                 if (
                     \array_key_exists('authKey', $credentials) &&
@@ -2381,7 +2541,7 @@ Http::delete('/v1/messaging/providers/:providerId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            )
+            ),
         ],
         contentType: ContentType::NONE
     ))
@@ -2424,12 +2584,12 @@ Http::post('/v1/messaging/topics')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_TOPIC,
-            )
+            ),
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID. Choose a custom Topic ID or a new Topic ID.', false, ['dbForProject'])
     ->param('name', '', new Text(128), 'Topic Name.')
-    ->param('subscribe', [Role::users()], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
+    ->param('subscribe', [Role::users()], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' roles are allowed, each 64 characters long.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2471,10 +2631,10 @@ Http::get('/v1/messaging/topics')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TOPIC_LIST,
-            )
+            ),
         ]
     ))
-    ->param('queries', [], new Topics(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Topics::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Topics, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Topics::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -2487,7 +2647,7 @@ Http::get('/v1/messaging/topics')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (!empty($search)) {
+        if (! empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -2495,8 +2655,8 @@ Http::get('/v1/messaging/topics')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor();
-            if (!$validator->isValid($cursor)) {
+            $validator = new Cursor;
+            if (! $validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -2536,11 +2696,11 @@ Http::get('/v1/messaging/topics/:topicId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            )
+            ),
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -2564,13 +2724,13 @@ Http::get('/v1/messaging/topics/:topicId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'topic/' . $topicId;
+        $resource = 'topic/'.$topicId;
         $logs = $audit->getLogsByResource($resource, offset: $offset, limit: $limit);
 
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -2598,14 +2758,14 @@ Http::get('/v1/messaging/topics/:topicId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel']
+                'deviceModel' => $device['deviceModel'],
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -2633,7 +2793,7 @@ Http::get('/v1/messaging/topics/:topicId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TOPIC,
-            )
+            ),
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID.', false, ['dbForProject'])
@@ -2668,12 +2828,12 @@ Http::patch('/v1/messaging/topics/:topicId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TOPIC,
-            )
+            ),
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID.', false, ['dbForProject'])
     ->param('name', null, new Nullable(new Text(128)), 'Topic Name.', true)
-    ->param('subscribe', null, new Nullable(new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
+    ->param('subscribe', null, new Nullable(new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of role strings with subscribe permission. By default all users are granted with any subscribe permission. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' roles are allowed, each 64 characters long.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
@@ -2684,11 +2844,11 @@ Http::patch('/v1/messaging/topics/:topicId')
             throw new Exception(Exception::TOPIC_NOT_FOUND);
         }
 
-        if (!\is_null($name)) {
+        if (! \is_null($name)) {
             $topic->setAttribute('name', $name);
         }
 
-        if (!\is_null($subscribe)) {
+        if (! \is_null($subscribe)) {
             $topic->setAttribute('subscribe', $subscribe);
         }
 
@@ -2719,7 +2879,7 @@ Http::delete('/v1/messaging/topics/:topicId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            )
+            ),
         ],
         contentType: ContentType::NONE
     ))
@@ -2767,7 +2927,7 @@ Http::post('/v1/messaging/topics/:topicId/subscribers')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_SUBSCRIBER,
-            )
+            ),
         ]
     ))
     ->param('subscriberId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Subscriber ID. Choose a custom Subscriber ID or a new Subscriber ID.', false, ['dbForProject'])
@@ -2785,7 +2945,7 @@ Http::post('/v1/messaging/topics/:topicId/subscribers')
         if ($topic->isEmpty()) {
             throw new Exception(Exception::TOPIC_NOT_FOUND);
         }
-        if (!$authorization->isValid(new Input('subscribe', $topic->getAttribute('subscribe')))) {
+        if (! $authorization->isValid(new Input('subscribe', $topic->getAttribute('subscribe')))) {
             throw new Exception(Exception::USER_UNAUTHORIZED, $authorization->getDescription());
         }
 
@@ -2865,11 +3025,11 @@ Http::get('/v1/messaging/topics/:topicId/subscribers')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_SUBSCRIBER_LIST,
-            )
+            ),
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID. The topic ID subscribed to.', false, ['dbForProject'])
-    ->param('queries', [], new Subscribers(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Subscribers::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Subscribers, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Subscribers::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -2882,7 +3042,7 @@ Http::get('/v1/messaging/topics/:topicId/subscribers')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (!empty($search)) {
+        if (! empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -2898,8 +3058,8 @@ Http::get('/v1/messaging/topics/:topicId/subscribers')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor();
-            if (!$validator->isValid($cursor)) {
+            $validator = new Cursor;
+            if (! $validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -2951,11 +3111,11 @@ Http::get('/v1/messaging/subscribers/:subscriberId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            )
+            ),
         ]
     ))
     ->param('subscriberId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Subscriber ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -2979,13 +3139,13 @@ Http::get('/v1/messaging/subscribers/:subscriberId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'subscriber/' . $subscriberId;
+        $resource = 'subscriber/'.$subscriberId;
         $logs = $audit->getLogsByResource($resource, limit: $limit, offset: $offset);
 
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -3013,14 +3173,14 @@ Http::get('/v1/messaging/subscribers/:subscriberId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel']
+                'deviceModel' => $device['deviceModel'],
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -3048,7 +3208,7 @@ Http::get('/v1/messaging/topics/:topicId/subscribers/:subscriberId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_SUBSCRIBER,
-            )
+            ),
         ]
     ))
     ->param('topicId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Topic ID. The topic ID subscribed to.', false, ['dbForProject'])
@@ -3098,7 +3258,7 @@ Http::delete('/v1/messaging/topics/:topicId/subscribers/:subscriberId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            )
+            ),
         ],
         contentType: ContentType::NONE
     ))
@@ -3166,7 +3326,7 @@ Http::post('/v1/messaging/messages/email')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_MESSAGE,
-            )
+            ),
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
@@ -3177,9 +3337,9 @@ Http::post('/v1/messaging/messages/email')
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('cc', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Array of target IDs to be added as CC.', true, ['dbForProject'])
     ->param('bcc', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Array of target IDs to be added as BCC.', true, ['dbForProject'])
-    ->param('attachments', [], new ArrayList(new CompoundUID()), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
-    ->param('draft', false, new Boolean(), 'Is message a draft', true)
-    ->param('html', false, new Boolean(), 'Is content of type HTML', true)
+    ->param('attachments', [], new ArrayList(new CompoundUID), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('draft', false, new Boolean, 'Is message a draft', true)
+    ->param('html', false, new Boolean, 'Is content of type HTML', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -3210,7 +3370,7 @@ Http::post('/v1/messaging/messages/email')
 
         $mergedTargets = \array_merge($targets, $cc, $bcc);
 
-        if (!empty($mergedTargets)) {
+        if (! empty($mergedTargets)) {
             $foundTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $mergedTargets),
                 Query::equal('providerType', [MESSAGE_TYPE_EMAIL]),
@@ -3228,7 +3388,7 @@ Http::post('/v1/messaging/messages/email')
             }
         }
 
-        if (!empty($attachments)) {
+        if (! empty($attachments)) {
             foreach ($attachments as &$attachment) {
                 [$bucketId, $fileId] = CompoundUID::parse($attachment);
 
@@ -3238,7 +3398,7 @@ Http::post('/v1/messaging/messages/email')
                     throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
                 }
 
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
 
                 if ($file->isEmpty()) {
                     throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
@@ -3331,7 +3491,7 @@ Http::post('/v1/messaging/messages/sms')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_MESSAGE,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -3349,16 +3509,16 @@ Http::post('/v1/messaging/messages/sms')
                 new SDKResponse(
                     code: Response::STATUS_CODE_CREATED,
                     model: Response::MODEL_MESSAGE,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('messageId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
     ->param('content', '', new Text(64230), 'SMS Content.')
     ->param('topics', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
-    ->param('draft', false, new Boolean(), 'Is message a draft', true)
+    ->param('draft', false, new Boolean, 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -3387,7 +3547,7 @@ Http::post('/v1/messaging/messages/sms')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (!empty($targets)) {
+        if (! empty($targets)) {
             $foundTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $targets),
                 Query::equal('providerType', [MESSAGE_TYPE_SMS]),
@@ -3478,7 +3638,7 @@ Http::post('/v1/messaging/messages/push')
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
                 model: Response::MODEL_MESSAGE,
-            )
+            ),
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
@@ -3487,18 +3647,18 @@ Http::post('/v1/messaging/messages/push')
     ->param('topics', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
-    ->param('data', null, new Nullable(new JSON()), 'Additional key-value pair data for push notification.', true)
+    ->param('data', null, new Nullable(new JSON), 'Additional key-value pair data for push notification.', true)
     ->param('action', '', new Text(256), 'Action for push notification.', true)
-    ->param('image', '', new CompoundUID(), 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('image', '', new CompoundUID, 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
     ->param('icon', '', new Text(256), 'Icon for push notification. Available only for Android and Web Platform.', true)
     ->param('sound', '', new Text(256), 'Sound for push notification. Available only for Android and iOS Platform.', true)
     ->param('color', '', new Text(256), 'Color for push notification. Available only for Android Platform.', true)
     ->param('tag', '', new Text(256), 'Tag for push notification. Available only for Android Platform.', true)
-    ->param('badge', -1, new Integer(), 'Badge for push notification. Available only for iOS Platform.', true)
-    ->param('draft', false, new Boolean(), 'Is message a draft', true)
+    ->param('badge', -1, new Integer, 'Badge for push notification. Available only for iOS Platform.', true)
+    ->param('draft', false, new Boolean, 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
-    ->param('contentAvailable', false, new Boolean(), 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
-    ->param('critical', false, new Boolean(), 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
+    ->param('contentAvailable', false, new Boolean, 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
+    ->param('critical', false, new Boolean, 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
     ->param('priority', 'high', new WhiteList(['normal', 'high']), 'Set the notification priority. "normal" will consider device state and may not deliver notifications immediately. "high" will always attempt to immediately deliver the notification.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -3528,7 +3688,7 @@ Http::post('/v1/messaging/messages/push')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (!empty($targets)) {
+        if (! empty($targets)) {
             $foundTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $targets),
                 Query::equal('providerType', [MESSAGE_TYPE_PUSH]),
@@ -3546,7 +3706,7 @@ Http::post('/v1/messaging/messages/push')
             }
         }
 
-        if (!empty($image)) {
+        if (! empty($image)) {
             [$bucketId, $fileId] = CompoundUID::parse($image);
 
             $bucket = $dbForProject->getDocument('buckets', $bucketId);
@@ -3554,12 +3714,12 @@ Http::post('/v1/messaging/messages/push')
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+            $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
             if ($file->isEmpty()) {
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            if (!\in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
+            if (! \in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
                 throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
             }
 
@@ -3567,10 +3727,10 @@ Http::post('/v1/messaging/messages/push')
             $endpoint = "$protocol://{$platform['apiHostname']}/v1";
 
             $scheduleTime = $currentScheduledAt ?? $scheduledAt;
-            if (!\is_null($scheduleTime)) {
-                $expiry = (new \DateTime($scheduleTime))->add(new \DateInterval('P15D'))->format('U');
+            if (! \is_null($scheduleTime)) {
+                $expiry = (new \DateTime($scheduleTime))->add(new DateInterval('P15D'))->format('U');
             } else {
-                $expiry = (new \DateTime())->add(new \DateInterval('P15D'))->format('U');
+                $expiry = (new \DateTime)->add(new DateInterval('P15D'))->format('U');
             }
 
             $encoder = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', \intval($expiry), 0);
@@ -3590,31 +3750,31 @@ Http::post('/v1/messaging/messages/push')
 
         $pushData = [];
 
-        if (!empty($title)) {
+        if (! empty($title)) {
             $pushData['title'] = $title;
         }
-        if (!empty($body)) {
+        if (! empty($body)) {
             $pushData['body'] = $body;
         }
-        if (!empty($data)) {
+        if (! empty($data)) {
             $pushData['data'] = $data;
         }
-        if (!empty($action)) {
+        if (! empty($action)) {
             $pushData['action'] = $action;
         }
-        if (!empty($image)) {
+        if (! empty($image)) {
             $pushData['image'] = $image;
         }
-        if (!empty($icon)) {
+        if (! empty($icon)) {
             $pushData['icon'] = $icon;
         }
-        if (!empty($sound)) {
+        if (! empty($sound)) {
             $pushData['sound'] = $sound;
         }
-        if (!empty($color)) {
+        if (! empty($color)) {
             $pushData['color'] = $color;
         }
-        if (!empty($tag)) {
+        if (! empty($tag)) {
             $pushData['tag'] = $tag;
         }
         if ($badge >= 0) {
@@ -3626,7 +3786,7 @@ Http::post('/v1/messaging/messages/push')
         if ($critical) {
             $pushData['critical'] = true;
         }
-        if (!empty($priority)) {
+        if (! empty($priority)) {
             $pushData['priority'] = $priority;
         }
 
@@ -3699,10 +3859,10 @@ Http::get('/v1/messaging/messages')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE_LIST,
-            )
+            ),
         ],
     ))
-    ->param('queries', [], new Messages(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Messages::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Messages, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Messages::ALLOWED_ATTRIBUTES), true)
     ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('dbForProject')
@@ -3715,7 +3875,7 @@ Http::get('/v1/messaging/messages')
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (!empty($search)) {
+        if (! empty($search)) {
             $queries[] = Query::search('search', $search);
         }
 
@@ -3723,8 +3883,8 @@ Http::get('/v1/messaging/messages')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor();
-            if (!$validator->isValid($cursor)) {
+            $validator = new Cursor;
+            if (! $validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -3764,11 +3924,11 @@ Http::get('/v1/messaging/messages/:messageId/logs')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_LOG_LIST,
-            )
+            ),
         ],
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
-    ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
+    ->param('queries', [], new Queries([new Limit, new Offset]), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset', true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -3792,13 +3952,13 @@ Http::get('/v1/messaging/messages/:messageId/logs')
         $limit = $grouped['limit'] ?? 25;
         $offset = $grouped['offset'] ?? 0;
 
-        $resource = 'message/' . $messageId;
+        $resource = 'message/'.$messageId;
         $logs = $audit->getLogsByResource($resource, limit: $limit, offset: $offset);
 
         $output = [];
 
         foreach ($logs as $i => &$log) {
-            $log['userAgent'] = (!empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
+            $log['userAgent'] = (! empty($log['userAgent'])) ? $log['userAgent'] : 'UNKNOWN';
 
             $detector = new Detector($log['userAgent']);
             $detector->skipBotDetection(); // OPTIONAL: If called, bot detection will completely be skipped (bots will be detected as regular devices then)
@@ -3826,14 +3986,14 @@ Http::get('/v1/messaging/messages/:messageId/logs')
                 'clientEngineVersion' => $client['clientEngineVersion'],
                 'deviceName' => $device['deviceName'],
                 'deviceBrand' => $device['deviceBrand'],
-                'deviceModel' => $device['deviceModel']
+                'deviceModel' => $device['deviceModel'],
             ]);
 
             $record = $geodb->get($log['ip']);
 
             if ($record) {
-                $output[$i]['countryCode'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
-                $output[$i]['countryName'] = $locale->getText('countries.' . strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
+                $output[$i]['countryCode'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), false) ? \strtolower($record['country']['iso_code']) : '--';
+                $output[$i]['countryName'] = $locale->getText('countries.'.strtolower($record['country']['iso_code']), $locale->getText('locale.country.unknown'));
             } else {
                 $output[$i]['countryCode'] = '--';
                 $output[$i]['countryName'] = $locale->getText('locale.country.unknown');
@@ -3861,11 +4021,11 @@ Http::get('/v1/messaging/messages/:messageId/targets')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_TARGET_LIST,
-            )
+            ),
         ],
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
-    ->param('queries', [], new Targets(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Targets::ALLOWED_ATTRIBUTES), true)
+    ->param('queries', [], new Targets, 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of '.APP_LIMIT_ARRAY_PARAMS_SIZE.' queries are allowed, each '.APP_LIMIT_ARRAY_ELEMENT_SIZE.' characters long. You may filter on the following attributes: '.implode(', ', Targets::ALLOWED_ATTRIBUTES), true)
     ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
     ->inject('response')
     ->inject('dbForProject')
@@ -3883,6 +4043,7 @@ Http::get('/v1/messaging/messages/:messageId/targets')
                 'targets' => [],
                 'total' => 0,
             ]), Response::MODEL_TARGET_LIST);
+
             return;
         }
 
@@ -3898,8 +4059,8 @@ Http::get('/v1/messaging/messages/:messageId/targets')
         $cursor = \reset($cursor);
 
         if ($cursor !== false) {
-            $validator = new Cursor();
-            if (!$validator->isValid($cursor)) {
+            $validator = new Cursor;
+            if (! $validator->isValid($cursor)) {
                 throw new Exception(Exception::GENERAL_QUERY_INVALID, $validator->getDescription());
             }
 
@@ -3939,7 +4100,7 @@ Http::get('/v1/messaging/messages/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE,
-            )
+            ),
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
@@ -3973,7 +4134,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE,
-            )
+            ),
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
@@ -3982,12 +4143,12 @@ Http::patch('/v1/messaging/messages/email/:messageId')
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('subject', null, new Nullable(new Text(998)), 'Email Subject.', true)
     ->param('content', null, new Nullable(new Text(64230)), 'Email Content.', true)
-    ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
-    ->param('html', null, new Nullable(new Boolean()), 'Is content of type HTML', true)
+    ->param('draft', null, new Nullable(new Boolean), 'Is message a draft', true)
+    ->param('html', null, new Nullable(new Boolean), 'Is content of type HTML', true)
     ->param('cc', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'Array of target IDs to be added as CC.', true, ['dbForProject'])
     ->param('bcc', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'Array of target IDs to be added as BCC.', true, ['dbForProject'])
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
-    ->param('attachments', null, new Nullable(new ArrayList(new CompoundUID())), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('attachments', null, new Nullable(new ArrayList(new CompoundUID)), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('dbForPlatform')
@@ -4001,7 +4162,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             throw new Exception(Exception::MESSAGE_NOT_FOUND);
         }
 
-        if (!\is_null($draft) || !\is_null($scheduledAt)) {
+        if (! \is_null($draft) || ! \is_null($scheduledAt)) {
             if ($draft) {
                 $status = MessageStatus::DRAFT;
             } else {
@@ -4041,11 +4202,11 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (!\is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime()) {
+        if (! \is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime) {
             throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
         }
 
-        if (\is_null($currentScheduledAt) && !\is_null($scheduledAt)) {
+        if (\is_null($currentScheduledAt) && ! \is_null($scheduledAt)) {
             $schedule = $dbForPlatform->createDocument('schedules', new Document([
                 'region' => $project->getAttribute('region'),
                 'resourceType' => SCHEDULE_RESOURCE_TYPE_MESSAGE,
@@ -4060,7 +4221,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             $message->setAttribute('scheduleId', $schedule->getId());
         }
 
-        if (!\is_null($currentScheduledAt)) {
+        if (! \is_null($currentScheduledAt)) {
             $schedule = $dbForPlatform->getDocument('schedules', $message->getAttribute('scheduleId'));
             $scheduledStatus = ($status ?? $message->getAttribute('status')) === MessageStatus::SCHEDULED;
 
@@ -4072,40 +4233,40 @@ Http::patch('/v1/messaging/messages/email/:messageId')
                 ->setAttribute('resourceUpdatedAt', DateTime::now())
                 ->setAttribute('active', $scheduledStatus);
 
-            if (!\is_null($scheduledAt)) {
+            if (! \is_null($scheduledAt)) {
                 $schedule->setAttribute('schedule', $scheduledAt);
             }
 
             $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule);
         }
 
-        if (!\is_null($scheduledAt)) {
+        if (! \is_null($scheduledAt)) {
             $message->setAttribute('scheduledAt', $scheduledAt);
         }
 
-        if (!\is_null($topics)) {
+        if (! \is_null($topics)) {
             $message->setAttribute('topics', $topics);
         }
 
-        if (!\is_null($users)) {
+        if (! \is_null($users)) {
             $message->setAttribute('users', $users);
         }
 
-        if (!\is_null($targets)) {
+        if (! \is_null($targets)) {
             $message->setAttribute('targets', $targets);
         }
 
         $data = $message->getAttribute('data');
 
-        if (!\is_null($subject)) {
+        if (! \is_null($subject)) {
             $data['subject'] = $subject;
         }
 
-        if (!\is_null($content)) {
+        if (! \is_null($content)) {
             $data['content'] = $content;
         }
 
-        if (!is_null($attachments)) {
+        if (! is_null($attachments)) {
             foreach ($attachments as &$attachment) {
                 [$bucketId, $fileId] = CompoundUID::parse($attachment);
 
@@ -4115,7 +4276,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
                     throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
                 }
 
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
 
                 if ($file->isEmpty()) {
                     throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
@@ -4129,21 +4290,21 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             $data['attachments'] = $attachments;
         }
 
-        if (!\is_null($html)) {
+        if (! \is_null($html)) {
             $data['html'] = $html;
         }
 
-        if (!\is_null($cc)) {
+        if (! \is_null($cc)) {
             $data['cc'] = $cc;
         }
 
-        if (!\is_null($bcc)) {
+        if (! \is_null($bcc)) {
             $data['bcc'] = $bcc;
         }
 
         $message->setAttribute('data', $data);
 
-        if (!\is_null($status)) {
+        if (! \is_null($status)) {
             $message->setAttribute('status', $status);
         }
 
@@ -4181,7 +4342,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_MESSAGE,
-                )
+                ),
             ],
             deprecated: new Deprecated(
                 since: '1.8.0',
@@ -4199,16 +4360,16 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
                 new SDKResponse(
                     code: Response::STATUS_CODE_OK,
                     model: Response::MODEL_MESSAGE,
-                )
+                ),
             ]
-        )
+        ),
     ])
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
     ->param('topics', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('content', null, new Nullable(new Text(64230)), 'Email Content.', true)
-    ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
+    ->param('draft', null, new Nullable(new Boolean), 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -4223,7 +4384,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
             throw new Exception(Exception::MESSAGE_NOT_FOUND);
         }
 
-        if (!\is_null($draft) || !\is_null($scheduledAt)) {
+        if (! \is_null($draft) || ! \is_null($scheduledAt)) {
             if ($draft) {
                 $status = MessageStatus::DRAFT;
             } else {
@@ -4263,11 +4424,11 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (!\is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime()) {
+        if (! \is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime) {
             throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
         }
 
-        if (\is_null($currentScheduledAt) && !\is_null($scheduledAt)) {
+        if (\is_null($currentScheduledAt) && ! \is_null($scheduledAt)) {
             $schedule = $dbForPlatform->createDocument('schedules', new Document([
                 'region' => $project->getAttribute('region'),
                 'resourceType' => SCHEDULE_RESOURCE_TYPE_MESSAGE,
@@ -4282,7 +4443,7 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
             $message->setAttribute('scheduleId', $schedule->getId());
         }
 
-        if (!\is_null($currentScheduledAt)) {
+        if (! \is_null($currentScheduledAt)) {
             $schedule = $dbForPlatform->getDocument('schedules', $message->getAttribute('scheduleId'));
             $scheduledStatus = ($status ?? $message->getAttribute('status')) === MessageStatus::SCHEDULED;
 
@@ -4294,38 +4455,38 @@ Http::patch('/v1/messaging/messages/sms/:messageId')
                 ->setAttribute('resourceUpdatedAt', DateTime::now())
                 ->setAttribute('active', $scheduledStatus);
 
-            if (!\is_null($scheduledAt)) {
+            if (! \is_null($scheduledAt)) {
                 $schedule->setAttribute('schedule', $scheduledAt);
             }
 
             $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule);
         }
 
-        if (!\is_null($scheduledAt)) {
+        if (! \is_null($scheduledAt)) {
             $message->setAttribute('scheduledAt', $scheduledAt);
         }
 
-        if (!\is_null($topics)) {
+        if (! \is_null($topics)) {
             $message->setAttribute('topics', $topics);
         }
 
-        if (!\is_null($users)) {
+        if (! \is_null($users)) {
             $message->setAttribute('users', $users);
         }
 
-        if (!\is_null($targets)) {
+        if (! \is_null($targets)) {
             $message->setAttribute('targets', $targets);
         }
 
         $data = $message->getAttribute('data');
 
-        if (!\is_null($content)) {
+        if (! \is_null($content)) {
             $data['content'] = $content;
         }
 
         $message->setAttribute('data', $data);
 
-        if (!\is_null($status)) {
+        if (! \is_null($status)) {
             $message->setAttribute('status', $status);
         }
 
@@ -4362,7 +4523,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
                 model: Response::MODEL_MESSAGE,
-            )
+            ),
         ]
     ))
     ->param('messageId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Message ID.', false, ['dbForProject'])
@@ -4371,18 +4532,18 @@ Http::patch('/v1/messaging/messages/push/:messageId')
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
     ->param('title', null, new Nullable(new Text(256)), 'Title for push notification.', true)
     ->param('body', null, new Nullable(new Text(64230)), 'Body for push notification.', true)
-    ->param('data', null, new Nullable(new JSON()), 'Additional Data for push notification.', true)
+    ->param('data', null, new Nullable(new JSON), 'Additional Data for push notification.', true)
     ->param('action', null, new Nullable(new Text(256)), 'Action for push notification.', true)
-    ->param('image', null, new Nullable(new CompoundUID()), 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
+    ->param('image', null, new Nullable(new CompoundUID), 'Image for push notification. Must be a compound bucket ID to file ID of a jpeg, png, or bmp image in Appwrite Storage. It should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
     ->param('icon', null, new Nullable(new Text(256)), 'Icon for push notification. Available only for Android and Web platforms.', true)
     ->param('sound', null, new Nullable(new Text(256)), 'Sound for push notification. Available only for Android and iOS platforms.', true)
     ->param('color', null, new Nullable(new Text(256)), 'Color for push notification. Available only for Android platforms.', true)
     ->param('tag', null, new Nullable(new Text(256)), 'Tag for push notification. Available only for Android platforms.', true)
-    ->param('badge', null, new Nullable(new Integer()), 'Badge for push notification. Available only for iOS platforms.', true)
-    ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
+    ->param('badge', null, new Nullable(new Integer), 'Badge for push notification. Available only for iOS platforms.', true)
+    ->param('draft', null, new Nullable(new Boolean), 'Is message a draft', true)
     ->param('scheduledAt', null, new Nullable(new DatetimeValidator(requireDateInFuture: true)), 'Scheduled delivery time for message in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. DateTime value must be in future.', true)
-    ->param('contentAvailable', null, new Nullable(new Boolean()), 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
-    ->param('critical', null, new Nullable(new Boolean()), 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
+    ->param('contentAvailable', null, new Nullable(new Boolean), 'If set to true, the notification will be delivered in the background. Available only for iOS Platform.', true)
+    ->param('critical', null, new Nullable(new Boolean), 'If set to true, the notification will be marked as critical. This requires the app to have the critical notification entitlement. Available only for iOS Platform.', true)
     ->param('priority', null, new Nullable(new WhiteList(['normal', 'high'])), 'Set the notification priority. "normal" will consider device battery state and may send notifications later. "high" will always attempt to immediately deliver the notification.', true)
     ->inject('queueForEvents')
     ->inject('dbForProject')
@@ -4398,7 +4559,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             throw new Exception(Exception::MESSAGE_NOT_FOUND);
         }
 
-        if (!\is_null($draft) || !\is_null($scheduledAt)) {
+        if (! \is_null($draft) || ! \is_null($scheduledAt)) {
             if ($draft) {
                 $status = MessageStatus::DRAFT;
             } else {
@@ -4438,11 +4599,11 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             throw new Exception(Exception::MESSAGE_MISSING_SCHEDULE);
         }
 
-        if (!\is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime()) {
+        if (! \is_null($currentScheduledAt) && new \DateTime($currentScheduledAt) < new \DateTime) {
             throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
         }
 
-        if (\is_null($currentScheduledAt) && !\is_null($scheduledAt)) {
+        if (\is_null($currentScheduledAt) && ! \is_null($scheduledAt)) {
             $schedule = $dbForPlatform->createDocument('schedules', new Document([
                 'region' => $project->getAttribute('region'),
                 'resourceType' => SCHEDULE_RESOURCE_TYPE_MESSAGE,
@@ -4457,7 +4618,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
             $message->setAttribute('scheduleId', $schedule->getId());
         }
 
-        if (!\is_null($currentScheduledAt)) {
+        if (! \is_null($currentScheduledAt)) {
             $schedule = $dbForPlatform->getDocument('schedules', $message->getAttribute('scheduleId'));
             $scheduledStatus = ($status ?? $message->getAttribute('status')) === MessageStatus::SCHEDULED;
 
@@ -4469,80 +4630,80 @@ Http::patch('/v1/messaging/messages/push/:messageId')
                 ->setAttribute('resourceUpdatedAt', DateTime::now())
                 ->setAttribute('active', $scheduledStatus);
 
-            if (!\is_null($scheduledAt)) {
+            if (! \is_null($scheduledAt)) {
                 $schedule->setAttribute('schedule', $scheduledAt);
             }
 
             $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule);
         }
 
-        if (!\is_null($scheduledAt)) {
+        if (! \is_null($scheduledAt)) {
             $message->setAttribute('scheduledAt', $scheduledAt);
         }
 
-        if (!\is_null($topics)) {
+        if (! \is_null($topics)) {
             $message->setAttribute('topics', $topics);
         }
 
-        if (!\is_null($users)) {
+        if (! \is_null($users)) {
             $message->setAttribute('users', $users);
         }
 
-        if (!\is_null($targets)) {
+        if (! \is_null($targets)) {
             $message->setAttribute('targets', $targets);
         }
 
         $pushData = $message->getAttribute('data');
 
-        if (!\is_null($title)) {
+        if (! \is_null($title)) {
             $pushData['title'] = $title;
         }
 
-        if (!\is_null($body)) {
+        if (! \is_null($body)) {
             $pushData['body'] = $body;
         }
 
-        if (!\is_null($data)) {
+        if (! \is_null($data)) {
             $pushData['data'] = $data;
         }
 
-        if (!\is_null($action)) {
+        if (! \is_null($action)) {
             $pushData['action'] = $action;
         }
 
-        if (!\is_null($icon)) {
+        if (! \is_null($icon)) {
             $pushData['icon'] = $icon;
         }
 
-        if (!\is_null($sound)) {
+        if (! \is_null($sound)) {
             $pushData['sound'] = $sound;
         }
 
-        if (!\is_null($color)) {
+        if (! \is_null($color)) {
             $pushData['color'] = $color;
         }
 
-        if (!\is_null($tag)) {
+        if (! \is_null($tag)) {
             $pushData['tag'] = $tag;
         }
 
-        if (!\is_null($badge)) {
+        if (! \is_null($badge)) {
             $pushData['badge'] = $badge;
         }
 
-        if (!\is_null($contentAvailable)) {
+        if (! \is_null($contentAvailable)) {
             $pushData['contentAvailable'] = $contentAvailable;
         }
 
-        if (!\is_null($critical)) {
+        if (! \is_null($critical)) {
             $pushData['critical'] = $critical;
         }
 
-        if (!\is_null($priority)) {
+        if (! \is_null($priority)) {
             $pushData['priority'] = $priority;
         }
 
-        if (!\is_null($image)) {
+        if (! \is_null($image)) {
             [$bucketId, $fileId] = CompoundUID::parse($image);
 
             $bucket = $dbForProject->getDocument('buckets', $bucketId);
@@ -4550,20 +4711,20 @@ Http::patch('/v1/messaging/messages/push/:messageId')
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+            $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
             if ($file->isEmpty()) {
                 throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
             }
 
-            if (!\in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
+            if (! \in_array($file->getAttribute('mimeType'), ['image/png', 'image/jpeg'])) {
                 throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
             }
 
             $scheduleTime = $currentScheduledAt ?? $scheduledAt;
-            if (!\is_null($scheduleTime)) {
-                $expiry = (new \DateTime($scheduleTime))->add(new \DateInterval('P15D'))->format('U');
+            if (! \is_null($scheduleTime)) {
+                $expiry = (new \DateTime($scheduleTime))->add(new DateInterval('P15D'))->format('U');
             } else {
-                $expiry = (new \DateTime())->add(new \DateInterval('P15D'))->format('U');
+                $expiry = (new \DateTime)->add(new DateInterval('P15D'))->format('U');
             }
 
             $encoder = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', \intval($expiry), 0);
@@ -4586,7 +4747,7 @@ Http::patch('/v1/messaging/messages/push/:messageId')
 
         $message->setAttribute('data', $pushData);
 
-        if (!\is_null($status)) {
+        if (! \is_null($status)) {
             $message->setAttribute('status', $status);
         }
 
@@ -4623,7 +4784,7 @@ Http::delete('/v1/messaging/messages/:messageId')
             new SDKResponse(
                 code: Response::STATUS_CODE_NOCONTENT,
                 model: Response::MODEL_NONE,
-            )
+            ),
         ],
         contentType: ContentType::NONE
     ))
@@ -4653,7 +4814,7 @@ Http::delete('/v1/messaging/messages/:messageId')
                     throw new Exception(Exception::MESSAGE_ALREADY_SCHEDULED);
                 }
 
-                if (!empty($scheduleId)) {
+                if (! empty($scheduleId)) {
                     try {
                         $dbForPlatform->deleteDocument('schedules', $scheduleId);
                     } catch (Exception) {

--- a/docs/references/messaging/create-telnyx-provider.md
+++ b/docs/references/messaging/create-telnyx-provider.md
@@ -1,0 +1,1 @@
+Create a new Telnyx provider.

--- a/docs/references/messaging/update-telnyx-provider.md
+++ b/docs/references/messaging/update-telnyx-provider.md
@@ -1,0 +1,1 @@
+Update a Telnyx provider by its unique ID.

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -820,7 +820,7 @@ class Messaging extends Action
                     'apiSecret' => $password,
                 ],
                 'telnyx' => [
-                    'apiKey' => $password ?: $user,
+                    'apiKey' => $password,
                 ],
                 'fast2sms' => [
                     'senderId' => $user,

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -31,8 +31,8 @@ use Utopia\Messaging\Adapter\SMS\GEOSMS;
 use Utopia\Messaging\Adapter\SMS\Inforu;
 use Utopia\Messaging\Adapter\SMS\Mock;
 use Utopia\Messaging\Adapter\SMS\Msg91;
-use Utopia\Messaging\Adapter\SMS\Telesign;
 use Utopia\Messaging\Adapter\SMS\Telnyx;
+use Utopia\Messaging\Adapter\SMS\Telesign;
 use Utopia\Messaging\Adapter\SMS\TextMagic;
 use Utopia\Messaging\Adapter\SMS\Twilio;
 use Utopia\Messaging\Adapter\SMS\Vonage;
@@ -79,6 +79,13 @@ class Messaging extends Action
     }
 
     /**
+     * @param Message $message
+     * @param Document $project
+     * @param Log $log
+     * @param Database $dbForProject
+     * @param Device $deviceForFiles
+     * @param UsagePublisher $publisherForUsage
+     * @return void
      * @throws \Exception
      */
     public function action(
@@ -114,7 +121,7 @@ class Messaging extends Action
                     $this->sendExternalMessage($dbForProject, $message, $deviceForFiles, $project, $publisherForUsage);
                     break;
                 default:
-                    throw new \Exception('Unknown message type: '.$type);
+                    throw new \Exception('Unknown message type: ' . $type);
             }
         } catch (\Throwable $e) {
             Span::error($e);
@@ -182,11 +189,10 @@ class Messaging extends Action
         if (empty($allTargets)) {
             $dbForProject->updateDocument('messages', $message->getId(), new Document([
                 'status' => MessageStatus::FAILED,
-                'deliveryErrors' => ['No valid recipients found.'],
+                'deliveryErrors' => ['No valid recipients found.']
             ]));
 
             Span::add('message.skipped', 'no_valid_recipients');
-
             return;
         }
 
@@ -198,11 +204,10 @@ class Messaging extends Action
         if ($default->isEmpty()) {
             $dbForProject->updateDocument('messages', $message->getId(), new Document([
                 'status' => MessageStatus::FAILED,
-                'deliveryErrors' => ['No enabled provider found.'],
+                'deliveryErrors' => ['No enabled provider found.']
             ]));
 
             Span::add('message.skipped', 'no_enabled_provider');
-
             return;
         }
 
@@ -215,18 +220,18 @@ class Messaging extends Action
          * @var array<Document> $providers
          */
         $providers = [
-            $default->getId() => $default,
+            $default->getId() => $default
         ];
 
         foreach ($allTargets as $target) {
             $providerId = $target->getAttribute('providerId');
 
-            if (! $providerId) {
+            if (!$providerId) {
                 $providerId = $default->getId();
             }
 
             if ($providerId) {
-                if (! \array_key_exists($providerId, $identifiers)) {
+                if (!\array_key_exists($providerId, $identifiers)) {
                     $identifiers[$providerId] = [];
                 }
                 // Use null as value to avoid duplicate keys
@@ -244,7 +249,7 @@ class Messaging extends Action
                 } else {
                     $provider = $dbForProject->getDocument('providers', $providerId);
 
-                    if ($provider->isEmpty() || ! $provider->getAttribute('enabled')) {
+                    if ($provider->isEmpty() || !$provider->getAttribute('enabled')) {
                         $provider = $default;
                     } else {
                         $providers[$providerId] = $provider;
@@ -288,12 +293,12 @@ class Messaging extends Action
                                 }
 
                                 // Deleting push targets when token has expired.
-                                if (($result['error'] ?? '') === 'Expired device token') {
+                                if (($result['error'] ??  '') === 'Expired device token') {
                                     $target = $dbForProject->findOne('targets', [
-                                        Query::equal('identifier', [$result['recipient']]),
+                                        Query::equal('identifier', [$result['recipient']])
                                     ]);
 
-                                    if (! $target->isEmpty()) {
+                                    if (!$target->isEmpty()) {
                                         $dbForProject->updateDocument(
                                             'targets',
                                             $target->getId(),
@@ -305,10 +310,10 @@ class Messaging extends Action
                                 }
                             }
                         } catch (\Throwable $e) {
-                            $deliveryErrors[] = 'Failed sending to targets with error: '.$e->getMessage();
+                            $deliveryErrors[] = 'Failed sending to targets with error: ' . $e->getMessage();
                         } finally {
                             $errorTotal = \count($deliveryErrors);
-                            $usage = new UsageContext;
+                            $usage = new UsageContext();
                             $usage
                                 ->addMetric(METRIC_MESSAGES, ($deliveredTotal + $errorTotal))
                                 ->addMetric(METRIC_MESSAGES_SENT, $deliveredTotal)
@@ -395,7 +400,7 @@ class Messaging extends Action
                     throw new \Exception('Storage bucket with the requested ID could not be found');
                 }
 
-                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
                 if ($file->isEmpty()) {
                     throw new \Exception('Storage file with the requested ID could not be found');
                 }
@@ -427,7 +432,6 @@ class Messaging extends Action
         $denyList = explode(',', $denyList);
         if (\in_array($project->getId(), $denyList)) {
             Span::add('message.skipped', 'project_denied');
-
             return;
         }
 
@@ -449,6 +453,7 @@ class Messaging extends Action
 
         $this->adapter->send($sms);
     }
+
 
     private function getSmsAdapter(Document $provider): ?SMSAdapter
     {
@@ -477,7 +482,7 @@ class Messaging extends Action
             ),
             'vonage' => new Vonage(
                 $credentials['apiKey'] ?? '',
-                $credentials['apiSecret'] ?? ''
+                $credentials['apiSecret'] ??  ''
             ),
             'telnyx' => new Telnyx(
                 $credentials['apiKey'] ?? ''
@@ -524,13 +529,13 @@ class Messaging extends Action
         return match ($provider->getAttribute('provider')) {
             'mock' => new Mock('username', 'password'),
             'smtp' => new SMTP(
-                $credentials['host'] ?? '',
+                $credentials['host'] ??  '',
                 $credentials['port'] ?? 25,
                 $credentials['username'] ?? '',
                 $credentials['password'] ?? '',
                 $options['encryption'] ?? '',
-                $options['autoTLS'] ?? false,
-                $options['mailer'] ?? '',
+                $options['autoTLS'] ??  false,
+                $options['mailer'] ??  '',
             ),
             'mailgun' => new Mailgun(
                 $apiKey,
@@ -561,7 +566,7 @@ class Messaging extends Action
         $bcc = [];
         $attachments = $data['attachments'] ?? [];
 
-        if (! empty($ccTargets)) {
+        if (!empty($ccTargets)) {
             $ccTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $ccTargets),
                 Query::limit(\count($ccTargets)),
@@ -571,7 +576,7 @@ class Messaging extends Action
             }
         }
 
-        if (! empty($bccTargets)) {
+        if (!empty($bccTargets)) {
             $bccTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $bccTargets),
                 Query::limit(\count($bccTargets)),
@@ -581,7 +586,7 @@ class Messaging extends Action
             }
         }
 
-        if (! empty($attachments)) {
+        if (!empty($attachments)) {
             foreach ($attachments as &$attachment) {
                 $bucketId = $attachment['bucketId'];
                 $fileId = $attachment['fileId'];
@@ -591,7 +596,7 @@ class Messaging extends Action
                     throw new \Exception('Storage bucket with the requested ID could not be found');
                 }
 
-                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
                 if ($file->isEmpty()) {
                     throw new \Exception('Storage file with the requested ID could not be found');
                 }
@@ -599,8 +604,8 @@ class Messaging extends Action
                 $mimes = Config::getParam('storage-mimes');
                 $path = $file->getAttribute('path', '');
 
-                if (! $deviceForFiles->exists($path)) {
-                    throw new \Exception('File not found in '.$path);
+                if (!$deviceForFiles->exists($path)) {
+                    throw new \Exception('File not found in ' . $path);
                 }
 
                 $contentType = 'text/plain';
@@ -712,7 +717,7 @@ class Messaging extends Action
     private function getLocalDevice($project): Local
     {
         if ($this->localDevice === null) {
-            $this->localDevice = new Local(APP_STORAGE_UPLOADS.'/app-'.$project->getId());
+            $this->localDevice = new Local(APP_STORAGE_UPLOADS . '/app-' . $project->getId());
         }
 
         return $this->localDevice;
@@ -727,7 +732,7 @@ class Messaging extends Action
         $providers = System::getEnv('_APP_SMS_PROVIDER', '');
 
         $dsns = [];
-        if (! empty($providers)) {
+        if (!empty($providers)) {
             $providers = explode(',', $providers);
             foreach ($providers as $provider) {
                 $dsns[] = new DSN($provider);
@@ -737,7 +742,6 @@ class Messaging extends Action
         if (count($dsns) === 1) {
             $provider = $this->createProviderFromDSN($dsns[0]);
             $adapter = $this->getSmsAdapter($provider);
-
             return $adapter;
         }
 
@@ -777,7 +781,6 @@ class Messaging extends Action
 
             $geosms->setLocal($callingCode, $adapter);
         }
-
         return $geosms;
     }
 
@@ -800,15 +803,15 @@ class Messaging extends Action
                     'authToken' => $password,
                     // Twilio Messaging Service SIDs always start with MG
                     // https://www.twilio.com/docs/messaging/services
-                    'messagingServiceSid' => \str_starts_with($from, 'MG') ? $from : null,
+                    'messagingServiceSid' => \str_starts_with($from, 'MG') ? $from : null
                 ],
                 'textmagic' => [
                     'username' => $user,
-                    'apiKey' => $password,
+                    'apiKey' => $password
                 ],
                 'telesign' => [
                     'customerId' => $user,
-                    'apiKey' => $password,
+                    'apiKey' => $password
                 ],
                 'msg91' => [
                     'senderId' => $user,
@@ -817,7 +820,7 @@ class Messaging extends Action
                 ],
                 'vonage' => [
                     'apiKey' => $user,
-                    'apiSecret' => $password,
+                    'apiSecret' => $password
                 ],
                 'telnyx' => [
                     'apiKey' => $password,
@@ -836,12 +839,12 @@ class Messaging extends Action
             },
             'options' => match ($host) {
                 'twilio' => [
-                    'from' => \str_starts_with($from, 'MG') ? null : $from,
+                    'from' => \str_starts_with($from, 'MG') ? null : $from
                 ],
                 default => [
-                    'from' => $from,
+                    'from' => $from
                 ]
-            },
+            }
         ]);
 
         return $provider;

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -297,7 +297,9 @@ class Messaging extends Action
                                         $dbForProject->updateDocument(
                                             'targets',
                                             $target->getId(),
-                                            $target->setAttribute('expired', true)
+                                            new Document([
+                                                'expired' => true,
+                                            ])
                                         );
                                     }
                                 }

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -478,8 +478,7 @@ class Messaging extends Action
                 $credentials['apiSecret'] ?? ''
             ),
             'telnyx' => new Telnyx(
-                $credentials['apiKey'] ?? '',
-                $provider->getAttribute('options')['from'] ?? null
+                $credentials['apiKey'] ?? ''
             ),
             'fast2sms' => new Fast2SMS(
                 $credentials['apiKey'] ?? '',

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -32,6 +32,7 @@ use Utopia\Messaging\Adapter\SMS\Inforu;
 use Utopia\Messaging\Adapter\SMS\Mock;
 use Utopia\Messaging\Adapter\SMS\Msg91;
 use Utopia\Messaging\Adapter\SMS\Telesign;
+use Utopia\Messaging\Adapter\SMS\Telnyx;
 use Utopia\Messaging\Adapter\SMS\TextMagic;
 use Utopia\Messaging\Adapter\SMS\Twilio;
 use Utopia\Messaging\Adapter\SMS\Vonage;
@@ -78,13 +79,6 @@ class Messaging extends Action
     }
 
     /**
-     * @param Message $message
-     * @param Document $project
-     * @param Log $log
-     * @param Database $dbForProject
-     * @param Device $deviceForFiles
-     * @param UsagePublisher $publisherForUsage
-     * @return void
      * @throws \Exception
      */
     public function action(
@@ -120,7 +114,7 @@ class Messaging extends Action
                     $this->sendExternalMessage($dbForProject, $message, $deviceForFiles, $project, $publisherForUsage);
                     break;
                 default:
-                    throw new \Exception('Unknown message type: ' . $type);
+                    throw new \Exception('Unknown message type: '.$type);
             }
         } catch (\Throwable $e) {
             Span::error($e);
@@ -188,10 +182,11 @@ class Messaging extends Action
         if (empty($allTargets)) {
             $dbForProject->updateDocument('messages', $message->getId(), $message->setAttributes([
                 'status' => MessageStatus::FAILED,
-                'deliveryErrors' => ['No valid recipients found.']
+                'deliveryErrors' => ['No valid recipients found.'],
             ]));
 
             Span::add('message.skipped', 'no_valid_recipients');
+
             return;
         }
 
@@ -203,10 +198,11 @@ class Messaging extends Action
         if ($default->isEmpty()) {
             $dbForProject->updateDocument('messages', $message->getId(), $message->setAttributes([
                 'status' => MessageStatus::FAILED,
-                'deliveryErrors' => ['No enabled provider found.']
+                'deliveryErrors' => ['No enabled provider found.'],
             ]));
 
             Span::add('message.skipped', 'no_enabled_provider');
+
             return;
         }
 
@@ -219,18 +215,18 @@ class Messaging extends Action
          * @var array<Document> $providers
          */
         $providers = [
-            $default->getId() => $default
+            $default->getId() => $default,
         ];
 
         foreach ($allTargets as $target) {
             $providerId = $target->getAttribute('providerId');
 
-            if (!$providerId) {
+            if (! $providerId) {
                 $providerId = $default->getId();
             }
 
             if ($providerId) {
-                if (!\array_key_exists($providerId, $identifiers)) {
+                if (! \array_key_exists($providerId, $identifiers)) {
                     $identifiers[$providerId] = [];
                 }
                 // Use null as value to avoid duplicate keys
@@ -248,7 +244,7 @@ class Messaging extends Action
                 } else {
                     $provider = $dbForProject->getDocument('providers', $providerId);
 
-                    if ($provider->isEmpty() || !$provider->getAttribute('enabled')) {
+                    if ($provider->isEmpty() || ! $provider->getAttribute('enabled')) {
                         $provider = $default;
                     } else {
                         $providers[$providerId] = $provider;
@@ -292,12 +288,12 @@ class Messaging extends Action
                                 }
 
                                 // Deleting push targets when token has expired.
-                                if (($result['error'] ??  '') === 'Expired device token') {
+                                if (($result['error'] ?? '') === 'Expired device token') {
                                     $target = $dbForProject->findOne('targets', [
-                                        Query::equal('identifier', [$result['recipient']])
+                                        Query::equal('identifier', [$result['recipient']]),
                                     ]);
 
-                                    if (!$target->isEmpty()) {
+                                    if (! $target->isEmpty()) {
                                         $dbForProject->updateDocument(
                                             'targets',
                                             $target->getId(),
@@ -307,10 +303,10 @@ class Messaging extends Action
                                 }
                             }
                         } catch (\Throwable $e) {
-                            $deliveryErrors[] = 'Failed sending to targets with error: ' . $e->getMessage();
+                            $deliveryErrors[] = 'Failed sending to targets with error: '.$e->getMessage();
                         } finally {
                             $errorTotal = \count($deliveryErrors);
-                            $usage = new UsageContext();
+                            $usage = new UsageContext;
                             $usage
                                 ->addMetric(METRIC_MESSAGES, ($deliveredTotal + $errorTotal))
                                 ->addMetric(METRIC_MESSAGES_SENT, $deliveredTotal)
@@ -397,7 +393,7 @@ class Messaging extends Action
                     throw new \Exception('Storage bucket with the requested ID could not be found');
                 }
 
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
                 if ($file->isEmpty()) {
                     throw new \Exception('Storage file with the requested ID could not be found');
                 }
@@ -429,6 +425,7 @@ class Messaging extends Action
         $denyList = explode(',', $denyList);
         if (\in_array($project->getId(), $denyList)) {
             Span::add('message.skipped', 'project_denied');
+
             return;
         }
 
@@ -450,7 +447,6 @@ class Messaging extends Action
 
         $this->adapter->send($sms);
     }
-
 
     private function getSmsAdapter(Document $provider): ?SMSAdapter
     {
@@ -479,7 +475,11 @@ class Messaging extends Action
             ),
             'vonage' => new Vonage(
                 $credentials['apiKey'] ?? '',
-                $credentials['apiSecret'] ??  ''
+                $credentials['apiSecret'] ?? ''
+            ),
+            'telnyx' => new Telnyx(
+                $credentials['apiKey'] ?? '',
+                $provider->getAttribute('options')['from'] ?? null
             ),
             'fast2sms' => new Fast2SMS(
                 $credentials['apiKey'] ?? '',
@@ -523,13 +523,13 @@ class Messaging extends Action
         return match ($provider->getAttribute('provider')) {
             'mock' => new Mock('username', 'password'),
             'smtp' => new SMTP(
-                $credentials['host'] ??  '',
+                $credentials['host'] ?? '',
                 $credentials['port'] ?? 25,
                 $credentials['username'] ?? '',
                 $credentials['password'] ?? '',
                 $options['encryption'] ?? '',
-                $options['autoTLS'] ??  false,
-                $options['mailer'] ??  '',
+                $options['autoTLS'] ?? false,
+                $options['mailer'] ?? '',
             ),
             'mailgun' => new Mailgun(
                 $apiKey,
@@ -560,7 +560,7 @@ class Messaging extends Action
         $bcc = [];
         $attachments = $data['attachments'] ?? [];
 
-        if (!empty($ccTargets)) {
+        if (! empty($ccTargets)) {
             $ccTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $ccTargets),
                 Query::limit(\count($ccTargets)),
@@ -570,7 +570,7 @@ class Messaging extends Action
             }
         }
 
-        if (!empty($bccTargets)) {
+        if (! empty($bccTargets)) {
             $bccTargets = $dbForProject->find('targets', [
                 Query::equal('$id', $bccTargets),
                 Query::limit(\count($bccTargets)),
@@ -580,7 +580,7 @@ class Messaging extends Action
             }
         }
 
-        if (!empty($attachments)) {
+        if (! empty($attachments)) {
             foreach ($attachments as &$attachment) {
                 $bucketId = $attachment['bucketId'];
                 $fileId = $attachment['fileId'];
@@ -590,7 +590,7 @@ class Messaging extends Action
                     throw new \Exception('Storage bucket with the requested ID could not be found');
                 }
 
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+                $file = $dbForProject->getDocument('bucket_'.$bucket->getSequence(), $fileId);
                 if ($file->isEmpty()) {
                     throw new \Exception('Storage file with the requested ID could not be found');
                 }
@@ -598,8 +598,8 @@ class Messaging extends Action
                 $mimes = Config::getParam('storage-mimes');
                 $path = $file->getAttribute('path', '');
 
-                if (!$deviceForFiles->exists($path)) {
-                    throw new \Exception('File not found in ' . $path);
+                if (! $deviceForFiles->exists($path)) {
+                    throw new \Exception('File not found in '.$path);
                 }
 
                 $contentType = 'text/plain';
@@ -711,7 +711,7 @@ class Messaging extends Action
     private function getLocalDevice($project): Local
     {
         if ($this->localDevice === null) {
-            $this->localDevice = new Local(APP_STORAGE_UPLOADS . '/app-' . $project->getId());
+            $this->localDevice = new Local(APP_STORAGE_UPLOADS.'/app-'.$project->getId());
         }
 
         return $this->localDevice;
@@ -726,7 +726,7 @@ class Messaging extends Action
         $providers = System::getEnv('_APP_SMS_PROVIDER', '');
 
         $dsns = [];
-        if (!empty($providers)) {
+        if (! empty($providers)) {
             $providers = explode(',', $providers);
             foreach ($providers as $provider) {
                 $dsns[] = new DSN($provider);
@@ -736,6 +736,7 @@ class Messaging extends Action
         if (count($dsns) === 1) {
             $provider = $this->createProviderFromDSN($dsns[0]);
             $adapter = $this->getSmsAdapter($provider);
+
             return $adapter;
         }
 
@@ -775,6 +776,7 @@ class Messaging extends Action
 
             $geosms->setLocal($callingCode, $adapter);
         }
+
         return $geosms;
     }
 
@@ -797,15 +799,15 @@ class Messaging extends Action
                     'authToken' => $password,
                     // Twilio Messaging Service SIDs always start with MG
                     // https://www.twilio.com/docs/messaging/services
-                    'messagingServiceSid' => \str_starts_with($from, 'MG') ? $from : null
+                    'messagingServiceSid' => \str_starts_with($from, 'MG') ? $from : null,
                 ],
                 'textmagic' => [
                     'username' => $user,
-                    'apiKey' => $password
+                    'apiKey' => $password,
                 ],
                 'telesign' => [
                     'customerId' => $user,
-                    'apiKey' => $password
+                    'apiKey' => $password,
                 ],
                 'msg91' => [
                     'senderId' => $user,
@@ -814,7 +816,10 @@ class Messaging extends Action
                 ],
                 'vonage' => [
                     'apiKey' => $user,
-                    'apiSecret' => $password
+                    'apiSecret' => $password,
+                ],
+                'telnyx' => [
+                    'apiKey' => $password ?: $user,
                 ],
                 'fast2sms' => [
                     'senderId' => $user,
@@ -830,12 +835,12 @@ class Messaging extends Action
             },
             'options' => match ($host) {
                 'twilio' => [
-                    'from' => \str_starts_with($from, 'MG') ? null : $from
+                    'from' => \str_starts_with($from, 'MG') ? null : $from,
                 ],
                 default => [
-                    'from' => $from
+                    'from' => $from,
                 ]
-            }
+            },
         ]);
 
         return $provider;

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -180,7 +180,7 @@ class Messaging extends Action
         }
 
         if (empty($allTargets)) {
-            $dbForProject->updateDocument('messages', $message->getId(), $message->setAttributes([
+            $dbForProject->updateDocument('messages', $message->getId(), new Document([
                 'status' => MessageStatus::FAILED,
                 'deliveryErrors' => ['No valid recipients found.'],
             ]));
@@ -196,7 +196,7 @@ class Messaging extends Action
         ]);
 
         if ($default->isEmpty()) {
-            $dbForProject->updateDocument('messages', $message->getId(), $message->setAttributes([
+            $dbForProject->updateDocument('messages', $message->getId(), new Document([
                 'status' => MessageStatus::FAILED,
                 'deliveryErrors' => ['No enabled provider found.'],
             ]));

--- a/tests/e2e/Services/GraphQL/Base.php
+++ b/tests/e2e/Services/GraphQL/Base.php
@@ -9,340 +9,586 @@ trait Base
 {
     // Databases
     public const string CREATE_DATABASE = 'create_database';
+
     public const string GET_DATABASES = 'get_databases';
+
     public const string GET_DATABASE = 'get_database';
+
     public const string UPDATE_DATABASE = 'update_database';
+
     public const string DELETE_DATABASE = 'delete_database';
 
     // Collections
     public const string CREATE_COLLECTION = 'create_collection';
+
     public const string GET_COLLECTION = 'get_collection';
+
     public const string GET_COLLECTIONS = 'list_collections';
+
     public const string UPDATE_COLLECTION = 'update_collection';
+
     public const string DELETE_COLLECTION = 'delete_collection';
 
     // Grid databases
     public const string TABLESDB_CREATE_DATABASE = 'tablesdb_create_database';
+
     public const string TABLESDB_GET_DATABASES = 'tablesdb_get_databases';
+
     public const string TABLESDB_GET_DATABASE = 'tablesdb_get_database';
+
     public const string TABLESDB_UPDATE_DATABASE = 'tablesdb_update_database';
+
     public const string TABLESDB_DELETE_DATABASE = 'tablesdb_delete_database';
 
     // Grid tables
     public const string CREATE_TABLE = 'create_table';
+
     public const string GET_TABLE = 'get_table';
+
     public const string GET_TABLES = 'list_tables';
+
     public const string UPDATE_TABLE = 'update_table';
+
     public const string DELETE_TABLE = 'delete_table';
 
     // Attributes
     public const string CREATE_STRING_ATTRIBUTE = 'create_string_attribute';
+
     public const string CREATE_INTEGER_ATTRIBUTE = 'create_integer_attribute';
+
     public const string CREATE_FLOAT_ATTRIBUTE = 'create_float_attribute';
+
     public const string CREATE_BOOLEAN_ATTRIBUTE = 'create_boolean_attribute';
+
     public const string CREATE_URL_ATTRIBUTE = 'create_url_attribute';
+
     public const string CREATE_EMAIL_ATTRIBUTE = 'create_email_attribute';
+
     public const string CREATE_IP_ATTRIBUTE = 'create_ip_attribute';
+
     public const string CREATE_ENUM_ATTRIBUTE = 'create_enum_attribute';
+
     public const string CREATE_DATETIME_ATTRIBUTE = 'create_datetime_attribute';
+
     public const string CREATE_POINT_ATTRIBUTE = 'create_point_attribute';
+
     public const string CREATE_LINE_ATTRIBUTE = 'create_line_attribute';
+
     public const string CREATE_POLYGON_ATTRIBUTE = 'create_polygon_attribute';
 
     public const string CREATE_RELATIONSHIP_ATTRIBUTE = 'create_relationship_attribute';
+
     public const string UPDATE_STRING_ATTRIBUTE = 'update_string_attribute';
+
     public const string UPDATE_INTEGER_ATTRIBUTE = 'update_integer_attribute';
+
     public const string UPDATE_FLOAT_ATTRIBUTE = 'update_float_attribute';
+
     public const string UPDATE_BOOLEAN_ATTRIBUTE = 'update_boolean_attribute';
+
     public const string UPDATE_URL_ATTRIBUTE = 'update_url_attribute';
+
     public const string UPDATE_EMAIL_ATTRIBUTE = 'update_email_attribute';
+
     public const string UPDATE_IP_ATTRIBUTE = 'update_ip_attribute';
+
     public const string UPDATE_ENUM_ATTRIBUTE = 'update_enum_attribute';
+
     public const string UPDATE_DATETIME_ATTRIBUTE = 'update_datetime_attribute';
+
     public const string UPDATE_POINT_ATTRIBUTE = 'update_point_attribute';
+
     public const string UPDATE_LINE_ATTRIBUTE = 'update_line_attribute';
+
     public const string UPDATE_POLYGON_ATTRIBUTE = 'update_polygon_attribute';
 
     public const string UPDATE_RELATIONSHIP_ATTRIBUTE = 'update_relationship_attribute';
+
     public const string GET_ATTRIBUTES = 'get_attributes';
+
     public const string GET_ATTRIBUTE = 'get_attribute';
+
     public const string DELETE_ATTRIBUTE = 'delete_attribute';
 
     // TablesDB columns
     public const string CREATE_STRING_COLUMN = 'create_string_column';
+
     public const string CREATE_INTEGER_COLUMN = 'create_integer_column';
+
     public const string CREATE_FLOAT_COLUMN = 'create_float_column';
+
     public const string CREATE_BOOLEAN_COLUMN = 'create_boolean_column';
+
     public const string CREATE_URL_COLUMN = 'create_url_column';
+
     public const string CREATE_EMAIL_COLUMN = 'create_email_column';
+
     public const string CREATE_IP_COLUMN = 'create_ip_column';
+
     public const string CREATE_ENUM_COLUMN = 'create_enum_column';
+
     public const string CREATE_DATETIME_COLUMN = 'create_datetime_column';
+
     public const string CREATE_POINT_COLUMN = 'create_point_column';
+
     public const string CREATE_LINE_COLUMN = 'create_line_column';
+
     public const string CREATE_POLYGON_COLUMN = 'create_polygon_column';
 
     public const string CREATE_RELATIONSHIP_COLUMN = 'create_relationship_column';
+
     public const string UPDATE_STRING_COLUMN = 'update_string_column';
+
     public const string UPDATE_INTEGER_COLUMN = 'update_integer_column';
+
     public const string UPDATE_FLOAT_COLUMN = 'update_float_column';
+
     public const string UPDATE_BOOLEAN_COLUMN = 'update_boolean_column';
+
     public const string UPDATE_URL_COLUMN = 'update_url_column';
+
     public const string UPDATE_EMAIL_COLUMN = 'update_email_column';
+
     public const string UPDATE_IP_COLUMN = 'update_ip_column';
+
     public const string UPDATE_ENUM_COLUMN = 'update_enum_column';
+
     public const string UPDATE_DATETIME_COLUMN = 'update_datetime_column';
+
     public const string UPDATE_POINT_COLUMN = 'update_point_column';
+
     public const string UPDATE_LINE_COLUMN = 'update_line_column';
+
     public const string UPDATE_POLYGON_COLUMN = 'update_polygon_column';
 
     public const string UPDATE_RELATIONSHIP_COLUMN = 'update_relationship_column';
+
     public const string GET_COLUMNS = 'get_columns';
+
     public const string GET_COLUMN = 'get_column';
+
     public const string DELETE_COLUMN = 'delete_column';
 
     // Attribute Indexes
     public const string CREATE_INDEX = 'create_attribute_index';
+
     public const string GET_INDEXES = 'get_attribute_indexes';
+
     public const string GET_INDEX = 'get_attribute_index';
+
     public const string DELETE_INDEX = 'delete_attribute_index';
 
     // Grid column indexes
     public const string CREATE_COLUMN_INDEX = 'create_column_index';
+
     public const string GET_COLUMN_INDEXES = 'get_column_indexes';
+
     public const string GET_COLUMN_INDEX = 'get_column_index';
+
     public const string DELETE_COLUMN_INDEX = 'delete_column_index';
 
     // Documents
     public const string CREATE_DOCUMENT = 'create_document_rest';
+
     public const string GET_DOCUMENTS = 'list_documents';
+
     public const string GET_DOCUMENT = 'get_document';
+
     public const string UPDATE_DOCUMENT = 'update_document';
-    public const string UPSERT_DOCUMENT  = 'upsert_document';
+
+    public const string UPSERT_DOCUMENT = 'upsert_document';
+
     public const string DELETE_DOCUMENT = 'delete_document';
 
     // Documents - Bulk APIs
     public const string CREATE_DOCUMENTS = 'create_documents_rest';
+
     public const string UPDATE_DOCUMENTS = 'update_documents';
+
     public const string UPSERT_DOCUMENTS = 'upsert_documents';
+
     public const string DELETE_DOCUMENTS = 'delete_documents';
 
     // Grid rows
     public const string CREATE_ROW = 'create_row_rest';
+
     public const string GET_ROWS = 'list_rows';
+
     public const string GET_ROW = 'get_row';
+
     public const string UPDATE_ROW = 'update_row';
-    public const string UPSERT_ROW  = 'upsert_row';
+
+    public const string UPSERT_ROW = 'upsert_row';
+
     public const string DELETE_ROW = 'delete_row';
 
     // Grid rows - Bulk APIs
     public const string CREATE_ROWS = 'create_rows_rest';
+
     public const string UPDATE_ROWS = 'update_rows';
+
     public const string UPSERT_ROWS = 'upsert_rows';
+
     public const string DELETE_ROWS = 'delete_rows';
 
     // Custom Entities
     public const string CREATE_CUSTOM_ENTITY = 'create_custom_entity';
+
     public const string GET_CUSTOM_ENTITIES = 'get_custom_entities';
+
     public const string GET_CUSTOM_ENTITY = 'get_custom_entity';
+
     public const string UPDATE_CUSTOM_ENTITY = 'update_custom_entity';
+
     public const string DELETE_CUSTOM_ENTITY = 'delete_custom_entity';
 
     // Account
     public const string CREATE_ACCOUNT = 'create_account';
+
     public const string CREATE_ACCOUNT_SESSION = 'create_account_session';
+
     public const string CREATE_ANONYMOUS_SESSION = 'create_anonymous_session';
+
     public const string CREATE_ACCOUNT_JWT = 'create_account_jwt';
+
     public const string CREATE_MAGIC_URL = 'create_magic_url';
+
     public const string CREATE_PASSWORD_RECOVERY = 'create_password_recovery';
+
     public const string CREATE_EMAIL_VERIFICATION = 'create_email_verification';
+
     public const string CREATE_PHONE_VERIFICATION = 'create_phone_verification';
+
     public const string GET_ACCOUNT = 'get_account';
+
     public const string GET_ACCOUNT_SESSION = 'get_account_session';
+
     public const string GET_ACCOUNT_SESSIONS = 'get_account_sessions';
+
     public const string GET_ACCOUNT_PREFS = 'get_account_preferences';
+
     public const string GET_ACCOUNT_LOGS = 'get_account_logs';
+
     public const string UPDATE_ACCOUNT_NAME = 'update_account_name';
+
     public const string UPDATE_ACCOUNT_EMAIL = 'update_account_email';
+
     public const string UPDATE_ACCOUNT_PASSWORD = 'update_account_password';
+
     public const string UPDATE_ACCOUNT_PREFS = 'update_account_prefs';
+
     public const string UPDATE_ACCOUNT_PHONE = 'update_account_phone';
+
     public const string UPDATE_ACCOUNT_STATUS = 'update_account_status';
+
     public const string UPDATE_MAGIC_URL = 'confirm_magic_url';
+
     public const string UPDATE_PASSWORD_RECOVERY = 'confirm_password_recovery';
+
     public const string UPDATE_EMAIL_VERIFICATION = 'confirm_email_verification';
+
     public const string UPDATE_PHONE_VERIFICATION = 'confirm_phone_verification';
+
     public const string DELETE_ACCOUNT_SESSION = 'delete_account_session';
+
     public const string DELETE_ACCOUNT_SESSIONS = 'delete_account_sessions';
 
     // Users
     public const string CREATE_USER = 'create_user';
+
     public const string GET_USER = 'get_user';
+
     public const string GET_USERS = 'list_user';
+
     public const string GET_USER_PREFERENCES = 'get_user_preferences';
+
     public const string GET_USER_SESSIONS = 'get_user_sessions';
+
     public const string GET_USER_MEMBERSHIPS = 'get_user_memberships';
+
     public const string GET_USER_LOGS = 'get_user_logs';
+
     public const string UPDATE_USER_STATUS = 'update_user_status';
+
     public const string UPDATE_USER_NAME = 'update_user_name';
+
     public const string UPDATE_USER_EMAIL = 'update_user_email';
+
     public const string UPDATE_USER_EMAIL_VERIFICATION = 'update_email_verification';
+
     public const string UPDATE_USER_PHONE_VERIFICATION = 'update_phone_verification';
+
     public const string UPDATE_USER_PASSWORD = 'update_user_password';
+
     public const string UPDATE_USER_PHONE = 'update_user_phone';
+
     public const string UPDATE_USER_PREFS = 'update_user_prefs';
+
     public const string DELETE_USER_SESSIONS = 'delete_user_sessions';
+
     public const string DELETE_USER_SESSION = 'delete_user_session';
+
     public const string DELETE_USER = 'delete_user';
+
     public const string CREATE_USER_TARGET = 'create_user_target';
+
     public const string LIST_USER_TARGETS = 'list_user_targets';
+
     public const string GET_USER_TARGET = 'get_user_target';
+
     public const string UPDATE_USER_TARGET = 'update_user_target';
+
     public const string DELETE_USER_TARGET = 'delete_user_target';
 
     // Teams
     public const string GET_TEAM = 'get_team';
+
     public const string GET_TEAM_PREFERENCES = 'get_team_preferences';
+
     public const string GET_TEAMS = 'list_teams';
+
     public const string CREATE_TEAM = 'create_team';
+
     public const string UPDATE_TEAM_NAME = 'update_team_name';
+
     public const string UPDATE_TEAM_PREFERENCES = 'update_team_preferences';
 
     public const string DELETE_TEAM = 'delete_team';
+
     public const string GET_TEAM_MEMBERSHIP = 'get_team_membership';
+
     public const string GET_TEAM_MEMBERSHIPS = 'list_team_memberships';
+
     public const string CREATE_TEAM_MEMBERSHIP = 'create_team_membership';
+
     public const string UPDATE_TEAM_MEMBERSHIP = 'update_team_membership';
+
     public const string UPDATE_TEAM_MEMBERSHIP_STATUS = 'update_membership_status';
+
     public const string DELETE_TEAM_MEMBERSHIP = 'delete_team_membership';
 
     // Functions
     public const string CREATE_FUNCTION = 'create_function';
+
     public const string GET_FUNCTIONS = 'list_functions';
+
     public const string GET_FUNCTION = 'get_function';
+
     public const string GET_RUNTIMES = 'list_runtimes';
+
     public const string UPDATE_FUNCTION = 'update_function';
+
     public const string DELETE_FUNCTION = 'delete_function';
+
     // Variables
     public const string CREATE_VARIABLE = 'create_variable';
+
     public const string GET_VARIABLES = 'list_variables';
+
     public const string GET_VARIABLE = 'get_variable';
+
     public const string UPDATE_VARIABLE = 'update_variable';
+
     public const string DELETE_VARIABLE = 'delete_variable';
 
-    //Deployments
+    // Deployments
     public const string CREATE_DEPLOYMENT = 'create_deployment';
+
     public const string GET_DEPLOYMENTS = 'list_deployments';
+
     public const string GET_DEPLOYMENT = 'get_deployment';
+
     public const string UPDATE_DEPLOYMENT = 'update_deployment';
+
     public const string DELETE_DEPLOYMENT = 'delete_deployment';
+
     // Executions
     public const string GET_EXECUTIONS = 'list_executions';
+
     public const string GET_EXECUTION = 'get_execution';
+
     public const string CREATE_EXECUTION = 'create_execution';
+
     public const string DELETE_EXECUTION = 'delete_execution';
+
     public const string RETRY_BUILD = 'retry_build';
 
     // Buckets
     public const string CREATE_BUCKET = 'create_bucket';
+
     public const string GET_BUCKETS = 'list_buckets';
+
     public const string GET_BUCKET = 'get_bucket';
+
     public const string UPDATE_BUCKET = 'update_bucket';
+
     public const string DELETE_BUCKET = 'delete_bucket';
+
     // Files
     public const string CREATE_FILE = 'create_file';
+
     public const string GET_FILES = 'list_files';
+
     public const string GET_FILE = 'get_file';
+
     public const string GET_FILE_PREVIEW = 'get_file_preview';
+
     public const string GET_FILE_DOWNLOAD = 'get_file_download';
+
     public const string GET_FILE_VIEW = 'get_file_view';
+
     public const string UPDATE_FILE = 'update_file';
+
     public const string DELETE_FILE = 'delete_file';
 
     // Health
     public const string GET_HTTP_HEALTH = 'get_http_health';
+
     public const string GET_DB_HEALTH = 'get_db_health';
+
     public const string GET_CACHE_HEALTH = 'get_cache_health';
+
     public const string GET_TIME_HEALTH = 'get_time_health';
+
     public const string GET_WEBHOOKS_QUEUE_HEALTH = 'get_webhooks_queue_health';
+
     public const string GET_LOGS_QUEUE_HEALTH = 'get_logs_queue_health';
+
     public const string GET_CERTIFICATES_QUEUE_HEALTH = 'get_certificates_queue_health';
+
     public const string GET_FUNCTION_QUEUE_HEALTH = 'get_functions_queue_health';
+
     public const string GET_LOCAL_STORAGE_HEALTH = 'get_local_storage_health';
+
     public const string GET_ANITVIRUS_HEALTH = 'get_antivirus_health';
 
     // Localization
     public const string GET_LOCALE = 'get_locale';
+
     public const string LIST_COUNTRIES = 'list_countries';
+
     public const string LIST_EU_COUNTRIES = 'list_eu_countries';
+
     public const string LIST_COUNTRY_PHONE_CODES = 'list_country_phone_codes';
+
     public const string LIST_CONTINENTS = 'list_continents';
+
     public const string LIST_CURRENCIES = 'list_currencies';
+
     public const string LIST_LANGUAGES = 'list_languages';
 
     // Avatars
     public const string GET_CREDIT_CARD_ICON = 'get_credit_card_icon';
+
     public const string GET_BROWSER_ICON = 'get_browser_icon';
+
     public const string GET_COUNTRY_FLAG = 'get_country_flag';
+
     public const string GET_IMAGE_FROM_URL = 'get_image_from_url';
+
     public const string GET_FAVICON = 'get_favicon';
+
     public const string GET_QRCODE = 'get_qrcode';
+
     public const string GET_USER_INITIALS = 'get_user_initials';
+
     public const string GET_SCREENSHOT = 'get_screenshot';
 
     // Providers
     public const string CREATE_MAILGUN_PROVIDER = 'create_mailgun_provider';
+
     public const string CREATE_SENDGRID_PROVIDER = 'create_sendgrid_provider';
+
     public const string CREATE_RESEND_PROVIDER = 'create_resend_provider';
+
     public const string CREATE_SMTP_PROVIDER = 'create_smtp_provider';
+
     public const string CREATE_TWILIO_PROVIDER = 'create_twilio_provider';
+
     public const string CREATE_TELESIGN_PROVIDER = 'create_telesign_provider';
+
     public const string CREATE_TEXTMAGIC_PROVIDER = 'create_textmagic_provider';
+
     public const string CREATE_MSG91_PROVIDER = 'create_msg91_provider';
+
     public const string CREATE_VONAGE_PROVIDER = 'create_vonage_provider';
+
+    public const string CREATE_TELNYX_PROVIDER = 'create_telnyx_provider';
+
     public const string CREATE_FCM_PROVIDER = 'create_fcm_provider';
+
     public const string CREATE_APNS_PROVIDER = 'create_apns_provider';
+
     public const string LIST_PROVIDERS = 'list_providers';
+
     public const string GET_PROVIDER = 'get_provider';
+
     public const string UPDATE_MAILGUN_PROVIDER = 'update_mailgun_provider';
+
     public const string UPDATE_SENDGRID_PROVIDER = 'update_sendgrid_provider';
+
     public const string UPDATE_RESEND_PROVIDER = 'update_resend_provider';
+
     public const string UPDATE_SMTP_PROVIDER = 'update_smtp_provider';
+
     public const string UPDATE_TWILIO_PROVIDER = 'update_twilio_provider';
+
     public const string UPDATE_TELESIGN_PROVIDER = 'update_telesign_provider';
+
     public const string UPDATE_TEXTMAGIC_PROVIDER = 'update_textmagic_provider';
+
     public const string UPDATE_MSG91_PROVIDER = 'update_msg91_provider';
+
     public const string UPDATE_VONAGE_PROVIDER = 'update_vonage_provider';
+
+    public const string UPDATE_TELNYX_PROVIDER = 'update_telnyx_provider';
+
     public const string UPDATE_FCM_PROVIDER = 'update_fcm_provider';
+
     public const string UPDATE_APNS_PROVIDER = 'update_apns_provider';
+
     public const string DELETE_PROVIDER = 'delete_provider';
 
     // Topics
     public const string CREATE_TOPIC = 'create_topic';
+
     public const string LIST_TOPICS = 'list_topics';
+
     public const string GET_TOPIC = 'get_topic';
+
     public const string UPDATE_TOPIC = 'update_topic';
+
     public const string DELETE_TOPIC = 'delete_topic';
 
     // Subscriptions
     public const string CREATE_SUBSCRIBER = 'create_subscriber';
+
     public const string LIST_SUBSCRIBERS = 'list_subscribers';
+
     public const string GET_SUBSCRIBER = 'get_subscriber';
+
     public const string DELETE_SUBSCRIBER = 'delete_subscriber';
 
     // Messages
     public const string CREATE_EMAIL = 'create_email';
+
     public const string CREATE_SMS = 'create_sms';
+
     public const string CREATE_PUSH_NOTIFICATION = 'create_push_notification';
+
     public const string LIST_MESSAGES = 'list_messages';
+
     public const string GET_MESSAGE = 'get_message';
 
     public const string UPDATE_EMAIL = 'update_email';
+
     public const string UPDATE_SMS = 'update_sms';
+
     public const string UPDATE_PUSH_NOTIFICATION = 'update_push_notification';
 
     // Complex queries
     public const string COMPLEX_QUERY_TABLE = 'complex_query_table';
+
     public const string COMPLEX_QUERY_COLLECTION = 'complex_query_collection';
 
     // Attribute Fragments
@@ -1159,13 +1405,13 @@ trait Base
                             ...attributeProperties
                         }
                     }
-                }' . PHP_EOL . self::FRAGMENT_ATTRIBUTES;
+                }'.PHP_EOL.self::FRAGMENT_ATTRIBUTES;
             case self::GET_ATTRIBUTE:
                 return 'query getAttribute($databaseId: String!, $collectionId: String!, $key: String!) {
                     databasesGetAttribute(databaseId: $databaseId, collectionId: $collectionId, key: $key) {
                         ...attributeProperties
                     }
-                }' . PHP_EOL . self::FRAGMENT_ATTRIBUTES;
+                }'.PHP_EOL.self::FRAGMENT_ATTRIBUTES;
             case self::DELETE_ATTRIBUTE:
                 return 'mutation deleteAttribute($databaseId: String!, $collectionId: String!, $key: String!) {
                     databasesDeleteAttribute(databaseId: $databaseId, collectionId: $collectionId, key: $key) {
@@ -1180,13 +1426,13 @@ trait Base
                             ...columnProperties
                         }
                     }
-                }' . PHP_EOL . self::FRAGMENT_COLUMNS;
+                }'.PHP_EOL.self::FRAGMENT_COLUMNS;
             case self::GET_COLUMN:
                 return 'query getColumn($databaseId: String!, $tableId: String!, $key: String!) {
                     tablesDBGetColumn(databaseId: $databaseId, tableId: $tableId, key: $key) {
                         ...columnProperties
                     }
-                }' . PHP_EOL . self::FRAGMENT_COLUMNS;
+                }'.PHP_EOL.self::FRAGMENT_COLUMNS;
             case self::DELETE_COLUMN:
                 return 'mutation deleteColumn($databaseId: String!, $tableId: String!, $key: String!) {
                     tablesDBDeleteColumn(databaseId: $databaseId, tableId: $tableId, key: $key) {
@@ -1470,7 +1716,7 @@ trait Base
                             ...options
                         }
                     }
-                }' . PHP_EOL . self::FRAGMENT_HASH_OPTIONS;
+                }'.PHP_EOL.self::FRAGMENT_HASH_OPTIONS;
             case self::GET_USER_PREFERENCES:
                 return 'query getUserPreferences($userId : String!) {
                     usersGetPrefs(userId : $userId) {
@@ -2581,6 +2827,16 @@ trait Base
                         enabled
                     }
                 }';
+            case self::CREATE_TELNYX_PROVIDER:
+                return 'mutation createTelnyxProvider($providerId: String!, $name: String!, $from: String!, $apiKey: String!) {
+                    messagingCreateTelnyxProvider(providerId: $providerId, name: $name, from: $from, apiKey: $apiKey) {
+                        _id
+                        name
+                        provider
+                        type
+                        enabled
+                    }
+                }';
             case self::CREATE_FCM_PROVIDER:
                 return 'mutation createFcmProvider($providerId: String!, $name: String!, $serviceAccountJSON: Json) {
                     messagingCreateFcmProvider(providerId: $providerId, name: $name, serviceAccountJSON: $serviceAccountJSON) {
@@ -2708,6 +2964,16 @@ trait Base
             case self::UPDATE_VONAGE_PROVIDER:
                 return 'mutation updateVonageProvider($providerId: String!, $name: String!, $apiKey: String!, $apiSecret: String!) {
                     messagingUpdateVonageProvider(providerId: $providerId, name: $name, apiKey: $apiKey, apiSecret: $apiSecret) {
+                        _id
+                        name
+                        provider
+                        type
+                        enabled
+                    }
+                }';
+            case self::UPDATE_TELNYX_PROVIDER:
+                return 'mutation updateTelnyxProvider($providerId: String!, $name: String!, $apiKey: String!) {
+                    messagingUpdateTelnyxProvider(providerId: $providerId, name: $name, apiKey: $apiKey) {
                         _id
                         name
                         provider
@@ -3206,7 +3472,7 @@ trait Base
                             data
                         }
                     }
-                }' . PHP_EOL . self::FRAGMENT_ATTRIBUTES;
+                }'.PHP_EOL.self::FRAGMENT_ATTRIBUTES;
             case self::COMPLEX_QUERY_TABLE:
                 return 'mutation complex($databaseId: String!, $databaseName: String!, $tableId: String!, $tableName: String!, $rowSecurity: Boolean!, $tablePermissions: [String!]!) {
                     databasesCreate(databaseId: $databaseId, name: $databaseName) {
@@ -3449,7 +3715,7 @@ trait Base
                             data
                         }
                     }
-                }' . PHP_EOL . self::FRAGMENT_COLUMNS;
+                }'.PHP_EOL.self::FRAGMENT_COLUMNS;
         }
 
         throw new \InvalidArgumentException('Invalid query type');
@@ -3457,11 +3723,12 @@ trait Base
 
     // Function-related methods
     protected string $stdout = '';
+
     protected string $stderr = '';
 
     protected function packageFunction(string $function): CURLFile
     {
-        $folderPath = realpath(__DIR__ . '/../../../resources/functions') . "/$function";
+        $folderPath = realpath(__DIR__.'/../../../resources/functions')."/$function";
         $tarPath = "$folderPath/code.tar.gz";
 
         Console::execute("cd $folderPath && tar --exclude code.tar.gz -czf code.tar.gz .", '', $this->stdout, $this->stderr);

--- a/tests/e2e/Services/GraphQL/Base.php
+++ b/tests/e2e/Services/GraphQL/Base.php
@@ -9,586 +9,342 @@ trait Base
 {
     // Databases
     public const string CREATE_DATABASE = 'create_database';
-
     public const string GET_DATABASES = 'get_databases';
-
     public const string GET_DATABASE = 'get_database';
-
     public const string UPDATE_DATABASE = 'update_database';
-
     public const string DELETE_DATABASE = 'delete_database';
 
     // Collections
     public const string CREATE_COLLECTION = 'create_collection';
-
     public const string GET_COLLECTION = 'get_collection';
-
     public const string GET_COLLECTIONS = 'list_collections';
-
     public const string UPDATE_COLLECTION = 'update_collection';
-
     public const string DELETE_COLLECTION = 'delete_collection';
 
     // Grid databases
     public const string TABLESDB_CREATE_DATABASE = 'tablesdb_create_database';
-
     public const string TABLESDB_GET_DATABASES = 'tablesdb_get_databases';
-
     public const string TABLESDB_GET_DATABASE = 'tablesdb_get_database';
-
     public const string TABLESDB_UPDATE_DATABASE = 'tablesdb_update_database';
-
     public const string TABLESDB_DELETE_DATABASE = 'tablesdb_delete_database';
 
     // Grid tables
     public const string CREATE_TABLE = 'create_table';
-
     public const string GET_TABLE = 'get_table';
-
     public const string GET_TABLES = 'list_tables';
-
     public const string UPDATE_TABLE = 'update_table';
-
     public const string DELETE_TABLE = 'delete_table';
 
     // Attributes
     public const string CREATE_STRING_ATTRIBUTE = 'create_string_attribute';
-
     public const string CREATE_INTEGER_ATTRIBUTE = 'create_integer_attribute';
-
     public const string CREATE_FLOAT_ATTRIBUTE = 'create_float_attribute';
-
     public const string CREATE_BOOLEAN_ATTRIBUTE = 'create_boolean_attribute';
-
     public const string CREATE_URL_ATTRIBUTE = 'create_url_attribute';
-
     public const string CREATE_EMAIL_ATTRIBUTE = 'create_email_attribute';
-
     public const string CREATE_IP_ATTRIBUTE = 'create_ip_attribute';
-
     public const string CREATE_ENUM_ATTRIBUTE = 'create_enum_attribute';
-
     public const string CREATE_DATETIME_ATTRIBUTE = 'create_datetime_attribute';
-
     public const string CREATE_POINT_ATTRIBUTE = 'create_point_attribute';
-
     public const string CREATE_LINE_ATTRIBUTE = 'create_line_attribute';
-
     public const string CREATE_POLYGON_ATTRIBUTE = 'create_polygon_attribute';
 
     public const string CREATE_RELATIONSHIP_ATTRIBUTE = 'create_relationship_attribute';
-
     public const string UPDATE_STRING_ATTRIBUTE = 'update_string_attribute';
-
     public const string UPDATE_INTEGER_ATTRIBUTE = 'update_integer_attribute';
-
     public const string UPDATE_FLOAT_ATTRIBUTE = 'update_float_attribute';
-
     public const string UPDATE_BOOLEAN_ATTRIBUTE = 'update_boolean_attribute';
-
     public const string UPDATE_URL_ATTRIBUTE = 'update_url_attribute';
-
     public const string UPDATE_EMAIL_ATTRIBUTE = 'update_email_attribute';
-
     public const string UPDATE_IP_ATTRIBUTE = 'update_ip_attribute';
-
     public const string UPDATE_ENUM_ATTRIBUTE = 'update_enum_attribute';
-
     public const string UPDATE_DATETIME_ATTRIBUTE = 'update_datetime_attribute';
-
     public const string UPDATE_POINT_ATTRIBUTE = 'update_point_attribute';
-
     public const string UPDATE_LINE_ATTRIBUTE = 'update_line_attribute';
-
     public const string UPDATE_POLYGON_ATTRIBUTE = 'update_polygon_attribute';
 
     public const string UPDATE_RELATIONSHIP_ATTRIBUTE = 'update_relationship_attribute';
-
     public const string GET_ATTRIBUTES = 'get_attributes';
-
     public const string GET_ATTRIBUTE = 'get_attribute';
-
     public const string DELETE_ATTRIBUTE = 'delete_attribute';
 
     // TablesDB columns
     public const string CREATE_STRING_COLUMN = 'create_string_column';
-
     public const string CREATE_INTEGER_COLUMN = 'create_integer_column';
-
     public const string CREATE_FLOAT_COLUMN = 'create_float_column';
-
     public const string CREATE_BOOLEAN_COLUMN = 'create_boolean_column';
-
     public const string CREATE_URL_COLUMN = 'create_url_column';
-
     public const string CREATE_EMAIL_COLUMN = 'create_email_column';
-
     public const string CREATE_IP_COLUMN = 'create_ip_column';
-
     public const string CREATE_ENUM_COLUMN = 'create_enum_column';
-
     public const string CREATE_DATETIME_COLUMN = 'create_datetime_column';
-
     public const string CREATE_POINT_COLUMN = 'create_point_column';
-
     public const string CREATE_LINE_COLUMN = 'create_line_column';
-
     public const string CREATE_POLYGON_COLUMN = 'create_polygon_column';
 
     public const string CREATE_RELATIONSHIP_COLUMN = 'create_relationship_column';
-
     public const string UPDATE_STRING_COLUMN = 'update_string_column';
-
     public const string UPDATE_INTEGER_COLUMN = 'update_integer_column';
-
     public const string UPDATE_FLOAT_COLUMN = 'update_float_column';
-
     public const string UPDATE_BOOLEAN_COLUMN = 'update_boolean_column';
-
     public const string UPDATE_URL_COLUMN = 'update_url_column';
-
     public const string UPDATE_EMAIL_COLUMN = 'update_email_column';
-
     public const string UPDATE_IP_COLUMN = 'update_ip_column';
-
     public const string UPDATE_ENUM_COLUMN = 'update_enum_column';
-
     public const string UPDATE_DATETIME_COLUMN = 'update_datetime_column';
-
     public const string UPDATE_POINT_COLUMN = 'update_point_column';
-
     public const string UPDATE_LINE_COLUMN = 'update_line_column';
-
     public const string UPDATE_POLYGON_COLUMN = 'update_polygon_column';
 
     public const string UPDATE_RELATIONSHIP_COLUMN = 'update_relationship_column';
-
     public const string GET_COLUMNS = 'get_columns';
-
     public const string GET_COLUMN = 'get_column';
-
     public const string DELETE_COLUMN = 'delete_column';
 
     // Attribute Indexes
     public const string CREATE_INDEX = 'create_attribute_index';
-
     public const string GET_INDEXES = 'get_attribute_indexes';
-
     public const string GET_INDEX = 'get_attribute_index';
-
     public const string DELETE_INDEX = 'delete_attribute_index';
 
     // Grid column indexes
     public const string CREATE_COLUMN_INDEX = 'create_column_index';
-
     public const string GET_COLUMN_INDEXES = 'get_column_indexes';
-
     public const string GET_COLUMN_INDEX = 'get_column_index';
-
     public const string DELETE_COLUMN_INDEX = 'delete_column_index';
 
     // Documents
     public const string CREATE_DOCUMENT = 'create_document_rest';
-
     public const string GET_DOCUMENTS = 'list_documents';
-
     public const string GET_DOCUMENT = 'get_document';
-
     public const string UPDATE_DOCUMENT = 'update_document';
-
-    public const string UPSERT_DOCUMENT = 'upsert_document';
-
+    public const string UPSERT_DOCUMENT  = 'upsert_document';
     public const string DELETE_DOCUMENT = 'delete_document';
 
     // Documents - Bulk APIs
     public const string CREATE_DOCUMENTS = 'create_documents_rest';
-
     public const string UPDATE_DOCUMENTS = 'update_documents';
-
     public const string UPSERT_DOCUMENTS = 'upsert_documents';
-
     public const string DELETE_DOCUMENTS = 'delete_documents';
 
     // Grid rows
     public const string CREATE_ROW = 'create_row_rest';
-
     public const string GET_ROWS = 'list_rows';
-
     public const string GET_ROW = 'get_row';
-
     public const string UPDATE_ROW = 'update_row';
-
-    public const string UPSERT_ROW = 'upsert_row';
-
+    public const string UPSERT_ROW  = 'upsert_row';
     public const string DELETE_ROW = 'delete_row';
 
     // Grid rows - Bulk APIs
     public const string CREATE_ROWS = 'create_rows_rest';
-
     public const string UPDATE_ROWS = 'update_rows';
-
     public const string UPSERT_ROWS = 'upsert_rows';
-
     public const string DELETE_ROWS = 'delete_rows';
 
     // Custom Entities
     public const string CREATE_CUSTOM_ENTITY = 'create_custom_entity';
-
     public const string GET_CUSTOM_ENTITIES = 'get_custom_entities';
-
     public const string GET_CUSTOM_ENTITY = 'get_custom_entity';
-
     public const string UPDATE_CUSTOM_ENTITY = 'update_custom_entity';
-
     public const string DELETE_CUSTOM_ENTITY = 'delete_custom_entity';
 
     // Account
     public const string CREATE_ACCOUNT = 'create_account';
-
     public const string CREATE_ACCOUNT_SESSION = 'create_account_session';
-
     public const string CREATE_ANONYMOUS_SESSION = 'create_anonymous_session';
-
     public const string CREATE_ACCOUNT_JWT = 'create_account_jwt';
-
     public const string CREATE_MAGIC_URL = 'create_magic_url';
-
     public const string CREATE_PASSWORD_RECOVERY = 'create_password_recovery';
-
     public const string CREATE_EMAIL_VERIFICATION = 'create_email_verification';
-
     public const string CREATE_PHONE_VERIFICATION = 'create_phone_verification';
-
     public const string GET_ACCOUNT = 'get_account';
-
     public const string GET_ACCOUNT_SESSION = 'get_account_session';
-
     public const string GET_ACCOUNT_SESSIONS = 'get_account_sessions';
-
     public const string GET_ACCOUNT_PREFS = 'get_account_preferences';
-
     public const string GET_ACCOUNT_LOGS = 'get_account_logs';
-
     public const string UPDATE_ACCOUNT_NAME = 'update_account_name';
-
     public const string UPDATE_ACCOUNT_EMAIL = 'update_account_email';
-
     public const string UPDATE_ACCOUNT_PASSWORD = 'update_account_password';
-
     public const string UPDATE_ACCOUNT_PREFS = 'update_account_prefs';
-
     public const string UPDATE_ACCOUNT_PHONE = 'update_account_phone';
-
     public const string UPDATE_ACCOUNT_STATUS = 'update_account_status';
-
     public const string UPDATE_MAGIC_URL = 'confirm_magic_url';
-
     public const string UPDATE_PASSWORD_RECOVERY = 'confirm_password_recovery';
-
     public const string UPDATE_EMAIL_VERIFICATION = 'confirm_email_verification';
-
     public const string UPDATE_PHONE_VERIFICATION = 'confirm_phone_verification';
-
     public const string DELETE_ACCOUNT_SESSION = 'delete_account_session';
-
     public const string DELETE_ACCOUNT_SESSIONS = 'delete_account_sessions';
 
     // Users
     public const string CREATE_USER = 'create_user';
-
     public const string GET_USER = 'get_user';
-
     public const string GET_USERS = 'list_user';
-
     public const string GET_USER_PREFERENCES = 'get_user_preferences';
-
     public const string GET_USER_SESSIONS = 'get_user_sessions';
-
     public const string GET_USER_MEMBERSHIPS = 'get_user_memberships';
-
     public const string GET_USER_LOGS = 'get_user_logs';
-
     public const string UPDATE_USER_STATUS = 'update_user_status';
-
     public const string UPDATE_USER_NAME = 'update_user_name';
-
     public const string UPDATE_USER_EMAIL = 'update_user_email';
-
     public const string UPDATE_USER_EMAIL_VERIFICATION = 'update_email_verification';
-
     public const string UPDATE_USER_PHONE_VERIFICATION = 'update_phone_verification';
-
     public const string UPDATE_USER_PASSWORD = 'update_user_password';
-
     public const string UPDATE_USER_PHONE = 'update_user_phone';
-
     public const string UPDATE_USER_PREFS = 'update_user_prefs';
-
     public const string DELETE_USER_SESSIONS = 'delete_user_sessions';
-
     public const string DELETE_USER_SESSION = 'delete_user_session';
-
     public const string DELETE_USER = 'delete_user';
-
     public const string CREATE_USER_TARGET = 'create_user_target';
-
     public const string LIST_USER_TARGETS = 'list_user_targets';
-
     public const string GET_USER_TARGET = 'get_user_target';
-
     public const string UPDATE_USER_TARGET = 'update_user_target';
-
     public const string DELETE_USER_TARGET = 'delete_user_target';
 
     // Teams
     public const string GET_TEAM = 'get_team';
-
     public const string GET_TEAM_PREFERENCES = 'get_team_preferences';
-
     public const string GET_TEAMS = 'list_teams';
-
     public const string CREATE_TEAM = 'create_team';
-
     public const string UPDATE_TEAM_NAME = 'update_team_name';
-
     public const string UPDATE_TEAM_PREFERENCES = 'update_team_preferences';
 
     public const string DELETE_TEAM = 'delete_team';
-
     public const string GET_TEAM_MEMBERSHIP = 'get_team_membership';
-
     public const string GET_TEAM_MEMBERSHIPS = 'list_team_memberships';
-
     public const string CREATE_TEAM_MEMBERSHIP = 'create_team_membership';
-
     public const string UPDATE_TEAM_MEMBERSHIP = 'update_team_membership';
-
     public const string UPDATE_TEAM_MEMBERSHIP_STATUS = 'update_membership_status';
-
     public const string DELETE_TEAM_MEMBERSHIP = 'delete_team_membership';
 
     // Functions
     public const string CREATE_FUNCTION = 'create_function';
-
     public const string GET_FUNCTIONS = 'list_functions';
-
     public const string GET_FUNCTION = 'get_function';
-
     public const string GET_RUNTIMES = 'list_runtimes';
-
     public const string UPDATE_FUNCTION = 'update_function';
-
     public const string DELETE_FUNCTION = 'delete_function';
-
     // Variables
     public const string CREATE_VARIABLE = 'create_variable';
-
     public const string GET_VARIABLES = 'list_variables';
-
     public const string GET_VARIABLE = 'get_variable';
-
     public const string UPDATE_VARIABLE = 'update_variable';
-
     public const string DELETE_VARIABLE = 'delete_variable';
 
-    // Deployments
+    //Deployments
     public const string CREATE_DEPLOYMENT = 'create_deployment';
-
     public const string GET_DEPLOYMENTS = 'list_deployments';
-
     public const string GET_DEPLOYMENT = 'get_deployment';
-
     public const string UPDATE_DEPLOYMENT = 'update_deployment';
-
     public const string DELETE_DEPLOYMENT = 'delete_deployment';
-
     // Executions
     public const string GET_EXECUTIONS = 'list_executions';
-
     public const string GET_EXECUTION = 'get_execution';
-
     public const string CREATE_EXECUTION = 'create_execution';
-
     public const string DELETE_EXECUTION = 'delete_execution';
-
     public const string RETRY_BUILD = 'retry_build';
 
     // Buckets
     public const string CREATE_BUCKET = 'create_bucket';
-
     public const string GET_BUCKETS = 'list_buckets';
-
     public const string GET_BUCKET = 'get_bucket';
-
     public const string UPDATE_BUCKET = 'update_bucket';
-
     public const string DELETE_BUCKET = 'delete_bucket';
-
     // Files
     public const string CREATE_FILE = 'create_file';
-
     public const string GET_FILES = 'list_files';
-
     public const string GET_FILE = 'get_file';
-
     public const string GET_FILE_PREVIEW = 'get_file_preview';
-
     public const string GET_FILE_DOWNLOAD = 'get_file_download';
-
     public const string GET_FILE_VIEW = 'get_file_view';
-
     public const string UPDATE_FILE = 'update_file';
-
     public const string DELETE_FILE = 'delete_file';
 
     // Health
     public const string GET_HTTP_HEALTH = 'get_http_health';
-
     public const string GET_DB_HEALTH = 'get_db_health';
-
     public const string GET_CACHE_HEALTH = 'get_cache_health';
-
     public const string GET_TIME_HEALTH = 'get_time_health';
-
     public const string GET_WEBHOOKS_QUEUE_HEALTH = 'get_webhooks_queue_health';
-
     public const string GET_LOGS_QUEUE_HEALTH = 'get_logs_queue_health';
-
     public const string GET_CERTIFICATES_QUEUE_HEALTH = 'get_certificates_queue_health';
-
     public const string GET_FUNCTION_QUEUE_HEALTH = 'get_functions_queue_health';
-
     public const string GET_LOCAL_STORAGE_HEALTH = 'get_local_storage_health';
-
     public const string GET_ANITVIRUS_HEALTH = 'get_antivirus_health';
 
     // Localization
     public const string GET_LOCALE = 'get_locale';
-
     public const string LIST_COUNTRIES = 'list_countries';
-
     public const string LIST_EU_COUNTRIES = 'list_eu_countries';
-
     public const string LIST_COUNTRY_PHONE_CODES = 'list_country_phone_codes';
-
     public const string LIST_CONTINENTS = 'list_continents';
-
     public const string LIST_CURRENCIES = 'list_currencies';
-
     public const string LIST_LANGUAGES = 'list_languages';
 
     // Avatars
     public const string GET_CREDIT_CARD_ICON = 'get_credit_card_icon';
-
     public const string GET_BROWSER_ICON = 'get_browser_icon';
-
     public const string GET_COUNTRY_FLAG = 'get_country_flag';
-
     public const string GET_IMAGE_FROM_URL = 'get_image_from_url';
-
     public const string GET_FAVICON = 'get_favicon';
-
     public const string GET_QRCODE = 'get_qrcode';
-
     public const string GET_USER_INITIALS = 'get_user_initials';
-
     public const string GET_SCREENSHOT = 'get_screenshot';
 
     // Providers
     public const string CREATE_MAILGUN_PROVIDER = 'create_mailgun_provider';
-
     public const string CREATE_SENDGRID_PROVIDER = 'create_sendgrid_provider';
-
     public const string CREATE_RESEND_PROVIDER = 'create_resend_provider';
-
     public const string CREATE_SMTP_PROVIDER = 'create_smtp_provider';
-
     public const string CREATE_TWILIO_PROVIDER = 'create_twilio_provider';
-
     public const string CREATE_TELESIGN_PROVIDER = 'create_telesign_provider';
-
     public const string CREATE_TEXTMAGIC_PROVIDER = 'create_textmagic_provider';
-
     public const string CREATE_MSG91_PROVIDER = 'create_msg91_provider';
-
     public const string CREATE_VONAGE_PROVIDER = 'create_vonage_provider';
-
     public const string CREATE_TELNYX_PROVIDER = 'create_telnyx_provider';
-
     public const string CREATE_FCM_PROVIDER = 'create_fcm_provider';
-
     public const string CREATE_APNS_PROVIDER = 'create_apns_provider';
-
     public const string LIST_PROVIDERS = 'list_providers';
-
     public const string GET_PROVIDER = 'get_provider';
-
     public const string UPDATE_MAILGUN_PROVIDER = 'update_mailgun_provider';
-
     public const string UPDATE_SENDGRID_PROVIDER = 'update_sendgrid_provider';
-
     public const string UPDATE_RESEND_PROVIDER = 'update_resend_provider';
-
     public const string UPDATE_SMTP_PROVIDER = 'update_smtp_provider';
-
     public const string UPDATE_TWILIO_PROVIDER = 'update_twilio_provider';
-
     public const string UPDATE_TELESIGN_PROVIDER = 'update_telesign_provider';
-
     public const string UPDATE_TEXTMAGIC_PROVIDER = 'update_textmagic_provider';
-
     public const string UPDATE_MSG91_PROVIDER = 'update_msg91_provider';
-
     public const string UPDATE_VONAGE_PROVIDER = 'update_vonage_provider';
-
     public const string UPDATE_TELNYX_PROVIDER = 'update_telnyx_provider';
-
     public const string UPDATE_FCM_PROVIDER = 'update_fcm_provider';
-
     public const string UPDATE_APNS_PROVIDER = 'update_apns_provider';
-
     public const string DELETE_PROVIDER = 'delete_provider';
 
     // Topics
     public const string CREATE_TOPIC = 'create_topic';
-
     public const string LIST_TOPICS = 'list_topics';
-
     public const string GET_TOPIC = 'get_topic';
-
     public const string UPDATE_TOPIC = 'update_topic';
-
     public const string DELETE_TOPIC = 'delete_topic';
 
     // Subscriptions
     public const string CREATE_SUBSCRIBER = 'create_subscriber';
-
     public const string LIST_SUBSCRIBERS = 'list_subscribers';
-
     public const string GET_SUBSCRIBER = 'get_subscriber';
-
     public const string DELETE_SUBSCRIBER = 'delete_subscriber';
 
     // Messages
     public const string CREATE_EMAIL = 'create_email';
-
     public const string CREATE_SMS = 'create_sms';
-
     public const string CREATE_PUSH_NOTIFICATION = 'create_push_notification';
-
     public const string LIST_MESSAGES = 'list_messages';
-
     public const string GET_MESSAGE = 'get_message';
 
     public const string UPDATE_EMAIL = 'update_email';
-
     public const string UPDATE_SMS = 'update_sms';
-
     public const string UPDATE_PUSH_NOTIFICATION = 'update_push_notification';
 
     // Complex queries
     public const string COMPLEX_QUERY_TABLE = 'complex_query_table';
-
     public const string COMPLEX_QUERY_COLLECTION = 'complex_query_collection';
 
     // Attribute Fragments
@@ -1405,13 +1161,13 @@ trait Base
                             ...attributeProperties
                         }
                     }
-                }'.PHP_EOL.self::FRAGMENT_ATTRIBUTES;
+                }' . PHP_EOL . self::FRAGMENT_ATTRIBUTES;
             case self::GET_ATTRIBUTE:
                 return 'query getAttribute($databaseId: String!, $collectionId: String!, $key: String!) {
                     databasesGetAttribute(databaseId: $databaseId, collectionId: $collectionId, key: $key) {
                         ...attributeProperties
                     }
-                }'.PHP_EOL.self::FRAGMENT_ATTRIBUTES;
+                }' . PHP_EOL . self::FRAGMENT_ATTRIBUTES;
             case self::DELETE_ATTRIBUTE:
                 return 'mutation deleteAttribute($databaseId: String!, $collectionId: String!, $key: String!) {
                     databasesDeleteAttribute(databaseId: $databaseId, collectionId: $collectionId, key: $key) {
@@ -1426,13 +1182,13 @@ trait Base
                             ...columnProperties
                         }
                     }
-                }'.PHP_EOL.self::FRAGMENT_COLUMNS;
+                }' . PHP_EOL . self::FRAGMENT_COLUMNS;
             case self::GET_COLUMN:
                 return 'query getColumn($databaseId: String!, $tableId: String!, $key: String!) {
                     tablesDBGetColumn(databaseId: $databaseId, tableId: $tableId, key: $key) {
                         ...columnProperties
                     }
-                }'.PHP_EOL.self::FRAGMENT_COLUMNS;
+                }' . PHP_EOL . self::FRAGMENT_COLUMNS;
             case self::DELETE_COLUMN:
                 return 'mutation deleteColumn($databaseId: String!, $tableId: String!, $key: String!) {
                     tablesDBDeleteColumn(databaseId: $databaseId, tableId: $tableId, key: $key) {
@@ -1716,7 +1472,7 @@ trait Base
                             ...options
                         }
                     }
-                }'.PHP_EOL.self::FRAGMENT_HASH_OPTIONS;
+                }' . PHP_EOL . self::FRAGMENT_HASH_OPTIONS;
             case self::GET_USER_PREFERENCES:
                 return 'query getUserPreferences($userId : String!) {
                     usersGetPrefs(userId : $userId) {
@@ -3472,7 +3228,7 @@ trait Base
                             data
                         }
                     }
-                }'.PHP_EOL.self::FRAGMENT_ATTRIBUTES;
+                }' . PHP_EOL . self::FRAGMENT_ATTRIBUTES;
             case self::COMPLEX_QUERY_TABLE:
                 return 'mutation complex($databaseId: String!, $databaseName: String!, $tableId: String!, $tableName: String!, $rowSecurity: Boolean!, $tablePermissions: [String!]!) {
                     databasesCreate(databaseId: $databaseId, name: $databaseName) {
@@ -3715,7 +3471,7 @@ trait Base
                             data
                         }
                     }
-                }'.PHP_EOL.self::FRAGMENT_COLUMNS;
+                }' . PHP_EOL . self::FRAGMENT_COLUMNS;
         }
 
         throw new \InvalidArgumentException('Invalid query type');
@@ -3723,12 +3479,11 @@ trait Base
 
     // Function-related methods
     protected string $stdout = '';
-
     protected string $stderr = '';
 
     protected function packageFunction(string $function): CURLFile
     {
-        $folderPath = realpath(__DIR__.'/../../../resources/functions')."/$function";
+        $folderPath = realpath(__DIR__ . '/../../../resources/functions') . "/$function";
         $tarPath = "$folderPath/code.tar.gz";
 
         Console::execute("cd $folderPath && tar --exclude code.tar.gz -czf code.tar.gz .", '', $this->stdout, $this->stderr);

--- a/tests/e2e/Services/GraphQL/MessagingTest.php
+++ b/tests/e2e/Services/GraphQL/MessagingTest.php
@@ -12,21 +12,26 @@ use Utopia\System\System;
 
 class MessagingTest extends Scope
 {
+    use Base;
     use ProjectCustom;
     use SideServer;
-    use Base;
 
     private static array $cachedProviders = [];
+
     private static array $cachedTopic = [];
+
     private static array $cachedSubscriber = [];
+
     private static array $cachedEmail = [];
+
     private static array $cachedSms = [];
+
     private static array $cachedPush = [];
 
     protected function setupProviders(): array
     {
         $key = $this->getProject()['$id'];
-        if (!empty(static::$cachedProviders[$key])) {
+        if (! empty(static::$cachedProviders[$key])) {
             return static::$cachedProviders[$key];
         }
 
@@ -80,7 +85,7 @@ class MessagingTest extends Scope
                 'name' => 'Ms91-1',
                 'senderId' => 'my-senderid',
                 'authKey' => 'my-authkey',
-                'templateId' => '123456'
+                'templateId' => '123456',
             ],
             'Vonage' => [
                 'providerId' => ID::unique(),
@@ -94,10 +99,10 @@ class MessagingTest extends Scope
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    "project_id" => "test-project",
-                    "private_key_id" => "test-private-key-id",
-                    "private_key" => "test-private-key",
-                ]
+                    'project_id' => 'test-project',
+                    'private_key_id' => 'test-private-key-id',
+                    'private_key' => 'test-private-key',
+                ],
             ],
             'Apns' => [
                 'providerId' => ID::unique(),
@@ -107,12 +112,18 @@ class MessagingTest extends Scope
                 'teamId' => 'my-teamid',
                 'bundleId' => 'my-bundleid',
             ],
+            'Telnyx' => [
+                'providerId' => ID::unique(),
+                'name' => 'Telnyx1',
+                'apiKey' => 'my-apikey',
+                'from' => '+123456789',
+            ],
         ];
 
         $providers = [];
 
         foreach (\array_keys($providersParams) as $providerKey) {
-            $query = $this->getQuery('create_' . \strtolower($providerKey) . '_provider');
+            $query = $this->getQuery('create_'.\strtolower($providerKey).'_provider');
             $graphQLPayload = [
                 'query' => $query,
                 'variables' => $providersParams[$providerKey],
@@ -123,19 +134,20 @@ class MessagingTest extends Scope
                 'x-appwrite-key' => $this->getProject()['apiKey'],
             ]), $graphQLPayload);
 
-            $providers[] = $response['body']['data']['messagingCreate' . $providerKey . 'Provider'];
+            $providers[] = $response['body']['data']['messagingCreate'.$providerKey.'Provider'];
             $this->assertEquals(200, $response['headers']['status-code']);
-            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingCreate' . $providerKey . 'Provider']['name']);
+            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingCreate'.$providerKey.'Provider']['name']);
         }
 
         static::$cachedProviders[$key] = $providers;
+
         return $providers;
     }
 
     protected function setupUpdatedProviders(): array
     {
-        $key = $this->getProject()['$id'] . '_updated';
-        if (!empty(static::$cachedProviders[$key])) {
+        $key = $this->getProject()['$id'].'_updated';
+        if (! empty(static::$cachedProviders[$key])) {
             return static::$cachedProviders[$key];
         }
 
@@ -196,8 +208,8 @@ class MessagingTest extends Scope
                     'type' => 'service_account',
                     'project_id' => 'test-project',
                     'private_key_id' => 'test-project-id',
-                    'private_key' => "test-private-key",
-                ]
+                    'private_key' => 'test-private-key',
+                ],
             ],
             'Apns' => [
                 'providerId' => $providers[9]['_id'],
@@ -207,9 +219,14 @@ class MessagingTest extends Scope
                 'teamId' => 'my-teamid',
                 'bundleId' => 'my-bundleid',
             ],
+            'Telnyx' => [
+                'providerId' => $providers[10]['_id'],
+                'name' => 'Telnyx2',
+                'apiKey' => 'my-apikey',
+            ],
         ];
         foreach (\array_keys($providersParams) as $index => $providerKey) {
-            $query = $this->getQuery('update_' . \strtolower($providerKey) . '_provider');
+            $query = $this->getQuery('update_'.\strtolower($providerKey).'_provider');
 
             $graphQLPayload = [
                 'query' => $query,
@@ -222,9 +239,9 @@ class MessagingTest extends Scope
                 'x-appwrite-key' => $this->getProject()['apiKey'],
             ], $graphQLPayload);
 
-            $providers[$index] = $response['body']['data']['messagingUpdate' . $providerKey . 'Provider'];
+            $providers[$index] = $response['body']['data']['messagingUpdate'.$providerKey.'Provider'];
             $this->assertEquals(200, $response['headers']['status-code']);
-            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingUpdate' . $providerKey . 'Provider']['name']);
+            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingUpdate'.$providerKey.'Provider']['name']);
         }
 
         $response = $this->client->call(Client::METHOD_POST, '/graphql', [
@@ -240,7 +257,7 @@ class MessagingTest extends Scope
                 'domain' => 'my-domain',
                 'isEuRegion' => true,
                 'enabled' => false,
-            ]
+            ],
         ]);
         $providers[2] = $response['body']['data']['messagingUpdateMailgunProvider'];
         $this->assertEquals(200, $response['headers']['status-code']);
@@ -248,13 +265,14 @@ class MessagingTest extends Scope
         $this->assertEquals(false, $response['body']['data']['messagingUpdateMailgunProvider']['enabled']);
 
         static::$cachedProviders[$key] = $providers;
+
         return $providers;
     }
 
     protected function setupTopic(): array
     {
         $key = $this->getProject()['$id'];
-        if (!empty(static::$cachedTopic[$key])) {
+        if (! empty(static::$cachedTopic[$key])) {
             return static::$cachedTopic[$key];
         }
 
@@ -276,13 +294,14 @@ class MessagingTest extends Scope
         $this->assertEquals('topic1', $response['body']['data']['messagingCreateTopic']['name']);
 
         static::$cachedTopic[$key] = $response['body']['data']['messagingCreateTopic'];
+
         return static::$cachedTopic[$key];
     }
 
     protected function setupUpdatedTopic(): string
     {
-        $key = $this->getProject()['$id'] . '_updated';
-        if (!empty(static::$cachedTopic[$key])) {
+        $key = $this->getProject()['$id'].'_updated';
+        if (! empty(static::$cachedTopic[$key])) {
             return static::$cachedTopic[$key];
         }
 
@@ -307,13 +326,14 @@ class MessagingTest extends Scope
         $this->assertEquals('topic2', $response['body']['data']['messagingUpdateTopic']['name']);
 
         static::$cachedTopic[$key] = $topicId;
+
         return $topicId;
     }
 
     protected function setupSubscriber(): array
     {
         $key = $this->getProject()['$id'];
-        if (!empty(static::$cachedSubscriber[$key])) {
+        if (! empty(static::$cachedSubscriber[$key])) {
             return static::$cachedSubscriber[$key];
         }
 
@@ -329,7 +349,7 @@ class MessagingTest extends Scope
                 'apiKey' => 'my-apikey',
                 'fromName' => 'Sender',
                 'fromEmail' => 'sender-email@my-domain.com',
-            ]
+            ],
         ];
         $query = $this->getQuery(self::CREATE_SENDGRID_PROVIDER);
         $graphQLPayload = [
@@ -387,13 +407,14 @@ class MessagingTest extends Scope
         $this->assertEquals($response['body']['data']['messagingCreateSubscriber']['target']['userId'], $userId);
 
         static::$cachedSubscriber[$key] = $response['body']['data']['messagingCreateSubscriber'];
+
         return static::$cachedSubscriber[$key];
     }
 
     protected function setupEmail(): array
     {
         $key = $this->getProject()['$id'];
-        if (!empty(static::$cachedEmail[$key])) {
+        if (! empty(static::$cachedEmail[$key])) {
             return static::$cachedEmail[$key];
         }
 
@@ -460,7 +481,7 @@ class MessagingTest extends Scope
                 'email' => 'random1-mail@mail.org',
                 'password' => 'password',
                 'name' => 'Messaging User',
-            ]
+            ],
         ];
         $user = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
             'content-type' => 'application/json',
@@ -525,7 +546,7 @@ class MessagingTest extends Scope
 
         $emailMessageId = $email['body']['data']['messagingCreateEmail']['_id'];
         $this->assertEventually(function () use ($emailMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emailMessageId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -551,13 +572,14 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
 
         static::$cachedEmail[$key] = $message['body']['data']['messagingGetMessage'];
+
         return static::$cachedEmail[$key];
     }
 
     protected function setupSms(): array
     {
         $key = $this->getProject()['$id'];
-        if (!empty(static::$cachedSms[$key])) {
+        if (! empty(static::$cachedSms[$key])) {
             return static::$cachedSms[$key];
         }
 
@@ -620,7 +642,7 @@ class MessagingTest extends Scope
                 'email' => 'random3-email@mail.org',
                 'password' => 'password',
                 'name' => 'Messaging User',
-            ]
+            ],
         ];
         $user = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
             'content-type' => 'application/json',
@@ -684,7 +706,7 @@ class MessagingTest extends Scope
 
         $smsMessageId = $sms['body']['data']['messagingCreateSMS']['_id'];
         $this->assertEventually(function () use ($smsMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -710,13 +732,14 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
 
         static::$cachedSms[$key] = $message['body']['data']['messagingGetMessage'];
+
         return static::$cachedSms[$key];
     }
 
     protected function setupPush(): array
     {
         $key = $this->getProject()['$id'];
-        if (!empty(static::$cachedPush[$key])) {
+        if (! empty(static::$cachedPush[$key])) {
             return static::$cachedPush[$key];
         }
 
@@ -740,10 +763,10 @@ class MessagingTest extends Scope
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    "project_id" => "test-project",
-                    "private_key_id" => "test-private-key-id",
-                    "private_key" => "test-private-key",
-                ]
+                    'project_id' => 'test-project',
+                    'private_key_id' => 'test-private-key-id',
+                    'private_key' => 'test-private-key',
+                ],
             ],
         ];
         $provider = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
@@ -780,7 +803,7 @@ class MessagingTest extends Scope
                 'email' => 'random5-mail@mail.org',
                 'password' => 'password',
                 'name' => 'Messaging User',
-            ]
+            ],
         ];
         $user = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
             'content-type' => 'application/json',
@@ -845,7 +868,7 @@ class MessagingTest extends Scope
 
         $pushMessageId = $push['body']['data']['messagingCreatePushNotification']['_id'];
         $this->assertEventually(function () use ($pushMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -871,22 +894,23 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
 
         static::$cachedPush[$key] = $message['body']['data']['messagingGetMessage'];
+
         return static::$cachedPush[$key];
     }
 
-    public function testCreateProviders(): void
+    public function test_create_providers(): void
     {
         $providers = $this->setupProviders();
         $this->assertCount(10, $providers);
     }
 
-    public function testUpdateProviders(): void
+    public function test_update_providers(): void
     {
         $providers = $this->setupUpdatedProviders();
         $this->assertEquals('Sengrid2', $providers[0]['name']);
     }
 
-    public function testListProviders()
+    public function test_list_providers()
     {
         $providers = $this->setupUpdatedProviders();
 
@@ -903,7 +927,7 @@ class MessagingTest extends Scope
         $this->assertEquals(\count($providers), \count($response['body']['data']['messagingListProviders']['providers']));
     }
 
-    public function testGetProvider()
+    public function test_get_provider()
     {
         $providers = $this->setupUpdatedProviders();
 
@@ -912,7 +936,7 @@ class MessagingTest extends Scope
             'query' => $query,
             'variables' => [
                 'providerId' => $providers[0]['_id'],
-            ]
+            ],
         ];
         $response = $this->client->call(Client::METHOD_POST, '/graphql', [
             'content-type' => 'application/json',
@@ -923,7 +947,7 @@ class MessagingTest extends Scope
         $this->assertEquals($providers[0]['name'], $response['body']['data']['messagingGetProvider']['name']);
     }
 
-    public function testDeleteProvider()
+    public function test_delete_provider()
     {
         $providers = $this->setupUpdatedProviders();
 
@@ -933,7 +957,7 @@ class MessagingTest extends Scope
                 'query' => $query,
                 'variables' => [
                     'providerId' => $provider['_id'],
-                ]
+                ],
             ];
             $response = $this->client->call(Client::METHOD_POST, '/graphql', [
                 'content-type' => 'application/json',
@@ -946,22 +970,22 @@ class MessagingTest extends Scope
         // Clear cache after deletion
         $key = $this->getProject()['$id'];
         static::$cachedProviders[$key] = [];
-        static::$cachedProviders[$key . '_updated'] = [];
+        static::$cachedProviders[$key.'_updated'] = [];
     }
 
-    public function testCreateTopic(): void
+    public function test_create_topic(): void
     {
         $topic = $this->setupTopic();
         $this->assertEquals('topic1', $topic['name']);
     }
 
-    public function testUpdateTopic(): void
+    public function test_update_topic(): void
     {
         $topicId = $this->setupUpdatedTopic();
         $this->assertNotEmpty($topicId);
     }
 
-    public function testListTopics()
+    public function test_list_topics()
     {
         $this->setupTopic();
 
@@ -979,7 +1003,7 @@ class MessagingTest extends Scope
         $this->assertEquals(1, \count($response['body']['data']['messagingListTopics']['topics']));
     }
 
-    public function testGetTopic()
+    public function test_get_topic()
     {
         $topicId = $this->setupUpdatedTopic();
 
@@ -1000,13 +1024,13 @@ class MessagingTest extends Scope
         $this->assertEquals('topic2', $response['body']['data']['messagingGetTopic']['name']);
     }
 
-    public function testCreateSubscriber(): void
+    public function test_create_subscriber(): void
     {
         $subscriber = $this->setupSubscriber();
         $this->assertNotEmpty($subscriber['_id']);
     }
 
-    public function testListSubscribers()
+    public function test_list_subscribers()
     {
         $subscriber = $this->setupSubscriber();
 
@@ -1030,7 +1054,7 @@ class MessagingTest extends Scope
         $this->assertEquals(1, \count($response['body']['data']['messagingListSubscribers']['subscribers']));
     }
 
-    public function testGetSubscriber()
+    public function test_get_subscriber()
     {
         $subscriber = $this->setupSubscriber();
         $topicId = $subscriber['topicId'];
@@ -1058,7 +1082,7 @@ class MessagingTest extends Scope
         $this->assertEquals($subscriber['target']['userId'], $response['body']['data']['messagingGetSubscriber']['target']['userId']);
     }
 
-    public function testDeleteSubscriber()
+    public function test_delete_subscriber()
     {
         $subscriber = $this->setupSubscriber();
         $topicId = $subscriber['topicId'];
@@ -1084,7 +1108,7 @@ class MessagingTest extends Scope
         static::$cachedSubscriber[$key] = [];
     }
 
-    public function testDeleteTopic()
+    public function test_delete_topic()
     {
         $topicId = $this->setupUpdatedTopic();
 
@@ -1106,16 +1130,16 @@ class MessagingTest extends Scope
         // Clear cache after deletion
         $key = $this->getProject()['$id'];
         static::$cachedTopic[$key] = [];
-        static::$cachedTopic[$key . '_updated'] = [];
+        static::$cachedTopic[$key.'_updated'] = [];
     }
 
-    public function testSendEmail(): void
+    public function test_send_email(): void
     {
         $email = $this->setupEmail();
         $this->assertEquals(1, $email['deliveredTotal']);
     }
 
-    public function testUpdateEmail()
+    public function test_update_email()
     {
         $email = $this->setupEmail();
 
@@ -1156,7 +1180,7 @@ class MessagingTest extends Scope
 
         $updatedEmailId = $email['body']['data']['messagingUpdateEmail']['_id'];
         $this->assertEventually(function () use ($updatedEmailId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedEmailId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedEmailId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1182,13 +1206,13 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
     }
 
-    public function testSendSMS(): void
+    public function test_send_sms(): void
     {
         $sms = $this->setupSms();
         $this->assertEquals(1, $sms['deliveredTotal']);
     }
 
-    public function testUpdateSMS()
+    public function test_update_sms()
     {
         $sms = $this->setupSms();
 
@@ -1228,7 +1252,7 @@ class MessagingTest extends Scope
 
         $updatedSmsId = $sms['body']['data']['messagingUpdateSMS']['_id'];
         $this->assertEventually(function () use ($updatedSmsId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedSmsId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedSmsId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1254,13 +1278,13 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
     }
 
-    public function testSendPushNotification(): void
+    public function test_send_push_notification(): void
     {
         $push = $this->setupPush();
         $this->assertEquals(1, $push['deliveredTotal']);
     }
 
-    public function testUpdatePushNotification()
+    public function test_update_push_notification()
     {
         $push = $this->setupPush();
 
@@ -1301,7 +1325,7 @@ class MessagingTest extends Scope
 
         $updatedPushId = $push['body']['data']['messagingUpdatePushNotification']['_id'];
         $this->assertEventually(function () use ($updatedPushId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedPushId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedPushId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],

--- a/tests/e2e/Services/GraphQL/MessagingTest.php
+++ b/tests/e2e/Services/GraphQL/MessagingTest.php
@@ -901,7 +901,7 @@ class MessagingTest extends Scope
     public function test_create_providers(): void
     {
         $providers = $this->setupProviders();
-        $this->assertCount(10, $providers);
+        $this->assertCount(11, $providers);
     }
 
     public function test_update_providers(): void

--- a/tests/e2e/Services/GraphQL/MessagingTest.php
+++ b/tests/e2e/Services/GraphQL/MessagingTest.php
@@ -12,26 +12,21 @@ use Utopia\System\System;
 
 class MessagingTest extends Scope
 {
-    use Base;
     use ProjectCustom;
     use SideServer;
+    use Base;
 
     private static array $cachedProviders = [];
-
     private static array $cachedTopic = [];
-
     private static array $cachedSubscriber = [];
-
     private static array $cachedEmail = [];
-
     private static array $cachedSms = [];
-
     private static array $cachedPush = [];
 
     protected function setupProviders(): array
     {
         $key = $this->getProject()['$id'];
-        if (! empty(static::$cachedProviders[$key])) {
+        if (!empty(static::$cachedProviders[$key])) {
             return static::$cachedProviders[$key];
         }
 
@@ -85,7 +80,7 @@ class MessagingTest extends Scope
                 'name' => 'Ms91-1',
                 'senderId' => 'my-senderid',
                 'authKey' => 'my-authkey',
-                'templateId' => '123456',
+                'templateId' => '123456'
             ],
             'Vonage' => [
                 'providerId' => ID::unique(),
@@ -99,10 +94,10 @@ class MessagingTest extends Scope
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    'project_id' => 'test-project',
-                    'private_key_id' => 'test-private-key-id',
-                    'private_key' => 'test-private-key',
-                ],
+                    "project_id" => "test-project",
+                    "private_key_id" => "test-private-key-id",
+                    "private_key" => "test-private-key",
+                ]
             ],
             'Apns' => [
                 'providerId' => ID::unique(),
@@ -123,7 +118,7 @@ class MessagingTest extends Scope
         $providers = [];
 
         foreach (\array_keys($providersParams) as $providerKey) {
-            $query = $this->getQuery('create_'.\strtolower($providerKey).'_provider');
+            $query = $this->getQuery('create_' . \strtolower($providerKey) . '_provider');
             $graphQLPayload = [
                 'query' => $query,
                 'variables' => $providersParams[$providerKey],
@@ -134,20 +129,19 @@ class MessagingTest extends Scope
                 'x-appwrite-key' => $this->getProject()['apiKey'],
             ]), $graphQLPayload);
 
-            $providers[] = $response['body']['data']['messagingCreate'.$providerKey.'Provider'];
+            $providers[] = $response['body']['data']['messagingCreate' . $providerKey . 'Provider'];
             $this->assertEquals(200, $response['headers']['status-code']);
-            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingCreate'.$providerKey.'Provider']['name']);
+            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingCreate' . $providerKey . 'Provider']['name']);
         }
 
         static::$cachedProviders[$key] = $providers;
-
         return $providers;
     }
 
     protected function setupUpdatedProviders(): array
     {
-        $key = $this->getProject()['$id'].'_updated';
-        if (! empty(static::$cachedProviders[$key])) {
+        $key = $this->getProject()['$id'] . '_updated';
+        if (!empty(static::$cachedProviders[$key])) {
             return static::$cachedProviders[$key];
         }
 
@@ -208,8 +202,8 @@ class MessagingTest extends Scope
                     'type' => 'service_account',
                     'project_id' => 'test-project',
                     'private_key_id' => 'test-project-id',
-                    'private_key' => 'test-private-key',
-                ],
+                    'private_key' => "test-private-key",
+                ]
             ],
             'Apns' => [
                 'providerId' => $providers[9]['_id'],
@@ -226,7 +220,7 @@ class MessagingTest extends Scope
             ],
         ];
         foreach (\array_keys($providersParams) as $index => $providerKey) {
-            $query = $this->getQuery('update_'.\strtolower($providerKey).'_provider');
+            $query = $this->getQuery('update_' . \strtolower($providerKey) . '_provider');
 
             $graphQLPayload = [
                 'query' => $query,
@@ -239,9 +233,9 @@ class MessagingTest extends Scope
                 'x-appwrite-key' => $this->getProject()['apiKey'],
             ], $graphQLPayload);
 
-            $providers[$index] = $response['body']['data']['messagingUpdate'.$providerKey.'Provider'];
+            $providers[$index] = $response['body']['data']['messagingUpdate' . $providerKey . 'Provider'];
             $this->assertEquals(200, $response['headers']['status-code']);
-            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingUpdate'.$providerKey.'Provider']['name']);
+            $this->assertEquals($providersParams[$providerKey]['name'], $response['body']['data']['messagingUpdate' . $providerKey . 'Provider']['name']);
         }
 
         $response = $this->client->call(Client::METHOD_POST, '/graphql', [
@@ -257,7 +251,7 @@ class MessagingTest extends Scope
                 'domain' => 'my-domain',
                 'isEuRegion' => true,
                 'enabled' => false,
-            ],
+            ]
         ]);
         $providers[2] = $response['body']['data']['messagingUpdateMailgunProvider'];
         $this->assertEquals(200, $response['headers']['status-code']);
@@ -265,14 +259,13 @@ class MessagingTest extends Scope
         $this->assertEquals(false, $response['body']['data']['messagingUpdateMailgunProvider']['enabled']);
 
         static::$cachedProviders[$key] = $providers;
-
         return $providers;
     }
 
     protected function setupTopic(): array
     {
         $key = $this->getProject()['$id'];
-        if (! empty(static::$cachedTopic[$key])) {
+        if (!empty(static::$cachedTopic[$key])) {
             return static::$cachedTopic[$key];
         }
 
@@ -294,14 +287,13 @@ class MessagingTest extends Scope
         $this->assertEquals('topic1', $response['body']['data']['messagingCreateTopic']['name']);
 
         static::$cachedTopic[$key] = $response['body']['data']['messagingCreateTopic'];
-
         return static::$cachedTopic[$key];
     }
 
     protected function setupUpdatedTopic(): string
     {
-        $key = $this->getProject()['$id'].'_updated';
-        if (! empty(static::$cachedTopic[$key])) {
+        $key = $this->getProject()['$id'] . '_updated';
+        if (!empty(static::$cachedTopic[$key])) {
             return static::$cachedTopic[$key];
         }
 
@@ -326,14 +318,13 @@ class MessagingTest extends Scope
         $this->assertEquals('topic2', $response['body']['data']['messagingUpdateTopic']['name']);
 
         static::$cachedTopic[$key] = $topicId;
-
         return $topicId;
     }
 
     protected function setupSubscriber(): array
     {
         $key = $this->getProject()['$id'];
-        if (! empty(static::$cachedSubscriber[$key])) {
+        if (!empty(static::$cachedSubscriber[$key])) {
             return static::$cachedSubscriber[$key];
         }
 
@@ -349,7 +340,7 @@ class MessagingTest extends Scope
                 'apiKey' => 'my-apikey',
                 'fromName' => 'Sender',
                 'fromEmail' => 'sender-email@my-domain.com',
-            ],
+            ]
         ];
         $query = $this->getQuery(self::CREATE_SENDGRID_PROVIDER);
         $graphQLPayload = [
@@ -407,14 +398,13 @@ class MessagingTest extends Scope
         $this->assertEquals($response['body']['data']['messagingCreateSubscriber']['target']['userId'], $userId);
 
         static::$cachedSubscriber[$key] = $response['body']['data']['messagingCreateSubscriber'];
-
         return static::$cachedSubscriber[$key];
     }
 
     protected function setupEmail(): array
     {
         $key = $this->getProject()['$id'];
-        if (! empty(static::$cachedEmail[$key])) {
+        if (!empty(static::$cachedEmail[$key])) {
             return static::$cachedEmail[$key];
         }
 
@@ -481,7 +471,7 @@ class MessagingTest extends Scope
                 'email' => 'random1-mail@mail.org',
                 'password' => 'password',
                 'name' => 'Messaging User',
-            ],
+            ]
         ];
         $user = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
             'content-type' => 'application/json',
@@ -546,7 +536,7 @@ class MessagingTest extends Scope
 
         $emailMessageId = $email['body']['data']['messagingCreateEmail']['_id'];
         $this->assertEventually(function () use ($emailMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emailMessageId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -572,14 +562,13 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
 
         static::$cachedEmail[$key] = $message['body']['data']['messagingGetMessage'];
-
         return static::$cachedEmail[$key];
     }
 
     protected function setupSms(): array
     {
         $key = $this->getProject()['$id'];
-        if (! empty(static::$cachedSms[$key])) {
+        if (!empty(static::$cachedSms[$key])) {
             return static::$cachedSms[$key];
         }
 
@@ -642,7 +631,7 @@ class MessagingTest extends Scope
                 'email' => 'random3-email@mail.org',
                 'password' => 'password',
                 'name' => 'Messaging User',
-            ],
+            ]
         ];
         $user = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
             'content-type' => 'application/json',
@@ -706,7 +695,7 @@ class MessagingTest extends Scope
 
         $smsMessageId = $sms['body']['data']['messagingCreateSMS']['_id'];
         $this->assertEventually(function () use ($smsMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -732,14 +721,13 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
 
         static::$cachedSms[$key] = $message['body']['data']['messagingGetMessage'];
-
         return static::$cachedSms[$key];
     }
 
     protected function setupPush(): array
     {
         $key = $this->getProject()['$id'];
-        if (! empty(static::$cachedPush[$key])) {
+        if (!empty(static::$cachedPush[$key])) {
             return static::$cachedPush[$key];
         }
 
@@ -763,10 +751,10 @@ class MessagingTest extends Scope
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    'project_id' => 'test-project',
-                    'private_key_id' => 'test-private-key-id',
-                    'private_key' => 'test-private-key',
-                ],
+                    "project_id" => "test-project",
+                    "private_key_id" => "test-private-key-id",
+                    "private_key" => "test-private-key",
+                ]
             ],
         ];
         $provider = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
@@ -803,7 +791,7 @@ class MessagingTest extends Scope
                 'email' => 'random5-mail@mail.org',
                 'password' => 'password',
                 'name' => 'Messaging User',
-            ],
+            ]
         ];
         $user = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
             'content-type' => 'application/json',
@@ -868,7 +856,7 @@ class MessagingTest extends Scope
 
         $pushMessageId = $push['body']['data']['messagingCreatePushNotification']['_id'];
         $this->assertEventually(function () use ($pushMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -894,23 +882,22 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
 
         static::$cachedPush[$key] = $message['body']['data']['messagingGetMessage'];
-
         return static::$cachedPush[$key];
     }
 
-    public function test_create_providers(): void
+    public function testCreateProviders(): void
     {
         $providers = $this->setupProviders();
         $this->assertCount(11, $providers);
     }
 
-    public function test_update_providers(): void
+    public function testUpdateProviders(): void
     {
         $providers = $this->setupUpdatedProviders();
         $this->assertEquals('Sengrid2', $providers[0]['name']);
     }
 
-    public function test_list_providers()
+    public function testListProviders()
     {
         $providers = $this->setupUpdatedProviders();
 
@@ -927,7 +914,7 @@ class MessagingTest extends Scope
         $this->assertEquals(\count($providers), \count($response['body']['data']['messagingListProviders']['providers']));
     }
 
-    public function test_get_provider()
+    public function testGetProvider()
     {
         $providers = $this->setupUpdatedProviders();
 
@@ -936,7 +923,7 @@ class MessagingTest extends Scope
             'query' => $query,
             'variables' => [
                 'providerId' => $providers[0]['_id'],
-            ],
+            ]
         ];
         $response = $this->client->call(Client::METHOD_POST, '/graphql', [
             'content-type' => 'application/json',
@@ -947,7 +934,7 @@ class MessagingTest extends Scope
         $this->assertEquals($providers[0]['name'], $response['body']['data']['messagingGetProvider']['name']);
     }
 
-    public function test_delete_provider()
+    public function testDeleteProvider()
     {
         $providers = $this->setupUpdatedProviders();
 
@@ -957,7 +944,7 @@ class MessagingTest extends Scope
                 'query' => $query,
                 'variables' => [
                     'providerId' => $provider['_id'],
-                ],
+                ]
             ];
             $response = $this->client->call(Client::METHOD_POST, '/graphql', [
                 'content-type' => 'application/json',
@@ -970,22 +957,22 @@ class MessagingTest extends Scope
         // Clear cache after deletion
         $key = $this->getProject()['$id'];
         static::$cachedProviders[$key] = [];
-        static::$cachedProviders[$key.'_updated'] = [];
+        static::$cachedProviders[$key . '_updated'] = [];
     }
 
-    public function test_create_topic(): void
+    public function testCreateTopic(): void
     {
         $topic = $this->setupTopic();
         $this->assertEquals('topic1', $topic['name']);
     }
 
-    public function test_update_topic(): void
+    public function testUpdateTopic(): void
     {
         $topicId = $this->setupUpdatedTopic();
         $this->assertNotEmpty($topicId);
     }
 
-    public function test_list_topics()
+    public function testListTopics()
     {
         $this->setupTopic();
 
@@ -1003,7 +990,7 @@ class MessagingTest extends Scope
         $this->assertEquals(1, \count($response['body']['data']['messagingListTopics']['topics']));
     }
 
-    public function test_get_topic()
+    public function testGetTopic()
     {
         $topicId = $this->setupUpdatedTopic();
 
@@ -1024,13 +1011,13 @@ class MessagingTest extends Scope
         $this->assertEquals('topic2', $response['body']['data']['messagingGetTopic']['name']);
     }
 
-    public function test_create_subscriber(): void
+    public function testCreateSubscriber(): void
     {
         $subscriber = $this->setupSubscriber();
         $this->assertNotEmpty($subscriber['_id']);
     }
 
-    public function test_list_subscribers()
+    public function testListSubscribers()
     {
         $subscriber = $this->setupSubscriber();
 
@@ -1054,7 +1041,7 @@ class MessagingTest extends Scope
         $this->assertEquals(1, \count($response['body']['data']['messagingListSubscribers']['subscribers']));
     }
 
-    public function test_get_subscriber()
+    public function testGetSubscriber()
     {
         $subscriber = $this->setupSubscriber();
         $topicId = $subscriber['topicId'];
@@ -1082,7 +1069,7 @@ class MessagingTest extends Scope
         $this->assertEquals($subscriber['target']['userId'], $response['body']['data']['messagingGetSubscriber']['target']['userId']);
     }
 
-    public function test_delete_subscriber()
+    public function testDeleteSubscriber()
     {
         $subscriber = $this->setupSubscriber();
         $topicId = $subscriber['topicId'];
@@ -1108,7 +1095,7 @@ class MessagingTest extends Scope
         static::$cachedSubscriber[$key] = [];
     }
 
-    public function test_delete_topic()
+    public function testDeleteTopic()
     {
         $topicId = $this->setupUpdatedTopic();
 
@@ -1130,16 +1117,16 @@ class MessagingTest extends Scope
         // Clear cache after deletion
         $key = $this->getProject()['$id'];
         static::$cachedTopic[$key] = [];
-        static::$cachedTopic[$key.'_updated'] = [];
+        static::$cachedTopic[$key . '_updated'] = [];
     }
 
-    public function test_send_email(): void
+    public function testSendEmail(): void
     {
         $email = $this->setupEmail();
         $this->assertEquals(1, $email['deliveredTotal']);
     }
 
-    public function test_update_email()
+    public function testUpdateEmail()
     {
         $email = $this->setupEmail();
 
@@ -1180,7 +1167,7 @@ class MessagingTest extends Scope
 
         $updatedEmailId = $email['body']['data']['messagingUpdateEmail']['_id'];
         $this->assertEventually(function () use ($updatedEmailId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedEmailId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedEmailId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1206,13 +1193,13 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
     }
 
-    public function test_send_sms(): void
+    public function testSendSMS(): void
     {
         $sms = $this->setupSms();
         $this->assertEquals(1, $sms['deliveredTotal']);
     }
 
-    public function test_update_sms()
+    public function testUpdateSMS()
     {
         $sms = $this->setupSms();
 
@@ -1252,7 +1239,7 @@ class MessagingTest extends Scope
 
         $updatedSmsId = $sms['body']['data']['messagingUpdateSMS']['_id'];
         $this->assertEventually(function () use ($updatedSmsId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedSmsId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedSmsId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1278,13 +1265,13 @@ class MessagingTest extends Scope
         $this->assertEquals(0, \count($message['body']['data']['messagingGetMessage']['deliveryErrors']));
     }
 
-    public function test_send_push_notification(): void
+    public function testSendPushNotification(): void
     {
         $push = $this->setupPush();
         $this->assertEquals(1, $push['deliveredTotal']);
     }
 
-    public function test_update_push_notification()
+    public function testUpdatePushNotification()
     {
         $push = $this->setupPush();
 
@@ -1325,7 +1312,7 @@ class MessagingTest extends Scope
 
         $updatedPushId = $push['body']['data']['messagingUpdatePushNotification']['_id'];
         $this->assertEventually(function () use ($updatedPushId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedPushId, array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedPushId, array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -20,21 +20,13 @@ trait MessagingBase
      * Static caches for test data
      */
     private static array $createdProviders = [];
-
     private static array $updatedProviders = [];
-
     private static array $createdTopics = [];
-
     private static array $updatedTopicId = [];
-
     private static array $subscriberData = [];
-
     private static array $draftEmailMessage = [];
-
     private static array $sentEmailData = [];
-
     private static array $sentSmsData = [];
-
     private static array $sentPushData = [];
 
     /**
@@ -43,7 +35,7 @@ trait MessagingBase
     protected function setupCreatedProviders(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$createdProviders[$cacheKey])) {
+        if (!empty(self::$createdProviders[$cacheKey])) {
             return self::$createdProviders[$cacheKey];
         }
 
@@ -107,7 +99,7 @@ trait MessagingBase
                 'name' => 'Ms91-1',
                 'senderId' => 'my-senderid',
                 'authKey' => 'my-authkey',
-                'templateId' => '123456',
+                'templateId' => '123456'
             ],
             'vonage' => [
                 'providerId' => ID::unique(),
@@ -121,9 +113,9 @@ trait MessagingBase
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    'project_id' => 'test-project',
-                    'private_key_id' => 'test-private-key-id',
-                    'private_key' => 'test-private-key',
+                    "project_id" => "test-project",
+                    "private_key_id" => "test-private-key-id",
+                    "private_key" => "test-private-key",
                 ],
             ],
             'apns' => [
@@ -144,7 +136,7 @@ trait MessagingBase
         $providers = [];
 
         foreach ($providersParams as $key => $params) {
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/'.$key, \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/' . $key, \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -154,7 +146,6 @@ trait MessagingBase
         }
 
         self::$createdProviders[$cacheKey] = $providers;
-
         return $providers;
     }
 
@@ -164,7 +155,7 @@ trait MessagingBase
     protected function setupUpdatedProviders(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$updatedProviders[$cacheKey])) {
+        if (!empty(self::$updatedProviders[$cacheKey])) {
             return self::$updatedProviders[$cacheKey];
         }
 
@@ -221,10 +212,10 @@ trait MessagingBase
                 'name' => 'FCM2',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    'project_id' => 'test-project',
-                    'private_key_id' => 'test-private-key-id',
-                    'private_key' => 'test-private-key',
-                ],
+                    "project_id" => "test-project",
+                    "private_key_id" => "test-private-key-id",
+                    "private_key" => "test-private-key",
+                ]
             ],
             'apns' => [
                 'name' => 'APNS2',
@@ -240,7 +231,7 @@ trait MessagingBase
         ];
 
         foreach (\array_keys($providersParams) as $index => $name) {
-            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/'.$name.'/'.$providers[$index]['$id'], [
+            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/' . $name . '/' . $providers[$index]['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -249,7 +240,7 @@ trait MessagingBase
             $providers[$index] = $response['body'];
         }
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/'.$providers[2]['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/' . $providers[2]['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -264,7 +255,6 @@ trait MessagingBase
         $providers[2] = $response['body'];
 
         self::$updatedProviders[$cacheKey] = $providers;
-
         return $providers;
     }
 
@@ -274,7 +264,7 @@ trait MessagingBase
     protected function setupCreatedTopics(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$createdTopics[$cacheKey])) {
+        if (!empty(self::$createdTopics[$cacheKey])) {
             return self::$createdTopics[$cacheKey];
         }
 
@@ -311,13 +301,13 @@ trait MessagingBase
     protected function setupUpdatedTopicId(): string
     {
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$updatedTopicId[$cacheKey])) {
+        if (!empty(self::$updatedTopicId[$cacheKey])) {
             return self::$updatedTopicId[$cacheKey];
         }
 
         $topics = $this->setupCreatedTopics();
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['public']['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -325,7 +315,7 @@ trait MessagingBase
             'name' => 'android-app',
         ]);
 
-        $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['private']['$id'], [
+        $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['private']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -335,7 +325,6 @@ trait MessagingBase
         ]);
 
         self::$updatedTopicId[$cacheKey] = $response['body']['$id'];
-
         return self::$updatedTopicId[$cacheKey];
     }
 
@@ -345,7 +334,7 @@ trait MessagingBase
     protected function setupSubscriberData(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$subscriberData[$cacheKey])) {
+        if (!empty(self::$subscriberData[$cacheKey])) {
             return self::$subscriberData[$cacheKey];
         }
 
@@ -366,7 +355,7 @@ trait MessagingBase
             'from' => 'sender-email@my-domain.com',
         ]);
 
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$userId.'/targets', array_merge([
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/targets', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -377,7 +366,7 @@ trait MessagingBase
             'identifier' => 'random-email@mail.org',
         ]);
 
-        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -403,7 +392,7 @@ trait MessagingBase
     protected function setupDraftEmailMessage(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$draftEmailMessage[$cacheKey])) {
+        if (!empty(self::$draftEmailMessage[$cacheKey])) {
             return self::$draftEmailMessage[$cacheKey];
         }
 
@@ -414,7 +403,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User Draft 1',
         ]);
@@ -429,7 +418,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User Draft 2',
         ]);
@@ -447,11 +436,10 @@ trait MessagingBase
             'targets' => [$targetId1, $targetId2],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'draft' => true,
+            'draft' => true
         ]);
 
         self::$draftEmailMessage[$cacheKey] = $response['body'];
-
         return self::$draftEmailMessage[$cacheKey];
     }
 
@@ -465,7 +453,7 @@ trait MessagingBase
         }
 
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$sentEmailData[$cacheKey])) {
+        if (!empty(self::$sentEmailData[$cacheKey])) {
             return self::$sentEmailData[$cacheKey];
         }
 
@@ -519,7 +507,7 @@ trait MessagingBase
         $target = $user['body']['targets'][0];
 
         // Create Subscriber
-        $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
+        $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -541,7 +529,7 @@ trait MessagingBase
 
         $messageId = $email['body']['$id'];
         $this->assertEventually(function () use ($messageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$messageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -567,7 +555,7 @@ trait MessagingBase
         }
 
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$sentSmsData[$cacheKey])) {
+        if (!empty(self::$sentSmsData[$cacheKey])) {
             return self::$sentSmsData[$cacheKey];
         }
 
@@ -618,7 +606,7 @@ trait MessagingBase
         ]);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -630,7 +618,7 @@ trait MessagingBase
         ]);
 
         // Create Subscriber
-        $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
+        $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -651,7 +639,7 @@ trait MessagingBase
 
         $smsMessageId = $sms['body']['$id'];
         $this->assertEventually(function () use ($smsMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -674,7 +662,7 @@ trait MessagingBase
         }
 
         $cacheKey = $this->getProject()['$id'];
-        if (! empty(self::$sentPushData[$cacheKey])) {
+        if (!empty(self::$sentPushData[$cacheKey])) {
             return self::$sentPushData[$cacheKey];
         }
 
@@ -721,7 +709,7 @@ trait MessagingBase
         ]);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -733,7 +721,7 @@ trait MessagingBase
         ]);
 
         // Create Subscriber
-        $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
+        $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -755,7 +743,7 @@ trait MessagingBase
 
         $pushMessageId = $push['body']['$id'];
         $this->assertEventually(function () use ($pushMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -830,7 +818,7 @@ trait MessagingBase
                 'name' => 'Ms91-1',
                 'senderId' => 'my-senderid',
                 'authKey' => 'my-authkey',
-                'templateId' => '123456',
+                'templateId' => '123456'
             ],
             'vonage' => [
                 'providerId' => ID::unique(),
@@ -844,9 +832,9 @@ trait MessagingBase
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    'project_id' => 'test-project',
-                    'private_key_id' => 'test-private-key-id',
-                    'private_key' => 'test-private-key',
+                    "project_id" => "test-project",
+                    "private_key_id" => "test-private-key-id",
+                    "private_key" => "test-private-key",
                 ],
             ],
             'apns' => [
@@ -860,7 +848,7 @@ trait MessagingBase
         ];
 
         foreach ($providersParams as $key => $params) {
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/'.$key, \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/' . $key, \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -932,10 +920,10 @@ trait MessagingBase
                 'name' => 'FCM2',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    'project_id' => 'test-project',
-                    'private_key_id' => 'test-private-key-id',
-                    'private_key' => 'test-private-key',
-                ],
+                    "project_id" => "test-project",
+                    "private_key_id" => "test-private-key-id",
+                    "private_key" => "test-private-key",
+                ]
             ],
             'apns' => [
                 'name' => 'APNS2',
@@ -947,7 +935,7 @@ trait MessagingBase
         ];
 
         foreach (\array_keys($providersParams) as $index => $name) {
-            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/'.$name.'/'.$providers[$index]['$id'], [
+            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/' . $name . '/' . $providers[$index]['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -966,7 +954,7 @@ trait MessagingBase
             }
         }
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/'.$providers[2]['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/' . $providers[2]['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -998,7 +986,7 @@ trait MessagingBase
         $this->assertEquals(201, $response['headers']['status-code']);
 
         // Enable provider with no serviceAccountJSON
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/fcm/'.$response['body']['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/fcm/' . $response['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1030,7 +1018,7 @@ trait MessagingBase
     {
         $providers = $this->setupUpdatedProviders();
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/providers/'.$providers[0]['$id'], [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/providers/' . $providers[0]['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1052,7 +1040,7 @@ trait MessagingBase
         ];
 
         foreach ($providersParams as $key => $params) {
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/'.$key, \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/' . $key, \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1060,7 +1048,7 @@ trait MessagingBase
 
             $this->assertEquals(201, $response['headers']['status-code']);
 
-            $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/providers/'.$response['body']['$id'], [
+            $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/providers/' . $response['body']['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1100,7 +1088,7 @@ trait MessagingBase
     {
         $topics = $this->setupCreatedTopics();
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['public']['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1110,7 +1098,7 @@ trait MessagingBase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('android-app', $response['body']['name']);
 
-        $response2 = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['private']['$id'], [
+        $response2 = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['private']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1163,7 +1151,7 @@ trait MessagingBase
     {
         $topicId = $this->setupUpdatedTopicId();
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$topicId, [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $topicId, [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1196,7 +1184,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $provider['headers']['status-code']);
 
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$userId.'/targets', array_merge([
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/targets', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1209,7 +1197,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $target['headers']['status-code']);
 
-        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1222,7 +1210,7 @@ trait MessagingBase
         $this->assertEquals($target['body']['providerType'], $response['body']['target']['providerType']);
 
         // Test duplicate subscribers not allowed
-        $failure = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
+        $failure = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1232,7 +1220,7 @@ trait MessagingBase
 
         $this->assertEquals(409, $failure['headers']['status-code']);
 
-        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$topics['public']['$id'], [
+        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1244,7 +1232,7 @@ trait MessagingBase
         $this->assertEquals(0, $topic['body']['smsTotal']);
         $this->assertEquals(0, $topic['body']['pushTotal']);
 
-        $response2 = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['private']['$id'].'/subscribers', \array_merge([
+        $response2 = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['private']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1296,7 +1284,7 @@ trait MessagingBase
 
             $target = $targets[0];
 
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['$id'].'/subscribers', \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['$id'] . '/subscribers', \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], $this->getHeaders()), [
@@ -1312,7 +1300,7 @@ trait MessagingBase
     {
         $data = $this->setupSubscriberData();
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers/'.$data['subscriberId'], \array_merge([
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers/' . $data['subscriberId'], \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1336,7 +1324,7 @@ trait MessagingBase
         $providerType = $data['providerType'];
         $identifier = $data['identifier'];
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1358,7 +1346,7 @@ trait MessagingBase
         $this->assertEquals($identifier, $ourSubscriber['target']['identifier']);
         $this->assertEquals(\count($response['body']['subscribers']), $response['body']['total']);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1373,10 +1361,10 @@ trait MessagingBase
             $subscriberId,
             $targetId,
             $userId,
-            $providerType,
+            $providerType
         ];
         foreach ($searches as $search) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1391,12 +1379,12 @@ trait MessagingBase
         /**
          * Test for SUCCESS with total=false
          */
-        $subscribersWithIncludeTotalFalse = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
+        $subscribersWithIncludeTotalFalse = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ]), [
-            'total' => false,
+            'total' => false
         ]);
 
         $this->assertEquals(200, $subscribersWithIncludeTotalFalse['headers']['status-code']);
@@ -1413,7 +1401,7 @@ trait MessagingBase
         /**
          * Test for SUCCESS
          */
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1423,7 +1411,7 @@ trait MessagingBase
         $this->assertIsArray($logs['body']['logs']);
         $this->assertIsNumeric($logs['body']['total']);
 
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1438,7 +1426,7 @@ trait MessagingBase
         $this->assertLessThanOrEqual(1, count($logs['body']['logs']));
         $this->assertIsNumeric($logs['body']['total']);
 
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1452,7 +1440,7 @@ trait MessagingBase
         $this->assertIsArray($logs['body']['logs']);
         $this->assertIsNumeric($logs['body']['total']);
 
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1471,7 +1459,7 @@ trait MessagingBase
         /**
          * Test for FAILURE
          */
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1483,7 +1471,7 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1495,7 +1483,7 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1507,7 +1495,7 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1519,14 +1507,14 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'queries' => [
-                '{ "method": "cursorAsc", "attribute": "$id" }',
-            ],
+                '{ "method": "cursorAsc", "attribute": "$id" }'
+            ]
         ]);
 
         $this->assertEquals($response['headers']['status-code'], 400);
@@ -1551,7 +1539,7 @@ trait MessagingBase
             'from' => 'sender-email@my-domain.com',
         ]);
 
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$userId.'/targets', array_merge([
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/targets', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1562,7 +1550,7 @@ trait MessagingBase
             'identifier' => 'random-email-delete@mail.org',
         ]);
 
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1570,14 +1558,14 @@ trait MessagingBase
             'targetId' => $target['body']['$id'],
         ]);
 
-        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/'.$topics['public']['$id'].'/subscribers/'.$subscriber['body']['$id'], \array_merge([
+        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers/' . $subscriber['body']['$id'], \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
         $this->assertEquals(204, $response['headers']['status-code']);
 
-        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$topics['public']['$id'], [
+        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1601,7 +1589,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $response['headers']['status-code']);
 
-        $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/'.$response['body']['$id'], [
+        $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/' . $response['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1621,7 +1609,7 @@ trait MessagingBase
 
         $this->assertEquals(404, $response['headers']['status-code']);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$message['$id'].'/targets', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $message['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1636,14 +1624,14 @@ trait MessagingBase
         /**
          * Cursor Test
          */
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$message['$id'].'/targets', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $message['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'queries' => [
                 Query::cursorAfter(new Document(['$id' => $targetList['targets'][0]['$id']]))->toString(),
-            ],
+            ]
         ]);
         $this->assertEquals(2, $response['body']['total']);
         $this->assertEquals(1, count($response['body']['targets']));
@@ -1658,14 +1646,14 @@ trait MessagingBase
             'messageId' => ID::unique(),
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'draft' => true,
+            'draft' => true
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
 
         $emptyMessage = $response['body'];
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emptyMessage['$id'].'/targets', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emptyMessage['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1687,12 +1675,12 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code'], 'Error creating user: '.var_export($response['body'], true));
+        $this->assertEquals(201, $response['headers']['status-code'], "Error creating user: " . var_export($response['body'], true));
 
         $user1 = $response['body'];
 
@@ -1706,12 +1694,12 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 2',
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code'], 'Error creating user: '.var_export($response['body'], true));
+        $this->assertEquals(201, $response['headers']['status-code'], "Error creating user: " . var_export($response['body'], true));
         $user2 = $response['body'];
 
         $this->assertEquals(1, \count($user2['targets']));
@@ -1727,7 +1715,7 @@ trait MessagingBase
             'targets' => [$targetId1, $targetId2],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'draft' => true,
+            'draft' => true
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
@@ -1744,16 +1732,16 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
 
-        $this->assertEquals(201, $user['headers']['status-code'], 'Error creating user: '.var_export($user['body'], true));
+        $this->assertEquals(201, $user['headers']['status-code'], "Error creating user: " . var_export($user['body'], true));
         $this->assertEquals(1, \count($user['body']['targets']));
 
         // Create push target
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1790,7 +1778,7 @@ trait MessagingBase
         $bucketId = $bucket['body']['$id'];
 
         $this->assertEventually(function () use ($bucketId) {
-            $response = $this->client->call(Client::METHOD_GET, '/storage/buckets/'.$bucketId, [
+            $response = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1799,13 +1787,13 @@ trait MessagingBase
         }, 10000, 500);
 
         // Create file
-        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/'.$bucketId.'/files', [
+        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', [
             'content-type' => 'multipart/form-data',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'fileId' => ID::unique(),
-            'file' => new CURLFile(realpath(__DIR__.'/../../../resources/logo.png'), 'image/png', 'logo.png'),
+            'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/logo.png'), 'image/png', 'logo.png'),
             'permissions' => [
                 Permission::read(Role::any()),
                 Permission::update(Role::any()),
@@ -1826,7 +1814,7 @@ trait MessagingBase
             'title' => 'New blog post',
             'body' => 'Check out the new blog post at http://localhost',
             'image' => "{$bucketId}:{$fileId}",
-            'draft' => true,
+            'draft' => true
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
@@ -1837,7 +1825,7 @@ trait MessagingBase
 
         $imageUrl = $message['data']['image']['url'];
 
-        $client = new Client;
+        $client = new Client();
         $client->setEndpoint('');
 
         $image = $client->call(Client::METHOD_GET, $imageUrl);
@@ -1854,7 +1842,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -1882,7 +1870,7 @@ trait MessagingBase
         // Wait for the messaging worker to process and fail the message
         // (no enabled provider exists in this project)
         $this->assertEventually(function () use ($messageId) {
-            $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$messageId, [
+            $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1902,7 +1890,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -1920,13 +1908,13 @@ trait MessagingBase
             'targets' => [$targetId],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'scheduledAt' => DateTime::addSeconds(new \DateTime, 120),
+            'scheduledAt' => DateTime::addSeconds(new \DateTime(), 120),
         ]);
 
         $this->assertEquals(201, $message['headers']['status-code']);
         $this->assertEquals(MessageStatus::SCHEDULED, $message['body']['status']);
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$message['body']['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $message['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1940,7 +1928,7 @@ trait MessagingBase
         // Verify the message remains in DRAFT status and is not processed by the scheduler
         $draftMessageId = $message['body']['$id'];
         $this->assertEventually(function () use ($draftMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$draftMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $draftMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1959,7 +1947,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -1984,9 +1972,9 @@ trait MessagingBase
 
         // Convert draft to scheduled message and verify the transition
         // Schedule far enough in the future to avoid scheduler processing
-        $scheduledAt = DateTime::addSeconds(new \DateTime, 300);
+        $scheduledAt = DateTime::addSeconds(new \DateTime(), 300);
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$message['body']['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $message['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2012,7 +2000,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid().'@example.com',
+            'email' => uniqid() . "@example.com",
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -2030,15 +2018,15 @@ trait MessagingBase
             'targets' => [$targetId],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'scheduledAt' => DateTime::addSeconds(new \DateTime, 20),
+            'scheduledAt' => DateTime::addSeconds(new \DateTime(), 20),
         ]);
 
         $this->assertEquals(201, $message['headers']['status-code']);
         $this->assertEquals(MessageStatus::SCHEDULED, $message['body']['status']);
 
-        $scheduledAt = DateTime::addSeconds(new \DateTime, 300);
+        $scheduledAt = DateTime::addSeconds(new \DateTime(), 300);
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$message['body']['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $message['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2058,7 +2046,7 @@ trait MessagingBase
         // Verify the message remains scheduled (scheduled far enough in the future
         // that the scheduler won't process it)
         $this->assertEventually(function () use ($messageId, $scheduledAt) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$messageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2134,7 +2122,7 @@ trait MessagingBase
         $target = $user['body']['targets'][0];
 
         // Create Subscriber
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2160,7 +2148,7 @@ trait MessagingBase
 
         $emailMessageId = $email['body']['$id'];
         $this->assertEventually(function () use ($emailMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emailMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2168,7 +2156,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emailMessageId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2195,7 +2183,7 @@ trait MessagingBase
 
         $email = $params['message'];
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$email['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $email['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2219,7 +2207,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $newEmail['headers']['status-code']);
 
-        $updatedEmail = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$newEmail['body']['$id'], [
+        $updatedEmail = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $newEmail['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2231,7 +2219,7 @@ trait MessagingBase
 
         $updatedEmailId = $updatedEmail['body']['$id'];
         $this->assertEventually(function () use ($updatedEmailId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedEmailId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedEmailId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2239,7 +2227,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedEmailId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedEmailId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2310,7 +2298,7 @@ trait MessagingBase
         $this->assertEquals(201, $user['headers']['status-code']);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2324,7 +2312,7 @@ trait MessagingBase
         $this->assertEquals(201, $target['headers']['status-code']);
 
         // Create Subscriber
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2349,7 +2337,7 @@ trait MessagingBase
 
         $smsMessageId = $sms['body']['$id'];
         $this->assertEventually(function () use ($smsMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2357,7 +2345,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2377,7 +2365,7 @@ trait MessagingBase
             $this->markTestSkipped('SMS DSN not provided');
         }
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/'.$sms['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/' . $sms['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2400,7 +2388,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $newSms['headers']['status-code']);
 
-        $updatedSms = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/'.$newSms['body']['$id'], [
+        $updatedSms = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/' . $newSms['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2412,7 +2400,7 @@ trait MessagingBase
 
         $updatedSmsId = $updatedSms['body']['$id'];
         $this->assertEventually(function () use ($updatedSmsId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedSmsId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedSmsId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2420,7 +2408,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedSmsId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedSmsId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2487,7 +2475,7 @@ trait MessagingBase
         $this->assertEquals(201, $user['headers']['status-code']);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2501,7 +2489,7 @@ trait MessagingBase
         $this->assertEquals(201, $target['headers']['status-code']);
 
         // Create Subscriber
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2527,7 +2515,7 @@ trait MessagingBase
 
         $pushMessageId = $push['body']['$id'];
         $this->assertEventually(function () use ($pushMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2535,7 +2523,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2555,7 +2543,7 @@ trait MessagingBase
             $this->markTestSkipped('Push DSN not provided');
         }
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/'.$push['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/' . $push['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2579,7 +2567,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $newPush['headers']['status-code']);
 
-        $updatedPush = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/'.$newPush['body']['$id'], [
+        $updatedPush = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/' . $newPush['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2591,7 +2579,7 @@ trait MessagingBase
 
         $updatedPushId = $updatedPush['body']['$id'];
         $this->assertEventually(function () use ($updatedPushId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedPushId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedPushId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2599,7 +2587,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedPushId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedPushId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2612,6 +2600,7 @@ trait MessagingBase
     }
 
     /**
+     * @return void
      * @throws \Exception
      */
     public function testDeleteMessage(): void
@@ -2625,7 +2614,7 @@ trait MessagingBase
         $message = $params['message'];
         $topic = $params['topic'];
 
-        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/'.$message['$id'], [
+        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/' . $message['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2645,7 +2634,7 @@ trait MessagingBase
             'content' => 'Test content',
         ]);
 
-        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/'.$response['body']['$id'], [
+        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/' . $response['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -1021,7 +1021,7 @@ trait MessagingBase
 
         $this->assertEquals(200, $response['headers']['status-code']);
         // Count may vary due to other tests creating providers
-        $this->assertGreaterThanOrEqual(11, \count($response['body']['providers']));
+        $this->assertGreaterThanOrEqual(12, \count($response['body']['providers']));
 
         return $providers;
     }

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -20,13 +20,21 @@ trait MessagingBase
      * Static caches for test data
      */
     private static array $createdProviders = [];
+
     private static array $updatedProviders = [];
+
     private static array $createdTopics = [];
+
     private static array $updatedTopicId = [];
+
     private static array $subscriberData = [];
+
     private static array $draftEmailMessage = [];
+
     private static array $sentEmailData = [];
+
     private static array $sentSmsData = [];
+
     private static array $sentPushData = [];
 
     /**
@@ -35,7 +43,7 @@ trait MessagingBase
     protected function setupCreatedProviders(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$createdProviders[$cacheKey])) {
+        if (! empty(self::$createdProviders[$cacheKey])) {
             return self::$createdProviders[$cacheKey];
         }
 
@@ -99,7 +107,7 @@ trait MessagingBase
                 'name' => 'Ms91-1',
                 'senderId' => 'my-senderid',
                 'authKey' => 'my-authkey',
-                'templateId' => '123456'
+                'templateId' => '123456',
             ],
             'vonage' => [
                 'providerId' => ID::unique(),
@@ -113,9 +121,9 @@ trait MessagingBase
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    "project_id" => "test-project",
-                    "private_key_id" => "test-private-key-id",
-                    "private_key" => "test-private-key",
+                    'project_id' => 'test-project',
+                    'private_key_id' => 'test-private-key-id',
+                    'private_key' => 'test-private-key',
                 ],
             ],
             'apns' => [
@@ -126,11 +134,17 @@ trait MessagingBase
                 'teamId' => 'my-teamid',
                 'bundleId' => 'my-bundleid',
             ],
+            'telnyx' => [
+                'providerId' => ID::unique(),
+                'name' => 'Telnyx1',
+                'apiKey' => 'my-apikey',
+                'from' => '+123456789',
+            ],
         ];
         $providers = [];
 
         foreach ($providersParams as $key => $params) {
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/' . $key, \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/'.$key, \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -140,6 +154,7 @@ trait MessagingBase
         }
 
         self::$createdProviders[$cacheKey] = $providers;
+
         return $providers;
     }
 
@@ -149,7 +164,7 @@ trait MessagingBase
     protected function setupUpdatedProviders(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$updatedProviders[$cacheKey])) {
+        if (! empty(self::$updatedProviders[$cacheKey])) {
             return self::$updatedProviders[$cacheKey];
         }
 
@@ -206,10 +221,10 @@ trait MessagingBase
                 'name' => 'FCM2',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    "project_id" => "test-project",
-                    "private_key_id" => "test-private-key-id",
-                    "private_key" => "test-private-key",
-                ]
+                    'project_id' => 'test-project',
+                    'private_key_id' => 'test-private-key-id',
+                    'private_key' => 'test-private-key',
+                ],
             ],
             'apns' => [
                 'name' => 'APNS2',
@@ -218,10 +233,14 @@ trait MessagingBase
                 'teamId' => 'my-teamid',
                 'bundleId' => 'my-bundleid',
             ],
+            'telnyx' => [
+                'name' => 'Telnyx2',
+                'apiKey' => 'my-apikey',
+            ],
         ];
 
         foreach (\array_keys($providersParams) as $index => $name) {
-            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/' . $name . '/' . $providers[$index]['$id'], [
+            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/'.$name.'/'.$providers[$index]['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -230,7 +249,7 @@ trait MessagingBase
             $providers[$index] = $response['body'];
         }
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/' . $providers[2]['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/'.$providers[2]['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -245,6 +264,7 @@ trait MessagingBase
         $providers[2] = $response['body'];
 
         self::$updatedProviders[$cacheKey] = $providers;
+
         return $providers;
     }
 
@@ -254,7 +274,7 @@ trait MessagingBase
     protected function setupCreatedTopics(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$createdTopics[$cacheKey])) {
+        if (! empty(self::$createdTopics[$cacheKey])) {
             return self::$createdTopics[$cacheKey];
         }
 
@@ -291,13 +311,13 @@ trait MessagingBase
     protected function setupUpdatedTopicId(): string
     {
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$updatedTopicId[$cacheKey])) {
+        if (! empty(self::$updatedTopicId[$cacheKey])) {
             return self::$updatedTopicId[$cacheKey];
         }
 
         $topics = $this->setupCreatedTopics();
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['public']['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -305,7 +325,7 @@ trait MessagingBase
             'name' => 'android-app',
         ]);
 
-        $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['private']['$id'], [
+        $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['private']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -315,6 +335,7 @@ trait MessagingBase
         ]);
 
         self::$updatedTopicId[$cacheKey] = $response['body']['$id'];
+
         return self::$updatedTopicId[$cacheKey];
     }
 
@@ -324,7 +345,7 @@ trait MessagingBase
     protected function setupSubscriberData(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$subscriberData[$cacheKey])) {
+        if (! empty(self::$subscriberData[$cacheKey])) {
             return self::$subscriberData[$cacheKey];
         }
 
@@ -345,7 +366,7 @@ trait MessagingBase
             'from' => 'sender-email@my-domain.com',
         ]);
 
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/targets', array_merge([
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$userId.'/targets', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -356,7 +377,7 @@ trait MessagingBase
             'identifier' => 'random-email@mail.org',
         ]);
 
-        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -382,7 +403,7 @@ trait MessagingBase
     protected function setupDraftEmailMessage(): array
     {
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$draftEmailMessage[$cacheKey])) {
+        if (! empty(self::$draftEmailMessage[$cacheKey])) {
             return self::$draftEmailMessage[$cacheKey];
         }
 
@@ -393,7 +414,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User Draft 1',
         ]);
@@ -408,7 +429,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User Draft 2',
         ]);
@@ -426,10 +447,11 @@ trait MessagingBase
             'targets' => [$targetId1, $targetId2],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'draft' => true
+            'draft' => true,
         ]);
 
         self::$draftEmailMessage[$cacheKey] = $response['body'];
+
         return self::$draftEmailMessage[$cacheKey];
     }
 
@@ -443,7 +465,7 @@ trait MessagingBase
         }
 
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$sentEmailData[$cacheKey])) {
+        if (! empty(self::$sentEmailData[$cacheKey])) {
             return self::$sentEmailData[$cacheKey];
         }
 
@@ -497,7 +519,7 @@ trait MessagingBase
         $target = $user['body']['targets'][0];
 
         // Create Subscriber
-        $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+        $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -519,7 +541,7 @@ trait MessagingBase
 
         $messageId = $email['body']['$id'];
         $this->assertEventually(function () use ($messageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$messageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -545,7 +567,7 @@ trait MessagingBase
         }
 
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$sentSmsData[$cacheKey])) {
+        if (! empty(self::$sentSmsData[$cacheKey])) {
             return self::$sentSmsData[$cacheKey];
         }
 
@@ -596,7 +618,7 @@ trait MessagingBase
         ]);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -608,7 +630,7 @@ trait MessagingBase
         ]);
 
         // Create Subscriber
-        $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+        $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -629,7 +651,7 @@ trait MessagingBase
 
         $smsMessageId = $sms['body']['$id'];
         $this->assertEventually(function () use ($smsMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -652,7 +674,7 @@ trait MessagingBase
         }
 
         $cacheKey = $this->getProject()['$id'];
-        if (!empty(self::$sentPushData[$cacheKey])) {
+        if (! empty(self::$sentPushData[$cacheKey])) {
             return self::$sentPushData[$cacheKey];
         }
 
@@ -699,7 +721,7 @@ trait MessagingBase
         ]);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -711,7 +733,7 @@ trait MessagingBase
         ]);
 
         // Create Subscriber
-        $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+        $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -733,7 +755,7 @@ trait MessagingBase
 
         $pushMessageId = $push['body']['$id'];
         $this->assertEventually(function () use ($pushMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -808,7 +830,7 @@ trait MessagingBase
                 'name' => 'Ms91-1',
                 'senderId' => 'my-senderid',
                 'authKey' => 'my-authkey',
-                'templateId' => '123456'
+                'templateId' => '123456',
             ],
             'vonage' => [
                 'providerId' => ID::unique(),
@@ -822,9 +844,9 @@ trait MessagingBase
                 'name' => 'FCM1',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    "project_id" => "test-project",
-                    "private_key_id" => "test-private-key-id",
-                    "private_key" => "test-private-key",
+                    'project_id' => 'test-project',
+                    'private_key_id' => 'test-private-key-id',
+                    'private_key' => 'test-private-key',
                 ],
             ],
             'apns' => [
@@ -838,7 +860,7 @@ trait MessagingBase
         ];
 
         foreach ($providersParams as $key => $params) {
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/' . $key, \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/'.$key, \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -910,10 +932,10 @@ trait MessagingBase
                 'name' => 'FCM2',
                 'serviceAccountJSON' => [
                     'type' => 'service_account',
-                    "project_id" => "test-project",
-                    "private_key_id" => "test-private-key-id",
-                    "private_key" => "test-private-key",
-                ]
+                    'project_id' => 'test-project',
+                    'private_key_id' => 'test-private-key-id',
+                    'private_key' => 'test-private-key',
+                ],
             ],
             'apns' => [
                 'name' => 'APNS2',
@@ -925,7 +947,7 @@ trait MessagingBase
         ];
 
         foreach (\array_keys($providersParams) as $index => $name) {
-            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/' . $name . '/' . $providers[$index]['$id'], [
+            $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/'.$name.'/'.$providers[$index]['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -944,7 +966,7 @@ trait MessagingBase
             }
         }
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/' . $providers[2]['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/mailgun/'.$providers[2]['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -976,7 +998,7 @@ trait MessagingBase
         $this->assertEquals(201, $response['headers']['status-code']);
 
         // Enable provider with no serviceAccountJSON
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/fcm/' . $response['body']['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/providers/fcm/'.$response['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1008,7 +1030,7 @@ trait MessagingBase
     {
         $providers = $this->setupUpdatedProviders();
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/providers/' . $providers[0]['$id'], [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/providers/'.$providers[0]['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1030,7 +1052,7 @@ trait MessagingBase
         ];
 
         foreach ($providersParams as $key => $params) {
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/' . $key, \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/providers/'.$key, \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1038,7 +1060,7 @@ trait MessagingBase
 
             $this->assertEquals(201, $response['headers']['status-code']);
 
-            $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/providers/' . $response['body']['$id'], [
+            $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/providers/'.$response['body']['$id'], [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1078,7 +1100,7 @@ trait MessagingBase
     {
         $topics = $this->setupCreatedTopics();
 
-        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['public']['$id'], [
+        $response = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1088,7 +1110,7 @@ trait MessagingBase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('android-app', $response['body']['name']);
 
-        $response2 = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/' . $topics['private']['$id'], [
+        $response2 = $this->client->call(Client::METHOD_PATCH, '/messaging/topics/'.$topics['private']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1141,7 +1163,7 @@ trait MessagingBase
     {
         $topicId = $this->setupUpdatedTopicId();
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $topicId, [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$topicId, [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1174,7 +1196,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $provider['headers']['status-code']);
 
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/targets', array_merge([
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$userId.'/targets', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1187,7 +1209,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $target['headers']['status-code']);
 
-        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1200,7 +1222,7 @@ trait MessagingBase
         $this->assertEquals($target['body']['providerType'], $response['body']['target']['providerType']);
 
         // Test duplicate subscribers not allowed
-        $failure = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
+        $failure = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1210,7 +1232,7 @@ trait MessagingBase
 
         $this->assertEquals(409, $failure['headers']['status-code']);
 
-        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $topics['public']['$id'], [
+        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1222,7 +1244,7 @@ trait MessagingBase
         $this->assertEquals(0, $topic['body']['smsTotal']);
         $this->assertEquals(0, $topic['body']['pushTotal']);
 
-        $response2 = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['private']['$id'] . '/subscribers', \array_merge([
+        $response2 = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['private']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1274,7 +1296,7 @@ trait MessagingBase
 
             $target = $targets[0];
 
-            $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['$id'] . '/subscribers', \array_merge([
+            $response = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['$id'].'/subscribers', \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], $this->getHeaders()), [
@@ -1290,7 +1312,7 @@ trait MessagingBase
     {
         $data = $this->setupSubscriberData();
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers/' . $data['subscriberId'], \array_merge([
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers/'.$data['subscriberId'], \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1314,7 +1336,7 @@ trait MessagingBase
         $providerType = $data['providerType'];
         $identifier = $data['identifier'];
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1336,7 +1358,7 @@ trait MessagingBase
         $this->assertEquals($identifier, $ourSubscriber['target']['identifier']);
         $this->assertEquals(\count($response['body']['subscribers']), $response['body']['total']);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1351,10 +1373,10 @@ trait MessagingBase
             $subscriberId,
             $targetId,
             $userId,
-            $providerType
+            $providerType,
         ];
         foreach ($searches as $search) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1369,12 +1391,12 @@ trait MessagingBase
         /**
          * Test for SUCCESS with total=false
          */
-        $subscribersWithIncludeTotalFalse = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $data['topicId'] . '/subscribers', \array_merge([
+        $subscribersWithIncludeTotalFalse = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$data['topicId'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ]), [
-            'total' => false
+            'total' => false,
         ]);
 
         $this->assertEquals(200, $subscribersWithIncludeTotalFalse['headers']['status-code']);
@@ -1391,7 +1413,7 @@ trait MessagingBase
         /**
          * Test for SUCCESS
          */
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1401,7 +1423,7 @@ trait MessagingBase
         $this->assertIsArray($logs['body']['logs']);
         $this->assertIsNumeric($logs['body']['total']);
 
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1416,7 +1438,7 @@ trait MessagingBase
         $this->assertLessThanOrEqual(1, count($logs['body']['logs']));
         $this->assertIsNumeric($logs['body']['total']);
 
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1430,7 +1452,7 @@ trait MessagingBase
         $this->assertIsArray($logs['body']['logs']);
         $this->assertIsNumeric($logs['body']['total']);
 
-        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $logs = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1449,7 +1471,7 @@ trait MessagingBase
         /**
          * Test for FAILURE
          */
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1461,7 +1483,7 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1473,7 +1495,7 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1485,7 +1507,7 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1497,14 +1519,14 @@ trait MessagingBase
 
         $this->assertEquals($response['headers']['status-code'], 400);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/' . $data['subscriberId'] . '/logs', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/subscribers/'.$data['subscriberId'].'/logs', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'queries' => [
-                '{ "method": "cursorAsc", "attribute": "$id" }'
-            ]
+                '{ "method": "cursorAsc", "attribute": "$id" }',
+            ],
         ]);
 
         $this->assertEquals($response['headers']['status-code'], 400);
@@ -1529,7 +1551,7 @@ trait MessagingBase
             'from' => 'sender-email@my-domain.com',
         ]);
 
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $userId . '/targets', array_merge([
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$userId.'/targets', array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1540,7 +1562,7 @@ trait MessagingBase
             'identifier' => 'random-email-delete@mail.org',
         ]);
 
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topics['public']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -1548,14 +1570,14 @@ trait MessagingBase
             'targetId' => $target['body']['$id'],
         ]);
 
-        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/' . $topics['public']['$id'] . '/subscribers/' . $subscriber['body']['$id'], \array_merge([
+        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/'.$topics['public']['$id'].'/subscribers/'.$subscriber['body']['$id'], \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()));
 
         $this->assertEquals(204, $response['headers']['status-code']);
 
-        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/' . $topics['public']['$id'], [
+        $topic = $this->client->call(Client::METHOD_GET, '/messaging/topics/'.$topics['public']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1579,7 +1601,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $response['headers']['status-code']);
 
-        $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/' . $response['body']['$id'], [
+        $deleteResponse = $this->client->call(Client::METHOD_DELETE, '/messaging/topics/'.$response['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1599,7 +1621,7 @@ trait MessagingBase
 
         $this->assertEquals(404, $response['headers']['status-code']);
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $message['$id'] . '/targets', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$message['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1614,14 +1636,14 @@ trait MessagingBase
         /**
          * Cursor Test
          */
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $message['$id'] . '/targets', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$message['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'queries' => [
                 Query::cursorAfter(new Document(['$id' => $targetList['targets'][0]['$id']]))->toString(),
-            ]
+            ],
         ]);
         $this->assertEquals(2, $response['body']['total']);
         $this->assertEquals(1, count($response['body']['targets']));
@@ -1636,14 +1658,14 @@ trait MessagingBase
             'messageId' => ID::unique(),
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'draft' => true
+            'draft' => true,
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
 
         $emptyMessage = $response['body'];
 
-        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emptyMessage['$id'] . '/targets', [
+        $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emptyMessage['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1665,12 +1687,12 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code'], "Error creating user: " . var_export($response['body'], true));
+        $this->assertEquals(201, $response['headers']['status-code'], 'Error creating user: '.var_export($response['body'], true));
 
         $user1 = $response['body'];
 
@@ -1684,12 +1706,12 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 2',
         ]);
 
-        $this->assertEquals(201, $response['headers']['status-code'], "Error creating user: " . var_export($response['body'], true));
+        $this->assertEquals(201, $response['headers']['status-code'], 'Error creating user: '.var_export($response['body'], true));
         $user2 = $response['body'];
 
         $this->assertEquals(1, \count($user2['targets']));
@@ -1705,7 +1727,7 @@ trait MessagingBase
             'targets' => [$targetId1, $targetId2],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'draft' => true
+            'draft' => true,
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
@@ -1722,16 +1744,16 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
 
-        $this->assertEquals(201, $user['headers']['status-code'], "Error creating user: " . var_export($user['body'], true));
+        $this->assertEquals(201, $user['headers']['status-code'], 'Error creating user: '.var_export($user['body'], true));
         $this->assertEquals(1, \count($user['body']['targets']));
 
         // Create push target
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1768,7 +1790,7 @@ trait MessagingBase
         $bucketId = $bucket['body']['$id'];
 
         $this->assertEventually(function () use ($bucketId) {
-            $response = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId, [
+            $response = $this->client->call(Client::METHOD_GET, '/storage/buckets/'.$bucketId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1777,13 +1799,13 @@ trait MessagingBase
         }, 10000, 500);
 
         // Create file
-        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', [
+        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/'.$bucketId.'/files', [
             'content-type' => 'multipart/form-data',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'fileId' => ID::unique(),
-            'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/logo.png'), 'image/png', 'logo.png'),
+            'file' => new CURLFile(realpath(__DIR__.'/../../../resources/logo.png'), 'image/png', 'logo.png'),
             'permissions' => [
                 Permission::read(Role::any()),
                 Permission::update(Role::any()),
@@ -1804,7 +1826,7 @@ trait MessagingBase
             'title' => 'New blog post',
             'body' => 'Check out the new blog post at http://localhost',
             'image' => "{$bucketId}:{$fileId}",
-            'draft' => true
+            'draft' => true,
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);
@@ -1815,7 +1837,7 @@ trait MessagingBase
 
         $imageUrl = $message['data']['image']['url'];
 
-        $client = new Client();
+        $client = new Client;
         $client->setEndpoint('');
 
         $image = $client->call(Client::METHOD_GET, $imageUrl);
@@ -1832,7 +1854,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -1860,7 +1882,7 @@ trait MessagingBase
         // Wait for the messaging worker to process and fail the message
         // (no enabled provider exists in this project)
         $this->assertEventually(function () use ($messageId) {
-            $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
+            $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$messageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1880,7 +1902,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -1898,13 +1920,13 @@ trait MessagingBase
             'targets' => [$targetId],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'scheduledAt' => DateTime::addSeconds(new \DateTime(), 120),
+            'scheduledAt' => DateTime::addSeconds(new \DateTime, 120),
         ]);
 
         $this->assertEquals(201, $message['headers']['status-code']);
         $this->assertEquals(MessageStatus::SCHEDULED, $message['body']['status']);
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $message['body']['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$message['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1918,7 +1940,7 @@ trait MessagingBase
         // Verify the message remains in DRAFT status and is not processed by the scheduler
         $draftMessageId = $message['body']['$id'];
         $this->assertEventually(function () use ($draftMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $draftMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$draftMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1937,7 +1959,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -1962,9 +1984,9 @@ trait MessagingBase
 
         // Convert draft to scheduled message and verify the transition
         // Schedule far enough in the future to avoid scheduler processing
-        $scheduledAt = DateTime::addSeconds(new \DateTime(), 300);
+        $scheduledAt = DateTime::addSeconds(new \DateTime, 300);
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $message['body']['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$message['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -1990,7 +2012,7 @@ trait MessagingBase
             'x-appwrite-key' => $this->getProject()['apiKey'],
         ], [
             'userId' => ID::unique(),
-            'email' => uniqid() . "@example.com",
+            'email' => uniqid().'@example.com',
             'password' => 'password',
             'name' => 'Messaging User 1',
         ]);
@@ -2008,15 +2030,15 @@ trait MessagingBase
             'targets' => [$targetId],
             'subject' => 'New blog post',
             'content' => 'Check out the new blog post at http://localhost',
-            'scheduledAt' => DateTime::addSeconds(new \DateTime(), 20),
+            'scheduledAt' => DateTime::addSeconds(new \DateTime, 20),
         ]);
 
         $this->assertEquals(201, $message['headers']['status-code']);
         $this->assertEquals(MessageStatus::SCHEDULED, $message['body']['status']);
 
-        $scheduledAt = DateTime::addSeconds(new \DateTime(), 300);
+        $scheduledAt = DateTime::addSeconds(new \DateTime, 300);
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $message['body']['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$message['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2036,7 +2058,7 @@ trait MessagingBase
         // Verify the message remains scheduled (scheduled far enough in the future
         // that the scheduler won't process it)
         $this->assertEventually(function () use ($messageId, $scheduledAt) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$messageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2112,7 +2134,7 @@ trait MessagingBase
         $target = $user['body']['targets'][0];
 
         // Create Subscriber
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2138,7 +2160,7 @@ trait MessagingBase
 
         $emailMessageId = $email['body']['$id'];
         $this->assertEventually(function () use ($emailMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emailMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2146,7 +2168,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$emailMessageId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2173,7 +2195,7 @@ trait MessagingBase
 
         $email = $params['message'];
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $email['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$email['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2197,7 +2219,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $newEmail['headers']['status-code']);
 
-        $updatedEmail = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/' . $newEmail['body']['$id'], [
+        $updatedEmail = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/email/'.$newEmail['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2209,7 +2231,7 @@ trait MessagingBase
 
         $updatedEmailId = $updatedEmail['body']['$id'];
         $this->assertEventually(function () use ($updatedEmailId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedEmailId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedEmailId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2217,7 +2239,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedEmailId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedEmailId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2288,7 +2310,7 @@ trait MessagingBase
         $this->assertEquals(201, $user['headers']['status-code']);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2302,7 +2324,7 @@ trait MessagingBase
         $this->assertEquals(201, $target['headers']['status-code']);
 
         // Create Subscriber
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2327,7 +2349,7 @@ trait MessagingBase
 
         $smsMessageId = $sms['body']['$id'];
         $this->assertEventually(function () use ($smsMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2335,7 +2357,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $smsMessageId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$smsMessageId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2355,7 +2377,7 @@ trait MessagingBase
             $this->markTestSkipped('SMS DSN not provided');
         }
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/' . $sms['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/'.$sms['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2378,7 +2400,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $newSms['headers']['status-code']);
 
-        $updatedSms = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/' . $newSms['body']['$id'], [
+        $updatedSms = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/sms/'.$newSms['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2390,7 +2412,7 @@ trait MessagingBase
 
         $updatedSmsId = $updatedSms['body']['$id'];
         $this->assertEventually(function () use ($updatedSmsId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedSmsId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedSmsId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2398,7 +2420,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedSmsId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedSmsId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2465,7 +2487,7 @@ trait MessagingBase
         $this->assertEquals(201, $user['headers']['status-code']);
 
         // Create Target
-        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+        $target = $this->client->call(Client::METHOD_POST, '/users/'.$user['body']['$id'].'/targets', [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2479,7 +2501,7 @@ trait MessagingBase
         $this->assertEquals(201, $target['headers']['status-code']);
 
         // Create Subscriber
-        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/' . $topic['body']['$id'] . '/subscribers', \array_merge([
+        $subscriber = $this->client->call(Client::METHOD_POST, '/messaging/topics/'.$topic['body']['$id'].'/subscribers', \array_merge([
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders()), [
@@ -2505,7 +2527,7 @@ trait MessagingBase
 
         $pushMessageId = $push['body']['$id'];
         $this->assertEventually(function () use ($pushMessageId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2513,7 +2535,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $pushMessageId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$pushMessageId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2533,7 +2555,7 @@ trait MessagingBase
             $this->markTestSkipped('Push DSN not provided');
         }
 
-        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/' . $push['$id'], [
+        $message = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/'.$push['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2557,7 +2579,7 @@ trait MessagingBase
 
         $this->assertEquals(201, $newPush['headers']['status-code']);
 
-        $updatedPush = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/' . $newPush['body']['$id'], [
+        $updatedPush = $this->client->call(Client::METHOD_PATCH, '/messaging/messages/push/'.$newPush['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2569,7 +2591,7 @@ trait MessagingBase
 
         $updatedPushId = $updatedPush['body']['$id'];
         $this->assertEventually(function () use ($updatedPushId) {
-            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedPushId, [
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedPushId, [
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
                 'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2577,7 +2599,7 @@ trait MessagingBase
             $this->assertContains($response['body']['status'], ['sent', 'failed']);
         }, 30000, 500);
 
-        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $updatedPushId, [
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/'.$updatedPushId, [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
@@ -2590,7 +2612,6 @@ trait MessagingBase
     }
 
     /**
-     * @return void
      * @throws \Exception
      */
     public function testDeleteMessage(): void
@@ -2604,7 +2625,7 @@ trait MessagingBase
         $message = $params['message'];
         $topic = $params['topic'];
 
-        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/' . $message['$id'], [
+        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/'.$message['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],
@@ -2624,7 +2645,7 @@ trait MessagingBase
             'content' => 'Test content',
         ]);
 
-        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/' . $response['body']['$id'], [
+        $response = $this->client->call(Client::METHOD_DELETE, '/messaging/messages/'.$response['body']['$id'], [
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-key' => $this->getProject()['apiKey'],


### PR DESCRIPTION
## What does this PR do?

Adds **Telnyx SMS provider support** to Appwrite Messaging.

## Changes

- Adds provider endpoints:
  - `POST /v1/messaging/providers/telnyx`
  - `PATCH /v1/messaging/providers/telnyx/:providerId`
- Adds Telnyx adapter wiring in messaging worker (external + internal SMS provider resolution)
- Updates Messaging and GraphQL e2e provider fixtures for Telnyx
- Adds docs:
  - create-telnyx-provider.md
  - update-telnyx-provider.md
- Updates `_APP_SMS_PROVIDER` docs text to include `telnyx`

## Test Plan

- [x] Format run on changed files (Pint)
- [x] Lint check on changed files (Pint `--test`)
- [ ] Full relevant e2e run completed successfully in this environment  
  Note: Messaging e2e run was attempted, but local container was terminated with `exit 137` (resource limit).

## Related PRs and Issues

- Closes #7811

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?