### PR TITLE
Fix vague error on user registration when name is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,4 @@ Join our growing community around the world! Check out our official [Blog](https
 ## License
 
 This repository is available under the [BSD 3-Clause License](./LICENSE).
+# Auto‑generated contribution

--- a/README.md
+++ b/README.md
@@ -238,4 +238,3 @@ Join our growing community around the world! Check out our official [Blog](https
 ## License
 
 This repository is available under the [BSD 3-Clause License](./LICENSE).
-# Auto‑generated contribution

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3179,8 +3179,7 @@ Http::patch('/v1/account/name')
     ->inject('user')
     ->inject('dbForProject')
     ->inject('queueForEvents')
-    ->action(function (?string $name, Response $response, Document $user, Database $dbForProject, Event $queueForEvents) {
-        $name = $name ?? '';
+    ->action(function (string $name, Response $response, Document $user, Database $dbForProject, Event $queueForEvents) {
 
         $user->setAttribute('name', $name);
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -403,7 +403,8 @@ Http::post('/v1/account')
     ->inject('dbForProject')
     ->inject('authorization')
     ->inject('hooks')
-    ->action(function (string $userId, string $email, string $password, string $name, Request $request, Response $response, Document $user, Document $project, Database $dbForProject, Authorization $authorization, Hooks $hooks) {
+    ->action(function (string $userId, string $email, string $password, ?string $name, Request $request, Response $response, Document $user, Document $project, Database $dbForProject, Authorization $authorization, Hooks $hooks) {
+        $name = $name ?? '';
 
         $email = \strtolower($email);
         if ('console' === $project->getId()) {
@@ -3178,7 +3179,8 @@ Http::patch('/v1/account/name')
     ->inject('user')
     ->inject('dbForProject')
     ->inject('queueForEvents')
-    ->action(function (string $name, Response $response, Document $user, Database $dbForProject, Event $queueForEvents) {
+    ->action(function (?string $name, Response $response, Document $user, Database $dbForProject, Event $queueForEvents) {
+        $name = $name ?? '';
 
         $user->setAttribute('name', $name);
 


### PR DESCRIPTION
Closes #8785. Added nullable type-hint for name in account creation and update actions to prevent PHP TypeError crashes when name is explicitly set to null.