### PR TITLE
fix(oauth): update Yahoo OAuth scopes from deprecated scopes

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Yahoo.php
+++ b/src/Appwrite/Auth/OAuth2/Yahoo.php
@@ -23,8 +23,9 @@ class Yahoo extends OAuth2
      * @var array
      */
     protected array $scopes = [
-        'sdct-r',
-        'sdpp-w',
+        'openid',
+        'profile',
+        'email',
     ];
 
     /**


### PR DESCRIPTION
The Yahoo OAuth provider was using deprecated Social Directory API scopes ('sdct-r' and 'sdpp-w') which are no longer valid and causing authentication failures with the error: invalid_scope

Changes:
- Replace deprecated scopes 'sdct-r' (Social Directory Contacts Read) and 'sdpp-w' (Social Directory Profile Write) with standard OIDC scopes
- Add 'openid' scope for OpenID Connect authentication
- Add 'profile' scope for basic profile information
- Add 'email' scope for email address access

These new scopes align with Yahoo's OpenID Connect implementation and are listed in their discovery document at:
https://api.login.yahoo.com/.well-known/openid-configuration

Custom scopes passed via the API are still supported and will be merged with these defaults via the base OAuth2 class constructor.

Fixes #10982 

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
