### PR TITLE
Make rule deploymentResourceType optional for non-deployment rules

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Rule.php
+++ b/src/Appwrite/Utopia/Response/Model/Rule.php
@@ -66,8 +66,9 @@ class Rule extends Model
             ])
             ->addRule('deploymentResourceType', [
                 'type' => self::TYPE_ENUM,
+                'required' => false,
                 'description' => 'Type of deployment. Possible values are "function", "site". Used if rule\'s type is "deployment".',
-                'default' => '',
+                'default' => null,
                 'example' => 'function',
                 'enum' => ['function', 'site'],
             ])


### PR DESCRIPTION
## What does this PR do?

Makes `deploymentResourceType` optional in the `Rule` response model.

This field is only meaningful for deployment rules, but the response model currently marks it as required with a default empty string. That causes generated SDKs to treat it as a required enum-backed field, which breaks hydration when non-deployment rules are serialized with `deploymentResourceType: ""`.

## Test Plan

Not run.

Verified the response-model contract and traced the failure path from response serialization to generated SDK enum hydration.

## Related PRs and Issues

- N/A (internal Sentry issue `EDGE-PZJ`)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
