### PR TITLE
fix: correct typos in Exception comment and error description

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -457,7 +457,7 @@ return [
     ],
     Exception::AVATAR_NOT_FOUND => [
         'name' => Exception::AVATAR_NOT_FOUND,
-        'description' => 'The request avatar could not be found.',
+        'description' => 'The requested avatar could not be found.',
         'code' => 404,
     ],
     Exception::AVATAR_IMAGE_NOT_FOUND => [

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -336,7 +336,7 @@ class Exception extends \Exception
     public const string PLATFORM_METHOD_UNSUPPORTED = 'platform_method_unsupported';
     public const string PLATFORM_ALREADY_EXISTS = 'platform_already_exists';
 
-    /** GraphqQL */
+    /** GraphQL */
     public const string GRAPHQL_NO_QUERY = 'graphql_no_query';
     public const string GRAPHQL_TOO_MANY_QUERIES = 'graphql_too_many_queries';
 


### PR DESCRIPTION
## Summary

- Fixed typo `GraphqQL` to `GraphQL` in the section comment of `Exception.php` (line 339)
- Fixed typo `The request avatar` to `The requested avatar` in the `AVATAR_NOT_FOUND` error description in `errors.php`, matching the consistent pattern used by all other error messages (e.g., `The requested file could not be found.`, `The requested favicon could not be found.`)

## Test plan

- [ ] Verify `Exception.php` comment reads `/** GraphQL */`
- [ ] Verify the `AVATAR_NOT_FOUND` error description reads `The requested avatar could not be found.`