### PR TITLE
docs: replace architecture SVG with Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ flowchart TD
     classDef gateway  fill:#d5e8d4,stroke:#82b366,color:#000
     classDef api      fill:#e1d5e7,stroke:#9673a6,color:#000
     classDef service  fill:#f5f5f5,stroke:#bbb,color:#000
-    classDef security fill:#d5e8d4,stroke:#82b366,color:#000
     classDef hot      fill:#f8cecc,stroke:#b85450,color:#000
     classDef store    fill:#fff2cc,stroke:#d6b656,color:#000
     classDef compute  fill:#dae8fc,stroke:#6c8ebf,color:#000
@@ -231,8 +230,8 @@ flowchart TD
     Clients --> LB{{Loadbalancer}}:::gateway
     LB --> Console(Console):::api & GQL(GraphQL API):::api & REST(REST API):::api & RT(Realtime API):::api & SSL{{SSL Gateway}}:::gateway
     REST --> APIServices
-    REST & GQL & RT --> SecLayer[Security Layer]:::security
-    SecLayer --> Cache & Queue & AV
+    REST & GQL & RT --> Cache & Queue
+    Storage --> AV
     Cache --> DB
     Queue --> Workers
     Workers --> DB

--- a/README.md
+++ b/README.md
@@ -197,37 +197,48 @@ Looking for more SDKs? - Help us by contributing a pull request to our [SDK Gene
 
 ```mermaid
 flowchart TD
+    classDef client   fill:#dae8fc,stroke:#6c8ebf,color:#000
+    classDef gateway  fill:#d5e8d4,stroke:#82b366,color:#000
+    classDef api      fill:#e1d5e7,stroke:#9673a6,color:#000
+    classDef service  fill:#f5f5f5,stroke:#bbb,color:#000
+    classDef security fill:#d5e8d4,stroke:#82b366,color:#000
+    classDef hot      fill:#f8cecc,stroke:#b85450,color:#000
+    classDef store    fill:#fff2cc,stroke:#d6b656,color:#000
+    classDef compute  fill:#dae8fc,stroke:#6c8ebf,color:#000
+    classDef worker   fill:#b0e3e6,stroke:#007080,color:#000
+    classDef external fill:#ffe6cc,stroke:#d79b00,color:#000
+
     subgraph Clients
         direction LR
-        Web ~~~ Flutter ~~~ iOS ~~~ Android ~~~ Servers
+        Web(Web):::client ~~~ Flutter(Flutter):::client ~~~ iOS(iOS):::client ~~~ Android(Android):::client ~~~ Servers(Servers):::client
     end
 
     subgraph APIServices["API Services"]
         direction LR
-        Users ~~~ Account ~~~ Teams ~~~ Databases ~~~ Storage ~~~ Locale ~~~ Avatars ~~~ Health ~~~ Functions ~~~ Sites ~~~ Messaging ~~~ VCS ~~~ Tokens ~~~ Proxy
+        Users(Users):::service ~~~ Account(Account):::service ~~~ Teams(Teams):::service ~~~ Databases(Databases):::service ~~~ Storage(Storage):::service ~~~ Locale(Locale):::service ~~~ Avatars(Avatars):::service ~~~ Health(Health):::service ~~~ Functions(Functions):::service ~~~ Sites(Sites):::service ~~~ Messaging(Messaging):::service ~~~ VCS(VCS):::service ~~~ Tokens(Tokens):::service ~~~ Proxy(Proxy):::service
     end
 
     subgraph Infra["Infrastructure"]
         direction LR
-        Cache["Cache (Redis)"] ~~~ Queue["Queue (Redis)"] ~~~ AV["AntiVirus (ClamAV)"] ~~~ DB[(Database)] ~~~ Executor["Executor (Open-Runtimes)"] ~~~ Docker[Docker / K8S]
+        Cache["Cache (Redis)"]:::hot ~~~ Queue["Queue (Redis)"]:::hot ~~~ AV["AntiVirus (ClamAV)"]:::external ~~~ DB[(Database)]:::store ~~~ Executor[["Executor (Open-Runtimes)"]]:::compute ~~~ Docker(Docker / K8S):::service
     end
 
     subgraph Workers["Background Workers"]
         direction LR
-        Schedulers ~~~ StatsUsage[Usage] ~~~ Maintenance ~~~ Audits ~~~ Mails ~~~ DBw[Databases] ~~~ Webhooks ~~~ FnW[Functions] ~~~ Certificates ~~~ Deletes ~~~ Builds ~~~ MessagingW[Messaging] ~~~ Migrations ~~~ Executions
+        Schedulers(Schedulers):::worker ~~~ StatsUsage(Usage):::worker ~~~ Maintenance(Maintenance):::worker ~~~ Audits(Audits):::worker ~~~ Mails(Mails):::worker ~~~ DBw(Databases):::worker ~~~ Webhooks(Webhooks):::worker ~~~ FnW(Functions):::worker ~~~ Certificates(Certificates):::worker ~~~ Deletes(Deletes):::worker ~~~ Builds(Builds):::worker ~~~ MessagingW(Messaging):::worker ~~~ Migrations(Migrations):::worker ~~~ Executions(Executions):::worker
     end
 
-    Clients --> LB[Loadbalancer]
-    LB --> Console & GQL[GraphQL API] & REST[REST API] & RT[Realtime API] & SSL[SSL Gateway]
+    Clients --> LB{{Loadbalancer}}:::gateway
+    LB --> Console(Console):::api & GQL(GraphQL API):::api & REST(REST API):::api & RT(Realtime API):::api & SSL{{SSL Gateway}}:::gateway
     REST --> APIServices
-    REST & GQL & RT --> SecLayer[Security Layer]
+    REST & GQL & RT --> SecLayer[Security Layer]:::security
     SecLayer --> Cache & Queue & AV
     Cache --> DB
     Queue --> Workers
     Workers --> DB
     FnW --> Executor
-    Mails & MessagingW --> SMTP
-    Certificates --> LE[Letsencrypt] --> LB
+    Mails & MessagingW --> SMTP(SMTP):::external
+    Certificates --> LE(Letsencrypt):::external --> LB
 ```
 
 Appwrite uses a microservices architecture that was designed for easy scaling and delegation of responsibilities. In addition, Appwrite supports multiple APIs, such as REST, WebSocket, and GraphQL to allow you to interact with your resources by leveraging your existing knowledge and protocols of choice.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,42 @@ Looking for more SDKs? - Help us by contributing a pull request to our [SDK Gene
 
 ## Architecture
 
-![Appwrite Architecture showing how Appwrite is built and the services and tools it uses](docs/specs/overview.drawio.svg)
+```mermaid
+flowchart TD
+    subgraph Clients
+        direction LR
+        Web ~~~ Flutter ~~~ iOS ~~~ Android ~~~ Servers
+    end
+
+    subgraph APIServices["API Services"]
+        direction LR
+        Users ~~~ Account ~~~ Teams ~~~ Databases ~~~ Storage ~~~ Locale ~~~ Avatars ~~~ Health ~~~ Functions ~~~ Sites ~~~ Messaging ~~~ VCS ~~~ Tokens ~~~ Proxy
+    end
+
+    subgraph Workers["Background Workers"]
+        direction LR
+        Schedulers ~~~ StatsUsage[Usage] ~~~ Maintenance ~~~ Audits ~~~ Mails ~~~ DBw[Databases] ~~~ Webhooks ~~~ FnW[Functions] ~~~ Certificates ~~~ Deletes ~~~ Builds ~~~ MessagingW[Messaging] ~~~ Migrations ~~~ Executions
+    end
+
+    Clients --> LB[Loadbalancer]
+    LB --> Console & GQL[GraphQL API] & REST[REST API] & RT[Realtime API] & SSL[SSL Gateway]
+
+    REST --> APIServices
+    REST & GQL & RT --> SecLayer[Security Layer]
+
+    SecLayer --> Cache["Cache (Redis)"] & Queue["Queue (Redis)"] & AV["AntiVirus (ClamAV)"]
+    Cache --> DB[(Database)]
+
+    Queue --> Workers
+    StatsUsage & Maintenance & Audits & DBw & Webhooks & FnW & Certificates --> DB
+
+    FnW --> Executor["Executor (Open-Runtimes)"]
+    Executor -.- Docker[Docker / K8S]
+    Executor --> Builds
+
+    Mails & MessagingW --> SMTP
+    Certificates --> LE[Letsencrypt] --> LB
+```
 
 Appwrite uses a microservices architecture that was designed for easy scaling and delegation of responsibilities. In addition, Appwrite supports multiple APIs, such as REST, WebSocket, and GraphQL to allow you to interact with your resources by leveraging your existing knowledge and protocols of choice.
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ flowchart TD
 
     subgraph Infra["Infrastructure"]
         direction LR
-        Cache["Cache (Redis)"]:::hot ~~~ Queue["Queue (Redis)"]:::hot ~~~ AV["AntiVirus (ClamAV)"]:::external ~~~ DB[(Database)]:::store ~~~ Executor[["Executor (Open-Runtimes)"]]:::compute ~~~ Docker(Docker / K8S):::service
+        Cache[("Cache (Redis)")]:::hot ~~~ Queue[("Queue (Redis)")]:::hot ~~~ AV["AntiVirus (ClamAV)"]:::external ~~~ DB[(Database)]:::store ~~~ Executor[["Executor (Open-Runtimes)"]]:::compute ~~~ Docker(Docker / K8S):::service
     end
 
     subgraph Workers["Background Workers"]

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ flowchart TD
         Users ~~~ Account ~~~ Teams ~~~ Databases ~~~ Storage ~~~ Locale ~~~ Avatars ~~~ Health ~~~ Functions ~~~ Sites ~~~ Messaging ~~~ VCS ~~~ Tokens ~~~ Proxy
     end
 
+    subgraph Infra["Infrastructure"]
+        direction LR
+        Cache["Cache (Redis)"] ~~~ Queue["Queue (Redis)"] ~~~ AV["AntiVirus (ClamAV)"] ~~~ DB[(Database)] ~~~ Executor["Executor (Open-Runtimes)"] ~~~ Docker[Docker / K8S]
+    end
+
     subgraph Workers["Background Workers"]
         direction LR
         Schedulers ~~~ StatsUsage[Usage] ~~~ Maintenance ~~~ Audits ~~~ Mails ~~~ DBw[Databases] ~~~ Webhooks ~~~ FnW[Functions] ~~~ Certificates ~~~ Deletes ~~~ Builds ~~~ MessagingW[Messaging] ~~~ Migrations ~~~ Executions
@@ -214,20 +219,13 @@ flowchart TD
 
     Clients --> LB[Loadbalancer]
     LB --> Console & GQL[GraphQL API] & REST[REST API] & RT[Realtime API] & SSL[SSL Gateway]
-
     REST --> APIServices
     REST & GQL & RT --> SecLayer[Security Layer]
-
-    SecLayer --> Cache["Cache (Redis)"] & Queue["Queue (Redis)"] & AV["AntiVirus (ClamAV)"]
-    Cache --> DB[(Database)]
-
+    SecLayer --> Cache & Queue & AV
+    Cache --> DB
     Queue --> Workers
-    StatsUsage & Maintenance & Audits & DBw & Webhooks & FnW & Certificates --> DB
-
-    FnW --> Executor["Executor (Open-Runtimes)"]
-    Executor -.- Docker[Docker / K8S]
-    Executor --> Builds
-
+    Workers --> DB
+    FnW --> Executor
     Mails & MessagingW --> SMTP
     Certificates --> LE[Letsencrypt] --> LB
 ```


### PR DESCRIPTION
## Summary

- Replaces the static `overview.drawio.svg` image with an embedded Mermaid diagram that renders natively in GitHub markdown
- Updated stale component names to match the current codebase
- Added new services and workers introduced since the original diagram (2023)

## Changes

| Category | Updates |
|----------|---------|
| Renamed | `Localization` → `Locale`, `Database` → `Databases`, `Usage` worker → `StatsUsage`, `Certs` worker → `Certificates`, `Scheduler` → `Schedulers` |
| Removed label | `GraphQL API (Coming Soon)` — GraphQL is fully shipped |
| New API services | `Sites`, `Messaging`, `VCS`, `Tokens`, `Proxy` |
| New workers | `Messaging`, `Migrations`, `Executions` |

## Test plan

- [ ] Verify Mermaid diagram renders correctly on GitHub
- [ ] Check all component names match current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)