### PR TITLE
fix(locale): add missing session alert translations for Spanish (es)

### DIFF
--- a/app/config/locale/translations/es.json
+++ b/app/config/locale/translations/es.json
@@ -245,5 +245,15 @@
     "emails.otpSession.clientInfo": "Este inicio de sesión fue solicitado usando {{agentClient}} en {{agentDevice}} {{agentOs}}. Si no solicitaste el inicio de sesión, puedes ignorar este correo electrónico de forma segura.",
     "emails.otpSession.securityPhrase": "La frase de seguridad para este correo electrónico es {{phrase}}. Puedes confiar en este correo si esta frase coincide con la frase mostrada durante el inicio de sesión.",
     "emails.otpSession.thanks": "Gracias.,",
-    "emails.otpSession.signature": "El equipo de {{project}}"
+    "emails.otpSession.signature": "El equipo de {{project}}",
+        "emails.sessionAlert.subject": "Alerta de seguridad: nueva sesión en tu cuenta de {{project}}",
+        "emails.sessionAlert.preview": "Nuevo inicio de sesión detectado en {{project}} a las {{time}} UTC.",
+        "emails.sessionAlert.hello": "Hola {{user}},",
+        "emails.sessionAlert.body": "Se ha creado una nueva sesión en tu cuenta de {{b}}{{project}}{{/b}}, {{b}}el {{date}}, {{year}} a las {{time}} UTC{{/b}}.\nAquí están los detalles de la nueva sesión: ",
+        "emails.sessionAlert.listDevice": "Dispositivo: {{b}}{{device}}{{/b}}",
+        "emails.sessionAlert.listIpAddress": "Dirección IP: {{b}}{{ipAddress}}{{/b}}",
+        "emails.sessionAlert.listCountry": "País: {{b}}{{country}}{{/b}}",
+        "emails.sessionAlert.footer": "Si fuiste tú, no necesitas hacer nada más.\nSi no iniciaste esta sesión o sospechas de alguna actividad no autorizada, por favor asegura tu cuenta.",
+        "emails.sessionAlert.thanks": "Gracias,",
+        "emails.sessionAlert.signature": "El equipo de {{project}}"
 }


### PR DESCRIPTION
Adds the missing sessionAlert email translation keys to es.json to fix issue #8659.

The following keys were added with proper Spanish translations:
- emails.sessionAlert.subject
- emails.sessionAlert.preview
- emails.sessionAlert.hello
- emails.sessionAlert.body
- emails.sessionAlert.listDevice
- emails.sessionAlert.listIpAddress
- emails.sessionAlert.listCountry
- emails.sessionAlert.footer
- emails.sessionAlert.thanks
- emails.sessionAlert.signature

Fixes: #8659

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds the missing `emails.sessionAlert.*` translation keys to the Spanish (`es.json`) locale file. When users had their locale set to Spanish (`X-Appwrite-Locale: es`), the session alert email would show raw template placeholders like `{{emails.sessionAlert.subject}}` instead of the actual translated text. This fix provides proper Spanish translations for all session alert email keys.

## Test Plan

1. Send a session alert email with `X-Appwrite-Locale: es` header set.
2. 2. Verify the email subject, body, and all content appear in Spanish instead of raw template placeholder strings.work. 

## Related PRs and Issues

- Fixes #8659

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?(https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (N/A - this is a translation-only change)example docs?
