### PR TITLE
fix: avoid DOMDocument in favicon parsing

### DIFF
--- a/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
@@ -11,8 +11,6 @@ use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\URL\URL as URLParse;
 use Appwrite\Utopia\Response;
-use DOMDocument;
-use DOMElement;
 use enshrined\svgSanitize\Sanitizer as SvgSanitizer;
 use Utopia\Domains\Domain;
 use Utopia\Fetch\Client;
@@ -94,50 +92,56 @@ class Get extends Action
             throw new Exception(Exception::AVATAR_REMOTE_URL_FAILED);
         }
 
-        $doc = new DOMDocument();
-        $doc->strictErrorChecking = false;
-        @$doc->loadHTML($res->getBody());
-
-        $links = $doc->getElementsByTagName('link') ?? [];
         $outputHref = '';
         $outputExt = '';
         $space = 0;
 
-        foreach ($links as $link) { /* @var $link DOMElement */
-            $href = $link->getAttribute('href');
-            $rel = $link->getAttribute('rel');
-            $sizes = $link->getAttribute('sizes');
+        $linkTags = [];
+        \preg_match_all('/<link\b[^>]*>/i', $res->getBody(), $linkTags);
+
+        foreach ($linkTags[0] ?? [] as $tag) {
+            $attributes = [];
+
+            \preg_match_all('/([a-zA-Z:-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/s', $tag, $attributeMatches, \PREG_SET_ORDER);
+
+            foreach ($attributeMatches as $attributeMatch) {
+                $attributes[\strtolower($attributeMatch[1])] = \html_entity_decode(
+                    $attributeMatch[2] ?: $attributeMatch[3] ?: $attributeMatch[4],
+                    \ENT_QUOTES | \ENT_HTML5
+                );
+            }
+
+            $href = $attributes['href'] ?? '';
+            $rel = \strtolower(\preg_replace('/\s+/', ' ', \trim($attributes['rel'] ?? '')));
+            $sizes = $attributes['sizes'] ?? '';
+
+            if (empty($href) || !\in_array($rel, ['icon', 'shortcut icon'], true)) {
+                continue;
+            }
+
             $absolute = URLParse::unparse(\array_merge(\parse_url($url), \parse_url($href)));
 
-            switch (\strtolower($rel)) {
-                case 'icon':
-                case 'shortcut icon':
-                    //case 'apple-touch-icon':
-                    $ext = \pathinfo(\parse_url($absolute, PHP_URL_PATH), PATHINFO_EXTENSION);
+            $ext = \pathinfo(\parse_url($absolute, PHP_URL_PATH), PATHINFO_EXTENSION);
 
-                    switch ($ext) {
-                        case 'svg':
-                            // SVG icons are prioritized by assigning the maximum possible value.
-                            $space = PHP_INT_MAX;
-                            $outputHref = $absolute;
-                            $outputExt = $ext;
-                            break;
-                        case 'ico':
-                        case 'png':
-                        case 'jpg':
-                        case 'jpeg':
-                            $size = \explode('x', \strtolower($sizes));
+            switch ($ext) {
+                case 'svg':
+                    $space = PHP_INT_MAX;
+                    $outputHref = $absolute;
+                    $outputExt = $ext;
+                    break;
+                case 'ico':
+                case 'png':
+                case 'jpg':
+                case 'jpeg':
+                    $size = \explode('x', \strtolower($sizes));
 
-                            $sizeWidth = (int) ($size[0] ?? 0);
-                            $sizeHeight = (int) ($size[1] ?? 0);
+                    $sizeWidth = (int) ($size[0] ?? 0);
+                    $sizeHeight = (int) ($size[1] ?? 0);
 
-                            if (($sizeWidth * $sizeHeight) >= $space) {
-                                $space = $sizeWidth * $sizeHeight;
-                                $outputHref = $absolute;
-                                $outputExt = $ext;
-                            }
-
-                            break;
+                    if (($sizeWidth * $sizeHeight) >= $space) {
+                        $space = $sizeWidth * $sizeHeight;
+                        $outputHref = $absolute;
+                        $outputExt = $ext;
                     }
 
                     break;

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
@@ -97,7 +97,8 @@ class Get extends Action
         $space = 0;
 
         $linkTags = [];
-        \preg_match_all('/<link\b[^>]*>/i', $res->getBody(), $linkTags);
+        $html = \preg_replace('/<!--.*?-->/s', '', $res->getBody()) ?? $res->getBody();
+        \preg_match_all('/<link\b[^>]*>/i', $html, $linkTags);
 
         foreach ($linkTags[0] ?? [] as $tag) {
             $attributes = [];
@@ -107,7 +108,7 @@ class Get extends Action
 
             foreach ($attributeMatches as $attributeMatch) {
                 $attributes[\strtolower($attributeMatch[1])] = \html_entity_decode(
-                    $attributeMatch[2] ?: $attributeMatch[3] ?: $attributeMatch[4],
+                    $attributeMatch[2] !== '' ? $attributeMatch[2] : ($attributeMatch[3] !== '' ? $attributeMatch[3] : $attributeMatch[4]),
                     \ENT_QUOTES | \ENT_HTML5
                 );
             }

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
@@ -97,7 +97,10 @@ class Get extends Action
         $space = 0;
 
         $linkTags = [];
-        $html = \preg_replace('/<!--.*?-->/s', '', $res->getBody()) ?? $res->getBody();
+        $html = $res->getBody();
+        $html = \preg_replace('/<!--.*?-->/s', '', $html) ?? $html;
+        $html = \preg_replace('/<script\b[^>]*>.*?<\/script>/is', '', $html) ?? $html;
+        $html = \preg_replace('/<style\b[^>]*>.*?<\/style>/is', '', $html) ?? $html;
         \preg_match_all('/<link\b[^>]*>/i', $html, $linkTags);
 
         foreach ($linkTags[0] ?? [] as $tag) {

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
@@ -102,6 +102,7 @@ class Get extends Action
         foreach ($linkTags[0] ?? [] as $tag) {
             $attributes = [];
 
+            // Match HTML attributes in double quotes, single quotes, or bare form.
             \preg_match_all('/([a-zA-Z:-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s"\'>]+))/s', $tag, $attributeMatches, \PREG_SET_ORDER);
 
             foreach ($attributeMatches as $attributeMatch) {


### PR DESCRIPTION
## What

Replace `DOMDocument::loadHTML()` in the favicon avatar route with inline `<link>` tag parsing.

## Why

The favicon route only needs to read `href`, `rel`, and `sizes` from icon `<link>` tags. Using `DOMDocument` pulls in libxml HTML parsing for that small task, and this path was failing under the coroutine server.

This change keeps the existing behavior intact:
- fetch the page HTML
- inspect icon `<link>` tags
- prefer `svg`
- otherwise choose the largest `ico` / `png` / `jpg` / `jpeg`
- fall back to `/favicon.ico`

## Scope

This PR only changes:
- `src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php`

## Verification

- `composer format src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php`
- `composer lint src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php`
- `docker compose exec -T appwrite test tests/e2e/Services/Avatars --filter='/::testGetFavicon$/'`
- `docker compose exec -T appwrite test tests/e2e/Services/GraphQL/AvatarsTest.php --filter='/::testGetFavicon$/'`
