### PR TITLE
fix(vcs): reindex providerPullRequestIds after array_diff

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
@@ -234,7 +234,7 @@ class Create extends Action
                     $providerPullRequestIds = $repository->getAttribute('providerPullRequestIds', []);
 
                     if (\in_array($providerPullRequestId, $providerPullRequestIds)) {
-                        $providerPullRequestIds = \array_diff($providerPullRequestIds, [$providerPullRequestId]);
+                        $providerPullRequestIds = \array_values(\array_diff($providerPullRequestIds, [$providerPullRequestId]));
                         $repository = $repository->setAttribute('providerPullRequestIds', $providerPullRequestIds);
                         $repository = $authorization->skip(fn () => $dbForPlatform->updateDocument('repositories', $repository->getId(), new Document(['providerPullRequestIds' => $providerPullRequestIds])));
                     }


### PR DESCRIPTION
## Summary
- wrap `array_diff()` with `array_values()` when removing closed PR IDs from `providerPullRequestIds`
- ensure the stored value remains a sequential array instead of a sparse keyed array/object after JSON serialization

## Why
`array_diff()` preserves numeric keys. Without reindexing, removing one PR ID can produce sparse arrays and malformed JSON object storage for `providerPullRequestIds`.

Fixes #11741