### PR TITLE
chore: remove redundant isEmpty checks in variable endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
@@ -81,10 +81,6 @@ class Delete extends Base
             throw new Exception(Exception::VARIABLE_NOT_FOUND);
         }
 
-        if ($variable === false || $variable->isEmpty()) {
-            throw new Exception(Exception::VARIABLE_NOT_FOUND);
-        }
-
         $dbForProject->deleteDocument('variables', $variable->getId());
 
         $function->setAttribute('live', false);

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Get.php
@@ -74,10 +74,6 @@ class Get extends Base
             throw new Exception(Exception::VARIABLE_NOT_FOUND);
         }
 
-        if ($variable === false || $variable->isEmpty()) {
-            throw new Exception(Exception::VARIABLE_NOT_FOUND);
-        }
-
         $response->dynamic($variable, Response::MODEL_VARIABLE);
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Delete.php
@@ -71,10 +71,6 @@ class Delete extends Base
             throw new Exception(Exception::VARIABLE_NOT_FOUND);
         }
 
-        if ($variable === false || $variable->isEmpty()) {
-            throw new Exception(Exception::VARIABLE_NOT_FOUND);
-        }
-
         $dbForProject->deleteDocument('variables', $variable->getId());
 
         $dbForProject->updateDocument('sites', $site->getId(), new Document([

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Get.php
@@ -74,10 +74,6 @@ class Get extends Base
             throw new Exception(Exception::VARIABLE_NOT_FOUND);
         }
 
-        if ($variable === false || $variable->isEmpty()) {
-            throw new Exception(Exception::VARIABLE_NOT_FOUND);
-        }
-
         $response->dynamic($variable, Response::MODEL_VARIABLE);
     }
 }


### PR DESCRIPTION
## Summary

- Removed duplicate `isEmpty` checks in four variable endpoint files that were already covered by the preceding ownership validation block:
  - `Functions/Http/Variables/Get.php`
  - `Functions/Http/Variables/Delete.php`
  - `Sites/Http/Variables/Get.php`
  - `Sites/Http/Variables/Delete.php`
- In each file, the first condition block already checks `$variable === false || $variable->isEmpty() || ...resourceInternalId... || ...resourceType...`, so the subsequent `$variable === false || $variable->isEmpty()` check was unreachable dead code
- No behavioral change; purely a code cleanup

## Test plan

- [ ] Verify that getting a function variable with a valid ID returns the variable
- [ ] Verify that getting a function variable with an invalid or mismatched ID returns 404
- [ ] Verify that deleting a site variable with a valid ID succeeds
- [ ] Verify that deleting a site variable with a mismatched ID returns 404