### PR TITLE
[codex] Reduce specs task memory retention

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -347,6 +347,15 @@ class Specs extends Action
         $keys = $this->getKeys();
 
         $generatedFiles = [];
+        $endpoint = System::getEnv('_APP_HOME', '[HOSTNAME]');
+        $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', APP_EMAIL_TEAM);
+        $specsDir = __DIR__ . '/../../../../app/config/specs';
+
+        if (!is_dir($specsDir)) {
+            if (!mkdir($specsDir, 0755, true)) {
+                throw new Exception('Failed to create specs directory: ' . $specsDir);
+            }
+        }
 
         foreach ($platforms as $platform) {
             $routes = [];
@@ -443,8 +452,6 @@ class Specs extends Action
             foreach (['swagger2', 'open-api3'] as $format) {
                 $formatInstance = $this->getFormatInstance($format, $arguments);
                 $specs = new Specification($formatInstance);
-                $endpoint = System::getEnv('_APP_HOME', '[HOSTNAME]');
-                $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', APP_EMAIL_TEAM);
 
                 $formatInstance
                     ->setParam('name', APP_NAME)
@@ -463,36 +470,26 @@ class Specs extends Action
                     ->setParam('docs.description', 'Full API docs, specs and tutorials')
                     ->setParam('docs.url', $endpoint . '/docs');
 
-                $specsDir = __DIR__ . '/../../../../app/config/specs';
+                $path = $mocks
+                    ? $specsDir . '/' . $format . '-mocks-' . $platform . '.json'
+                    : $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
 
-                if (!is_dir($specsDir)) {
-                    if (!mkdir($specsDir, 0755, true)) {
-                        throw new Exception('Failed to create specs directory: ' . $specsDir);
-                    }
-                }
+                $parsedSpecs = $specs->parse();
+                $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);
 
-                if ($mocks) {
-                    $path = $specsDir . '/' . $format . '-mocks-' . $platform . '.json';
+                unset($parsedSpecs);
 
-                    if (!file_put_contents($path, json_encode($specs->parse(), JSON_PRETTY_PRINT))) {
-                        throw new Exception('Failed to save mocks spec file: ' . $path);
-                    }
-
-                    $generatedFiles[] = realpath($path);
-                    Console::success('Saved mocks spec file: ' . realpath($path));
-
-                    continue;
-                }
-
-                $path = $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
-
-                if (!file_put_contents($path, json_encode($specs->parse(), JSON_PRETTY_PRINT))) {
-                    throw new Exception('Failed to save spec file: ' . $path);
+                if ($encodedSpecs === false || !file_put_contents($path, $encodedSpecs)) {
+                    throw new Exception('Failed to save ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . $path);
                 }
 
                 $generatedFiles[] = realpath($path);
-                Console::success('Saved spec file: ' . realpath($path));
+                Console::success('Saved ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . realpath($path));
+
+                unset($encodedSpecs, $specs, $formatInstance);
             }
+
+            unset($arguments, $models, $routes, $services);
         }
 
         if ($git === 'yes') {


### PR DESCRIPTION
## What changed

This updates `src/Appwrite/Platform/Tasks/Specs.php` to release large intermediate spec-generation values as soon as they are no longer needed.

## Why

The specs task generates multiple large API spec documents in one process. The previous implementation kept heavy intermediates alive longer than necessary inside the platform and format loops, which increases peak memory pressure and can contribute to OOM kills in constrained CI containers.

## Implementation

- move one-time `endpoint`, `email`, and `specsDir` setup out of the inner format loop
- split spec generation into `parse -> json_encode -> file_put_contents`
- explicitly `unset()` the parsed spec payload, encoded JSON string, and per-format objects after each write
- explicitly `unset()` per-platform route, model, service, and argument arrays after each platform pass

## Impact

This does not change output filenames or spec contents. It only narrows the lifetime of large in-memory structures during generation.

## Validation

- `php -l src/Appwrite/Platform/Tasks/Specs.php`
