### PR TITLE
fix: throw RuntimeException for unresolved response models in spec generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,26 @@ jobs:
       - name: Run PHPStan
         run: composer analyze -- --no-progress
 
+  specs:
+    name: Checks / Specs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
+
+      - name: Generate specs
+        run: _APP_STORAGE_LIMIT=5368709120 php app/cli.php specs --version=latest --git=no
+
   locale:
     name: Checks / Locale
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          extensions: swoole
           tools: composer:v2
           coverage: none
 

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -482,7 +482,12 @@ class Specs extends Action
                     ? $specsDir . '/' . $format . '-mocks-' . $platform . '.json'
                     : $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
 
-                $parsedSpecs = $specs->parse();
+                try {
+                    $parsedSpecs = $specs->parse();
+                } catch (\RuntimeException $e) {
+                    throw new \RuntimeException("Spec generation failed for {$platform} ({$format}): " . $e->getMessage(), 0, $e);
+                }
+
                 $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);
 
                 unset($parsedSpecs);

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -278,6 +278,18 @@ class OpenAPI3 extends Format
                     }
                 }
 
+                if (\is_string($model)) {
+                    throw new \RuntimeException("Unresolved response model '{$model}' for method '{$sdk->getNamespace()}.{$sdk->getMethodName()}'. Ensure the model is registered.");
+                }
+
+                if (\is_array($model)) {
+                    foreach ($model as $m) {
+                        if (\is_string($m)) {
+                            throw new \RuntimeException("Unresolved response model '{$m}' for method '{$sdk->getNamespace()}.{$sdk->getMethodName()}'. Ensure the model is registered.");
+                        }
+                    }
+                }
+
                 if (!(\is_array($model)) && $model->isNone()) {
                     $temp['responses'][(string)$response->getCode() ?? '500'] = [
                         'description' => in_array($produces, [

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -285,6 +285,18 @@ class Swagger2 extends Format
                     }
                 }
 
+                if (\is_string($model)) {
+                    throw new \RuntimeException("Unresolved response model '{$model}' for method '{$sdk->getNamespace()}.{$sdk->getMethodName()}'. Ensure the model is registered.");
+                }
+
+                if (\is_array($model)) {
+                    foreach ($model as $m) {
+                        if (\is_string($m)) {
+                            throw new \RuntimeException("Unresolved response model '{$m}' for method '{$sdk->getNamespace()}.{$sdk->getMethodName()}'. Ensure the model is registered.");
+                        }
+                    }
+                }
+
                 if (!(\is_array($model)) &&  $model->isNone()) {
                     $temp['responses'][(string)$response->getCode() ?? '500'] = [
                         'description' => in_array($produces, [

--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -12,7 +12,7 @@ class Project extends Model
     /**
      * @var bool
      */
-    protected bool $public = false;
+    protected bool $public = true;
 
     public function __construct()
     {


### PR DESCRIPTION
## Summary

- Spec generation crashed with `Call to a member function isNone() on string` when a response model couldn't be resolved from the registered models list
- Added explicit `RuntimeException` checks in both `Swagger2.php` and `OpenAPI3.php` format classes for single and array model responses
- Wrapped `$specs->parse()` in `Specs.php` task to catch and re-throw with platform/format context
- Made `Project` model public since `project.updateLabels` (added in #11812) uses `AuthType::KEY`, exposing it to the server platform
- Added `Checks / Specs` CI job to run spec generation on every PR so unresolved models are caught before merge

## Test plan

- [x] Verified spec generation produces clear error for unresolved models
- [x] Verified all 6 spec files generate successfully after fix
- [ ] CI job runs `php app/cli.php specs --version=latest --git=no` on PRs