### PR TITLE
Fix flaky vectordb migration test

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
@@ -130,9 +130,11 @@ class Create extends CollectionAction
             $indexes[] = new Document($index);
         }
         try {
-            // passing null in creates only creates the metadata collection
             if (!$dbForDatabases->exists(null, Database::METADATA)) {
-                $dbForDatabases->create();
+                try {
+                    $dbForDatabases->create();
+                } catch (DuplicateException) {
+                }
             }
             $dbForDatabases->createCollection(
                 id: 'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),


### PR DESCRIPTION
- make VectorsDB metadata initialization concurrency-safe during collection creation
- fix the flaky CSV export migration flow that creates VectorsDB collections during parallel test runs
- keep duplicate handling scoped only to one-time metadata bootstrap, not user collection creation
The swallowed `DuplicateException` only wraps `$dbForDatabases->create()`, which bootstraps the internal metadata collection.
In parallel runs, two requests can both observe that metadata does not exist yet, then race to create it:
1. request A checks `exists(..., Database::METADATA)` and gets `false`
2. request B checks `exists(..., Database::METADATA)` and gets `false`
3. request A calls `create()` and succeeds
4. request B calls `create()` and gets a duplicate because the desired state already exists
That duplicate is benign because the metadata collection is now present. The code still throws normally for:
- duplicate user-facing collection documents in the project database
- duplicate VectorsDB collection creation in `$dbForDatabases->createCollection(...)`
So this change only makes the one-time metadata bootstrap idempotent under concurrency; it does not hide real duplicate errors for actual collection creation.
- `php -l src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php`
- Docker-based focused regression test could not be run from the sandboxed environment
