### PR TITLE
ci: reduce jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,14 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          extensions: swoole
           tools: composer:v2
           coverage: none
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
 
       - name: Validate
         run: composer validate
@@ -121,47 +127,17 @@ jobs:
       - name: Run PHPStan
         run: composer analyze -- --no-progress
 
+      - name: Generate specs
+        run: _APP_STORAGE_LIMIT=5368709120 php app/cli.php specs --version=latest --git=no
+
+      - name: Run Locale check
+        run: node .github/workflows/static-analysis/locale/index.js
+
       - run: git checkout HEAD^2
         if: github.event_name == 'pull_request'
 
       - name: Run Pint
         run: composer format:check
-
-  specs:
-    name: Checks / Specs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: swoole
-          tools: composer:v2
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
-
-      - name: Generate specs
-        run: _APP_STORAGE_LIMIT=5368709120 php app/cli.php specs --version=latest --git=no
-
-  locale:
-    name: Checks / Locale
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Run Locale check
-        run: node .github/workflows/static-analysis/locale/index.js
 
   matrix:
     name: Tests / Matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,18 +307,13 @@ jobs:
 
       - name: Run Tests
         timeout-minutes: 60
-        run: |
-          docker compose exec -T \
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
-            appwrite test /usr/src/code/tests/e2e/General
-
-          for service in Account Avatars Console Health Locale Messaging Project Projects ProjectWebhooks Proxy Storage Teams Tokens Users VCS Webhooks; do
-            docker compose exec -T \
-              -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
-              appwrite vendor/bin/paratest --processes $(nproc) --functional \
-              "/usr/src/code/tests/e2e/Services/$service" \
-              --exclude-group abuseEnabled --exclude-group screenshots
-          done
+        run: >-
+          docker compose exec -T
+          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+          appwrite vendor/bin/paratest --processes $(nproc) --functional
+          --configuration /usr/src/code/phpunit.xml
+          --testsuite e2e
+          --exclude-group abuseEnabled --exclude-group screenshots
 
       - name: Failure Logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
         run: >-
           docker compose exec -T
           -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite vendor/bin/paratest --processes $(nproc) --functional
+          appwrite vendor/bin/paratest --processes $(($(nproc) * 2)) --functional
           --configuration /usr/src/code/phpunit.xml
           --testsuite e2e
           --exclude-group abuseEnabled --exclude-group screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,12 +268,17 @@ jobs:
             appwrite test /usr/src/code/tests/unit
 
   e2e:
-    name: Tests / E2E
+    name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    needs: build_development
+    needs: [build_development, matrix]
     permissions:
       contents: read
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ${{ fromJSON(needs.matrix.outputs.databases) }}
+        mode: ${{ fromJSON(needs.matrix.outputs.modes) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -284,6 +289,25 @@ jobs:
           name: ${{ env.IMAGE }}
           path: /tmp
 
+      - name: Set database environment
+        run: |
+          if [ "${{ matrix.database }}" = "MariaDB" ]; then
+            echo "COMPOSE_PROFILES=mariadb" >> $GITHUB_ENV
+            echo "_APP_DB_ADAPTER=mariadb" >> $GITHUB_ENV
+            echo "_APP_DB_HOST=mariadb" >> $GITHUB_ENV
+            echo "_APP_DB_PORT=3306" >> $GITHUB_ENV
+          elif [ "${{ matrix.database }}" = "MongoDB" ]; then
+            echo "COMPOSE_PROFILES=mongodb" >> $GITHUB_ENV
+            echo "_APP_DB_ADAPTER=mongodb" >> $GITHUB_ENV
+            echo "_APP_DB_HOST=mongodb" >> $GITHUB_ENV
+            echo "_APP_DB_PORT=27017" >> $GITHUB_ENV
+          elif [ "${{ matrix.database }}" = "PostgreSQL" ]; then
+            echo "COMPOSE_PROFILES=postgresql" >> $GITHUB_ENV
+            echo "_APP_DB_ADAPTER=postgresql" >> $GITHUB_ENV
+            echo "_APP_DB_HOST=postgresql" >> $GITHUB_ENV
+            echo "_APP_DB_PORT=5432" >> $GITHUB_ENV
+          fi
+
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -292,6 +316,14 @@ jobs:
 
       - name: Load and Start Appwrite
         timeout-minutes: 5
+        env:
+          _APP_BROWSER_HOST: http://invalid-browser/v1
+          _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
+          _APP_DATABASE_SHARED_TABLES_V1: ${{ matrix.mode == 'shared_v1' && 'database_db_main' || '' }}
+          _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
+          _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES_V1: ${{ matrix.mode == 'shared_v1' && 'documentsdb_db_main' || '' }}
+          _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
+          _APP_DATABASE_VECTORSDB_SHARED_TABLES_V1: ${{ matrix.mode == 'shared_v1' && 'vectorsdb_db_main' || '' }}
         run: |
           docker load --input /tmp/${{ env.IMAGE }}.tar
           docker compose pull --quiet --ignore-buildable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,6 @@ on:
         default: ''
 
 jobs:
-  dependencies:
-    name: Checks / Dependencies
-    if: github.event_name == 'pull_request'
-    permissions:
-      actions: read
-      security-events: write
-      contents: read
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.3"
-
   security:
     name: Checks / Image
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,12 @@ jobs:
             core.setOutput('databases', JSON.stringify(databaseChanged ? allDatabases : defaultDatabases));
             core.setOutput('modes', JSON.stringify(databaseChanged ? allModes : defaultModes));
 
-  build_development:
-    name: Build / Development
+  build:
+    name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -162,11 +165,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ env.IMAGE }}.tar
-          target: development
-          build-args: |
-            DEBUG=false
-            TESTING=true
-            VERSION=dev
+          target: production
 
       - name: Upload Docker Image
         uses: actions/upload-artifact@v7
@@ -175,40 +174,10 @@ jobs:
           path: /tmp/${{ env.IMAGE }}.tar
           retention-days: 1
 
-  build_production:
-    name: Build / Production
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build Appwrite
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          load: true
-          tags: appwrite:${{ github.sha }}
-          target: production
-
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: appwrite:${{ github.sha }}
+          image-ref: ${{ env.IMAGE }}
           format: 'sarif'
           output: 'trivy-image-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -223,7 +192,7 @@ jobs:
   unit:
     name: Tests / Unit
     runs-on: ubuntu-latest
-    needs: build_development
+    needs: build
     permissions:
       contents: read
       pull-requests: write
@@ -270,7 +239,7 @@ jobs:
   e2e:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    needs: [build_development, matrix]
+    needs: [build, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -356,7 +325,7 @@ jobs:
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service }}
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
-    needs: [build_development, matrix]
+    needs: [build, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -475,7 +444,7 @@ jobs:
   e2e_abuse:
     name: Tests / E2E / Abuse (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    needs: [build_development, matrix]
+    needs: [build, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -537,7 +506,7 @@ jobs:
   e2e_screenshots:
     name: Tests / E2E / Screenshots (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    needs: [build_development, matrix]
+    needs: [build, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -606,7 +575,7 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
-    needs: build_development
+    needs: build
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,9 @@ jobs:
             core.setOutput('databases', JSON.stringify(databaseChanged ? allDatabases : defaultDatabases));
             core.setOutput('modes', JSON.stringify(databaseChanged ? allModes : defaultModes));
 
-  build:
-    name: Build
+  build_development:
+    name: Build / Development
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -178,10 +175,40 @@ jobs:
           path: /tmp/${{ env.IMAGE }}.tar
           retention-days: 1
 
+  build_production:
+    name: Build / Production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Appwrite
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: appwrite:${{ github.sha }}
+          target: production
+
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: ${{ env.IMAGE }}
+          image-ref: appwrite:${{ github.sha }}
           format: 'sarif'
           output: 'trivy-image-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -196,7 +223,7 @@ jobs:
   unit:
     name: Tests / Unit
     runs-on: ubuntu-latest
-    needs: build
+    needs: build_development
     permissions:
       contents: read
       pull-requests: write
@@ -243,7 +270,7 @@ jobs:
   e2e_general:
     name: Tests / E2E / General
     runs-on: ubuntu-latest
-    needs: build
+    needs: build_development
     permissions:
       contents: read
       pull-requests: write
@@ -301,7 +328,7 @@ jobs:
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service }}
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
-    needs: [build, matrix]
+    needs: [build_development, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -438,7 +465,7 @@ jobs:
   e2e_abuse:
     name: Tests / E2E / Abuse (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    needs: [build, matrix]
+    needs: [build_development, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -500,7 +527,7 @@ jobs:
   e2e_screenshots:
     name: Tests / E2E / Screenshots (${{ matrix.mode }})
     runs-on: ubuntu-latest
-    needs: [build, matrix]
+    needs: [build_development, matrix]
     permissions:
       contents: read
       pull-requests: write
@@ -569,7 +596,7 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
-    needs: build
+    needs: build_development
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -71,9 +69,6 @@ jobs:
 
       - name: Run Locale check
         run: node .github/workflows/static-analysis/locale/index.js
-
-      - run: git checkout HEAD^2
-        if: github.event_name == 'pull_request'
 
       - name: Run Pint
         run: composer format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,64 +19,12 @@ on:
         default: ''
 
 jobs:
-  security:
-    name: Checks / Image
-    if: github.event_name == 'pull_request'
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Build the Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          load: true
-          tags: pr_image:${{ github.sha }}
-          target: production
-
-      - name: Run Trivy vulnerability scanner on image
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: 'pr_image:${{ github.sha }}'
-          format: 'sarif'
-          output: 'trivy-image-results.sarif'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Run Trivy vulnerability scanner on source code
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-fs-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          skip-setup-trivy: true
-
-      - name: Upload image scan results
-        uses: github/codeql-action/upload-sarif@v4
-        if: always() && hashFiles('trivy-image-results.sarif') != ''
-        with:
-          sarif_file: 'trivy-image-results.sarif'
-          category: 'trivy-image'
-
-      - name: Upload source code scan results
-        uses: github/codeql-action/upload-sarif@v4
-        if: always() && hashFiles('trivy-fs-results.sarif') != ''
-        with:
-          sarif_file: 'trivy-fs-results.sarif'
-          category: 'trivy-source'
-
-  lint:
-    name: Checks / Lint
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -130,6 +78,22 @@ jobs:
       - name: Run Pint
         run: composer format:check
 
+      - name: Run Trivy vulnerability scanner on source code
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-fs-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload source code scan results
+        uses: github/codeql-action/upload-sarif@v4
+        if: always() && hashFiles('trivy-fs-results.sarif') != ''
+        with:
+          sarif_file: 'trivy-fs-results.sarif'
+          category: 'trivy-source'
+
   matrix:
     name: Tests / Matrix
     runs-on: ubuntu-latest
@@ -178,6 +142,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -215,6 +182,21 @@ jobs:
           name: ${{ env.IMAGE }}
           path: /tmp/${{ env.IMAGE }}.tar
           retention-days: 1
+
+      - name: Run Trivy vulnerability scanner on image
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: 'sarif'
+          output: 'trivy-image-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload image scan results
+        uses: github/codeql-action/upload-sarif@v4
+        if: always() && hashFiles('trivy-image-results.sarif') != ''
+        with:
+          sarif_file: 'trivy-image-results.sarif'
+          category: 'trivy-image'
 
   unit:
     name: Tests / Unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
             -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
             appwrite test /usr/src/code/tests/e2e/General
 
-          for service in Account Avatars Console Health Locale Project ProjectWebhooks Storage Teams Tokens Users VCS; do
+          for service in Account Avatars Console Health Locale Messaging Project ProjectWebhooks Proxy Storage Teams Tokens Users VCS Webhooks; do
             docker compose exec -T \
               -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
               appwrite vendor/bin/paratest --processes $(nproc) --functional \
@@ -347,9 +347,6 @@ jobs:
           Projects,
           Realtime,
           Sites,
-          Proxy,
-          Webhooks,
-          Messaging,
           Migrations,
         ]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
             -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
             appwrite test /usr/src/code/tests/e2e/General
 
-          for service in Account Avatars Console Health Locale Messaging Project ProjectWebhooks Proxy Storage Teams Tokens Users VCS Webhooks; do
+          for service in Account Avatars Console Health Locale Messaging Project Projects ProjectWebhooks Proxy Storage Teams Tokens Users VCS Webhooks; do
             docker compose exec -T \
               -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
               appwrite vendor/bin/paratest --processes $(nproc) --functional \
@@ -344,7 +344,6 @@ jobs:
           Functions,
           FunctionsSchedule,
           GraphQL,
-          Projects,
           Realtime,
           Sites,
           Migrations,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,15 +267,15 @@ jobs:
             -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
             appwrite test /usr/src/code/tests/unit
 
-  e2e_general:
-    name: Tests / E2E / General
+  e2e:
+    name: Tests / E2E
     runs-on: ubuntu-latest
     needs: build_development
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - name: checkout
+      - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Download Docker Image
@@ -305,19 +305,20 @@ jobs:
             sleep 1
           done
 
-      - name: Run General Tests
-        uses: itznotabug/php-retry@v3
-        with:
-          max_attempts: 2
-          retry_wait_seconds: 60
-          timeout_minutes: 15
-          job_id: ${{ job.check_run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_dir: tests/e2e/General
-          command: >-
-            docker compose exec -T
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+      - name: Run Tests
+        timeout-minutes: 60
+        run: |
+          docker compose exec -T \
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
             appwrite test /usr/src/code/tests/e2e/General
+
+          for service in Account Avatars Console Health Locale Project ProjectWebhooks Storage Teams Tokens Users VCS; do
+            docker compose exec -T \
+              -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
+              appwrite vendor/bin/paratest --processes $(nproc) --functional \
+              "/usr/src/code/tests/e2e/Services/$service" \
+              --exclude-group abuseEnabled --exclude-group screenshots
+          done
 
       - name: Failure Logs
         if: failure()
@@ -338,30 +339,18 @@ jobs:
         database: ${{ fromJSON(needs.matrix.outputs.databases) }}
         mode: ${{ fromJSON(needs.matrix.outputs.modes) }}
         service: [
-          Account,
-          Avatars,
-          Console,
           Databases,
           TablesDB,
           Functions,
           FunctionsSchedule,
           GraphQL,
-          Health,
-          Locale,
           Projects,
           Realtime,
           Sites,
           Proxy,
-          Storage,
-          Tokens,
-          Teams,
-          Users,
-          ProjectWebhooks,
           Webhooks,
-          VCS,
           Messaging,
           Migrations,
-          Project
         ]
         include:
           - service: Databases
@@ -369,8 +358,6 @@ jobs:
           - service: Sites
             runner: blacksmith-4vcpu-ubuntu-2404
           - service: Functions
-            runner: blacksmith-4vcpu-ubuntu-2404
-          - service: Avatars
             runner: blacksmith-4vcpu-ubuntu-2404
           - service: Realtime
             runner: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: ${{ env.IMAGE }}
+          input: /tmp/${{ env.IMAGE }}.tar
           format: 'sarif'
           output: 'trivy-image-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,14 @@ jobs:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-source'
 
-  composer:
-    name: Checks / Composer
+  lint:
+    name: Checks / Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -108,48 +110,6 @@ jobs:
           COMPOSER_NO_AUDIT: 0
         run: composer audit
 
-  format:
-    name: Checks / Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-
-      - run: git checkout HEAD^2
-        if: github.event_name == 'pull_request'
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          tools: composer:v2
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
-
-      - name: Run Linter
-        run: composer lint
-
-  analyze:
-    name: Checks / Analyze
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          tools: composer:v2
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
-
       - name: Cache PHPStan result cache
         uses: actions/cache@v4
         with:
@@ -160,6 +120,12 @@ jobs:
 
       - name: Run PHPStan
         run: composer analyze -- --no-progress
+
+      - run: git checkout HEAD^2
+        if: github.event_name == 'pull_request'
+
+      - name: Run Pint
+        run: composer format:check
 
   specs:
     name: Checks / Specs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Self-hosted Backend-as-a-Service platform. Hybrid monolithic-microservice archit
 | `docker compose exec appwrite test tests/unit/` | Run unit tests |
 | `composer format` | Auto-format code (Pint, PSR-12) |
 | `composer format <file>` | Format a specific file |
-| `composer lint <file>` | Check formatting of a file |
+| `composer format:check <file>` | Check formatting of a file |
 | `composer analyze` | Static analysis (PHPStan level 3) |
 | `composer check` | Same as `analyze` |
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "lint": "vendor/bin/pint --test --config pint.json",
+        "format:check": "vendor/bin/pint --test --config pint.json",
         "format": "vendor/bin/pint --config pint.json",
         "analyze": "./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G",
         "bench": "vendor/bin/phpbench run --report=benchmark",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,30 +17,23 @@
             <directory>./tests/unit</directory>
         </testsuite>
         <testsuite name="e2e">
-            <file>./tests/e2e/Client.php</file>
             <directory>./tests/e2e/General</directory>
-            <directory>./tests/e2e/Scopes</directory>
-            <directory>./tests/e2e/Services/Teams</directory>
-            <directory>./tests/e2e/Services/Realtime</directory>
             <directory>./tests/e2e/Services/Account</directory>
-            <directory>./tests/e2e/Services/Users</directory>
-            <directory>./tests/e2e/Services/Console</directory>
             <directory>./tests/e2e/Services/Avatars</directory>
-            <directory>./tests/e2e/Services/Databases</directory>
-            <directory>./tests/e2e/Services/GraphQL</directory>
+            <directory>./tests/e2e/Services/Console</directory>
             <directory>./tests/e2e/Services/Health</directory>
             <directory>./tests/e2e/Services/Locale</directory>
-            <directory>./tests/e2e/Services/Projects</directory>
-            <directory>./tests/e2e/Services/Storage</directory>
-            <directory>./tests/e2e/Services/Tokens</directory>
-            <directory>./tests/e2e/Services/Webhooks</directory>
-            <directory>./tests/e2e/Services/ProjectWebhooks</directory>
             <directory>./tests/e2e/Services/Messaging</directory>
-            <directory>./tests/e2e/Services/Migrations</directory>
             <directory>./tests/e2e/Services/Project</directory>
-            <file>./tests/e2e/Services/Functions/FunctionsBase.php</file>
-            <file>./tests/e2e/Services/Functions/FunctionsCustomServerTest.php</file>
-            <file>./tests/e2e/Services/Functions/FunctionsCustomClientTest.php</file>
+            <directory>./tests/e2e/Services/Projects</directory>
+            <directory>./tests/e2e/Services/ProjectWebhooks</directory>
+            <directory>./tests/e2e/Services/Proxy</directory>
+            <directory>./tests/e2e/Services/Storage</directory>
+            <directory>./tests/e2e/Services/Teams</directory>
+            <directory>./tests/e2e/Services/Tokens</directory>
+            <directory>./tests/e2e/Services/Users</directory>
+            <directory>./tests/e2e/Services/VCS</directory>
+            <directory>./tests/e2e/Services/Webhooks</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
## Summary

- Combines `Checks / Composer`, `Checks / Format`, `Checks / Analyze`, `Checks / Specs`, and `Checks / Locale` into a single **`Lint`** job, sharing one checkout and one `composer install`
- Renames `composer lint` → `composer format:check` and updates `AGENTS.md` accordingly
- Removes the OSV scanner action
- Moves Trivy source scan into the `Lint` job; splits `Build` into **`Build / Development`** (dev image + artifact for tests) and **`Build / Production`** (production image + Trivy image scan), so the image scan targets the same target that ships
- PHPStan and Pint now run on the same commit — the `git checkout HEAD^2` workaround is removed since the base branch is always correctly formatted
- Adds a `e2e` PHPUnit test suite to `phpunit.xml` covering General, Account, Avatars, Console, Health, Locale, Messaging, Project, Projects, ProjectWebhooks, Proxy, Storage, Teams, Tokens, Users, VCS, and Webhooks; the new **`Tests / E2E`** job runs this suite via paratest with `nproc * 2` processes (I/O-bound workload) across the full database × mode matrix
- The remaining `e2e_service` matrix retains only the heavier services: Databases, TablesDB, Functions, FunctionsSchedule, GraphQL, Realtime, Sites, Migrations

## Test plan

- [ ] `Lint` job passes (validate, audit, PHPStan, specs, locale, Pint, Trivy source scan)
- [ ] `Build / Production` Trivy image scan runs against the production image
- [ ] `Tests / E2E` runs across all database × mode combinations
- [ ] `e2e_service` matrix still covers the remaining heavy services

🤖 Generated with [Claude Code](https://claude.com/claude-code)