### PR TITLE
docs: add note about version usage in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ docker run -it --rm \
     --entrypoint="install" \
     appwrite/appwrite:1.9.0
 ```
+> **Note:** You can replace `1.9.0` with the latest stable version if needed. Using a fixed version ensures reproducibility, while updating allows access to new features and fixes.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run -it --rm \
     --entrypoint="install" \
     appwrite/appwrite:1.9.0
 ```
-> **Note:** You can replace `1.9.0` with the latest stable version if needed. Using a fixed version ensures reproducibility, while updating allows access to new features and fixes.
+> **Note:** You can replace `1.9.0` with the [latest stable version](https://github.com/appwrite/appwrite/releases/latest) if needed. Using a fixed version ensures reproducibility, while updating allows access to new features and fixes.
 
 ### Windows
 
@@ -90,6 +90,7 @@ docker run -it --rm ^
     --entrypoint="install" ^
     appwrite/appwrite:1.9.0
 ```
+> **Note:** You can replace `1.9.0` with the [latest stable version](https://github.com/appwrite/appwrite/releases/latest) if needed. Using a fixed version ensures reproducibility, while updating allows access to new features and fixes.
 
 #### PowerShell
 
@@ -100,6 +101,7 @@ docker run -it --rm `
     --entrypoint="install" `
     appwrite/appwrite:1.9.0
 ```
+> **Note:** You can replace `1.9.0` with the [latest stable version](https://github.com/appwrite/appwrite/releases/latest) if needed. Using a fixed version ensures reproducibility, while updating allows access to new features and fixes.
 
 Once the Docker installation is complete, go to http://localhost to access the Appwrite console from your browser. Please note that on non-Linux native hosts, the server might take a few minutes to start after completing the installation.
 


### PR DESCRIPTION
## What does this PR do?

Adds a note in the installation section explaining that users can replace the fixed Appwrite version with the latest stable version if needed.

## Test Plan

- Verified the note appears correctly below the Unix installation command in the README.
- Checked formatting and readability in Markdown preview.

## Related PRs and Issues

- None

## Checklist

- Have you read the Contributing Guidelines on issues?
- If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?