### PR TITLE
Fix spec output for nested sub-model properties

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -932,10 +932,11 @@ class OpenAPI3 extends Format
                 }
                 if ($items) {
                     if (!empty($rule['nestedModel']) && !$rule['array']) {
-                        unset($output['components']['schemas'][$model->getType()]['properties'][$name]['type']);
+                        $existing = $output['components']['schemas'][$model->getType()]['properties'][$name];
+                        unset($existing['type']);
                         $output['components']['schemas'][$model->getType()]['properties'][$name] = \array_merge(
-                            $output['components']['schemas'][$model->getType()]['properties'][$name],
-                            $items
+                            $existing,
+                            ['allOf' => [$items]]
                         );
                     } else {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['items'] = $items;

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -931,7 +931,15 @@ class OpenAPI3 extends Format
                     }
                 }
                 if ($items) {
-                    $output['components']['schemas'][$model->getType()]['properties'][$name]['items'] = $items;
+                    if (!empty($rule['nestedModel']) && !$rule['array']) {
+                        unset($output['components']['schemas'][$model->getType()]['properties'][$name]['type']);
+                        $output['components']['schemas'][$model->getType()]['properties'][$name] = \array_merge(
+                            $output['components']['schemas'][$model->getType()]['properties'][$name],
+                            $items
+                        );
+                    } else {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['items'] = $items;
+                    }
                 }
                 if ($rule['type'] === 'enum' && !empty($rule['enum'])) {
                     if ($rule['array']) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -924,7 +924,15 @@ class Swagger2 extends Format
                     }
                 }
                 if ($items) {
-                    $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;
+                    if (!empty($rule['nestedModel']) && !$rule['array']) {
+                        unset($output['definitions'][$model->getType()]['properties'][$name]['type']);
+                        $output['definitions'][$model->getType()]['properties'][$name] = \array_merge(
+                            $output['definitions'][$model->getType()]['properties'][$name],
+                            $items
+                        );
+                    } else {
+                        $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;
+                    }
                 }
                 if ($rule['type'] === 'enum' && !empty($rule['enum'])) {
                     if ($rule['array']) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -925,15 +925,9 @@ class Swagger2 extends Format
                 }
                 if ($items) {
                     if (!empty($rule['nestedModel']) && !$rule['array']) {
-                        $existing = $output['definitions'][$model->getType()]['properties'][$name];
-                        unset($existing['type']);
-                        $output['definitions'][$model->getType()]['properties'][$name] = \array_merge(
-                            $existing,
-                            ['allOf' => [$items]]
-                        );
-                    } else {
-                        $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;
+                        unset($output['definitions'][$model->getType()]['properties'][$name]['type']);
                     }
+                    $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;
                 }
                 if ($rule['type'] === 'enum' && !empty($rule['enum'])) {
                     if ($rule['array']) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -925,10 +925,11 @@ class Swagger2 extends Format
                 }
                 if ($items) {
                     if (!empty($rule['nestedModel']) && !$rule['array']) {
-                        unset($output['definitions'][$model->getType()]['properties'][$name]['type']);
+                        $existing = $output['definitions'][$model->getType()]['properties'][$name];
+                        unset($existing['type']);
                         $output['definitions'][$model->getType()]['properties'][$name] = \array_merge(
-                            $output['definitions'][$model->getType()]['properties'][$name],
-                            $items
+                            $existing,
+                            ['allOf' => [$items]]
                         );
                     } else {
                         $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;


### PR DESCRIPTION
## Summary
- Adds support for `nestedModel` flag in response model rules
- When `nestedModel => true` and the field is not an array, the spec formatters now emit a direct `$ref` instead of wrapping it in `items`
- Fixes both OpenAPI3 and Swagger2 formatters
- This allows SDK generators to produce proper typed classes for singular object sub-models (e.g. `managerTags` on Rule/Runtime responses)

## Test plan
- [ ] Regenerate manager specs and verify `tags` field uses `$ref` directly
- [ ] Regenerate manager SDK and verify `ManagerTags` class is produced