### PR TITLE
fix: add missing deployment ownership check in status update endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -83,6 +83,10 @@ class Update extends Action
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
+        if ($deployment->getAttribute('resourceId') !== $function->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
         if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
             throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
         }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -81,6 +81,10 @@ class Update extends Action
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
+        if ($deployment->getAttribute('resourceId') !== $site->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
         if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
             throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
         }


### PR DESCRIPTION
## Summary

- Added missing deployment ownership validation to the deployment status update (cancel build) endpoints for both functions and sites
- The `PATCH /v1/functions/:functionId/deployments/:deploymentId/status` and `PATCH /v1/sites/:siteId/deployments/:deploymentId/status` endpoints did not verify that the deployment belongs to the specified function/site
- The corresponding `GET` and `DELETE` deployment endpoints already perform this check (`$deployment->getAttribute('resourceId') !== $function->getId()`), so this was an oversight in the status update endpoints
- Without this check, a valid deployment ID from a different function/site could be used to cancel builds through a mismatched parent resource

## Test plan

- [ ] Verify that canceling a deployment build with a matching function/site ID works correctly
- [ ] Verify that attempting to cancel a deployment using a function/site ID that does not own the deployment returns a 404 error
- [ ] Verify the same behavior for both the functions and sites deployment status update endpoints