### PR TITLE
[codex] ci: disable functional GraphQL e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,7 @@ jobs:
             # Services that rely on sequential test method execution (shared static state)
             FUNCTIONAL_FLAG="--functional"
             case "${{ matrix.service }}" in
-              Databases|TablesDB|Functions|Realtime) FUNCTIONAL_FLAG="" ;;
+              Databases|TablesDB|Functions|Realtime|GraphQL) FUNCTIONAL_FLAG="" ;;
             esac
 
             docker compose exec -T \


### PR DESCRIPTION
## Summary
Disables ParaTest `--functional` mode for the GraphQL E2E job in CI.

## Why
GraphQL E2E includes TablesDB coverage that relies on sequential test method execution and shared static setup within the test class.

With `--functional`, ParaTest splits methods from the same class across workers. On the reproducing branch from #11887, that causes concurrent TablesDB schema setup and eventually flakes like:

- `Tests\E2E\Services\GraphQL\TablesDB\DatabaseServerTest::testCreateRow`
- expected column status: `available`
- actual column status: `processing`

The same CI-style run also showed long TablesDB requests and Mongo receive timeouts once those setup flows overlapped.

## Change
Treat `GraphQL` the same as the other services that already opt out of `--functional`:

- `Databases`
- `TablesDB`
- `Functions`
- `Realtime`
- `GraphQL`

## Impact
GraphQL E2E still runs in parallel across workers, but no longer parallelizes methods inside the same class. That keeps the suite fast while avoiding the shared-state flake.

## Validation
Validated locally against the reproducing GraphQL-upgrade branch from #11887:

```bash
docker compose exec -T appwrite vendor/bin/paratest --processes 4 --functional /usr/src/code/tests/e2e/Services/GraphQL --exclude-group abuseEnabled --exclude-group screenshots
```

This reproduced GraphQL/TablesDB failures.

After removing `--functional`, the representative run passed:

```bash
docker compose exec -T appwrite sh -lc 'vendor/bin/paratest --processes 4 /usr/src/code/tests/e2e/Services/GraphQL --exclude-group abuseEnabled --exclude-group screenshots'
```

Result:

- `304` tests
- `1668` assertions
- `12` skipped
- `0` failures
