### PR TITLE
fix: reindex array after array_diff to prevent malformed output (#11741)

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
@@ -234,7 +234,7 @@ class Create extends Action
                     $providerPullRequestIds = $repository->getAttribute('providerPullRequestIds', []);
 
                     if (\in_array($providerPullRequestId, $providerPullRequestIds)) {
-                        $providerPullRequestIds = \array_diff($providerPullRequestIds, [$providerPullRequestId]);
+                        $providerPullRequestIds = \array_values(\array_diff($providerPullRequestIds, [$providerPullRequestId]));
                         $repository = $repository->setAttribute('providerPullRequestIds', $providerPullRequestIds);
                         $repository = $authorization->skip(fn () => $dbForPlatform->updateDocument('repositories', $repository->getId(), new Document(['providerPullRequestIds' => $providerPullRequestIds])));
                     }


### PR DESCRIPTION
## Summary

This fixes an issue in the GitHub pull request cleanup flow where rray_diff() was used without reindexing the result before storing it back on the repository document.

## Root Cause

rray_diff() preserves the original numeric keys. After removing a pull request ID from providerPullRequestIds, the resulting array could contain gaps in its indexes.

When that sparse array was stored, it could be serialized as an object-like structure instead of a proper JSON array, which can break downstream code expecting a sequential list.

## Fix

Wrap the existing rray_diff() call with rray_values() in src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php so providerPullRequestIds is always reindexed before it is written back.

## Why This Change Is Minimal

This keeps the patch intentionally small and follows the existing pattern already used elsewhere in the codebase for rray_diff() results that are persisted or returned.