### PR TITLE
Fix missing array_values() after array_diff() in VCS PR cleanup

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
@@ -234,7 +234,7 @@ class Create extends Action
                     $providerPullRequestIds = $repository->getAttribute('providerPullRequestIds', []);
 
                     if (\in_array($providerPullRequestId, $providerPullRequestIds)) {
-                        $providerPullRequestIds = \array_diff($providerPullRequestIds, [$providerPullRequestId]);
+                        $providerPullRequestIds = \array_values(\array_diff($providerPullRequestIds, [$providerPullRequestId]));
                         $repository = $repository->setAttribute('providerPullRequestIds', $providerPullRequestIds);
                         $repository = $authorization->skip(fn () => $dbForPlatform->updateDocument('repositories', $repository->getId(), new Document(['providerPullRequestIds' => $providerPullRequestIds])));
                     }


### PR DESCRIPTION
## Description
Fixes #11741

When a pull request is closed and external contribution cleanup runs in the VCS GitHub events handler, `array_diff()` is used to remove the PR ID from `providerPullRequestIds` without wrapping in `array_values()`.

## Problem

`array_diff()` preserves the original numeric keys after removing elements:

```php
$ids = ['101', '102', '103'];
$result = array_diff($ids, ['102']);
// Result: [0 => '101', 2 => '103'] — non-sequential keys
```

When stored in the database (JSON-encoded), PHP produces a JSON **object** `{"0":"101","2":"103"}` instead of a JSON **array** `["101","103"]`, causing malformed data storage.

## Fix

Wrap `array_diff()` with `array_values()` to reindex the array, consistent with the pattern used elsewhere in the codebase:

- `Databases/Workers/Databases.php:368` — `\array_values(\array_diff(...))`
- `Account/Http/Account/MFA/Challenges/Update.php:150` — `\array_values(\array_diff(...))`