### PR TITLE
fix(graphql): prevent null return in escapePayload at max depth

### DIFF
--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -301,7 +301,7 @@ class Resolvers
     private static function escapePayload(array $payload, int $depth)
     {
         if ($depth > System::getEnv('_APP_GRAPHQL_MAX_DEPTH', 3)) {
-            return;
+            return $payload;
         }
 
         foreach ($payload as $key => $value) {

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -298,7 +298,7 @@ class Resolvers
         $resolve($payload);
     }
 
-    private static function escapePayload(array $payload, int $depth)
+    private static function escapePayload(array $payload, int $depth): array
     {
         if ($depth > System::getEnv('_APP_GRAPHQL_MAX_DEPTH', 3)) {
             return $payload;


### PR DESCRIPTION
## What does this PR do?

Fixes an issue in `escapePayload` where the function returned `null` when the recursion depth exceeded `_APP_GRAPHQL_MAX_DEPTH`.

This caused unexpected data loss and potential runtime errors in GraphQL responses, since the function is expected to always return an array.

This PR ensures the function returns the current `$payload` instead, maintaining consistent return type and preventing data loss.

## Test Plan

- Manually reviewed the `escapePayload` function
- Verified that when max depth is exceeded, the function now returns `$payload` instead of `null`
- Ensured recursive behavior remains unchanged
- Confirmed return type consistency (always array)

## Related PRs and Issues

- Fixes #11897

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?