### PR TITLE
fix: webhook paused email template broken rendering

### DIFF
--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -237,33 +237,32 @@ class Webhooks extends Action
         $template->setParam('{{path}}', "/console/project-$region-$projectId/settings/webhooks/$webhookId");
         $template->setParam('{{attempts}}', $attempts);
 
-        $template->setParam('{{logoUrl}}', $plan['logoUrl'] ?? APP_EMAIL_LOGO_URL);
-        $template->setParam('{{accentColor}}', $plan['accentColor'] ?? APP_EMAIL_ACCENT_COLOR);
-        $template->setParam('{{twitterUrl}}', $plan['twitterUrl'] ?? APP_SOCIAL_TWITTER);
-        $template->setParam('{{discordUrl}}', $plan['discordUrl'] ?? APP_SOCIAL_DISCORD);
-        $template->setParam('{{githubUrl}}', $plan['githubUrl'] ?? APP_SOCIAL_GITHUB_APPWRITE);
-        $template->setParam('{{termsUrl}}', $plan['termsUrl'] ?? APP_EMAIL_TERMS_URL);
-        $template->setParam('{{privacyUrl}}', $plan['privacyUrl'] ?? APP_EMAIL_PRIVACY_URL);
-
-        // TODO: Use setbodyTemplate once #7307 is merged
         $subject = 'Webhook deliveries have been paused';
         $preview = 'Webhook deliveries to your endpoint have been paused.';
-        $body = Template::fromFile(__DIR__ . '/../../../../app/config/locale/templates/email-base-styled.tpl');
 
-        $body
-            ->setParam('{{subject}}', $subject)
-            ->setParam('{{message}}', $template->render())
-            ->setParam('{{year}}', date("Y"));
+        $emailVariables = [
+            'logoUrl' => $plan['logoUrl'] ?? APP_EMAIL_LOGO_URL,
+            'accentColor' => $plan['accentColor'] ?? APP_EMAIL_ACCENT_COLOR,
+            'twitter' => $plan['twitterUrl'] ?? APP_SOCIAL_TWITTER,
+            'discord' => $plan['discordUrl'] ?? APP_SOCIAL_DISCORD,
+            'github' => $plan['githubUrl'] ?? APP_SOCIAL_GITHUB_APPWRITE,
+            'terms' => $plan['termsUrl'] ?? APP_EMAIL_TERMS_URL,
+            'privacy' => $plan['privacyUrl'] ?? APP_EMAIL_PRIVACY_URL,
+            'platform' => $plan['platformName'] ?? APP_NAME,
+        ];
 
         $queueForMails
             ->setProject($project)
             ->setSubject($subject)
             ->setPreview($preview)
-            ->setBody($body->render());
+            ->setBodyTemplate(__DIR__ . '/../../../../app/config/locale/templates/email-base-styled.tpl');
 
         foreach ($users as $user) {
+            $template->setParam('{{user}}', $user->getAttribute('name', ''));
+
             $queueForMails
-                ->setVariables(['user' => $user->getAttribute('name', '')])
+                ->setBody($template->render())
+                ->setVariables($emailVariables)
                 ->setName($user->getAttribute('name', ''))
                 ->setRecipient($user->getAttribute('email'))
                 ->trigger();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

 Fixes #8931 — The webhook paused email notification was broken and rendered with   
  duplicated/malformed content.                                                    
                                                                                     
  **Root causes:**                                                                   
  - `{{subject}}` and `{{message}}` were used instead of `{{heading}}` and
  `{{body}}`, so the content never rendered in the base styled template              
  - Styling variables (logo, social links, terms/privacy) were set on the inner    
  template instead of the base template                                              
  - `{{user}}` was never resolved because the body was rendered before the user loop
  - `{{host}}` was never set, breaking the "Webhook settings" link                   
                                                                                   
  **Fix:** Migrated to `setBodyTemplate()` pattern, consistent with                  
  `Certificates.php` and `Migrations.php` workers (as the TODO comment on the removed
   line suggested).  

## Test Plan

  1. Create a webhook pointing to a non-existent URL
  2. Assign events (e.g. `buckets.*`) and trigger them until retry threshold is
  exceeded                                                                           
  3. Verify the paused email renders correctly: heading, user name, webhook details,
  social links, and a working "Webhook settings" link                                
                                          

## Related PRs and Issues

 - Fixes #8931

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
