### PR TITLE
fix: set team object as event payload for teams.*.update.prefs

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
@@ -76,7 +76,9 @@ class Update extends Action
             'prefs' => $prefs->getArrayCopy()
         ]));
 
-        $queueForEvents->setParam('teamId', $team->getId());
+        $queueForEvents
+            ->setParam('teamId', $team->getId())
+            ->setPayload($response->output($team, Response::MODEL_TEAM));
 
         $response->dynamic($prefs, Response::MODEL_PREFERENCES);
     }


### PR DESCRIPTION
## Summary

- The `teams.*.update.prefs` event was sending only the preferences object as its payload instead of the full team object
- This happened because the HTTP response returns preferences via `Response::MODEL_PREFERENCES`, and the event system auto-populates event payloads from the response when no explicit payload is set
- Now the team object is explicitly set as the event payload via `setPayload()`, which matches the [documented behavior](https://appwrite.io/docs/advanced/platform/events) that the event payload should be the Team Object

Closes #9409

## Test plan

- [ ] Update a team's preferences and verify the `teams.*.update.prefs` event payload now contains the full team object (including `$id`, `name`, `total`, `prefs`, etc.) instead of just the prefs key-value object
- [ ] Verify the HTTP response still correctly returns only the preferences object
- [ ] Verify realtime subscriptions for `teams` channel receive the team object in the payload