### PR TITLE
feat: add tracing spans for storage file preview timing and cache state

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -37,6 +37,7 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Authorization\Input;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Http;
+use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Validator\WhiteList;
@@ -633,6 +634,7 @@ Http::init()
             $isDisabled = isset($plan['imageTransformations']) && $plan['imageTransformations'] === -1 && ! $user->isPrivileged($authorization->getRoles());
 
             $key = $request->cacheIdentifier();
+            Span::add('storage.cache.key', $key);
             $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
             $cache = new Cache(
                 new Filesystem(APP_STORAGE_CACHE . DIRECTORY_SEPARATOR . 'app-' . $project->getId())
@@ -681,6 +683,8 @@ Http::init()
                     if ($file->isEmpty()) {
                         throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
                     }
+                    Span::add('storage.bucket_id', $bucketId);
+                    Span::add('storage.file_id', $fileId);
                     // Do not update transformedAt if it's a console user
                     if (! $user->isPrivileged($authorization->getRoles())) {
                         $transformedAt = $file->getAttribute('transformedAt', '');
@@ -708,10 +712,12 @@ Http::init()
                     ->setContentType($cacheLog->getAttribute('mimeType'));
                 $storageCacheOperationsCounter->add(1, ['result' => 'hit']);
                 if (! $isImageTransformation || ! $isDisabled) {
+                    Span::add('storage.cache.hit', true);
                     $response->send($data);
                 }
             } else {
                 $storageCacheOperationsCounter->add(1, ['result' => 'miss']);
+                Span::add('storage.cache.hit', false);
                 $response
                     ->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
                     ->addHeader('Pragma', 'no-cache')

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -683,8 +683,8 @@ Http::init()
                     if ($file->isEmpty()) {
                         throw new Exception(Exception::STORAGE_FILE_NOT_FOUND);
                     }
-                    Span::add('storage.bucket_id', $bucketId);
-                    Span::add('storage.file_id', $fileId);
+                    Span::add('storage.bucket.id', $bucketId);
+                    Span::add('storage.file.id', $fileId);
                     // Do not update transformedAt if it's a console user
                     if (! $user->isPrivileged($authorization->getRoles())) {
                         $transformedAt = $file->getAttribute('transformedAt', '');

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -269,8 +269,8 @@ class Get extends Action
 
         $totalTime = \microtime(true) - $startTime;
 
-        Span::add('storage.file_id', $file->getId());
-        Span::add('storage.bucket_id', $bucketId);
+        Span::add('storage.file.id', $file->getId());
+        Span::add('storage.bucket.id', $bucketId);
         Span::add('storage.file_size_bytes', $file->getAttribute('sizeActual'));
         if (!empty($type)) {
             Span::add('storage.file_extension', $type);

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -271,9 +271,9 @@ class Get extends Action
 
         Span::add('storage.file.id', $file->getId());
         Span::add('storage.bucket.id', $bucketId);
-        Span::add('storage.file_size_bytes', $file->getAttribute('sizeActual'));
+        Span::add('storage.file.size_bytes', $file->getAttribute('sizeActual'));
         if (!empty($type)) {
-            Span::add('storage.file_extension', $type);
+            Span::add('storage.file.extension', $type);
         }
         Span::add('storage.timing.download_seconds', $downloadTime);
         Span::add('storage.timing.decryption_seconds', $decryptionTime);

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -15,7 +15,6 @@ use Utopia\Compression\Algorithms\GZIP;
 use Utopia\Compression\Algorithms\Zstd;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
-use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -26,6 +25,7 @@ use Utopia\Http\Adapter\Swoole\Request;
 use Utopia\Image\Image;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\Span\Span;
 use Utopia\Storage\Device;
 use Utopia\System\System;
 use Utopia\Validator\HexColor;
@@ -269,7 +269,17 @@ class Get extends Action
 
         $totalTime = \microtime(true) - $startTime;
 
-        Console::info("File preview rendered,project=" . $project->getId() . ",bucket=" . $bucketId . ",file=" . $file->getId() . ",uri=" . $request->getURI() . ",total=" . $totalTime . ",rendering=" . $renderingTime . ",decryption=" . $decryptionTime . ",decompression=" . $decompressionTime . ",download=" . $downloadTime);
+        Span::add('storage.file_id', $file->getId());
+        Span::add('storage.bucket_id', $bucketId);
+        Span::add('storage.file_size_bytes', $file->getAttribute('sizeActual'));
+        if (!empty($type)) {
+            Span::add('storage.file_extension', $type);
+        }
+        Span::add('storage.timing.download_seconds', $downloadTime);
+        Span::add('storage.timing.decryption_seconds', $decryptionTime);
+        Span::add('storage.timing.decompression_seconds', $decompressionTime);
+        Span::add('storage.timing.rendering_seconds', $renderingTime);
+        Span::add('storage.timing.total_seconds', $totalTime);
 
         $contentType = (\array_key_exists($output, $outputs)) ? $outputs[$output] : $outputs['jpg'];
 


### PR DESCRIPTION
## Summary

- Adds `Span::add` calls to the file preview action (`Get.php`) replacing the `Console::info` log with structured span attributes: `storage.file_id`, `storage.bucket_id`, `storage.file_size_bytes`, `storage.file_extension`, and timing spans (`storage.timing.download_seconds`, `storage.timing.decryption_seconds`, `storage.timing.decompression_seconds`, `storage.timing.rendering_seconds`, `storage.timing.total_seconds`)
- Adds cache observability in the shared API middleware (`api.php`): `storage.cache.key`, `storage.cache.hit` (only set to `true` when the response is actually served from cache, not in the disabled-transformation bypass case)

## Test plan

- [ ] Request a file preview — verify span contains timing attributes and file/bucket IDs
- [ ] Request the same preview again — verify `storage.cache.hit = true` is present and no timing spans are emitted
- [ ] Request a preview on a plan with image transformations disabled — verify `storage.cache.hit` is not set (cache bypassed)
- [ ] Request a file with no extension — verify `storage.file_extension` span is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)