### PR TITLE
fix(storage): add missing encryption and compression properties to File model

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/File.php
+++ b/src/Appwrite/Utopia/Response/Model/File.php
@@ -4,6 +4,8 @@ namespace Appwrite\Utopia\Response\Model;
 
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
+use Utopia\Compression\Compression;
+use Utopia\Database\Document;
 
 class File extends Model
 {
@@ -77,6 +79,18 @@ class File extends Model
                 'default' => 0,
                 'example' => 17890,
             ])
+            ->addRule('encryption', [
+                'type' => self::TYPE_BOOLEAN,
+                'description' => 'Whether file contents are encrypted at rest.',
+                'default' => false,
+                'example' => true,
+            ])
+            ->addRule('compression', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Compression algorithm used for the file. Will be one of ' . Compression::NONE . ', [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd).',
+                'default' => '',
+                'example' => 'gzip'
+            ])
         ;
     }
 
@@ -98,5 +112,15 @@ class File extends Model
     public function getType(): string
     {
         return Response::MODEL_FILE;
+    }
+
+    public function filter(Document $document): Document
+    {
+        $document->setAttribute('compression', $document->getAttribute('algorithm', ''));
+
+        $encryption = !empty($document->getAttribute('openSSLCipher', ''));
+        $document->setAttribute('encryption', $encryption);
+
+        return $document;
     }
 }


### PR DESCRIPTION
The File model on main was missing the `encryption` and `compression` properties that exist in the 1.9.x branch. When the Flutter SDK (>= 20.3.3) tries to access `file.encryption`, it returns null instead of a boolean, causing a crash.

The fix adds both properties to the File model schema and a `filter()` method that derives them from the actual file attributes (`openSSLCipher` and `algorithm`), matching the pattern already present in 1.9.x.

Fixes #11647