### PR TITLE
fix: pass response to Http::execute() in GraphQL resolver

### DIFF
--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -266,7 +266,7 @@ class Resolvers
         try {
             $route = $utopia->match($request, fresh: true);
 
-            $utopia->execute($route, $request);
+            $utopia->execute($route, $request, $response);
         } catch (\Throwable $e) {
             if ($beforeReject) {
                 $e = $beforeReject($e);


### PR DESCRIPTION
## Summary
- `Http::execute()` now requires a `Response` parameter as of utopia-php/http 0.34.20
- The GraphQL resolver was only passing `route` and `request`, causing all GraphQL queries/mutations to fail with "Internal server error"
- Pass the already-available `$response` as the 3rd argument

## Test plan
- [ ] GraphQL E2E tests pass (previously 280/304 failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)