### PR TITLE
Fix spec generation defaults for _APP_HOME and _APP_SYSTEM_TEAM_EMAIL

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -347,8 +347,8 @@ class Specs extends Action
         $keys = $this->getKeys();
 
         $generatedFiles = [];
-        $endpoint = System::getEnv('_APP_HOME', '[HOSTNAME]');
-        $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', APP_EMAIL_TEAM);
+        $endpoint = System::getEnv('_APP_HOME', 'https://appwrite.io');
+        $email = System::getEnv('_APP_SYSTEM_TEAM_EMAIL', 'team@appwrite.io');
         $specsDir = __DIR__ . '/../../../../app/config/specs';
 
         if (!is_dir($specsDir) && !@mkdir($specsDir, 0755, true) && !is_dir($specsDir)) {


### PR DESCRIPTION
## Summary

- Use `https://appwrite.io` as default for `_APP_HOME` instead of `[HOSTNAME]` placeholder
- Use `team@appwrite.io` as default for `_APP_SYSTEM_TEAM_EMAIL` instead of `team@localhost.test`

These placeholders were leaking into generated specs (e.g. `package.json` homepage becoming `[HOSTNAME]/support`) when running spec generation outside Docker.

## Test plan

- [ ] Run `php app/cli.php specs --version=1.9.x --git=no` without setting `_APP_HOME` or `_APP_SYSTEM_TEAM_EMAIL`
- [ ] Verify generated spec `info.contact.url` is `https://appwrite.io/support`
- [ ] Verify generated spec `info.contact.email` is `team@appwrite.io`