### PR TITLE
feat: improve SDK PR summary with platform grouping and clipboard copy

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -142,6 +142,15 @@ class SDKs extends Action
 
         $selectedPlatforms = ($selectedPlatform === '*' || $selectedPlatform === null) ? null : \array_map('trim', \explode(',', $selectedPlatform));
 
+        if ($selectedPlatforms !== null) {
+            $validPlatforms = static::getPlatforms();
+            foreach ($selectedPlatforms as $p) {
+                if (! \in_array($p, $validPlatforms)) {
+                    throw new \Exception('Unknown platform "' . $p . '". Options are: ' . implode(', ', $validPlatforms));
+                }
+            }
+        }
+
         $platforms = Config::getParam('sdks');
         foreach ($platforms as $key => $platform) {
             if ($selectedPlatforms !== null && ! \in_array($key, $selectedPlatforms) && ($sdks === null)) {
@@ -557,25 +566,34 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             }
             Console::log('');
 
-            Console::confirm('Press Enter to copy PR summary to clipboard');
+            if (\function_exists('posix_isatty') && \posix_isatty(STDIN)) {
+                Console::confirm('Press Enter to copy PR summary to clipboard');
 
-            $markdown = "## Pull Request Summary\n\n";
-            foreach ($prUrls as $platformName => $sdks) {
-                $markdown .= "### {$platformName}\n";
-                foreach ($sdks as $sdkName => $url) {
-                    $markdown .= "- {$sdkName}: {$url}\n";
+                $markdown = "## Pull Request Summary\n\n";
+                foreach ($prUrls as $platformName => $sdks) {
+                    $markdown .= "### {$platformName}\n";
+                    foreach ($sdks as $sdkName => $url) {
+                        $markdown .= "- {$sdkName}: {$url}\n";
+                    }
+                    $markdown .= "\n";
                 }
-                $markdown .= "\n";
-            }
 
-            $copyCommand = PHP_OS_FAMILY === 'Darwin' ? 'pbcopy' : 'xclip -selection clipboard';
-            $process = \popen($copyCommand, 'w');
-            if ($process) {
-                \fwrite($process, $markdown);
-                \pclose($process);
-                Console::success('PR summary copied to clipboard!');
-            } else {
-                Console::error('Failed to copy to clipboard');
+                if (PHP_OS_FAMILY === 'Darwin') {
+                    $copyCommand = 'pbcopy';
+                } elseif (! empty(\getenv('WAYLAND_DISPLAY'))) {
+                    $copyCommand = 'wl-copy';
+                } else {
+                    $copyCommand = 'xclip -selection clipboard';
+                }
+
+                $process = \popen($copyCommand, 'w');
+                if ($process) {
+                    \fwrite($process, $markdown);
+                    \pclose($process);
+                    Console::success('PR summary copied to clipboard!');
+                } else {
+                    Console::error('Failed to copy to clipboard. Install pbcopy (macOS), wl-clipboard (Wayland), or xclip (X11).');
+                }
             }
         }
     }

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -89,7 +89,7 @@ class SDKs extends Action
         $selectedSDK = $sdk;
 
         if (! $sdks) {
-            $selectedPlatform ??= Console::confirm('Choose Platform ("' . implode('", "', static::getPlatforms()) . '" or "*" for all):');
+            $selectedPlatform ??= Console::confirm('Choose Platform ("' . implode('", "', static::getPlatforms()) . '", comma-separated, or "*" for all):');
             $selectedSDK ??= \strtolower(Console::confirm('Choose SDK ("*" for all):'));
             $supportedSDKs = $this->getSupportedSDKs();
             if ($selectedSDK !== '*' && ! \in_array($selectedSDK, $supportedSDKs)) {
@@ -140,9 +140,11 @@ class SDKs extends Action
             throw new \Exception('Unknown version given');
         }
 
+        $selectedPlatforms = ($selectedPlatform === '*' || $selectedPlatform === null) ? null : \array_map('trim', \explode(',', $selectedPlatform));
+
         $platforms = Config::getParam('sdks');
         foreach ($platforms as $key => $platform) {
-            if ($selectedPlatform !== $key && $selectedPlatform !== '*' && ($sdks === null)) {
+            if ($selectedPlatforms !== null && ! \in_array($key, $selectedPlatforms) && ($sdks === null)) {
                 continue;
             }
 
@@ -532,7 +534,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                     $pushSuccess = $this->pushToGit($language, $target, $result, $gitUrl, $gitBranch, $repoBranch, $commitMessage);
 
                     if ($pushSuccess) {
-                        $this->createPullRequest($language, $target, $gitBranch, $repoBranch, $aiChangelog, $prUrls);
+                        $this->createPullRequest($language, $platform['name'], $target, $gitBranch, $repoBranch, $aiChangelog, $prUrls);
                     }
 
                     \exec('chmod -R u+w ' . $target . ' && rm -rf ' . $target);
@@ -546,10 +548,35 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         if (! empty($prUrls)) {
             Console::log('');
             Console::info('━━━ Pull Request Summary ━━━');
-            foreach ($prUrls as $sdkName => $url) {
-                Console::log("  {$sdkName}: {$url}");
+            foreach ($prUrls as $platformName => $sdks) {
+                Console::log('');
+                Console::info("  {$platformName}:");
+                foreach ($sdks as $sdkName => $url) {
+                    Console::log("    {$sdkName}: {$url}");
+                }
             }
             Console::log('');
+
+            Console::confirm('Press Enter to copy PR summary to clipboard');
+
+            $markdown = "## Pull Request Summary\n\n";
+            foreach ($prUrls as $platformName => $sdks) {
+                $markdown .= "### {$platformName}\n";
+                foreach ($sdks as $sdkName => $url) {
+                    $markdown .= "- {$sdkName}: {$url}\n";
+                }
+                $markdown .= "\n";
+            }
+
+            $copyCommand = PHP_OS_FAMILY === 'Darwin' ? 'pbcopy' : 'xclip -selection clipboard';
+            $process = \popen($copyCommand, 'w');
+            if ($process) {
+                \fwrite($process, $markdown);
+                \pclose($process);
+                Console::success('PR summary copied to clipboard!');
+            } else {
+                Console::error('Failed to copy to clipboard');
+            }
         }
     }
 
@@ -657,7 +684,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         return true;
     }
 
-    private function createPullRequest(array $language, string $target, string $gitBranch, string $repoBranch, string $aiChangelog, array &$prUrls): void
+    private function createPullRequest(array $language, string $platformName, string $target, string $gitBranch, string $repoBranch, string $aiChangelog, array &$prUrls): void
     {
         $prTitle = "feat: {$language['name']} SDK update for version {$language['version']}";
         $prBody = "This PR contains updates to the {$language['name']} SDK for version {$language['version']}.";
@@ -685,7 +712,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             Console::success("  Pull request created");
             foreach ($prOutput as $line) {
                 if (\str_starts_with(trim($line), 'https://')) {
-                    $prUrls[$language['name']] = trim($line);
+                    $prUrls[$platformName][$language['name']] = trim($line);
                     break;
                 }
             }
@@ -703,7 +730,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                     }
                 }
 
-                $this->updateExistingPr($repoName, $gitBranch, $prTitle, $prBody, $language['name'], $prUrls, $existingPrUrl);
+                $this->updateExistingPr($repoName, $gitBranch, $prTitle, $prBody, $platformName, $language['name'], $prUrls, $existingPrUrl);
             }
         }
     }
@@ -1081,7 +1108,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         }
     }
 
-    private function updateExistingPr(string $repoName, string $gitBranch, string $prTitle, string $prBody, string $sdkName, array &$prUrls, string $existingPrUrl = ''): void
+    private function updateExistingPr(string $repoName, string $gitBranch, string $prTitle, string $prBody, string $platformName, string $sdkName, array &$prUrls, string $existingPrUrl = ''): void
     {
         Console::log('  Pull request already exists, updating...');
 
@@ -1140,7 +1167,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         Console::success("  Pull request updated");
 
         if (! empty($prUrl)) {
-            $prUrls[$sdkName] = $prUrl;
+            $prUrls[$platformName][$sdkName] = $prUrl;
         }
     }
 }

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -565,36 +565,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                 }
             }
             Console::log('');
-
-            if (\function_exists('posix_isatty') && \posix_isatty(STDIN)) {
-                Console::confirm('Press Enter to copy PR summary to clipboard');
-
-                $markdown = "## Pull Request Summary\n\n";
-                foreach ($prUrls as $platformName => $sdks) {
-                    $markdown .= "### {$platformName}\n";
-                    foreach ($sdks as $sdkName => $url) {
-                        $markdown .= "- {$sdkName}: {$url}\n";
-                    }
-                    $markdown .= "\n";
-                }
-
-                if (PHP_OS_FAMILY === 'Darwin') {
-                    $copyCommand = 'pbcopy';
-                } elseif (! empty(\getenv('WAYLAND_DISPLAY'))) {
-                    $copyCommand = 'wl-copy';
-                } else {
-                    $copyCommand = 'xclip -selection clipboard';
-                }
-
-                $process = \popen($copyCommand, 'w');
-                if ($process) {
-                    \fwrite($process, $markdown);
-                    \pclose($process);
-                    Console::success('PR summary copied to clipboard!');
-                } else {
-                    Console::error('Failed to copy to clipboard. Install pbcopy (macOS), wl-clipboard (Wayland), or xclip (X11).');
-                }
-            }
         }
     }
 

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -745,7 +745,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                 'mkdir -p ' . $resultExamples . $languagePath . ' && \
                 cp -r ' . $examplesSource . ' ' . $resultExamples
             );
-            Console::success("  Examples copied to {$resultExamples}");
+            $label = \is_string($languageTitle) ? " ({$languageTitle})" : '';
+            Console::success("  Examples{$label} copied to {$resultExamples}{$languagePath}");
         }
     }
 


### PR DESCRIPTION
## Summary
- Groups PR links by platform (Client, Console, Server) in the summary output
- Adds prompt to copy the PR summary to clipboard in markdown format after display
- Supports comma-separated platform selection (e.g. `client,server`) in addition to single platform or `*`

## Test plan
- [ ] Run `sdks` task with git push enabled and verify PR summary is grouped by platform
- [ ] Verify pressing Enter copies markdown summary to clipboard
- [ ] Test comma-separated platform selection (e.g. `client,server`)
- [ ] Test single platform and `*` still work as before