### PR TITLE
[codex] Fix post-merge e2e test regressions

### DIFF
--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -122,14 +122,6 @@ class HTTPTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
     }
 
-    public function testConsoleRootWithoutRouteDoesNotFatal()
-    {
-        $response = $this->client->call(Client::METHOD_GET, '/console/', $this->getHeaders());
-
-        $this->assertEquals(404, $response['headers']['status-code']);
-        $this->assertEquals('general_route_not_found', $response['body']['type']);
-    }
-
     public function testCors()
     {
 

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -1324,8 +1324,8 @@ class UsageTest extends Scope
             $this->assertEquals($requestsTotal, $response['body']['requests'][array_key_last($response['body']['requests'])]['value']);
             $this->validateDates($response['body']['requests']);
             // vectordbTotal should reflect only VectorsDB instances, not relational databases.
-            $this->assertEquals($vectordbTotal, $response['body']['vectordbDatabasesTotal']);
-            $this->assertEquals($documentsTotal, $response['body']['vectordbDocumentsTotal']);
+            $this->assertEquals($vectordbTotal, $response['body']['vectorsdbDatabasesTotal']);
+            $this->assertEquals($documentsTotal, $response['body']['vectorsdbDocumentsTotal']);
         });
 
         $response = $this->client->call(


### PR DESCRIPTION
## Summary
- remove the unstable `GET /console/` regression from `HTTPTest`
- fix the VectorsDB project usage assertions to use the actual API response keys

## Why
The merged null-route fix addressed real production probes against invalid paths such as `/smtp/phpinfo.php`, `/webmail/phpinfo.php`, and similar scanner requests that reached API middleware without a matched route.

The added `/console/` e2e assertion was not a valid reproduction of that bug. `/console/` is a real web route in CE and production, so asserting `404 general_route_not_found` there was incorrect and caused CI failures.

The `UsageTest` failure is separate: `/project/usage` returns `vectorsdbDatabasesTotal` and `vectorsdbDocumentsTotal`, while the test asserted the misspelled `vectordb...` keys.

## Validation
- `composer lint tests/e2e/General/HTTPTest.php`
- `composer lint tests/e2e/General/UsageTest.php`
- targeted e2e suite not run locally in this workspace
