### PR TITLE
Fix domain validation checking wrong variable in functions domain loop

### DIFF
--- a/src/Appwrite/Platform/Modules/Proxy/Action.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Action.php
@@ -50,7 +50,7 @@ class Action extends PlatformAction
 
         $functionsDomains = System::getEnv('_APP_DOMAIN_FUNCTIONS', '');
         foreach (\explode(',', $functionsDomains) as $functionsDomain) {
-            if (empty($functionsDomains)) {
+            if (empty($functionsDomain)) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Fixed a typo bug in `src/Appwrite/Platform/Modules/Proxy/Action.php` where the `empty()` check inside the `foreach` loop was checking the outer variable `$functionsDomains` instead of the loop variable `$functionsDomain`
- The sites domain loop (line 40) correctly checks `$sitesDomain`, but the functions domain loop (line 53) was incorrectly checking `$functionsDomains`

## Impact

When `_APP_DOMAIN_FUNCTIONS` env var is set, empty entries from trailing/double commas are never skipped and get processed as invalid domain restrictions.

Fixes #11675