### PR TITLE
fix: remove INDEX_SPATIAL from DocumentsDB index creation

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Create.php
@@ -58,7 +58,7 @@ class Create extends IndexCreate
             ->param('databaseId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Database ID.', false, ['dbForProject'])
             ->param('collectionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Collection ID. You can create a new collection using the Database service [server integration](https://appwrite.io/docs/server/databases#databasesCreateCollection).', false, ['dbForProject'])
             ->param('key', null, fn (Database $dbForProject) => new Key(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Index Key.', false, ['dbForProject'])
-            ->param('type', null, new WhiteList([Database::INDEX_KEY, Database::INDEX_FULLTEXT, Database::INDEX_UNIQUE, Database::INDEX_SPATIAL]), 'Index type.')
+            ->param('type', null, new WhiteList([Database::INDEX_KEY, Database::INDEX_FULLTEXT, Database::INDEX_UNIQUE]), 'Index type.')
             ->param('attributes', null, fn (Database $dbForProject) => new ArrayList(new Key(true, $dbForProject->getAdapter()->getMaxUIDLength()), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of attributes to index. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' attributes are allowed, each 32 characters long.', false, ['dbForProject'])
             ->param('orders', [], new ArrayList(new WhiteList(['ASC', 'DESC'], false, Database::VAR_STRING), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of index orders. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' orders are allowed.', true)
             ->param('lengths', [], new ArrayList(new Nullable(new Integer()), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Length of index. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE, optional: true)


### PR DESCRIPTION
## Summary
Remove `Database::INDEX_SPATIAL` from the DocumentsDB index creation WhiteList. MongoDB's adapter silently fails on spatial indexes — the `createCollection` switch returns `false` in the default case for `INDEX_SPATIAL`, meaning the index never gets created but no error is thrown.

## Changes
- `src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Create.php` — removed `INDEX_SPATIAL` from the type param WhiteList

## Context
MongoDB adapter handles these index types:
- `INDEX_KEY` — works (mapped to ascending/descending)
- `INDEX_FULLTEXT` — works (mapped to MongoDB `text` index)
- `INDEX_UNIQUE` — works
- `INDEX_SPATIAL` — silently fails (falls through to `default => return false`)

## Test plan
- [ ] Create DocumentsDB collection → Indexes → verify Spatial is not in the type dropdown
- [ ] Create Key, Fulltext, Unique indexes — verify they work
- [ ] TablesDB/VectorsDB index creation unchanged