### PR TITLE
Add beforeCreateGitDeployment hook for deployment validation

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -70,6 +70,8 @@ trait Deployment
                     throw new Exception(Exception::PROJECT_NOT_FOUND, 'Repository references non-existent project');
                 }
 
+                $this->validateGitDeployment($project, $repository, $dbForPlatform, $authorization);
+
                 try {
                     $dsn = new DSN($project->getAttribute('database'));
                     $databaseName = $dsn->getHost();
@@ -559,6 +561,15 @@ trait Deployment
         if (!empty($errors)) {
             throw new Exception(Exception::GENERAL_UNKNOWN, \implode("\n", $errors));
         }
+    }
+
+    /**
+     * Validate a git deployment before processing.
+     *
+     * No-op in OSS — overridden in Cloud to enforce billing/block checks.
+     */
+    protected function validateGitDeployment(Document $project, Document $repository, Database $dbForPlatform, Authorization $authorization): void
+    {
     }
 
     protected function getBuildQueueName(Document $project, Database $dbForPlatform, Authorization $authorization): string

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -70,7 +70,7 @@ trait Deployment
                     throw new Exception(Exception::PROJECT_NOT_FOUND, 'Repository references non-existent project');
                 }
 
-                $this->validateGitDeployment($project, $repository, $dbForPlatform, $authorization);
+                $this->beforeCreateGitDeployment($project, $repository, $dbForPlatform, $authorization);
 
                 try {
                     $dsn = new DSN($project->getAttribute('database'));
@@ -568,7 +568,7 @@ trait Deployment
      *
      * No-op in OSS — overridden in Cloud to enforce billing/block checks.
      */
-    protected function validateGitDeployment(Document $project, Document $repository, Database $dbForPlatform, Authorization $authorization): void
+    protected function beforeCreateGitDeployment(Document $project, Document $repository, Database $dbForPlatform, Authorization $authorization): void
     {
     }
 

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -563,11 +563,6 @@ trait Deployment
         }
     }
 
-    /**
-     * Validate a git deployment before processing.
-     *
-     * No-op in OSS — overridden in Cloud to enforce billing/block checks.
-     */
     protected function beforeCreateGitDeployment(Document $project, Document $repository, Database $dbForPlatform, Authorization $authorization): void
     {
     }


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `beforeCreateGitDeployment()` hook method that is called before processing git deployments. This allows for extensibility in deployment validation logic, particularly for Cloud deployments that need to enforce billing and block checks.

The hook is implemented as a no-op in the base OSS implementation and is designed to be overridden in Cloud-specific subclasses to add custom validation logic before a git deployment is created.

## Test Plan

No testing needed. This is a straightforward extension point that:
- Adds a new protected method with no-op implementation in the base class
- Calls this method at an appropriate point in the deployment creation flow (after project validation, before database operations)
- Does not change any existing behavior in OSS deployments
- Existing deployment tests will continue to pass

## Related PRs and Issues

N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (N/A - internal refactoring)

https://claude.ai/code/session_01HP1N9hHbqMzxm5QmaoGhyZ