### PR TITLE
docs: clarify update messaging endpoints only work for draft messages

### DIFF
--- a/docs/references/messaging/update-email.md
+++ b/docs/references/messaging/update-email.md
@@ -1,1 +1,3 @@
 Update an email message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.
+
+> Note: This endpoint only works for messages in draft status.

--- a/docs/references/messaging/update-push.md
+++ b/docs/references/messaging/update-push.md
@@ -1,1 +1,3 @@
 Update a push notification by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.
+
+> Note: This endpoint only works for messages in draft status.

--- a/docs/references/messaging/update-sms.md
+++ b/docs/references/messaging/update-sms.md
@@ -1,1 +1,3 @@
 Update an SMS message by its unique ID. This endpoint only works on messages that are in draft status. Messages that are already processing, sent, or failed cannot be updated.
+
+> Note: This endpoint only works for messages in draft status.


### PR DESCRIPTION
## What does this PR do?

This PR updates the documentation for the `updateEmail()`, `updatePush()`, and `updateSms()` endpoints to clarify that they only work when the message is in draft status.

Currently, this behavior is not clearly mentioned in the docs, which may lead to confusion when the endpoints do not work as expected on non-draft messages.

## Test Plan

- Reviewed the existing documentation for the mentioned endpoints
- Updated the markdown files to include a note about draft-only behavior
- Verified consistency across related documentation files

## Related PRs and Issues

- Fixes #9057

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?