### PR TITLE
Revert "fix: make variableId optional in createProjectVariable endpoint"

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
@@ -53,7 +53,7 @@ class Create extends Action
                     )
                 ],
             ))
-            ->param('variableId', 'unique()', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', true, ['dbForProject'])
+            ->param('variableId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Variable ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
             ->param('key', null, new Text(Database::LENGTH_KEY), 'Variable key. Max length: ' . Database::LENGTH_KEY  . ' chars.')
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.')
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only projects can read them during build and runtime.', true)

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -4771,22 +4771,6 @@ class ProjectsConsoleClientTest extends Scope
         $this->assertEquals('APP_TEST_CREATE_1', $variable['body']['key']);
         $this->assertEmpty($variable['body']['value']);
 
-        // test for variable without variableId (auto-generated)
-        $variable = $this->client->call(Client::METHOD_POST, '/project/variables', array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $data['projectId'],
-            'x-appwrite-mode' => 'admin',
-        ], $this->getHeaders()), [
-            'key' => 'APP_TEST_CREATE_AUTO_ID',
-            'value' => 'AUTOIDVALUE',
-            'secret' => false
-        ]);
-
-        $this->assertEquals(201, $variable['headers']['status-code']);
-        $this->assertNotEmpty($variable['body']['$id']);
-        $this->assertEquals('APP_TEST_CREATE_AUTO_ID', $variable['body']['key']);
-        $this->assertEquals('AUTOIDVALUE', $variable['body']['value']);
-
         /**
          * Test for FAILURE
          */


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR reverts #11795 from `1.9.x`.

It restores the previous `createProjectVariable` behavior where `variableId` remains required and removes the E2E coverage that was added for creating a project variable without providing `variableId`.

## Test Plan

1. Verified the revert applies cleanly to `origin/1.9.x`.
2. Ran `git diff --check origin/1.9.x...HEAD`.
3. Attempted to run `composer lint src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php` and `composer lint tests/e2e/Services/Projects/ProjectsConsoleClientTest.php`, but local PHP tooling is unavailable in this worktree (`vendor/bin/pint` is missing).
4. Docker services are not running in this environment, so E2E tests were not run.

## Related PRs and Issues

- Reverts #11795

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
