### PR TITLE
feat: increase default build timeout to 45 minutes

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -872,18 +872,18 @@ return [
             ],
             [
                 'name' => '_APP_FUNCTIONS_BUILD_TIMEOUT',
-                'description' => 'Deprecated since 1.7.0. The maximum number of seconds allowed as a timeout value when building a new function. The default value is 900 seconds.',
+                'description' => 'Deprecated since 1.7.0. The maximum number of seconds allowed as a timeout value when building a new function. The default value is 2700 seconds.',
                 'introduction' => '0.13.0',
-                'default' => '900',
+                'default' => '2700',
                 'required' => false,
                 'question' => '',
                 'filter' => ''
             ],
             [
                 'name' => '_APP_COMPUTE_BUILD_TIMEOUT',
-                'description' => 'The maximum number of seconds allowed as a timeout value when building a new function or site. The default value is 900 seconds.',
+                'description' => 'The maximum number of seconds allowed as a timeout value when building a new function or site. The default value is 2700 seconds.',
                 'introduction' => '1.7.0',
-                'default' => '900',
+                'default' => '2700',
                 'required' => false,
                 'question' => '',
                 'filter' => ''

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -22,7 +22,7 @@ class Comment
         'Every Git commit and branch gets its own deployment URL automatically',
         'Custom domains work with both CNAME for subdomains and NS records for apex domains',
         'HTTPS and SSL certificates are handled automatically for all your Sites',
-        'Functions can run for up to 45 minutes before timing out',
+        'Function builds can take up to 45 minutes before timing out',
         'Schedule functions to run as often as every minute with cron expressions',
         'Environment variables can be scoped per function or shared across your project',
         'Function scopes give you fine-grained control over API permissions',

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -22,7 +22,7 @@ class Comment
         'Every Git commit and branch gets its own deployment URL automatically',
         'Custom domains work with both CNAME for subdomains and NS records for apex domains',
         'HTTPS and SSL certificates are handled automatically for all your Sites',
-        'Functions can run for up to 15 minutes before timing out',
+        'Functions can run for up to 45 minutes before timing out',
         'Schedule functions to run as often as every minute with cron expressions',
         'Environment variables can be scoped per function or shared across your project',
         'Function scopes give you fine-grained control over API permissions',


### PR DESCRIPTION
## Summary

- Increases default `_APP_COMPUTE_BUILD_TIMEOUT` from 900s (15 min) to 2700s (45 min)
- Updates deprecated `_APP_FUNCTIONS_BUILD_TIMEOUT` default to match
- Updates VCS comment fun fact to reflect the new 45-minute limit

## Test plan

- [ ] Verify builds respect the new default timeout when `_APP_COMPUTE_BUILD_TIMEOUT` is not set
- [ ] Verify existing explicit overrides of `_APP_COMPUTE_BUILD_TIMEOUT` still take precedence

🤖 Generated with [Claude Code](https://claude.ai/claude-code)