### PR TITLE
Remove duplicate publisherForStatsResources from cli.php

### DIFF
--- a/app/cli.php
+++ b/app/cli.php
@@ -6,7 +6,6 @@ use Appwrite\Event\Certificate;
 use Appwrite\Event\Delete;
 use Appwrite\Event\Event;
 use Appwrite\Event\Func;
-use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Platform\Appwrite;
 use Appwrite\Runtimes\Runtimes;
@@ -252,10 +251,6 @@ $container->set('usage', function () {
 $container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePublisher(
     $publisher,
     new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForStatsResources', fn (Publisher $publisher) => new StatsResourcesPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME))
 ), ['publisher']);
 $container->set('queueForFunctions', function (Publisher $publisher) {
     return new Func($publisher);


### PR DESCRIPTION
## Summary
- Removes `publisherForStatsResources` definition from `app/cli.php` — it's already defined in `app/init/resources.php` which is loaded via `init.php` before `cli.php` runs
- Removes the now-unused `StatsResourcesPublisher` import

## Test plan
- [ ] Verify stats-resources publisher resolves correctly in CLI tasks