### PR TITLE
Migrate executions, migrations, and stats resources to publishers

### DIFF
--- a/app/cli.php
+++ b/app/cli.php
@@ -6,8 +6,8 @@ use Appwrite\Event\Certificate;
 use Appwrite\Event\Delete;
 use Appwrite\Event\Event;
 use Appwrite\Event\Func;
+use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
-use Appwrite\Event\StatsResources;
 use Appwrite\Platform\Appwrite;
 use Appwrite\Runtimes\Runtimes;
 use Appwrite\Usage\Context as UsageContext;
@@ -253,9 +253,10 @@ $container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePubli
     $publisher,
     new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
 ), ['publisher']);
-$container->set('queueForStatsResources', function (Publisher $publisher) {
-    return new StatsResources($publisher);
-}, ['publisher']);
+$container->set('publisherForStatsResources', fn (Publisher $publisher) => new StatsResourcesPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME))
+), ['publisher']);
 $container->set('queueForFunctions', function (Publisher $publisher) {
     return new Func($publisher);
 }, ['publisher']);

--- a/app/controllers/api/migrations.php
+++ b/app/controllers/api/migrations.php
@@ -91,10 +91,9 @@ Http::post('/v1/migrations/appwrite')
     ->inject('dbForProject')
     ->inject('project')
     ->inject('platform')
-    ->inject('user')
     ->inject('queueForEvents')
     ->inject('publisherForMigrations')
-    ->action(function (array $resources, string $endpoint, string $projectId, string $apiKey, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
+    ->action(function (array $resources, string $endpoint, string $projectId, string $apiKey, Response $response, Database $dbForProject, Document $project, array $platform, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->createDocument('migrations', new Document([
             '$id' => ID::unique(),
             'status' => 'pending',
@@ -119,7 +118,6 @@ Http::post('/v1/migrations/appwrite')
             project: $project,
             migration: $migration,
             platform: $platform,
-            user: $user,
         ));
 
         $response
@@ -152,10 +150,9 @@ Http::post('/v1/migrations/firebase')
     ->inject('dbForProject')
     ->inject('project')
     ->inject('platform')
-    ->inject('user')
     ->inject('queueForEvents')
     ->inject('publisherForMigrations')
-    ->action(function (array $resources, string $serviceAccount, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
+    ->action(function (array $resources, string $serviceAccount, Response $response, Database $dbForProject, Document $project, array $platform, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $serviceAccountData = json_decode($serviceAccount, true);
 
         if (empty($serviceAccountData)) {
@@ -188,7 +185,6 @@ Http::post('/v1/migrations/firebase')
             project: $project,
             migration: $migration,
             platform: $platform,
-            user: $user,
         ));
 
         $response
@@ -226,10 +222,9 @@ Http::post('/v1/migrations/supabase')
     ->inject('dbForProject')
     ->inject('project')
     ->inject('platform')
-    ->inject('user')
     ->inject('queueForEvents')
     ->inject('publisherForMigrations')
-    ->action(function (array $resources, string $endpoint, string $apiKey, string $databaseHost, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
+    ->action(function (array $resources, string $endpoint, string $apiKey, string $databaseHost, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->createDocument('migrations', new Document([
             '$id' => ID::unique(),
             'status' => 'pending',
@@ -257,7 +252,6 @@ Http::post('/v1/migrations/supabase')
             project: $project,
             migration: $migration,
             platform: $platform,
-            user: $user,
         ));
 
         $response
@@ -296,10 +290,9 @@ Http::post('/v1/migrations/nhost')
     ->inject('dbForProject')
     ->inject('project')
     ->inject('platform')
-    ->inject('user')
     ->inject('queueForEvents')
     ->inject('publisherForMigrations')
-    ->action(function (array $resources, string $subdomain, string $region, string $adminSecret, string $database, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
+    ->action(function (array $resources, string $subdomain, string $region, string $adminSecret, string $database, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->createDocument('migrations', new Document([
             '$id' => ID::unique(),
             'status' => 'pending',
@@ -328,7 +321,6 @@ Http::post('/v1/migrations/nhost')
             project: $project,
             migration: $migration,
             platform: $platform,
-            user: $user,
         ));
 
         $response
@@ -1216,9 +1208,8 @@ Http::patch('/v1/migrations/:migrationId')
     ->inject('dbForProject')
     ->inject('project')
     ->inject('platform')
-    ->inject('user')
     ->inject('publisherForMigrations')
-    ->action(function (string $migrationId, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, MigrationPublisher $publisherForMigrations) {
+    ->action(function (string $migrationId, Response $response, Database $dbForProject, Document $project, array $platform, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->getDocument('migrations', $migrationId);
 
         if ($migration->isEmpty()) {
@@ -1238,7 +1229,6 @@ Http::patch('/v1/migrations/:migrationId')
             project: $project,
             migration: $migration,
             platform: $platform,
-            user: $user,
         ));
 
         $response->noContent();

--- a/app/controllers/api/migrations.php
+++ b/app/controllers/api/migrations.php
@@ -1,7 +1,8 @@
 <?php
 
 use Appwrite\Event\Event;
-use Appwrite\Event\Migration;
+use Appwrite\Event\Message\Migration as MigrationMessage;
+use Appwrite\Event\Publisher\Migration as MigrationPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\OpenSSL\OpenSSL;
 use Appwrite\SDK\AuthType;
@@ -92,8 +93,8 @@ Http::post('/v1/migrations/appwrite')
     ->inject('platform')
     ->inject('user')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
-    ->action(function (array $resources, string $endpoint, string $projectId, string $apiKey, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, Migration $queueForMigrations) {
+    ->inject('publisherForMigrations')
+    ->action(function (array $resources, string $endpoint, string $projectId, string $apiKey, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->createDocument('migrations', new Document([
             '$id' => ID::unique(),
             'status' => 'pending',
@@ -114,12 +115,12 @@ Http::post('/v1/migrations/appwrite')
         $queueForEvents->setParam('migrationId', $migration->getId());
 
         // Trigger Transfer
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->setUser($user)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+            user: $user,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -153,8 +154,8 @@ Http::post('/v1/migrations/firebase')
     ->inject('platform')
     ->inject('user')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
-    ->action(function (array $resources, string $serviceAccount, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, Migration $queueForMigrations) {
+    ->inject('publisherForMigrations')
+    ->action(function (array $resources, string $serviceAccount, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $serviceAccountData = json_decode($serviceAccount, true);
 
         if (empty($serviceAccountData)) {
@@ -183,12 +184,12 @@ Http::post('/v1/migrations/firebase')
         $queueForEvents->setParam('migrationId', $migration->getId());
 
         // Trigger Transfer
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->setUser($user)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+            user: $user,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -227,8 +228,8 @@ Http::post('/v1/migrations/supabase')
     ->inject('platform')
     ->inject('user')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
-    ->action(function (array $resources, string $endpoint, string $apiKey, string $databaseHost, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, Migration $queueForMigrations) {
+    ->inject('publisherForMigrations')
+    ->action(function (array $resources, string $endpoint, string $apiKey, string $databaseHost, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->createDocument('migrations', new Document([
             '$id' => ID::unique(),
             'status' => 'pending',
@@ -252,12 +253,12 @@ Http::post('/v1/migrations/supabase')
         $queueForEvents->setParam('migrationId', $migration->getId());
 
         // Trigger Transfer
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->setUser($user)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+            user: $user,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -297,8 +298,8 @@ Http::post('/v1/migrations/nhost')
     ->inject('platform')
     ->inject('user')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
-    ->action(function (array $resources, string $subdomain, string $region, string $adminSecret, string $database, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, Migration $queueForMigrations) {
+    ->inject('publisherForMigrations')
+    ->action(function (array $resources, string $subdomain, string $region, string $adminSecret, string $database, string $username, string $password, int $port, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Event $queueForEvents, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->createDocument('migrations', new Document([
             '$id' => ID::unique(),
             'status' => 'pending',
@@ -323,12 +324,12 @@ Http::post('/v1/migrations/nhost')
         $queueForEvents->setParam('migrationId', $migration->getId());
 
         // Trigger Transfer
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->setUser($user)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+            user: $user,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -368,7 +369,7 @@ Http::post('/v1/migrations/csv/imports')
     ->inject('deviceForFiles')
     ->inject('deviceForMigrations')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
+    ->inject('publisherForMigrations')
     ->action(function (
         string $bucketId,
         string $fileId,
@@ -383,7 +384,7 @@ Http::post('/v1/migrations/csv/imports')
         Device $deviceForFiles,
         Device $deviceForMigrations,
         Event $queueForEvents,
-        Migration $queueForMigrations
+        MigrationPublisher $publisherForMigrations
     ) {
         $bucket = $authorization->skip(function () use ($internalFile, $dbForPlatform, $dbForProject, $bucketId) {
             if ($internalFile) {
@@ -479,11 +480,10 @@ Http::post('/v1/migrations/csv/imports')
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setProject($project)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -526,7 +526,7 @@ Http::post('/v1/migrations/csv/exports')
     ->inject('project')
     ->inject('platform')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
+    ->inject('publisherForMigrations')
     ->action(function (
         string $resourceId,
         string $filename,
@@ -545,7 +545,7 @@ Http::post('/v1/migrations/csv/exports')
         Document $project,
         array $platform,
         Event $queueForEvents,
-        Migration $queueForMigrations
+        MigrationPublisher $publisherForMigrations
     ) {
         try {
             $parsedQueries = Query::parseQueries($queries);
@@ -630,11 +630,11 @@ Http::post('/v1/migrations/csv/exports')
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -673,7 +673,7 @@ Http::post('/v1/migrations/json/imports')
     ->inject('deviceForFiles')
     ->inject('deviceForMigrations')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
+    ->inject('publisherForMigrations')
     ->action(function (
         string $bucketId,
         string $fileId,
@@ -688,7 +688,7 @@ Http::post('/v1/migrations/json/imports')
         Device $deviceForFiles,
         Device $deviceForMigrations,
         Event $queueForEvents,
-        Migration $queueForMigrations
+        MigrationPublisher $publisherForMigrations
     ) {
         $bucket = $authorization->skip(function () use ($internalFile, $dbForPlatform, $dbForProject, $bucketId) {
             if ($internalFile) {
@@ -783,11 +783,11 @@ Http::post('/v1/migrations/json/imports')
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -826,7 +826,7 @@ Http::post('/v1/migrations/json/exports')
     ->inject('project')
     ->inject('platform')
     ->inject('queueForEvents')
-    ->inject('queueForMigrations')
+    ->inject('publisherForMigrations')
     ->action(function (
         string $resourceId,
         string $filename,
@@ -841,7 +841,7 @@ Http::post('/v1/migrations/json/exports')
         Document $project,
         array $platform,
         Event $queueForEvents,
-        Migration $queueForMigrations
+        MigrationPublisher $publisherForMigrations
     ) {
         try {
             $parsedQueries = Query::parseQueries($queries);
@@ -915,11 +915,11 @@ Http::post('/v1/migrations/json/exports')
 
         $queueForEvents->setParam('migrationId', $migration->getId());
 
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+        ));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
@@ -1217,8 +1217,8 @@ Http::patch('/v1/migrations/:migrationId')
     ->inject('project')
     ->inject('platform')
     ->inject('user')
-    ->inject('queueForMigrations')
-    ->action(function (string $migrationId, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, Migration $queueForMigrations) {
+    ->inject('publisherForMigrations')
+    ->action(function (string $migrationId, Response $response, Database $dbForProject, Document $project, array $platform, Document $user, MigrationPublisher $publisherForMigrations) {
         $migration = $dbForProject->getDocument('migrations', $migrationId);
 
         if ($migration->isEmpty()) {
@@ -1234,12 +1234,12 @@ Http::patch('/v1/migrations/:migrationId')
             ->setAttribute('dateUpdated', \time());
 
         // Trigger Migration
-        $queueForMigrations
-            ->setMigration($migration)
-            ->setProject($project)
-            ->setPlatform($platform)
-            ->setUser($user)
-            ->trigger();
+        $publisherForMigrations->enqueue(new MigrationMessage(
+            project: $project,
+            migration: $migration,
+            platform: $platform,
+            user: $user,
+        ));
 
         $response->noContent();
     });

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -1,6 +1,9 @@
 <?php
 
 use Appwrite\Event\Event;
+use Appwrite\Event\Publisher\Execution as ExecutionPublisher;
+use Appwrite\Event\Publisher\Migration as MigrationPublisher;
+use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Utopia\Database\Documents\User;
 use Executor\Executor;
@@ -81,6 +84,18 @@ $container->set('publisherWebhooks', function (Publisher $publisher) {
 $container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePublisher(
     $publisher,
     new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
+), ['publisher']);
+$container->set('publisherForExecutions', fn (Publisher $publisher) => new ExecutionPublisher(
+    $publisher,
+    new Queue(Event::EXECUTIONS_QUEUE_NAME)
+), ['publisher']);
+$container->set('publisherForMigrations', fn (Publisher $publisher) => new MigrationPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_MIGRATIONS_QUEUE_NAME', Event::MIGRATIONS_QUEUE_NAME))
+), ['publisher']);
+$container->set('publisherForStatsResources', fn (Publisher $publisher) => new StatsResourcesPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME))
 ), ['publisher']);
 
 /**

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -87,7 +87,7 @@ $container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePubli
 ), ['publisher']);
 $container->set('publisherForExecutions', fn (Publisher $publisher) => new ExecutionPublisher(
     $publisher,
-    new Queue(Event::EXECUTIONS_QUEUE_NAME)
+    new Queue(System::getEnv('_APP_EXECUTIONS_QUEUE_NAME', Event::EXECUTIONS_QUEUE_NAME))
 ), ['publisher']);
 $container->set('publisherForMigrations', fn (Publisher $publisher) => new MigrationPublisher(
     $publisher,

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -13,10 +13,8 @@ use Appwrite\Event\Event;
 use Appwrite\Event\Func;
 use Appwrite\Event\Mail;
 use Appwrite\Event\Messaging;
-use Appwrite\Event\Migration;
 use Appwrite\Event\Realtime;
 use Appwrite\Event\Screenshot;
-use Appwrite\Event\StatsResources;
 use Appwrite\Event\Webhook;
 use Appwrite\Extend\Exception;
 use Appwrite\Functions\EventProcessor;
@@ -163,13 +161,6 @@ return function (Container $container): void {
     $container->set('queueForCertificates', function (Publisher $publisher) {
         return new Certificate($publisher);
     }, ['publisher']);
-    $container->set('queueForMigrations', function (Publisher $publisher) {
-        return new Migration($publisher);
-    }, ['publisher']);
-    $container->set('queueForStatsResources', function (Publisher $publisher) {
-        return new StatsResources($publisher);
-    }, ['publisher']);
-
     $container->set('dbForPlatform', function (Group $pools, Cache $cache, Authorization $authorization) {
         $adapter = new DatabasePool($pools->get('console'));
         $database = new Database($adapter, $cache);

--- a/app/init/worker/message.php
+++ b/app/init/worker/message.php
@@ -9,7 +9,6 @@ use Appwrite\Event\Event;
 use Appwrite\Event\Func;
 use Appwrite\Event\Mail;
 use Appwrite\Event\Messaging;
-use Appwrite\Event\Migration;
 use Appwrite\Event\Realtime;
 use Appwrite\Event\Screenshot;
 use Appwrite\Event\Webhook;
@@ -342,10 +341,6 @@ return function (Container $container): void {
 
     $container->set('queueForCertificates', function (Publisher $publisher) {
         return new Certificate($publisher);
-    }, ['publisher']);
-
-    $container->set('queueForMigrations', function (Publisher $publisher) {
-        return new Migration($publisher);
     }, ['publisher']);
 
     $container->set('deviceForSites', function (Document $project, Telemetry $telemetry) {

--- a/src/Appwrite/Bus/Listeners/Log.php
+++ b/src/Appwrite/Bus/Listeners/Log.php
@@ -3,10 +3,10 @@
 namespace Appwrite\Bus\Listeners;
 
 use Appwrite\Bus\Events\ExecutionCompleted;
-use Appwrite\Event\Execution;
+use Appwrite\Event\Message\Execution as ExecutionMessage;
+use Appwrite\Event\Publisher\Execution as ExecutionPublisher;
 use Utopia\Bus\Listener;
 use Utopia\Database\Document;
-use Utopia\Queue\Publisher;
 
 class Log extends Listener
 {
@@ -24,16 +24,15 @@ class Log extends Listener
     {
         $this
             ->desc('Persists execution logs to database via queue')
-            ->inject('publisher')
+            ->inject('publisherForExecutions')
             ->callback($this->handle(...));
     }
 
-    public function handle(ExecutionCompleted $event, Publisher $publisher): void
+    public function handle(ExecutionCompleted $event, ExecutionPublisher $publisherForExecutions): void
     {
-        $queueForExecutions = new Execution($publisher);
-        $queueForExecutions
-            ->setExecution(new Document($event->execution))
-            ->setProject(new Document($event->project))
-            ->trigger();
+        $publisherForExecutions->enqueue(new ExecutionMessage(
+            project: new Document($event->project),
+            execution: new Document($event->execution),
+        ));
     }
 }

--- a/src/Appwrite/Event/Message/Execution.php
+++ b/src/Appwrite/Event/Message/Execution.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Appwrite\Event\Message;
+
+use Utopia\Database\Document;
+
+class Execution extends Base
+{
+    public function __construct(
+        public Document $project,
+        public Document $execution,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'project' => $this->project->getArrayCopy(),
+            'execution' => $this->execution->getArrayCopy(),
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        /** @phpstan-ignore new.static (subclass constructors are backwards-compatible via optional params) */
+        return new static(
+            project: new Document($data['project'] ?? []),
+            execution: new Document($data['execution'] ?? []),
+        );
+    }
+}

--- a/src/Appwrite/Event/Message/Execution.php
+++ b/src/Appwrite/Event/Message/Execution.php
@@ -4,11 +4,11 @@ namespace Appwrite\Event\Message;
 
 use Utopia\Database\Document;
 
-class Execution extends Base
+final class Execution extends Base
 {
     public function __construct(
-        public Document $project,
-        public Document $execution,
+        public readonly Document $project,
+        public readonly Document $execution,
     ) {
     }
 
@@ -22,8 +22,7 @@ class Execution extends Base
 
     public static function fromArray(array $data): static
     {
-        /** @phpstan-ignore new.static (subclass constructors are backwards-compatible via optional params) */
-        return new static(
+        return new self(
             project: new Document($data['project'] ?? []),
             execution: new Document($data['execution'] ?? []),
         );

--- a/src/Appwrite/Event/Message/Migration.php
+++ b/src/Appwrite/Event/Message/Migration.php
@@ -10,7 +10,6 @@ class Migration extends Base
         public Document $project,
         public Document $migration,
         public array $platform = [],
-        public ?Document $user = null,
     ) {
     }
 
@@ -20,7 +19,6 @@ class Migration extends Base
             'project' => $this->project->getArrayCopy(),
             'migration' => $this->migration->getArrayCopy(),
             'platform' => $this->platform,
-            'user' => $this->user?->getArrayCopy() ?? [],
         ];
     }
 
@@ -31,7 +29,6 @@ class Migration extends Base
             project: new Document($data['project'] ?? []),
             migration: new Document($data['migration'] ?? []),
             platform: $data['platform'] ?? [],
-            user: new Document($data['user'] ?? []),
         );
     }
 }

--- a/src/Appwrite/Event/Message/Migration.php
+++ b/src/Appwrite/Event/Message/Migration.php
@@ -4,12 +4,12 @@ namespace Appwrite\Event\Message;
 
 use Utopia\Database\Document;
 
-class Migration extends Base
+final class Migration extends Base
 {
     public function __construct(
-        public Document $project,
-        public Document $migration,
-        public array $platform = [],
+        public readonly Document $project,
+        public readonly Document $migration,
+        public readonly array $platform = [],
     ) {
     }
 
@@ -24,8 +24,7 @@ class Migration extends Base
 
     public static function fromArray(array $data): static
     {
-        /** @phpstan-ignore new.static (subclass constructors are backwards-compatible via optional params) */
-        return new static(
+        return new self(
             project: new Document($data['project'] ?? []),
             migration: new Document($data['migration'] ?? []),
             platform: $data['platform'] ?? [],

--- a/src/Appwrite/Event/Message/Migration.php
+++ b/src/Appwrite/Event/Message/Migration.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Appwrite\Event\Message;
+
+use Utopia\Database\Document;
+
+class Migration extends Base
+{
+    public function __construct(
+        public Document $project,
+        public Document $migration,
+        public array $platform = [],
+        public ?Document $user = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'project' => $this->project->getArrayCopy(),
+            'migration' => $this->migration->getArrayCopy(),
+            'platform' => $this->platform,
+            'user' => $this->user?->getArrayCopy() ?? [],
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        /** @phpstan-ignore new.static (subclass constructors are backwards-compatible via optional params) */
+        return new static(
+            project: new Document($data['project'] ?? []),
+            migration: new Document($data['migration'] ?? []),
+            platform: $data['platform'] ?? [],
+            user: new Document($data['user'] ?? []),
+        );
+    }
+}

--- a/src/Appwrite/Event/Message/StatsResources.php
+++ b/src/Appwrite/Event/Message/StatsResources.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Event\Message;
+
+use Utopia\Database\Document;
+
+class StatsResources extends Base
+{
+    public function __construct(
+        public Document $project,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'project' => $this->project->getArrayCopy(),
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        /** @phpstan-ignore new.static (subclass constructors are backwards-compatible via optional params) */
+        return new static(
+            project: new Document($data['project'] ?? []),
+        );
+    }
+}

--- a/src/Appwrite/Event/Message/StatsResources.php
+++ b/src/Appwrite/Event/Message/StatsResources.php
@@ -4,10 +4,10 @@ namespace Appwrite\Event\Message;
 
 use Utopia\Database\Document;
 
-class StatsResources extends Base
+final class StatsResources extends Base
 {
     public function __construct(
-        public Document $project,
+        public readonly Document $project,
     ) {
     }
 
@@ -20,8 +20,7 @@ class StatsResources extends Base
 
     public static function fromArray(array $data): static
     {
-        /** @phpstan-ignore new.static (subclass constructors are backwards-compatible via optional params) */
-        return new static(
+        return new self(
             project: new Document($data['project'] ?? []),
         );
     }

--- a/src/Appwrite/Event/Publisher/Execution.php
+++ b/src/Appwrite/Event/Publisher/Execution.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Appwrite\Event\Publisher;
+
+use Appwrite\Event\Message\Execution as ExecutionMessage;
+use Utopia\Queue\Publisher;
+use Utopia\Queue\Queue;
+
+readonly class Execution extends Base
+{
+    public function __construct(
+        Publisher $publisher,
+        protected Queue $queue
+    ) {
+        parent::__construct($publisher);
+    }
+
+    public function enqueue(ExecutionMessage $message): string|bool
+    {
+        return $this->publish($this->queue, $message);
+    }
+
+    public function getSize(bool $failed = false): int
+    {
+        return $this->getQueueSize($this->queue, $failed);
+    }
+}

--- a/src/Appwrite/Event/Publisher/Migration.php
+++ b/src/Appwrite/Event/Publisher/Migration.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Appwrite\Event\Publisher;
+
+use Appwrite\Event\Message\Migration as MigrationMessage;
+use Utopia\Queue\Publisher;
+use Utopia\Queue\Queue;
+
+readonly class Migration extends Base
+{
+    public function __construct(
+        Publisher $publisher,
+        protected Queue $queue
+    ) {
+        parent::__construct($publisher);
+    }
+
+    public function enqueue(MigrationMessage $message): string|bool
+    {
+        return $this->publish($this->queue, $message);
+    }
+
+    public function getSize(bool $failed = false): int
+    {
+        return $this->getQueueSize($this->queue, $failed);
+    }
+}

--- a/src/Appwrite/Event/Publisher/StatsResources.php
+++ b/src/Appwrite/Event/Publisher/StatsResources.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Appwrite\Event\Publisher;
+
+use Appwrite\Event\Message\StatsResources as StatsResourcesMessage;
+use Utopia\Console;
+use Utopia\Queue\Publisher;
+use Utopia\Queue\Queue;
+
+readonly class StatsResources extends Base
+{
+    public function __construct(
+        Publisher $publisher,
+        protected Queue $queue
+    ) {
+        parent::__construct($publisher);
+    }
+
+    public function enqueue(StatsResourcesMessage $message): string|bool
+    {
+        try {
+            return $this->publish($this->queue, $message);
+        } catch (\Throwable $th) {
+            Console::error('[StatsResources] Failed to publish stats resources message: ' . $th->getMessage());
+            return false;
+        }
+    }
+
+    public function getSize(bool $failed = false): int
+    {
+        return $this->getQueueSize($this->queue, $failed);
+    }
+}

--- a/src/Appwrite/Event/Publisher/StatsResources.php
+++ b/src/Appwrite/Event/Publisher/StatsResources.php
@@ -18,6 +18,7 @@ readonly class StatsResources extends Base
 
     public function enqueue(StatsResourcesMessage $message): string|bool
     {
+        // Resource stats are best-effort; publishing failures should not interrupt the scheduler loop.
         try {
             return $this->publish($this->queue, $message);
         } catch (\Throwable $th) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -305,9 +305,7 @@ class Create extends Base
 
         if ($async) {
             if (is_null($scheduledAt)) {
-                if ($project->getId() != '6862e6a6000cce69f9da') {
-                    $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
-                }
+                $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
                 $queueForFunctions
                     ->setType('http')
                     ->setExecution($execution)
@@ -348,9 +346,7 @@ class Create extends Base
                     ->setAttribute('scheduleInternalId', $schedule->getSequence())
                     ->setAttribute('scheduledAt', $scheduledAt);
 
-                if ($project->getId() != '6862e6a6000cce69f9da') {
-                    $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
-                }
+                $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
             }
 
             if ($executionsRetentionCount > 0 && ENABLE_EXECUTIONS_LIMIT_ON_ROUTE) {
@@ -516,9 +512,7 @@ class Create extends Base
                 ->addMetric(str_replace(['{resourceType}', '{resourceInternalId}'], [RESOURCE_TYPE_FUNCTIONS, $function->getSequence()], METRIC_RESOURCE_TYPE_ID_EXECUTIONS_MB_SECONDS), (int)(($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT) * $execution->getAttribute('duration', 0) * ($spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT)))
             ;
 
-            if ($project->getId() != '6862e6a6000cce69f9da') {
-                $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
-            }
+            $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
         }
 
         $executionResponse['headers']['x-appwrite-execution-id'] = $execution->getId();

--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Queue/Failed/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Queue/Failed/Get.php
@@ -11,10 +11,10 @@ use Appwrite\Event\Event;
 use Appwrite\Event\Func;
 use Appwrite\Event\Mail;
 use Appwrite\Event\Messaging;
-use Appwrite\Event\Migration;
+use Appwrite\Event\Publisher\Migration as MigrationPublisher;
+use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Event\Screenshot;
-use Appwrite\Event\StatsResources;
 use Appwrite\Event\Webhook;
 use Appwrite\Platform\Modules\Health\Http\Health\Queue\Base;
 use Appwrite\SDK\AuthType;
@@ -78,13 +78,13 @@ class Get extends Base
             ->inject('queueForAudits')
             ->inject('queueForMails')
             ->inject('queueForFunctions')
-            ->inject('queueForStatsResources')
+            ->inject('publisherForStatsResources')
             ->inject('publisherForUsage')
             ->inject('queueForWebhooks')
             ->inject('queueForCertificates')
             ->inject('queueForBuilds')
             ->inject('queueForMessaging')
-            ->inject('queueForMigrations')
+            ->inject('publisherForMigrations')
             ->inject('queueForScreenshots')
             ->callback($this->action(...));
     }
@@ -98,13 +98,13 @@ class Get extends Base
         Audit $queueForAudits,
         Mail $queueForMails,
         Func $queueForFunctions,
-        StatsResources $queueForStatsResources,
+        StatsResourcesPublisher $publisherForStatsResources,
         UsagePublisher $publisherForUsage,
         Webhook $queueForWebhooks,
         Certificate $queueForCertificates,
         Build $queueForBuilds,
         Messaging $queueForMessaging,
-        Migration $queueForMigrations,
+        MigrationPublisher $publisherForMigrations,
         Screenshot $queueForScreenshots,
     ): void {
         $threshold = (int) $threshold;
@@ -115,14 +115,14 @@ class Get extends Base
             System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME) => $queueForAudits,
             System::getEnv('_APP_MAILS_QUEUE_NAME', Event::MAILS_QUEUE_NAME) => $queueForMails,
             System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', Event::FUNCTIONS_QUEUE_NAME) => $queueForFunctions,
-            System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME) => $queueForStatsResources,
+            System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME) => $publisherForStatsResources,
             System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME) => $publisherForUsage,
             System::getEnv('_APP_WEBHOOK_QUEUE_NAME', Event::WEBHOOK_QUEUE_NAME) => $queueForWebhooks,
             System::getEnv('_APP_CERTIFICATES_QUEUE_NAME', Event::CERTIFICATES_QUEUE_NAME) => $queueForCertificates,
             System::getEnv('_APP_BUILDS_QUEUE_NAME', Event::BUILDS_QUEUE_NAME) => $queueForBuilds,
             System::getEnv('_APP_SCREENSHOTS_QUEUE_NAME', Event::SCREENSHOTS_QUEUE_NAME) => $queueForScreenshots,
             System::getEnv('_APP_MESSAGING_QUEUE_NAME', Event::MESSAGING_QUEUE_NAME) => $queueForMessaging,
-            System::getEnv('_APP_MIGRATIONS_QUEUE_NAME', Event::MIGRATIONS_QUEUE_NAME) => $queueForMigrations,
+            System::getEnv('_APP_MIGRATIONS_QUEUE_NAME', Event::MIGRATIONS_QUEUE_NAME) => $publisherForMigrations,
         };
         $failed = $queue->getSize(failed: true);
 

--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Queue/Migrations/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Queue/Migrations/Get.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Health\Http\Health\Queue\Migrations;
 
-use Appwrite\Event\Migration;
+use Appwrite\Event\Publisher\Migration as MigrationPublisher;
 use Appwrite\Platform\Modules\Health\Http\Health\Queue\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
@@ -42,16 +42,16 @@ class Get extends Base
                 contentType: ContentType::JSON
             ))
             ->param('threshold', 5000, new Integer(true), 'Queue size threshold. When hit (equal or higher), endpoint returns server error. Default value is 5000.', true)
-            ->inject('queueForMigrations')
+            ->inject('publisherForMigrations')
             ->inject('response')
             ->callback($this->action(...));
     }
 
-    public function action(int|string $threshold, Migration $queueForMigrations, Response $response): void
+    public function action(int|string $threshold, MigrationPublisher $publisherForMigrations, Response $response): void
     {
         $threshold = (int) $threshold;
 
-        $size = $queueForMigrations->getSize();
+        $size = $publisherForMigrations->getSize();
 
         $this->assertQueueThreshold($size, $threshold);
 

--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Queue/StatsResources/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Queue/StatsResources/Get.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Health\Http\Health\Queue\StatsResources;
 
-use Appwrite\Event\StatsResources;
+use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Platform\Modules\Health\Http\Health\Queue\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
@@ -42,16 +42,16 @@ class Get extends Base
                 contentType: ContentType::JSON
             ))
             ->param('threshold', 5000, new Integer(true), 'Queue size threshold. When hit (equal or higher), endpoint returns server error. Default value is 5000.', true)
-            ->inject('queueForStatsResources')
+            ->inject('publisherForStatsResources')
             ->inject('response')
             ->callback($this->action(...));
     }
 
-    public function action(int|string $threshold, StatsResources $queueForStatsResources, Response $response): void
+    public function action(int|string $threshold, StatsResourcesPublisher $publisherForStatsResources, Response $response): void
     {
         $threshold = (int) $threshold;
 
-        $size = $queueForStatsResources->getSize();
+        $size = $publisherForStatsResources->getSize();
 
         $this->assertQueueThreshold($size, $threshold);
 

--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -2,7 +2,6 @@
 
 namespace Appwrite\Platform\Tasks;
 
-use Appwrite\Event\Message\StatsResources as StatsResourcesMessage;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Platform\Action;
 use Utopia\Console;
@@ -71,7 +70,7 @@ class StatsResources extends Action
                 Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
                 Query::equal('region', [System::getEnv('_APP_REGION', 'default')])
             ], function ($project) use ($publisherForStatsResources) {
-                $publisherForStatsResources->enqueue(new StatsResourcesMessage(
+                $publisherForStatsResources->enqueue(new \Appwrite\Event\Message\StatsResources(
                     project: $project,
                 ));
                 Console::success('project: ' . $project->getId() . '(' . $project->getSequence() . ')' . ' queued');

--- a/src/Appwrite/Platform/Tasks/StatsResources.php
+++ b/src/Appwrite/Platform/Tasks/StatsResources.php
@@ -2,7 +2,8 @@
 
 namespace Appwrite\Platform\Tasks;
 
-use Appwrite\Event\StatsResources as EventStatsResources;
+use Appwrite\Event\Message\StatsResources as StatsResourcesMessage;
+use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Platform\Action;
 use Utopia\Console;
 use Utopia\Database\Database;
@@ -43,11 +44,11 @@ class StatsResources extends Action
             ->desc('Schedules projects for usage count')
             ->inject('dbForPlatform')
             ->inject('logError')
-            ->inject('queueForStatsResources')
+            ->inject('publisherForStatsResources')
             ->callback($this->action(...));
     }
 
-    public function action(Database $dbForPlatform, callable $logError, EventStatsResources $queueForStatsResources): void
+    public function action(Database $dbForPlatform, callable $logError, StatsResourcesPublisher $publisherForStatsResources): void
     {
         $this->logError = $logError;
         $this->dbForPlatform = $dbForPlatform;
@@ -60,7 +61,7 @@ class StatsResources extends Action
 
         $interval = (int) System::getEnv('_APP_STATS_RESOURCES_INTERVAL', '3600');
 
-        Console::loop(function () use ($queueForStatsResources) {
+        Console::loop(function () use ($publisherForStatsResources) {
 
             $last24Hours = (new \DateTime())->sub(\DateInterval::createFromDateString('24 hours'));
             /**
@@ -69,10 +70,10 @@ class StatsResources extends Action
             $this->foreachDocument($this->dbForPlatform, 'projects', [
                 Query::greaterThanEqual('accessedAt', DateTime::format($last24Hours)),
                 Query::equal('region', [System::getEnv('_APP_REGION', 'default')])
-            ], function ($project) use ($queueForStatsResources) {
-                $queueForStatsResources
-                    ->setProject($project)
-                    ->trigger();
+            ], function ($project) use ($publisherForStatsResources) {
+                $publisherForStatsResources->enqueue(new StatsResourcesMessage(
+                    project: $project,
+                ));
                 Console::success('project: ' . $project->getId() . '(' . $project->getSequence() . ')' . ' queued');
             });
         }, $interval);

--- a/src/Appwrite/Platform/Workers/Executions.php
+++ b/src/Appwrite/Platform/Workers/Executions.php
@@ -10,12 +10,6 @@ use Utopia\Queue\Message;
 
 class Executions extends Action
 {
-    /**
-     * Keep skipping execution upserts for this internal project.
-     * The HTTP execution flow applies the same exclusion separately.
-     */
-    private const string EXCLUDED_PROJECT_ID = '6862e6a6000cce69f9da';
-
     public static function getName(): string
     {
         return 'executions';
@@ -46,8 +40,6 @@ class Executions extends Action
         }
 
         $project = $executionMessage->project;
-        if ($project->getId() !== self::EXCLUDED_PROJECT_ID) {
-            $dbForProject->upsertDocument('executions', $execution);
-        }
+        $dbForProject->upsertDocument('executions', $execution);
     }
 }

--- a/src/Appwrite/Platform/Workers/Executions.php
+++ b/src/Appwrite/Platform/Workers/Executions.php
@@ -2,9 +2,9 @@
 
 namespace Appwrite\Platform\Workers;
 
+use Appwrite\Event\Message\Execution as ExecutionMessage;
 use Exception;
 use Utopia\Database\Database;
-use Utopia\Database\Document;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 
@@ -32,19 +32,14 @@ class Executions extends Action
         Message $message,
         Database $dbForProject,
     ): void {
-        $payload = $message->getPayload() ?? [];
-
-        if (empty($payload)) {
-            throw new Exception('Missing payload');
-        }
-
-        $execution = new Document($payload['execution'] ?? []);
+        $executionMessage = ExecutionMessage::fromArray($message->getPayload() ?? []);
+        $execution = $executionMessage->execution;
 
         if ($execution->isEmpty()) {
             throw new Exception('Missing execution');
         }
 
-        $project = new Document($payload['project'] ?? []);
+        $project = $executionMessage->project;
         if ($project->getId() != '6862e6a6000cce69f9da') {
             $dbForProject->upsertDocument('executions', $execution);
         }

--- a/src/Appwrite/Platform/Workers/Executions.php
+++ b/src/Appwrite/Platform/Workers/Executions.php
@@ -10,6 +10,12 @@ use Utopia\Queue\Message;
 
 class Executions extends Action
 {
+    /**
+     * Keep skipping execution upserts for this internal project.
+     * The HTTP execution flow applies the same exclusion separately.
+     */
+    private const string EXCLUDED_PROJECT_ID = '6862e6a6000cce69f9da';
+
     public static function getName(): string
     {
         return 'executions';
@@ -40,7 +46,7 @@ class Executions extends Action
         }
 
         $project = $executionMessage->project;
-        if ($project->getId() != '6862e6a6000cce69f9da') {
+        if ($project->getId() !== self::EXCLUDED_PROJECT_ID) {
             $dbForProject->upsertDocument('executions', $execution);
         }
     }

--- a/src/Appwrite/Platform/Workers/Executions.php
+++ b/src/Appwrite/Platform/Workers/Executions.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Workers;
 
-use Appwrite\Event\Message\Execution as ExecutionMessage;
+use Appwrite\Event\Message\Execution;
 use Exception;
 use Utopia\Database\Database;
 use Utopia\Platform\Action;
@@ -32,14 +32,13 @@ class Executions extends Action
         Message $message,
         Database $dbForProject,
     ): void {
-        $executionMessage = ExecutionMessage::fromArray($message->getPayload() ?? []);
+        $executionMessage = Execution::fromArray($message->getPayload() ?? []);
         $execution = $executionMessage->execution;
 
         if ($execution->isEmpty()) {
             throw new Exception('Missing execution');
         }
 
-        $project = $executionMessage->project;
         $dbForProject->upsertDocument('executions', $execution);
     }
 }

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Workers;
 
 use Ahc\Jwt\JWT;
 use Appwrite\Event\Mail;
+use Appwrite\Event\Message\Migration as MigrationMessage;
 use Appwrite\Event\Message\Usage as UsageMessage;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Event\Realtime;
@@ -129,7 +130,7 @@ class Migrations extends Action
         array $plan,
         Authorization $authorization,
     ): void {
-        $payload = $message->getPayload() ?? [];
+        $migrationMessage = MigrationMessage::fromArray($message->getPayload() ?? []);
         $this->getDatabasesDB = $getDatabasesDB;
         $this->getProjectDB = $getProjectDB;
 
@@ -137,12 +138,7 @@ class Migrations extends Action
         $this->deviceForFiles = $deviceForFiles;
         $this->plan = $plan;
 
-        if (empty($payload)) {
-            throw new Exception('Missing payload');
-        }
-
-        $events = $payload['events'] ?? [];
-        $migration = new Document($payload['migration'] ?? []);
+        $migration = $migrationMessage->migration;
 
         if ($migration->isEmpty()) {
             throw new \Exception('Migration not found');
@@ -161,11 +157,7 @@ class Migrations extends Action
         $this->project = $project;
         $this->logError = $logError;
 
-        $platform = $payload['platform'] ?? Config::getParam('platform', []);
-
-        if (!empty($events)) {
-            return;
-        }
+        $platform = $migrationMessage->platform ?: Config::getParam('platform', []);
 
         try {
             $this->processMigration(

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -4,7 +4,7 @@ namespace Appwrite\Platform\Workers;
 
 use Ahc\Jwt\JWT;
 use Appwrite\Event\Mail;
-use Appwrite\Event\Message\Migration as MigrationMessage;
+use Appwrite\Event\Message\Migration;
 use Appwrite\Event\Message\Usage as UsageMessage;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Event\Realtime;
@@ -130,7 +130,7 @@ class Migrations extends Action
         array $plan,
         Authorization $authorization,
     ): void {
-        $migrationMessage = MigrationMessage::fromArray($message->getPayload() ?? []);
+        $migrationMessage = Migration::fromArray($message->getPayload() ?? []);
         $this->getDatabasesDB = $getDatabasesDB;
         $this->getProjectDB = $getProjectDB;
 

--- a/src/Appwrite/Platform/Workers/StatsResources.php
+++ b/src/Appwrite/Platform/Workers/StatsResources.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Workers;
 
+use Appwrite\Event\Message\StatsResources as StatsResourcesMessage;
 use Appwrite\Platform\Action;
 use Exception;
 use Throwable;
@@ -67,8 +68,8 @@ class StatsResources extends Action
     {
         $this->logError = $logError;
 
-        $payload = $message->getPayload() ?? [];
-        if (empty($payload)) {
+        $statsResources = StatsResourcesMessage::fromArray($message->getPayload() ?? []);
+        if ($statsResources->project->isEmpty()) {
             throw new Exception('Missing payload');
         }
 


### PR DESCRIPTION
## What does this PR do?

Migrates a low-risk first slice of `queueForX` resources to the `publisherForX` pattern for `executions`, `migrations`, and `stats-resources`.

This introduces typed queue DTOs for those queues, switches producer callsites to typed publishers, updates worker consumers to decode typed payloads, and moves queue health endpoints for the migrated queues onto the publisher abstraction.

The goal is to establish the pattern in Appwrite without touching the more coupled request-scoped queue resources such as `queueForEvents`, `queueForAudits`, `queueForDeletes`, and related shared API shutdown flow.

## Test Plan

- Ran `composer lint` on all changed files
- Ran `git diff --check`
- Ran targeted syntax checks with `php -l` on changed PHP files during implementation
- Did not run the broader unit suite, E2E suite, or worker integration tests

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
