### PR TITLE
Register missing vectorsdb listDocumentLogs endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
@@ -116,6 +116,7 @@ class Create extends CollectionAction
         }
         /** @var Database $dbForDatabases */
         $dbForDatabases = $getDatabasesDB($database);
+        var_dump($database->getArrayCopy());
 
         $attributes = [];
         $indexes = [];

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
@@ -116,7 +116,6 @@ class Create extends CollectionAction
         }
         /** @var Database $dbForDatabases */
         $dbForDatabases = $getDatabasesDB($database);
-        var_dump($database->getArrayCopy());
 
         $attributes = [];
         $indexes = [];

--- a/src/Appwrite/Platform/Modules/Databases/Services/Registry/VectorsDB.php
+++ b/src/Appwrite/Platform/Modules/Databases/Services/Registry/VectorsDB.php
@@ -10,9 +10,9 @@ use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Bul
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Create as CreateDocument;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Delete as DeleteDocument;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Get as GetDocument;
+use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Logs\XList as ListDocumentLogs;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Update as UpdateDocument;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Upsert as UpsertDocument;
-use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Logs\XList as ListDocumentLogs;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\XList as ListDocuments;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Get as GetCollection;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Indexes\Create as CreateIndex;

--- a/src/Appwrite/Platform/Modules/Databases/Services/Registry/VectorsDB.php
+++ b/src/Appwrite/Platform/Modules/Databases/Services/Registry/VectorsDB.php
@@ -12,6 +12,7 @@ use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Del
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Get as GetDocument;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Update as UpdateDocument;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Upsert as UpsertDocument;
+use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\Logs\XList as ListDocumentLogs;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Documents\XList as ListDocuments;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Get as GetCollection;
 use Appwrite\Platform\Modules\Databases\Http\VectorsDB\Collections\Indexes\Create as CreateIndex;
@@ -91,6 +92,7 @@ class VectorsDB extends Base
         $service->addAction(UpdateDocuments::getName(), new UpdateDocuments());
         $service->addAction(UpsertDocuments::getName(), new UpsertDocuments());
         $service->addAction(DeleteDocuments::getName(), new DeleteDocuments());
+        $service->addAction(ListDocumentLogs::getName(), new ListDocumentLogs());
     }
 
     private function registerTransactionActions(Service $service): void


### PR DESCRIPTION
## Summary
- Register `ListDocumentLogs` handler in VectorsDB service registry
- The handler already existed but was not wired up, causing the SDK to not generate the `listDocumentLogs` method for vectorsdb
- Brings vectorsdb to parity with documentsdb for document-level audit logs

## Test plan
- [ ] Regenerate console SDK and verify `vectorsDB.listDocumentLogs()` is available
- [ ] Verify document Activity tab works for vectorsdb collections in console