### PR TITLE
fix: update search attribute on storage bucket and file name changes

### DIFF
--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
@@ -137,6 +137,7 @@ class Update extends Action
 
         if (!is_null($name)) {
             $file->setAttribute('name', $name);
+            $file->setAttribute('search', implode(' ', [$fileId, $name]));
         }
 
         try {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
@@ -115,7 +115,8 @@ class Update extends Action
             ->setAttribute('encryption', $encryption)
             ->setAttribute('compression', $compression)
             ->setAttribute('antivirus', $antivirus)
-            ->setAttribute('transformations', $transformations));
+            ->setAttribute('transformations', $transformations)
+            ->setAttribute('search', implode(' ', [$bucketId, $name])));
 
         $dbForProject->updateCollection('bucket_' . $bucket->getSequence(), $permissions, $fileSecurity);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a bucket name is updated via `PUT /v1/storage/buckets/:bucketId` or a file name is updated via `PUT /v1/storage/buckets/:bucketId/files/:fileId`, the `search` attribute is not updated. This means the fulltext search index retains the old name, making renamed buckets and files unfindable by their new names.

Every other module in the codebase correctly updates the `search` attribute when names change:

- `Databases/Http/Databases/Update.php` — `->setAttribute('search', implode(' ', [$databaseId, $searchName]))`
- `Functions/Http/Functions/Update.php` — `'search' => implode(' ', [$functionId, $name, $runtime])`
- `Sites/Http/Sites/Update.php` — `'search' => implode(' ', [$siteId, $name, $framework])`
- `Teams/Http/Teams/Name/Update.php` — `->setAttribute('search', implode(' ', [$teamId, $name]))`
- `Projects/Http/Projects/Update.php` — `->setAttribute('search', implode(' ', [$projectId, $name]))`

The Storage module is the only one missing this update.

## What is the new behavior?

- **Bucket Update**: The `search` attribute is now updated to `implode(' ', [$bucketId, $name])` when the bucket is updated, matching the format used during bucket creation.
- **File Update**: The `search` attribute is now updated to `implode(' ', [$fileId, $name])` when the file name is changed, matching the format used during file creation. This only happens when a new name is actually provided (the `name` parameter is optional).

## Test plan

- [ ] Update a bucket name and verify the bucket appears in search results using the new name
- [ ] Update a file name and verify the file appears in search results using the new name
- [ ] Verify that updating a file without providing a name does not change the search attribute
- [ ] Run existing storage E2E tests to confirm no regressions: `docker compose exec appwrite test tests/e2e/Services/Storage`