### PR TITLE
[codex] Handle null console routes in API middleware

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -401,6 +401,10 @@ Http::init()
             }
         }
 
+        if ($route === null) {
+            throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
+        }
+
         // Steps 7-9: Access Control - Method, Namespace and Scope Validation
         /**
          * @var ?Method $method
@@ -489,6 +493,10 @@ Http::init()
         $request->setUser($user);
 
         $route = $utopia->getRoute();
+        if ($route === null) {
+            throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
+        }
+
         $path = $route->getMatchedPath();
         $databaseType = match (true) {
             str_contains($path, '/documentsdb') => DATABASE_TYPE_DOCUMENTSDB,

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -98,6 +98,9 @@ Http::init()
     ->inject('authorization')
     ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, Audit $queueForAudits, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization) {
         $route = $utopia->getRoute();
+        if ($route === null) {
+            throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
+        }
 
         /**
          * Handle user authentication and session validation.
@@ -399,10 +402,6 @@ Http::init()
                     ])));
                 }
             }
-        }
-
-        if ($route === null) {
-            throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
 
         // Steps 7-9: Access Control - Method, Namespace and Scope Validation

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -122,6 +122,13 @@ class HTTPTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
     }
 
+    public function testConsoleRootWithoutRouteDoesNotFatal()
+    {
+        $response = $this->client->call(Client::METHOD_GET, '/console/', $this->getHeaders());
+
+        $this->assertEquals(404, $response['headers']['status-code']);
+    }
+
     public function testCors()
     {
 

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -127,6 +127,7 @@ class HTTPTest extends Scope
         $response = $this->client->call(Client::METHOD_GET, '/console/', $this->getHeaders());
 
         $this->assertEquals(404, $response['headers']['status-code']);
+        $this->assertEquals('general_route_not_found', $response['body']['type']);
     }
 
     public function testCors()


### PR DESCRIPTION
## Summary
- guard the shared API init handlers when a request reaches them without a matched route
- return `general_route_not_found` instead of fatalling on `$route->getLabel(...)` / `$route->getMatchedPath()`
- add a regression test for `GET /console/`

## Root cause
Sentry issue `CLOUD-STAGING-691` showed `GET /console/` entering `app/controllers/shared/api.php` with a null route. The middleware assumed route matching had already succeeded and dereferenced `$route`, which caused `Call to a member function getLabel() on null`.

## Impact
Unmatched console requests now fail cleanly with a normal 404-style Appwrite error instead of generating a server error in production.

## Validation
- `composer lint app/controllers/shared/api.php`
- `composer lint tests/e2e/General/HTTPTest.php`
- targeted e2e test not run locally because the `appwrite` container was not running in this workspace
