### PR TITLE
fix: skip orphaned VCS repositories referencing deleted projects

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -69,7 +69,9 @@ trait Deployment
                 $project = $authorization->skip(fn () => $dbForPlatform->getDocument('projects', $projectId));
 
                 if ($project->isEmpty()) {
-                    throw new Exception(Exception::PROJECT_NOT_FOUND, 'Repository references non-existent project');
+                    Console::warning("Repository {$repositoryId} references non-existent project {$projectId}, cleaning up");
+                    $authorization->skip(fn () => $dbForPlatform->deleteDocument('repositories', $repositoryId));
+                    continue;
                 }
 
                 $this->beforeCreateGitDeployment($project, $repository, $dbForPlatform, $authorization);

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
@@ -213,7 +213,8 @@ class Create extends Action
 
             $repositories = $authorization->skip(fn () => $dbForPlatform->find('repositories', [
                 Query::equal('providerRepositoryId', [$providerRepositoryId]),
-                Query::orderDesc('$createdAt')
+                Query::limit(100),
+                Query::orderDesc('$createdAt'),
             ]));
 
             $this->createGitDeployments($github, $providerInstallationId, $repositories, $providerBranch, $providerBranchUrl, $providerRepositoryName, $providerRepositoryUrl, $providerRepositoryOwner, $providerCommitHash, $providerCommitAuthor, $providerCommitAuthorUrl, $providerCommitMessage, $providerCommitUrl, $providerPullRequestId, $external, $dbForPlatform, $authorization, $queueForBuilds, $getProjectDB, $platform);


### PR DESCRIPTION
## Summary
- Fix `PROJECT_NOT_FOUND` errors (~3.1k Sentry events) caused by GitHub webhooks processing repositories that reference deleted projects
- Instead of throwing an exception that returns HTTP 500 to GitHub (causing retries), gracefully skip and clean up orphaned repository documents
- Add missing `Query::limit(100)` to pull request event handler's repository query, matching the existing push event handler

## Changes
- **`Deployment.php`** — Replace `throw Exception(PROJECT_NOT_FOUND)` with `Console::warning()` + orphaned repository cleanup + `continue` when a repository references a non-existent project
- **`Events/Create.php`** — Add `Query::limit(100)` to `handlePullRequestEvent()` repository query to match `handlePushEvent()` and prevent unbounded results

## Test plan
- [ ] GitHub push webhook with repository linked to deleted project no longer returns 500
- [ ] GitHub PR webhook with repository linked to deleted project no longer returns 500
- [ ] Orphaned repository documents are cleaned up on first webhook encounter
- [ ] Repositories linked to valid projects continue to trigger deployments normally
- [ ] PHPStan passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)