### PR TITLE
fix: correct date format for DAU calculation in StatsResources worker

### DIFF
--- a/src/Appwrite/Platform/Workers/StatsResources.php
+++ b/src/Appwrite/Platform/Workers/StatsResources.php
@@ -121,7 +121,7 @@ class StatsResources extends Action
             $usersMAU = $dbForProject->count('users', [
                 Query::greaterThanEqual('accessedAt', $last30Days)
             ]);
-            $last24Hours = (new \DateTime())->sub(\DateInterval::createFromDateString('24 hours'))->format('Y-m-d h:m:00');
+            $last24Hours = (new \DateTime())->sub(\DateInterval::createFromDateString('24 hours'))->format('Y-m-d H:i:00');
             $usersDAU = $dbForProject->count('users', [
                 Query::greaterThanEqual('accessedAt', $last24Hours)
             ]);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The DAU (Daily Active Users) threshold in the `StatsResources` worker uses the PHP date format string `'Y-m-d h:m:00'`, which contains two incorrect format specifiers:

- **`h`** produces 12-hour time (01–12) instead of 24-hour time. For example, 14:00 becomes `02` instead of `14`.
- **`m`** produces the **month number** (01–12) where minutes should be. For example, at 14:30 in April, the minutes position outputs `04` (the month) instead of `30` (the actual minutes).

Combined, this means at 14:30 on April 12 the computed threshold becomes `2026-04-11 02:04:00` instead of the intended `2026-04-11 14:30:00`. This causes the DAU count query to use an incorrect time boundary, producing inaccurate active user metrics.

The neighboring MAU and WAU calculations use `'Y-m-d 00:00:00'` (zeroed time), so they are not affected. Only the DAU path, which needs hour-and-minute precision, has this bug.

## What is the new behavior?

Changed the format string to `'Y-m-d H:i:00'`:

- **`H`** — 24-hour format hours (00–23)
- **`i`** — minutes (00–59)

This matches PHP's `DateTime::format()` specification and produces the correct threshold for the DAU query.

## Additional context

Single-line change in `src/Appwrite/Platform/Workers/StatsResources.php` line 124.