### PR TITLE
fix appwrite auth broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Table of Contents:
 
 ## Products
 
-- **[Appwrite Auth](https://appwrite.io/docs/products/authentication)** - Secure user authentication with multiple login methods including email/password, SMS, OAuth, anonymous sessions, and magic links. Includes session management, multi-factor authentication, and user verification flows.
+- **[Appwrite Auth](https://appwrite.io/docs/products/auth)** - Secure user authentication with multiple login methods including email/password, SMS, OAuth, anonymous sessions, and magic links. Includes session management, multi-factor authentication, and user verification flows.
 
 - **[Appwrite Databases](https://appwrite.io/docs/products/databases)** - Scalable structured data storage with support for databases, tables, and rows. Includes querying, pagination, indexing, and relationships to model complex application data.
 


### PR DESCRIPTION
## What does this PR do?

Fixes appwrite auth broken link in readme.md which leads to 404 page not found

## Changes Made
Replaced the broken link with the correct link to Appwrite Auth docs 