### PR TITLE
fix: require subdomain boundary in isAppwriteOwned domain check

### DIFF
--- a/src/Appwrite/Platform/Modules/Proxy/Action.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Action.php
@@ -228,7 +228,7 @@ class Action extends PlatformAction
         }
 
         foreach ($appwriteDomains as $appwriteDomain) {
-            if (\str_ends_with($domain, $appwriteDomain)) {
+            if ($domain === $appwriteDomain || \str_ends_with($domain, '.' . $appwriteDomain)) {
                 return true;
             }
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `isAppwriteOwned()` method in `src/Appwrite/Platform/Modules/Proxy/Action.php` uses `\str_ends_with($domain, $appwriteDomain)` to determine if a domain is owned by Appwrite. This check is too permissive — it matches any domain whose name ends with the Appwrite domain string, even if it is not an actual subdomain.

For example, if `_APP_DOMAIN_SITES` is set to `appwrite.network`:
- `myapp.appwrite.network` → correctly matches (legitimate subdomain)
- `evil-appwrite.network` → **incorrectly matches** (completely different domain)

When `isAppwriteOwned()` returns `true`, the proxy rule creation endpoints skip DNS verification and immediately set the rule status to `RULE_STATUS_VERIFIED` with owner `'Appwrite'`. This means a domain like `evil-appwrite.network` would bypass domain verification entirely.

## What is the new behavior?

The check now requires either:
1. An **exact match** (`$domain === $appwriteDomain`), or
2. A **proper subdomain match** — the domain must end with `'.' . $appwriteDomain` (note the dot separator)

This ensures only legitimate subdomains of Appwrite-owned domains are recognized:
- `myapp.appwrite.network` → matches (ends with `.appwrite.network`)
- `evil-appwrite.network` → does **not** match (does not end with `.appwrite.network`)

## Additional context

The fix is a single-line change. The same pattern of requiring a dot boundary for subdomain matching is a well-established security practice to prevent domain confusion attacks.

## Test plan

- [ ] Create a proxy rule with a domain that is a legitimate subdomain of an Appwrite domain (e.g., `test.appwrite.network` when `_APP_DOMAIN_SITES=appwrite.network`) — should be recognized as Appwrite-owned and skip verification
- [ ] Create a proxy rule with a domain that merely ends with an Appwrite domain string but is not a subdomain (e.g., `evil-appwrite.network`) — should NOT be recognized as Appwrite-owned and should require DNS verification
- [ ] Create a proxy rule with the exact Appwrite domain (e.g., `appwrite.network`) — should be recognized as Appwrite-owned