### PR TITLE
Fix users list pagination total by counting with filter-only queries

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -676,6 +676,8 @@ Http::get('/v1/users')
             $queries[] = Query::search('search', $search);
         }
 
+        $filterQueries = Query::groupByType($queries)['filters'];
+
         $cursor = Query::getCursorQueries($queries, false);
         $cursor = \reset($cursor);
 
@@ -698,10 +700,10 @@ Http::get('/v1/users')
         $users = [];
         $total = 0;
 
-        $dbForProject->skipFilters(function () use ($dbForProject, $queries, $includeTotal, &$users, &$total) {
+        $dbForProject->skipFilters(function () use ($dbForProject, $queries, $filterQueries, $includeTotal, &$users, &$total) {
             try {
                 $users = $dbForProject->find('users', $queries);
-                $total = $includeTotal ? $dbForProject->count('users', $queries, APP_LIMIT_COUNT) : 0;
+                $total = $includeTotal ? $dbForProject->count('users', $filterQueries, APP_LIMIT_COUNT) : 0;
             } catch (OrderException $e) {
                 throw new Exception(Exception::DATABASE_QUERY_ORDER_NULL, "The order attribute '{$e->getAttribute()}' had a null value. Cursor pagination requires all documents order attribute values are non-null.");
             } catch (QueryException $e) {


### PR DESCRIPTION
In users.php, the List Users endpoint was calculating total using the full query set (including pagination operators like cursor/limit/offset).
That can return incorrect totals for paginated requests.

I fixed this by:

- Extracting filter-only queries via users.php:677
- Keeping users.php:702 unchanged for paged results.
- Changing users.php:703 to use $filterQueries so total reflects the full filtered dataset, not just the current page window.
- This directly addresses the pagination behavior issue in the users listing flow.