### PR TITLE
fix: add missing enabled check in increment/decrement endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
@@ -97,12 +97,12 @@ class Decrement extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 
         $collection = $authorization->skip(fn () => $dbForProject->getDocument('database_' . $database->getSequence(), $collectionId));
-        if ($collection->isEmpty()) {
+        if ($collection->isEmpty() || (!$collection->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception($this->getParentNotFoundException(), params: [$collectionId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
@@ -97,12 +97,12 @@ class Increment extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 
         $collection = $authorization->skip(fn () => $dbForProject->getDocument('database_' . $database->getSequence(), $collectionId));
-        if ($collection->isEmpty()) {
+        if ($collection->isEmpty() || (!$collection->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception($this->getParentNotFoundException(), params: [$collectionId]);
         }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `incrementDocumentAttribute` and `decrementDocumentAttribute` endpoints do not check whether the database or collection is **enabled** before allowing operations. This means a non-privileged user (e.g., client SDK with session auth) can increment or decrement document attributes even when the database or collection has been disabled by an admin.

All other document endpoints (`Create`, `Get`, `Update`, `Delete`, `Upsert`, `XList`) already enforce this check consistently:

```php
if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
    throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
}
```

But `Increment.php` and `Decrement.php` only check `isEmpty()`:

```php
if ($database->isEmpty()) {
    throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
}
```

The same gap exists for the collection check in both files.

## What is the new behavior?

Both `Increment.php` and `Decrement.php` now check the `enabled` attribute on the database and collection, consistent with all other document endpoints. This ensures:
- Non-privileged users cannot increment/decrement attributes on disabled databases or collections
- API key and admin users can still access disabled databases/collections as expected
- The TablesDB and DocumentsDB variants (which inherit from these base classes) are also fixed

## Additional context

**Files changed:**
- `src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php`
- `src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php`

**Impact:** The DocumentsDB (`documentsdb/`) and TablesDB (`tablesdb/`) increment/decrement endpoints inherit from these base classes and share the same `action()` method, so they are also fixed by this change.