### PR TITLE
fix: storage preview cache misses and stale cache eviction

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -693,6 +693,15 @@ Http::init()
                     }
                 }
 
+                $accessedAt = $cacheLog->getAttribute('accessedAt', '');
+                if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_CACHE_UPDATE)) > $accessedAt) {
+                    $authorization->skip(fn () => $dbForProject->updateDocument('cache', $cacheLog->getId(), new Document([
+                        'accessedAt' => DateTime::now(),
+                    ])));
+                    // Refresh the filesystem file's mtime so TTL-based expiry in cache->load() stays valid
+                    $cache->save($key, $data);
+                }
+
                 $response
                     ->addHeader('Cache-Control', sprintf('private, max-age=%d', $timestamp))
                     ->addHeader('X-Appwrite-Cache', 'hit')

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -54,6 +54,7 @@ class Get extends Action
             ->label('cache', true)
             ->label('cache.resourceType', 'bucket/{request.bucketId}')
             ->label('cache.resource', 'file/{request.fileId}')
+            ->label('cache.params', ['width', 'height', 'gravity', 'quality', 'borderWidth', 'borderColor', 'borderRadius', 'opacity', 'rotation', 'background', 'output'])
             ->label('sdk', new Method(
                 namespace: 'storage',
                 group: 'files',
@@ -277,7 +278,9 @@ class Get extends Action
             $transformedAt = $file->getAttribute('transformedAt', '');
             if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $transformedAt) {
                 $file->setAttribute('transformedAt', DateTime::now());
-                $authorization->skip(fn () => $dbForProject->updateDocument('bucket_' . $file->getAttribute('bucketInternalId'), $file->getId(), $file));
+                $authorization->skip(fn () => $dbForProject->updateDocument('bucket_' . $file->getAttribute('bucketInternalId'), $file->getId(), new Document([
+                    'transformedAt' => $file->getAttribute('transformedAt'),
+                ])));
             }
         }
 

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -234,6 +234,10 @@ class Request extends UtopiaRequest
     public function cacheIdentifier(): string
     {
         $params = $this->getParams();
+        $allowedParams = $this->getRoute()?->getLabel('cache.params', null);
+        if ($allowedParams !== null) {
+            $params = array_intersect_key($params, array_flip($allowedParams));
+        }
         ksort($params);
         return md5($this->getURI() . '*' . serialize($params) . '*' . APP_CACHE_BUSTER);
     }


### PR DESCRIPTION
## Summary

- **Token in cache key**: The `token` auth param was included in cache keys for storage preview, so every request using a resource token generated a unique key and never hit cache. Introduced a `cache.params` route label to opt-in specific params; preview now declares only the image transform params.
- **Cache hits never refreshed TTL**: `accessedAt` and filesystem mtime were only updated in the shutdown hook, which is skipped on cache hits (response already sent in init hook). After 30 days the maintenance job evicted still-active entries, causing periodic full re-renders. The cache-hit path now refreshes both on the 24h `APP_CACHE_UPDATE` interval.
- **Full document update in preview action**: `updateDocument` was passing the full file document when only `transformedAt` changed; changed to a sparse document to match conventions.

## Test plan

- [ ] Request a file preview with a resource token multiple times — confirm only the first renders (`X-Appwrite-Cache: hit` on subsequent requests)
- [ ] Request a file preview with different tokens but same transform params — confirm same cache entry is reused
- [ ] Request a file preview with different transform params (width, height, etc.) — confirm separate cache entries
- [ ] Verify `accessedAt` in the `cache` collection updates on cache hits after 24h
- [ ] Confirm the maintenance job no longer evicts active preview cache entries after 30 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)