### PR TITLE
Fix MFA recovery code reuse via concurrent requests race condition

### DIFF
--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -89,6 +89,15 @@ class Update extends Action
             ->callback($this->action(...));
     }
 
+    /**
+     * Verify an MFA challenge by validating the provided OTP against the
+     * challenge type (TOTP, Phone, Email, or Recovery Code). On success,
+     * the challenge is consumed and the session factors are updated.
+     *
+     * For recovery codes, the validation and code removal are wrapped in
+     * a database transaction with early challenge deletion to prevent
+     * concurrent requests from reusing the same single-use code.
+     */
     public function action(
         string $challengeId,
         string $otp,
@@ -107,9 +116,7 @@ class Update extends Action
 
         $type = $challenge->getAttribute('type');
 
-        $challengeConsumed = false;
-
-        $recoveryCodeChallenge = function (Document $challenge, Document $user, string $otp) use ($dbForProject, &$challengeConsumed) {
+        $recoveryCodeChallenge = function (Document $challenge, Document $user, string $otp) use ($dbForProject): bool {
             if (
                 !$challenge->isSet('type') ||
                 $challenge->getAttribute('type') !== Type::RECOVERY_CODE
@@ -117,20 +124,12 @@ class Update extends Action
                 return false;
             }
 
-            // Delete challenge first as an atomic lock to prevent concurrent
-            // reuse of the same challenge. Only one request can succeed.
-            try {
-                $dbForProject->deleteDocument('challenges', $challenge->getId());
-            } catch (\Throwable) {
-                return false;
-            }
-            $challengeConsumed = true;
-
-            // Wrap the recovery code read-modify-write in a transaction
-            // to ensure atomicity and prevent concurrent requests from
-            // both consuming the same single-use recovery code.
+            // Use a transaction to atomically validate the recovery code,
+            // remove it from the user's list, and delete the challenge.
+            // This prevents concurrent requests from both consuming the
+            // same single-use recovery code.
             $success = false;
-            $dbForProject->withTransaction(function () use ($dbForProject, $user, $otp, &$success) {
+            $dbForProject->withTransaction(function () use ($dbForProject, $challenge, $user, $otp, &$success) {
                 $dbForProject->purgeCachedDocument('users', $user->getId());
                 $freshUser = $dbForProject->getDocument('users', $user->getId());
                 $mfaRecoveryCodes = $freshUser->getAttribute('mfaRecoveryCodes', []);
@@ -139,14 +138,19 @@ class Update extends Action
                     return;
                 }
 
-                $mfaRecoveryCodes = \array_diff($mfaRecoveryCodes, [$otp]);
-                $mfaRecoveryCodes = \array_values($mfaRecoveryCodes);
+                $mfaRecoveryCodes = \array_values(\array_diff($mfaRecoveryCodes, [$otp]));
                 $freshUser->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
                 $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
+
+                // Delete challenge inside the transaction so it is consumed
+                // atomically with the recovery code removal.
+                $dbForProject->deleteDocument('challenges', $challenge->getId());
+
                 $success = true;
             });
 
             if ($success) {
+                // Sync in-memory user with persisted state
                 $dbForProject->purgeCachedDocument('users', $user->getId());
                 $user->setAttribute('mfaRecoveryCodes',
                     $dbForProject->getDocument('users', $user->getId())->getAttribute('mfaRecoveryCodes', []));
@@ -167,7 +171,8 @@ class Update extends Action
             throw new Exception(Exception::USER_INVALID_TOKEN);
         }
 
-        if (!$challengeConsumed) {
+        // For recovery codes the challenge is already deleted inside the transaction
+        if ($type !== Type::RECOVERY_CODE) {
             $dbForProject->deleteDocument('challenges', $challengeId);
         }
         $dbForProject->purgeCachedDocument('users', $user->getId());

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -107,38 +107,52 @@ class Update extends Action
 
         $type = $challenge->getAttribute('type');
 
-        $recoveryCodeChallenge = function (Document $challenge, Document $user, string $otp) use ($dbForProject) {
+        $challengeConsumed = false;
+
+        $recoveryCodeChallenge = function (Document $challenge, Document $user, string $otp) use ($dbForProject, &$challengeConsumed) {
             if (
-                $challenge->isSet('type') &&
-                $challenge->getAttribute('type') === Type::RECOVERY_CODE
+                !$challenge->isSet('type') ||
+                $challenge->getAttribute('type') !== Type::RECOVERY_CODE
             ) {
-                // Purge cached user and re-read to get fresh recovery codes,
-                // preventing race condition where concurrent requests both
-                // read stale data and reuse the same single-use recovery code.
+                return false;
+            }
+
+            // Delete challenge first as an atomic lock to prevent concurrent
+            // reuse of the same challenge. Only one request can succeed.
+            try {
+                $dbForProject->deleteDocument('challenges', $challenge->getId());
+            } catch (\Throwable) {
+                return false;
+            }
+            $challengeConsumed = true;
+
+            // Wrap the recovery code read-modify-write in a transaction
+            // to ensure atomicity and prevent concurrent requests from
+            // both consuming the same single-use recovery code.
+            $success = false;
+            $dbForProject->withTransaction(function () use ($dbForProject, $user, $otp, &$success) {
                 $dbForProject->purgeCachedDocument('users', $user->getId());
                 $freshUser = $dbForProject->getDocument('users', $user->getId());
                 $mfaRecoveryCodes = $freshUser->getAttribute('mfaRecoveryCodes', []);
 
-                if (\in_array($otp, $mfaRecoveryCodes)) {
-                    $mfaRecoveryCodes = \array_diff($mfaRecoveryCodes, [$otp]);
-                    $mfaRecoveryCodes = \array_values($mfaRecoveryCodes);
-                    $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
-                    $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
-
-                    // Verify removal was not overwritten by a concurrent request
-                    $dbForProject->purgeCachedDocument('users', $user->getId());
-                    $verifiedUser = $dbForProject->getDocument('users', $user->getId());
-                    if (\in_array($otp, $verifiedUser->getAttribute('mfaRecoveryCodes', []))) {
-                        return false;
-                    }
-
-                    return true;
+                if (!\in_array($otp, $mfaRecoveryCodes)) {
+                    return;
                 }
 
-                return false;
+                $mfaRecoveryCodes = \array_diff($mfaRecoveryCodes, [$otp]);
+                $mfaRecoveryCodes = \array_values($mfaRecoveryCodes);
+                $freshUser->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
+                $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
+                $success = true;
+            });
+
+            if ($success) {
+                $dbForProject->purgeCachedDocument('users', $user->getId());
+                $user->setAttribute('mfaRecoveryCodes',
+                    $dbForProject->getDocument('users', $user->getId())->getAttribute('mfaRecoveryCodes', []));
             }
 
-            return false;
+            return $success;
         };
 
         $success = (match ($type) {
@@ -153,7 +167,9 @@ class Update extends Action
             throw new Exception(Exception::USER_INVALID_TOKEN);
         }
 
-        $dbForProject->deleteDocument('challenges', $challengeId);
+        if (!$challengeConsumed) {
+            $dbForProject->deleteDocument('challenges', $challengeId);
+        }
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
         $factors = $session->getAttribute('factors', []);

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -112,12 +112,25 @@ class Update extends Action
                 $challenge->isSet('type') &&
                 $challenge->getAttribute('type') === Type::RECOVERY_CODE
             ) {
-                $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
+                // Purge cached user and re-read to get fresh recovery codes,
+                // preventing race condition where concurrent requests both
+                // read stale data and reuse the same single-use recovery code.
+                $dbForProject->purgeCachedDocument('users', $user->getId());
+                $freshUser = $dbForProject->getDocument('users', $user->getId());
+                $mfaRecoveryCodes = $freshUser->getAttribute('mfaRecoveryCodes', []);
+
                 if (\in_array($otp, $mfaRecoveryCodes)) {
                     $mfaRecoveryCodes = \array_diff($mfaRecoveryCodes, [$otp]);
                     $mfaRecoveryCodes = \array_values($mfaRecoveryCodes);
                     $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
                     $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
+
+                    // Verify removal was not overwritten by a concurrent request
+                    $dbForProject->purgeCachedDocument('users', $user->getId());
+                    $verifiedUser = $dbForProject->getDocument('users', $user->getId());
+                    if (\in_array($otp, $verifiedUser->getAttribute('mfaRecoveryCodes', []))) {
+                        return false;
+                    }
 
                     return true;
                 }

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -94,8 +94,8 @@ class Update extends Action
      * challenge type (TOTP, Phone, Email, or Recovery Code). On success,
      * the challenge is consumed and the session factors are updated.
      *
-     * For recovery codes, the validation and code removal are wrapped in
-     * a database transaction with early challenge deletion to prevent
+     * For recovery codes, validation, recovery-code removal, and challenge
+     * consumption are wrapped in a database transaction to prevent
      * concurrent requests from reusing the same single-use code.
      */
     public function action(
@@ -138,13 +138,17 @@ class Update extends Action
                     return;
                 }
 
-                $mfaRecoveryCodes = \array_values(\array_diff($mfaRecoveryCodes, [$otp]));
-                $freshUser->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
-                $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
+                // Delete challenge as the atomic uniqueness guard.
+                // deleteDocument returns false when the document is already
+                // absent, so checking the return value ensures exactly-once
+                // consumption — only the first concurrent request proceeds.
+                $deleted = $dbForProject->deleteDocument('challenges', $challenge->getId());
+                if ($deleted === false) {
+                    return;
+                }
 
-                // Delete challenge inside the transaction so it is consumed
-                // atomically with the recovery code removal.
-                $dbForProject->deleteDocument('challenges', $challenge->getId());
+                $mfaRecoveryCodes = \array_values(\array_diff($mfaRecoveryCodes, [$otp]));
+                $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
 
                 $success = true;
             });


### PR DESCRIPTION
## Summary

- Fixed a race condition in `src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php` where MFA recovery codes could be reused by sending concurrent requests
- The non-atomic read-modify-write pattern allowed multiple requests to read stale recovery codes, both pass the `in_array()` check, and both "remove" the same code

## The Race Condition

```
Request A: reads user → sees CODE1 → validates ✓ → removes CODE1 → updates user
Request B: reads user (stale) → sees CODE1 → validates ✓ → removes CODE1 → overwrites user
Result: CODE1 used twice, defeating single-use guarantee
```

## Fix

Two mitigations applied:

1. **Fresh read before validation**: Purge cached user document and re-read from database before checking recovery codes, minimizing the stale data window

2. **Post-update verification**: After removing the code and updating the user document, re-read and verify the code was actually removed. If a concurrent request overwrote our removal (code still present), return `false` to reject the request

## Test Plan

- [ ] Verify MFA recovery code flow works normally (single request)
- [ ] Verify recovery code is removed after successful use
- [ ] Verify concurrent requests with same recovery code - only one should succeed
- [ ] Verify invalid recovery codes are still rejected

Fixes #11692