### PR TITLE
fix: map webhook pause email content to styled template placeholders

### DIFF
--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -251,8 +251,9 @@ class Webhooks extends Action
         $body = Template::fromFile(__DIR__ . '/../../../../app/config/locale/templates/email-base-styled.tpl');
 
         $body
-            ->setParam('{{subject}}', $subject)
-            ->setParam('{{message}}', $template->render())
+            ->setParam('{{heading}}', $subject)
+            ->setParam('{{body}}', $template->render(), escapeHtml: false)
+            ->setParam('{{preview}}', $preview)
             ->setParam('{{year}}', date("Y"));
 
         $queueForMails


### PR DESCRIPTION
map webhook pause email content to styled template placeholders