### PR TITLE
fix: trim execution queue payload to project ID only

### DIFF
--- a/src/Appwrite/Event/Execution.php
+++ b/src/Appwrite/Event/Execution.php
@@ -53,4 +53,23 @@ class Execution extends Event
             'execution' => $this->execution,
         ];
     }
+
+    /**
+     * Trim payload for the execution event.
+     * Only the project ID is needed — the worker DI fetches the full project from the platform database.
+     *
+     * @return array
+     */
+    protected function trimPayload(): array
+    {
+        $trimmed = [];
+
+        if ($this->project) {
+            $trimmed['project'] = new Document([
+                '$id' => $this->project->getId(),
+            ]);
+        }
+
+        return $trimmed;
+    }
 }


### PR DESCRIPTION
## Summary

- The `v1-executions` queue was serialising the full project document into every message, including OAuth providers, webhooks, API keys, auth config, permissions, and more — making payloads very large
- The worker DI system (`app/init/worker/message.php`) already re-fetches the complete project from the platform database using only `project.$id`, so the full document in the message was wasted bytes
- Override `trimPayload()` in `Execution` event class to include only `$id` in the project stub, consistent with how the base `Event` class trims project data for other queue types

## Test plan

- [ ] Trigger a function/site execution and verify the `v1-executions` Redis queue message only contains `project.$id` (not the full project document)
- [ ] Verify executions are still persisted correctly to the database after the worker processes the message
- [ ] Verify the console project exclusion check (`$project->getId() != '6862e6a6000cce69f9da'`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)