### PR TITLE
[codex] Reduce specs task memory retention

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -106,6 +106,10 @@ class SDKs extends Action
         $createRelease = ($release === 'yes');
         $commitRelease = ($commit === 'yes');
 
+        if ($createRelease && $examplesOnly) {
+            throw new \Exception('Cannot use --release=yes with --mode=examples');
+        }
+
         if (! $createRelease && ! $examplesOnly) {
             $git ??= Console::confirm('Should we use git push? (yes/no)');
             $git = ($git === 'yes');

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -102,7 +102,6 @@ class SDKs extends Action
         } else {
             $sdks = explode(',', $sdks);
         }
-        $version ??= Console::confirm('Choose an Appwrite version');
 
         $createRelease = ($release === 'yes');
         $commitRelease = ($commit === 'yes');
@@ -118,30 +117,34 @@ class SDKs extends Action
             $prUrls = [];
         }
 
-        if (! \in_array($version, [
-            '0.6.x',
-            '0.7.x',
-            '0.8.x',
-            '0.9.x',
-            '0.10.x',
-            '0.11.x',
-            '0.12.x',
-            '0.13.x',
-            '0.14.x',
-            '0.15.x',
-            '1.0.x',
-            '1.1.x',
-            '1.2.x',
-            '1.3.x',
-            '1.4.x',
-            '1.5.x',
-            '1.6.x',
-            '1.7.x',
-            '1.8.x',
-            '1.9.x',
-            'latest',
-        ])) {
-            throw new \Exception('Unknown version given');
+        if (! $createRelease) {
+            $version ??= Console::confirm('Choose an Appwrite version');
+
+            if (! \in_array($version, [
+                '0.6.x',
+                '0.7.x',
+                '0.8.x',
+                '0.9.x',
+                '0.10.x',
+                '0.11.x',
+                '0.12.x',
+                '0.13.x',
+                '0.14.x',
+                '0.15.x',
+                '1.0.x',
+                '1.1.x',
+                '1.2.x',
+                '1.3.x',
+                '1.4.x',
+                '1.5.x',
+                '1.6.x',
+                '1.7.x',
+                '1.8.x',
+                '1.9.x',
+                'latest',
+            ])) {
+                throw new \Exception('Unknown version given');
+            }
         }
 
         $selectedPlatforms = ($selectedPlatform === '*' || $selectedPlatform === null) ? null : \array_map('trim', \explode(',', $selectedPlatform));
@@ -173,6 +176,124 @@ class SDKs extends Action
                 }
 
                 Console::log('');
+
+                if ($createRelease && ! $examplesOnly) {
+                    Console::info("━━━ {$language['name']} SDK ({$platform['name']}, {$language['version']}) ━━━");
+                    $changelog = $language['changelog'] ?? '';
+                    $changelog = ($changelog) ? \file_get_contents($changelog) : '# Change Log';
+
+                    $repoName = $language['gitUserName'] . '/' . $language['gitRepoName'];
+                    $releaseVersion = $language['version'];
+                    $releaseNotes = $this->extractReleaseNotes($changelog, $releaseVersion);
+
+                    if (empty($releaseNotes)) {
+                        $releaseNotes = "Release version {$releaseVersion}";
+                    }
+
+                    $releaseTitle = $releaseVersion;
+                    $releaseTarget = $language['repoBranch'] ?? 'main';
+
+                    if ($repoName === '/') {
+                        Console::warning('  Not a releasable SDK, skipping');
+
+                        continue;
+                    }
+
+                    // Check if release already exists
+                    $checkReleaseCommand = 'gh release view ' . \escapeshellarg($releaseVersion) . ' --repo ' . \escapeshellarg($repoName) . ' --json url --jq ".url" 2>/dev/null';
+                    $existingReleaseUrl = trim(\shell_exec($checkReleaseCommand) ?? '');
+
+                    if (! empty($existingReleaseUrl)) {
+                        Console::warning("  Release {$releaseVersion} already exists, skipping");
+                        Console::log("  {$existingReleaseUrl}");
+
+                        continue;
+                    }
+
+                    // Check if the latest commit on the target branch already has a release
+                    $latestCommitCommand = 'gh api repos/' . $repoName . '/commits/' . $releaseTarget . ' --jq ".sha" 2>/dev/null';
+                    $latestCommitSha = trim(\shell_exec($latestCommitCommand) ?? '');
+
+                    if (! empty($latestCommitSha)) {
+                        $latestReleaseTagCommand = 'gh api repos/' . $repoName . '/releases --jq ".[0] | .tag_name" 2>/dev/null';
+                        $latestReleaseTag = trim(\shell_exec($latestReleaseTagCommand) ?? '');
+
+                        if (! empty($latestReleaseTag)) {
+                            $tagCommitCommand = 'gh api repos/' . $repoName . '/git/ref/tags/' . $latestReleaseTag . ' --jq ".object.sha" 2>/dev/null';
+                            $tagCommitSha = trim(\shell_exec($tagCommitCommand) ?? '');
+
+                            if (! empty($tagCommitSha) && $latestCommitSha === $tagCommitSha) {
+                                Console::warning("  Latest commit already released ({$latestReleaseTag}), skipping");
+
+                                continue;
+                            }
+                        }
+                    }
+
+                    $previousVersion = '';
+                    $tagListCommand = 'gh release list --repo ' . \escapeshellarg($repoName) . ' --limit 1 --json tagName --jq ".[0].tagName" 2>&1';
+                    $previousVersion = trim(\shell_exec($tagListCommand) ?? '');
+
+                    $formattedNotes = "## What's Changed\n\n";
+                    $formattedNotes .= $releaseNotes . "\n\n";
+
+                    if (! empty($previousVersion)) {
+                        $formattedNotes .= '**Full Changelog**: https://github.com/' . $repoName . '/compare/' . $previousVersion . '...' . $releaseVersion;
+                    } else {
+                        $formattedNotes .= '**Full Changelog**: https://github.com/' . $repoName . '/releases/tag/' . $releaseVersion;
+                    }
+
+                    if (! $commitRelease) {
+                        Console::info('  [DRY RUN] Would create release:');
+                        Console::log("    Repository:       {$repoName}");
+                        Console::log("    Version:          {$releaseVersion}");
+                        Console::log("    Title:            {$releaseTitle}");
+                        Console::log("    Target Branch:    {$releaseTarget}");
+                        Console::log('    Previous Version: ' . ($previousVersion ?: 'N/A'));
+                        Console::log('    Release Notes:');
+                        Console::log('    ' . str_replace("\n", "\n    ", $formattedNotes));
+                    } else {
+                        Console::log("  Creating release {$releaseVersion}...");
+
+                        $tempNotesFile = \tempnam(\sys_get_temp_dir(), 'release_notes_');
+                        \file_put_contents($tempNotesFile, $formattedNotes);
+
+                        $releaseCommand = 'gh release create ' . \escapeshellarg($releaseVersion) . ' \
+                            --repo ' . \escapeshellarg($repoName) . ' \
+                            --title ' . \escapeshellarg($releaseTitle) . ' \
+                            --notes-file ' . \escapeshellarg($tempNotesFile) . ' \
+                            --target ' . \escapeshellarg($releaseTarget) . ' \
+                            2>&1';
+
+                        $releaseOutput = [];
+                        $releaseReturnCode = 0;
+                        \exec($releaseCommand, $releaseOutput, $releaseReturnCode);
+
+                        \unlink($tempNotesFile);
+
+                        if ($releaseReturnCode === 0) {
+                            // Extract release URL from output
+                            $releaseUrl = '';
+                            foreach ($releaseOutput as $line) {
+                                if (strpos($line, 'https://github.com/') !== false) {
+                                    $releaseUrl = trim($line);
+                                    break;
+                                }
+                            }
+
+                            Console::success("  Release {$releaseVersion} created");
+                            if (! empty($releaseUrl)) {
+                                Console::log("  {$releaseUrl}");
+                            }
+                        } else {
+                            $errorMessage = implode("\n", $releaseOutput);
+                            Console::error("  Failed to create release: " . $errorMessage);
+                        }
+                    }
+
+                    continue;
+                }
+
                 Console::info("━━━ {$language['name']} SDK ({$platform['name']}, {$version}) ━━━");
                 $specFormat = $language['spec'] ?? 'swagger2';
                 $spec = null;
@@ -328,119 +449,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                         break;
                     default:
                         throw new \Exception('Language "' . $language['key'] . '" not supported');
-                }
-
-                if ($createRelease && ! $examplesOnly) {
-                    $repoName = $language['gitUserName'] . '/' . $language['gitRepoName'];
-                    $releaseVersion = $language['version'];
-                    $releaseNotes = $this->extractReleaseNotes($changelog, $releaseVersion);
-
-                    if (empty($releaseNotes)) {
-                        $releaseNotes = "Release version {$releaseVersion}";
-                    }
-
-                    $releaseTitle = $releaseVersion;
-                    $releaseTarget = $language['repoBranch'] ?? 'main';
-
-                    if ($repoName === '/') {
-                        Console::warning('  Not a releasable SDK, skipping');
-
-                        continue;
-                    }
-
-                    // Check if release already exists
-                    $checkReleaseCommand = 'gh release view ' . \escapeshellarg($releaseVersion) . ' --repo ' . \escapeshellarg($repoName) . ' --json url --jq ".url" 2>/dev/null';
-                    $existingReleaseUrl = trim(\shell_exec($checkReleaseCommand) ?? '');
-
-                    if (! empty($existingReleaseUrl)) {
-                        Console::warning("  Release {$releaseVersion} already exists, skipping");
-                        Console::log("  {$existingReleaseUrl}");
-
-                        continue;
-                    }
-
-                    // Check if the latest commit on the target branch already has a release
-                    $latestCommitCommand = 'gh api repos/' . $repoName . '/commits/' . $releaseTarget . ' --jq ".sha" 2>/dev/null';
-                    $latestCommitSha = trim(\shell_exec($latestCommitCommand) ?? '');
-
-                    if (! empty($latestCommitSha)) {
-                        $latestReleaseTagCommand = 'gh api repos/' . $repoName . '/releases --jq ".[0] | .tag_name" 2>/dev/null';
-                        $latestReleaseTag = trim(\shell_exec($latestReleaseTagCommand) ?? '');
-
-                        if (! empty($latestReleaseTag)) {
-                            $tagCommitCommand = 'gh api repos/' . $repoName . '/git/ref/tags/' . $latestReleaseTag . ' --jq ".object.sha" 2>/dev/null';
-                            $tagCommitSha = trim(\shell_exec($tagCommitCommand) ?? '');
-
-                            if (! empty($tagCommitSha) && $latestCommitSha === $tagCommitSha) {
-                                Console::warning("  Latest commit already released ({$latestReleaseTag}), skipping");
-
-                                continue;
-                            }
-                        }
-                    }
-
-                    $previousVersion = '';
-                    $tagListCommand = 'gh release list --repo ' . \escapeshellarg($repoName) . ' --limit 1 --json tagName --jq ".[0].tagName" 2>&1';
-                    $previousVersion = trim(\shell_exec($tagListCommand) ?? '');
-
-                    $formattedNotes = "## What's Changed\n\n";
-                    $formattedNotes .= $releaseNotes . "\n\n";
-
-                    if (! empty($previousVersion)) {
-                        $formattedNotes .= '**Full Changelog**: https://github.com/' . $repoName . '/compare/' . $previousVersion . '...' . $releaseVersion;
-                    } else {
-                        $formattedNotes .= '**Full Changelog**: https://github.com/' . $repoName . '/releases/tag/' . $releaseVersion;
-                    }
-
-                    if (! $commitRelease) {
-                        Console::info('  [DRY RUN] Would create release:');
-                        Console::log("    Repository:       {$repoName}");
-                        Console::log("    Version:          {$releaseVersion}");
-                        Console::log("    Title:            {$releaseTitle}");
-                        Console::log("    Target Branch:    {$releaseTarget}");
-                        Console::log('    Previous Version: ' . ($previousVersion ?: 'N/A'));
-                        Console::log('    Release Notes:');
-                        Console::log('    ' . str_replace("\n", "\n    ", $formattedNotes));
-                    } else {
-                        Console::log("  Creating release {$releaseVersion}...");
-
-                        $tempNotesFile = \tempnam(\sys_get_temp_dir(), 'release_notes_');
-                        \file_put_contents($tempNotesFile, $formattedNotes);
-
-                        $releaseCommand = 'gh release create ' . \escapeshellarg($releaseVersion) . ' \
-                            --repo ' . \escapeshellarg($repoName) . ' \
-                            --title ' . \escapeshellarg($releaseTitle) . ' \
-                            --notes-file ' . \escapeshellarg($tempNotesFile) . ' \
-                            --target ' . \escapeshellarg($releaseTarget) . ' \
-                            2>&1';
-
-                        $releaseOutput = [];
-                        $releaseReturnCode = 0;
-                        \exec($releaseCommand, $releaseOutput, $releaseReturnCode);
-
-                        \unlink($tempNotesFile);
-
-                        if ($releaseReturnCode === 0) {
-                            // Extract release URL from output
-                            $releaseUrl = '';
-                            foreach ($releaseOutput as $line) {
-                                if (strpos($line, 'https://github.com/') !== false) {
-                                    $releaseUrl = trim($line);
-                                    break;
-                                }
-                            }
-
-                            Console::success("  Release {$releaseVersion} created");
-                            if (! empty($releaseUrl)) {
-                                Console::log("  {$releaseUrl}");
-                            }
-                        } else {
-                            $errorMessage = implode("\n", $releaseOutput);
-                            Console::error("  Failed to create release: " . $errorMessage);
-                        }
-                    }
-
-                    continue;
                 }
 
                 Console::log($examplesOnly

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -351,10 +351,8 @@ class Specs extends Action
         $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', APP_EMAIL_TEAM);
         $specsDir = __DIR__ . '/../../../../app/config/specs';
 
-        if (!is_dir($specsDir)) {
-            if (!mkdir($specsDir, 0755, true)) {
-                throw new Exception('Failed to create specs directory: ' . $specsDir);
-            }
+        if (!is_dir($specsDir) && !@mkdir($specsDir, 0755, true) && !is_dir($specsDir)) {
+            throw new Exception('Failed to create specs directory: ' . $specsDir);
         }
 
         foreach ($platforms as $platform) {
@@ -479,7 +477,11 @@ class Specs extends Action
 
                 unset($parsedSpecs);
 
-                if ($encodedSpecs === false || !file_put_contents($path, $encodedSpecs)) {
+                if ($encodedSpecs === false) {
+                    throw new Exception('Failed to encode ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . \json_last_error_msg());
+                }
+
+                if (\file_put_contents($path, $encodedSpecs) === false) {
                     throw new Exception('Failed to save ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . $path);
                 }
 

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -347,6 +347,15 @@ class Specs extends Action
         $keys = $this->getKeys();
 
         $generatedFiles = [];
+        $endpoint = System::getEnv('_APP_HOME', '[HOSTNAME]');
+        $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', APP_EMAIL_TEAM);
+        $specsDir = __DIR__ . '/../../../../app/config/specs';
+
+        if (!is_dir($specsDir)) {
+            if (!mkdir($specsDir, 0755, true)) {
+                throw new Exception('Failed to create specs directory: ' . $specsDir);
+            }
+        }
 
         foreach ($platforms as $platform) {
             $routes = [];
@@ -443,8 +452,6 @@ class Specs extends Action
             foreach (['swagger2', 'open-api3'] as $format) {
                 $formatInstance = $this->getFormatInstance($format, $arguments);
                 $specs = new Specification($formatInstance);
-                $endpoint = System::getEnv('_APP_HOME', '[HOSTNAME]');
-                $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', APP_EMAIL_TEAM);
 
                 $formatInstance
                     ->setParam('name', APP_NAME)
@@ -463,36 +470,26 @@ class Specs extends Action
                     ->setParam('docs.description', 'Full API docs, specs and tutorials')
                     ->setParam('docs.url', $endpoint . '/docs');
 
-                $specsDir = __DIR__ . '/../../../../app/config/specs';
+                $path = $mocks
+                    ? $specsDir . '/' . $format . '-mocks-' . $platform . '.json'
+                    : $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
 
-                if (!is_dir($specsDir)) {
-                    if (!mkdir($specsDir, 0755, true)) {
-                        throw new Exception('Failed to create specs directory: ' . $specsDir);
-                    }
-                }
+                $parsedSpecs = $specs->parse();
+                $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);
 
-                if ($mocks) {
-                    $path = $specsDir . '/' . $format . '-mocks-' . $platform . '.json';
+                unset($parsedSpecs);
 
-                    if (!file_put_contents($path, json_encode($specs->parse(), JSON_PRETTY_PRINT))) {
-                        throw new Exception('Failed to save mocks spec file: ' . $path);
-                    }
-
-                    $generatedFiles[] = realpath($path);
-                    Console::success('Saved mocks spec file: ' . realpath($path));
-
-                    continue;
-                }
-
-                $path = $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
-
-                if (!file_put_contents($path, json_encode($specs->parse(), JSON_PRETTY_PRINT))) {
-                    throw new Exception('Failed to save spec file: ' . $path);
+                if ($encodedSpecs === false || !file_put_contents($path, $encodedSpecs)) {
+                    throw new Exception('Failed to save ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . $path);
                 }
 
                 $generatedFiles[] = realpath($path);
-                Console::success('Saved spec file: ' . realpath($path));
+                Console::success('Saved ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . realpath($path));
+
+                unset($encodedSpecs, $specs, $formatInstance);
             }
+
+            unset($arguments, $models, $routes, $services);
         }
 
         if ($git === 'yes') {


### PR DESCRIPTION
## What changed

This updates `src/Appwrite/Platform/Tasks/Specs.php` to release large intermediate spec-generation values as soon as they are no longer needed.

## Why

The specs task generates multiple large API spec documents in one process. The previous implementation kept heavy intermediates alive longer than necessary inside the platform and format loops, which increases peak memory pressure and can contribute to OOM kills in constrained CI containers.

## Implementation

- move one-time `endpoint`, `email`, and `specsDir` setup out of the inner format loop
- split spec generation into `parse -> json_encode -> file_put_contents`
- explicitly `unset()` the parsed spec payload, encoded JSON string, and per-format objects after each write
- explicitly `unset()` per-platform route, model, service, and argument arrays after each platform pass

## Impact

This does not change output filenames or spec contents. It only narrows the lifetime of large in-memory structures during generation.

## Validation

- `php -l src/Appwrite/Platform/Tasks/Specs.php`