### PR TITLE
fix: validate browser extensions by scheme instead of hostname

### DIFF
--- a/src/Appwrite/Network/Platform.php
+++ b/src/Appwrite/Network/Platform.php
@@ -124,6 +124,10 @@ class Platform
                 case self::TYPE_FLUTTER_WEB:
                     $schemes[] = self::SCHEME_HTTP;
                     $schemes[] = self::SCHEME_HTTPS;
+                    $schemes[] = self::SCHEME_CHROME_EXTENSION;
+                    $schemes[] = self::SCHEME_FIREFOX_EXTENSION;
+                    $schemes[] = self::SCHEME_SAFARI_EXTENSION;
+                    $schemes[] = self::SCHEME_EDGE_EXTENSION;
                     break;
                 case self::TYPE_FLUTTER_IOS:
                 case self::TYPE_APPLE_IOS:

--- a/src/Appwrite/Network/Validator/Origin.php
+++ b/src/Appwrite/Network/Validator/Origin.php
@@ -65,10 +65,6 @@ class Origin extends Validator
         $webPlatforms = [
             Platform::SCHEME_HTTP,
             Platform::SCHEME_HTTPS,
-            Platform::SCHEME_CHROME_EXTENSION,
-            Platform::SCHEME_FIREFOX_EXTENSION,
-            Platform::SCHEME_SAFARI_EXTENSION,
-            Platform::SCHEME_EDGE_EXTENSION,
             Platform::SCHEME_TAURI,
         ];
         if (in_array($this->scheme, $webPlatforms, true)) {

--- a/tests/unit/Network/Validators/OriginTest.php
+++ b/tests/unit/Network/Validators/OriginTest.php
@@ -61,17 +61,22 @@ class OriginTest extends TestCase
         $this->assertEquals(false, $validator->isValid('appwrite-windows://com.company.appname'));
         $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Windows platform on your project console dashboard', $validator->getDescription());
 
+        // Browser extensions are validated by scheme only, not hostname
         $this->assertEquals(false, $validator->isValid('chrome-extension://com.company.appname'));
-        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Web (Chrome Extension) platform on your project console dashboard', $validator->getDescription());
-
         $this->assertEquals(false, $validator->isValid('moz-extension://com.company.appname'));
-        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Web (Firefox Extension) platform on your project console dashboard', $validator->getDescription());
-
         $this->assertEquals(false, $validator->isValid('safari-web-extension://com.company.appname'));
-        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Web (Safari Extension) platform on your project console dashboard', $validator->getDescription());
-
         $this->assertEquals(false, $validator->isValid('ms-browser-extension://com.company.appname'));
-        $this->assertEquals('Invalid Origin. Register your new client (com.company.appname) as a new Web (Edge Extension) platform on your project console dashboard', $validator->getDescription());
+
+        // When extension schemes are in allowedSchemes, any extension ID is accepted
+        $validatorWithExtensions = new Origin(
+            allowedHostnames: ['appwrite.io'],
+            allowedSchemes: ['chrome-extension', 'moz-extension', 'safari-web-extension', 'ms-browser-extension']
+        );
+        $this->assertEquals(true, $validatorWithExtensions->isValid('chrome-extension://abcdefghijklmnop'));
+        $this->assertEquals(true, $validatorWithExtensions->isValid('chrome-extension://different-extension-id'));
+        $this->assertEquals(true, $validatorWithExtensions->isValid('moz-extension://some-uuid'));
+        $this->assertEquals(true, $validatorWithExtensions->isValid('safari-web-extension://some-id'));
+        $this->assertEquals(true, $validatorWithExtensions->isValid('ms-browser-extension://some-id'));
 
         $this->assertEquals(true, $validator->isValid('tauri://localhost'));
         $this->assertEquals(false, $validator->isValid('tauri://example.com'));


### PR DESCRIPTION
## Summary
- Browser extension IDs (e.g., `chrome-extension://abcdefg`) change every time an unpacked extension is reloaded during development, breaking origin validation since the extension ID was being validated as a hostname.
- Moves extension schemes (`chrome-extension`, `moz-extension`, `safari-web-extension`, `ms-browser-extension`) from hostname-based validation to scheme-only validation, consistent with how mobile/native platforms (iOS, Android, etc.) are already handled.
- Extension schemes are now automatically included in `allowedSchemes` when a web platform is registered via `Platform::getSchemes()`.

## Test plan
- [ ] Verify `chrome-extension://any-extension-id` passes validation when a web platform is registered
- [ ] Verify extension origins are rejected when no web platform is registered
- [ ] Verify existing web (HTTP/HTTPS) and Tauri hostname validation is unchanged
- [ ] Run unit tests: `OriginTest`