### PR TITLE
fix: add missing team-membership ownership check in get and update endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
@@ -70,6 +70,10 @@ class Get extends Action
             throw new Exception(Exception::MEMBERSHIP_NOT_FOUND);
         }
 
+        if ($membership->getAttribute('teamInternalId') !== $team->getSequence()) {
+            throw new Exception(Exception::TEAM_MEMBERSHIP_MISMATCH);
+        }
+
         $membershipsPrivacy =  [
             'userName' => $project->getAttribute('auths', [])['membershipsUserName'] ?? true,
             'userEmail' => $project->getAttribute('auths', [])['membershipsUserEmail'] ?? true,

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
@@ -78,6 +78,10 @@ class Update extends Action
             throw new Exception(Exception::MEMBERSHIP_NOT_FOUND);
         }
 
+        if ($membership->getAttribute('teamInternalId') !== $team->getSequence()) {
+            throw new Exception(Exception::TEAM_MEMBERSHIP_MISMATCH);
+        }
+
         $profile = $dbForProject->getDocument('users', $membership->getAttribute('userId'));
         if ($profile->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `GET /v1/teams/:teamId/memberships/:membershipId` and `PATCH /v1/teams/:teamId/memberships/:membershipId` (roles update) endpoints fetch the team and the membership independently but never verify that the membership actually belongs to the specified team.

This means a caller with access to **Team A** can supply a valid `membershipId` from **Team B** and successfully read or modify that membership, as long as the membership document itself passes permission checks.

The sibling endpoints `DELETE /v1/teams/:teamId/memberships/:membershipId` and `PATCH /v1/teams/:teamId/memberships/:membershipId/status` already have this check:

```php
if ($membership->getAttribute('teamInternalId') !== $team->getSequence()) {
    throw new Exception(Exception::TEAM_MEMBERSHIP_MISMATCH);
}
```

## What is the new behavior?

Both the Get and Update (roles) endpoints now validate that the membership belongs to the specified team before proceeding, using the same `teamInternalId` / `getSequence()` check that Delete and Status Update already use.

If the membership does not belong to the team, a `TEAM_MEMBERSHIP_MISMATCH` exception is thrown, consistent with the other endpoints.

## Additional context

Files changed:
- `src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php`
- `src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php`

## Test plan

- [ ] Call `GET /v1/teams/{teamA}/memberships/{membershipFromTeamB}` — should return `TEAM_MEMBERSHIP_MISMATCH` error instead of the membership details
- [ ] Call `PATCH /v1/teams/{teamA}/memberships/{membershipFromTeamB}` with roles — should return `TEAM_MEMBERSHIP_MISMATCH` error instead of updating roles
- [ ] Call `GET /v1/teams/{teamA}/memberships/{membershipFromTeamA}` — should still work normally
- [ ] Call `PATCH /v1/teams/{teamA}/memberships/{membershipFromTeamA}` — should still work normally
- [ ] Existing E2E tests for teams memberships should pass without modification