### PR TITLE
fix: use correct logical operator in resource ownership validation

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -86,7 +86,7 @@ class Delete extends Base
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
 
-        if ($execution->getAttribute('resourceType') !== 'functions' && $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
+        if ($execution->getAttribute('resourceType') !== 'functions' || $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
         $status = $execution->getAttribute('status');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/Delete.php
@@ -71,7 +71,7 @@ class Delete extends Base
             throw new Exception(Exception::LOG_NOT_FOUND);
         }
 
-        if ($log->getAttribute('resourceType') !== 'sites' && $log->getAttribute('resourceInternalId') !== $site->getSequence()) {
+        if ($log->getAttribute('resourceType') !== 'sites' || $log->getAttribute('resourceInternalId') !== $site->getSequence()) {
             throw new Exception(Exception::LOG_NOT_FOUND);
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/Get.php
@@ -63,7 +63,7 @@ class Get extends Base
 
         $log = $dbForProject->getDocument('executions', $logId);
 
-        if ($log->getAttribute('resourceType') !== 'sites' && $log->getAttribute('resourceInternalId') !== $site->getSequence()) {
+        if ($log->getAttribute('resourceType') !== 'sites' || $log->getAttribute('resourceInternalId') !== $site->getSequence()) {
             throw new Exception(Exception::LOG_NOT_FOUND);
         }
 


### PR DESCRIPTION
## Summary

- Fixed incorrect use of `&&` (AND) instead of `||` (OR) in resource ownership checks across three endpoints:
  - `Functions/Http/Executions/Delete.php`
  - `Sites/Http/Logs/Get.php`
  - `Sites/Http/Logs/Delete.php`
- With `&&`, a request could pass the ownership check if only **one** of the two conditions (`resourceType` or `resourceInternalId`) was wrong, but the other was correct. The correct behavior is to reject if **either** condition fails.
- The corresponding `Functions/Http/Executions/Get.php` endpoint already uses the correct `||` operator, confirming this was unintentional.

## Test plan

- [ ] Verify that attempting to delete an execution with a valid `executionId` but belonging to a different function correctly returns a 404
- [ ] Verify that getting a site log with a valid `logId` but belonging to a different site correctly returns a 404
- [ ] Verify that deleting a site log with a valid `logId` but belonging to a different site correctly returns a 404
- [ ] Verify that normal get/delete operations on correctly-owned resources still work as expected