### PR TITLE
fix: allow creating project variables without variableId (#11765)

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
@@ -53,7 +53,7 @@ class Create extends Action
                     )
                 ],
             ))
-            ->param('variableId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
+            ->param('variableId', 'unique()', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', true, ['dbForProject'])
             ->param('key', null, new Text(Database::LENGTH_KEY), 'Variable key. Max length: ' . Database::LENGTH_KEY  . ' chars.')
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.')
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only projects can read them during build and runtime.', true)

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -4744,7 +4744,6 @@ class ProjectsConsoleClientTest extends Scope
             'x-appwrite-project' => $data['projectId'],
             'x-appwrite-mode' => 'admin',
         ], $this->getHeaders()), [
-            'variableId' => 'unique()',
             'key' => 'APP_TEST_CREATE',
             'value' => 'TESTINGVALUE',
             'secret' => false


### PR DESCRIPTION
## Summary

This fixes project global variable creation in local 1.9.0 setups when the request omits ariableId.

## What was broken

Creating a global variable from the Console could fail with:

Param "variableId" is not optional.

## Root cause

src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php still treated ariableId as a required request parameter, even though the endpoint already supports unique() IDs internally and older compatibility filters already backfill the same default.

Functions and Sites already generate variable IDs server-side, but Project variables still required the client to send one. That made the project/global variables flow inconsistent and caused the request to fail before the existing unique() handling could run.

## Fix

- make ariableId optional for project variable creation
- default it to unique() at the request parameter level
- keep the existing server-side unique() to ID::unique() conversion unchanged
- add a regression test that creates a project variable without sending ariableId

## Validation

- Added an e2e regression in ProjectsConsoleClientTest that exercises POST /project/variables without ariableId
- I could not execute the PHP/e2e suite in this environment because PHP is not installed locally and the Docker Desktop daemon is unavailable from this shell

Fixes #11765