### PR TITLE
Upgrade graphql-php to v15.31.5

### DIFF
--- a/app/controllers/api/graphql.php
+++ b/app/controllers/api/graphql.php
@@ -231,7 +231,7 @@ function execute(
     $validations = GraphQL::getStandardValidationRules();
 
     if (System::getEnv('_APP_GRAPHQL_INTROSPECTION', 'enabled') === 'disabled') {
-        $validations[] = new DisableIntrospection();
+        $validations[] = new DisableIntrospection(DisableIntrospection::ENABLED);
     }
 
     if (System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') !== 'disabled') {

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "chillerlan/php-qrcode": "4.3.*",
         "adhocore/jwt": "1.1.*",
         "spomky-labs/otphp": "11.*",
-        "webonyx/graphql-php": "14.11.*",
+        "webonyx/graphql-php": "^15.31.5",
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "chillerlan/php-qrcode": "4.3.*",
         "adhocore/jwt": "1.1.*",
         "spomky-labs/otphp": "11.*",
-        "webonyx/graphql-php": "^15.31.5",
+        "webonyx/graphql-php": "15.31.*",
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36dc376acce480e002a8c3d07aff7628",
+    "content-hash": "f6a87c1012b316e614258f8f57a28e48",
     "packages": [
         {
             "name": "adhocore/jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fb974e9843f6104e40396e7cad4a833",
+    "content-hash": "36dc376acce480e002a8c3d07aff7628",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5381,38 +5381,48 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v14.11.10",
+            "version": "v15.31.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
+                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/089c4ef7e112df85788cfe06596278a8f99f4aa9",
+                "reference": "089c4ef7e112df85788cfe06596278a8f99f4aa9",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.1 || ^8"
+                "php": "^7.4 || ^8"
             },
             "require-dev": {
-                "amphp/amp": "^2.3",
-                "doctrine/coding-standard": "^6.0",
-                "nyholm/psr7": "^1.2",
+                "amphp/amp": "^2.6",
+                "amphp/http-server": "^2.1",
+                "dms/phpunit-arraysubset-asserts": "dev-master",
+                "ergebnis/composer-normalize": "^2.28",
+                "friendsofphp/php-cs-fixer": "3.94.2",
+                "mll-lab/php-cs-fixer-config": "5.13.0",
+                "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.82",
-                "phpstan/phpstan-phpunit": "0.12.18",
-                "phpstan/phpstan-strict-rules": "0.12.9",
-                "phpunit/phpunit": "^7.2 || ^8.5",
-                "psr/http-message": "^1.0",
-                "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0"
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "2.1.46",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.10",
+                "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
+                "psr/http-message": "^1 || ^2",
+                "react/http": "^1.6",
+                "react/promise": "^2.0 || ^3.0",
+                "rector/rector": "^2.0",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5 || ^6 || ^7 || ^8",
+                "thecodingmachine/safe": "^1.3 || ^2 || ^3",
+                "ticketswap/phpstan-error-formatter": "1.3.0"
             },
             "suggest": {
+                "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
                 "psr/http-message": "To use standard GraphQL server",
                 "react/promise": "To leverage async resolving on React PHP platform"
             },
@@ -5434,15 +5444,19 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.10"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.31.5"
             },
             "funding": [
+                {
+                    "url": "https://github.com/spawnia",
+                    "type": "github"
+                },
                 {
                     "url": "https://opencollective.com/webonyx-graphql-php",
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-07-05T14:23:37+00:00"
+            "time": "2026-04-11T18:06:15+00:00"
         }
     ],
     "packages-dev": [
@@ -8449,5 +8463,5 @@
     "platform-dev": {
         "ext-fileinfo": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Appwrite/GraphQL/Promises/Adapter.php
+++ b/src/Appwrite/GraphQL/Promises/Adapter.php
@@ -81,8 +81,8 @@ abstract class Adapter implements PromiseAdapter
     /**
      * Create a new promise that resolves when all passed in promises resolve.
      *
-     * @param array $promisesOrValues
+     * @param iterable $promisesOrValues
      * @return GQLPromise
      */
-    abstract public function all(array $promisesOrValues): GQLPromise;
+    abstract public function all(iterable $promisesOrValues): GQLPromise;
 }

--- a/src/Appwrite/GraphQL/Promises/Adapter/Swoole.php
+++ b/src/Appwrite/GraphQL/Promises/Adapter/Swoole.php
@@ -35,8 +35,12 @@ class Swoole extends Adapter
         return new GQLPromise($promise, $this);
     }
 
-    public function all(array $promisesOrValues): GQLPromise
+    public function all(iterable $promisesOrValues): GQLPromise
     {
+        if ($promisesOrValues instanceof \Traversable) {
+            $promisesOrValues = \iterator_to_array($promisesOrValues);
+        }
+
         return new GQLPromise(SwoolePromise::all($promisesOrValues), $this);
     }
 }

--- a/src/Appwrite/GraphQL/Types/Assoc.php
+++ b/src/Appwrite/GraphQL/Types/Assoc.php
@@ -7,8 +7,8 @@ use GraphQL\Language\AST\Node;
 // https://github.com/webonyx/graphql-php/issues/129#issuecomment-309366803
 class Assoc extends Json
 {
-    public $name = 'Assoc';
-    public $description = 'The `Assoc` scalar type represents associative array values.';
+    public string $name = 'Assoc';
+    public ?string $description = 'The `Assoc` scalar type represents associative array values.';
 
     public function serialize($value)
     {

--- a/src/Appwrite/GraphQL/Types/Assoc.php
+++ b/src/Appwrite/GraphQL/Types/Assoc.php
@@ -3,6 +3,7 @@
 namespace Appwrite\GraphQL\Types;
 
 use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\StringValueNode;
 
 // https://github.com/webonyx/graphql-php/issues/129#issuecomment-309366803
 class Assoc extends Json
@@ -30,6 +31,10 @@ class Assoc extends Json
 
     public function parseLiteral(Node $valueNode, ?array $variables = null)
     {
-        return \json_decode($valueNode->value, true);
+        if ($valueNode instanceof StringValueNode) {
+            return \json_decode($valueNode->value, true);
+        }
+
+        return parent::parseLiteral($valueNode, $variables);
     }
 }

--- a/src/Appwrite/GraphQL/Types/InputFile.php
+++ b/src/Appwrite/GraphQL/Types/InputFile.php
@@ -8,8 +8,8 @@ use GraphQL\Type\Definition\ScalarType;
 
 class InputFile extends ScalarType
 {
-    public $name = 'InputFile';
-    public $description = 'The `InputFile` special type represents a file to be uploaded in the same HTTP request as specified by
+    public string $name = 'InputFile';
+    public ?string $description = 'The `InputFile` special type represents a file to be uploaded in the same HTTP request as specified by
  [graphql-multipart-request-spec](https://github.com/jaydenseric/graphql-multipart-request-spec).';
 
     public function serialize($value)

--- a/src/Appwrite/GraphQL/Types/Json.php
+++ b/src/Appwrite/GraphQL/Types/Json.php
@@ -14,8 +14,8 @@ use GraphQL\Type\Definition\ScalarType;
 // https://github.com/webonyx/graphql-php/issues/129#issuecomment-309366803
 class Json extends ScalarType
 {
-    public $name = 'Json';
-    public $description = 'The `JSON` scalar type represents JSON values as specified by
+    public string $name = 'Json';
+    public ?string $description = 'The `JSON` scalar type represents JSON values as specified by
         [ECMA-404](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).';
 
     public function serialize($value)

--- a/tests/unit/GraphQL/BuilderTest.php
+++ b/tests/unit/GraphQL/BuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\GraphQL;
 
 use Appwrite\GraphQL\Types\Mapper;
 use Appwrite\Utopia\Response;
+use GraphQL\Type\Definition\NamedType;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Response as SwooleResponse;
 
@@ -24,6 +25,7 @@ class BuilderTest extends TestCase
     {
         $model = $this->response->getModel(Response::MODEL_TABLE);
         $type = Mapper::model(\ucfirst($model->getType()));
-        $this->assertEquals('Table', $type->name);
+        $this->assertInstanceOf(NamedType::class, $type);
+        $this->assertEquals('Table', $type->name());
     }
 }


### PR DESCRIPTION
## What does this PR do?

Upgrades `webonyx/graphql-php` to `v15.31.5` to clear the new Composer audit advisory (`PKSA-7h5p-prw9-w5nr` / `GHSA-68jq-c3rv-pcrr`).

GraphQL 15 also tightens the `ScalarType` property declarations, so this updates Appwrite's custom `Json`, `Assoc`, and `InputFile` scalar types to use typed `$name` and `$description` properties.

## Test Plan

- `composer audit`
- `composer validate --no-check-publish`
- `vendor/bin/phpunit tests/unit/GraphQL/BuilderTest.php`
- `composer format src/Appwrite/GraphQL/Types/Json.php src/Appwrite/GraphQL/Types/InputFile.php src/Appwrite/GraphQL/Types/Assoc.php`

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
