### PR TITLE
fix(ci): pin trivy-action to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           target: production
 
       - name: Run Trivy vulnerability scanner on image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 
         with:
           image-ref: 'pr_image:${{ github.sha }}'
           format: 'sarif'
@@ -60,7 +60,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Run Trivy vulnerability scanner on source code
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           target: production
 
       - name: Run Trivy vulnerability scanner on image
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: 'pr_image:${{ github.sha }}'
           format: 'sarif'
@@ -60,7 +60,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Run Trivy vulnerability scanner on source code
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
Closes #11605

## What does this PR do?

Pins `aquasecurity/trivy-action` to a full commit SHA in the CI workflow.

## Why?

Using mutable tags (e.g., `0.35.0`) can expose workflows to supply chain attacks.

## Changes

- Updated `ci.yml`:
  - Replaced tag with pinned SHA
  - Aligned with existing usage in `nightly.yml`