### PR TITLE
fix: map deprecated platform types in project response

### DIFF
--- a/app/init/database/filters.php
+++ b/app/init/database/filters.php
@@ -1,5 +1,6 @@
 <?php
 
+use Appwrite\Network\Platform;
 use Appwrite\OpenSSL\OpenSSL;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -123,11 +124,17 @@ Database::addFilter(
         return;
     },
     function (mixed $value, Document $document, Database $database) {
-        return $database->getAuthorization()->skip(fn () => $database
+        $platforms = $database->getAuthorization()->skip(fn () => $database
             ->find('platforms', [
                 Query::equal('projectInternalId', [$document->getSequence()]),
                 Query::limit(APP_LIMIT_SUBQUERY),
             ]));
+
+        foreach ($platforms as $platform) {
+            $platform->setAttribute('type', Platform::mapDeprecatedType($platform->getAttribute('type')));
+        }
+
+        return $platforms;
     }
 );
 


### PR DESCRIPTION
## Summary
- When a project document is fetched from the database, platforms are loaded via the `subQueryPlatforms` database filter in `app/init/database/filters.php`
- Old platform type values in the DB (e.g. `flutter-android`, `flutter-ios`, `apple-macos`) were not being mapped to the new consolidated types (`android`, `apple`, etc.) before being included in the project response
- This meant the frontend/console received stale type values when loading a project with its platforms as a sub-attribute
- Added `Platform::mapDeprecatedType()` call in the `subQueryPlatforms` filter so all platforms returned as part of a project document have their types mapped consistently

This complements the mapping already added in the dedicated platform Get and List endpoints (#11833).

## Test plan
- [ ] Verify that fetching a project via GET `/v1/projects/:projectId` returns platforms with mapped types (e.g. `flutter-android` -> `android`)
- [ ] Verify that listing projects via GET `/v1/projects` returns platforms with mapped types
- [ ] Verify the console displays correct platform types for projects with old platform entries
- [ ] Verify that new platform types (`web`, `apple`, `android`, `windows`, `linux`) pass through unchanged

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>