### PR TITLE
fix: replace force-push with regular push in SDK release task

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -622,29 +622,28 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             $repo->execute('config', 'advice.defaultBranchName', 'false');
             $repo->addRemote('origin', $gitUrl);
 
-            // Fetch and checkout base branch (or create if new repo)
+            // Fetch and checkout the target branch (e.g. dev) if it exists on remote,
+            // otherwise create it from the base branch (e.g. main).
+            // We build on top of the existing remote branch so a regular push
+            // works without force-pushing against protected branches.
+            $hasBranch = false;
             try {
-                $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $repoBranch);
+                $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $gitBranch);
+                $hasBranch = true;
+            } catch (\Throwable) {
+                // Branch doesn't exist on remote yet
+            }
+
+            if ($hasBranch) {
+                $repo->execute('checkout', '-f', $gitBranch);
+            } else {
+                // Fetch base branch to create the target branch from it
                 try {
+                    $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $repoBranch);
                     $repo->execute('checkout', '-f', $repoBranch);
                 } catch (\Throwable) {
                     $repo->execute('checkout', '-b', $repoBranch);
                 }
-            } catch (\Throwable) {
-                $repo->execute('checkout', '-b', $repoBranch);
-            }
-
-            try {
-                $repo->execute('pull', 'origin', $repoBranch, '--quiet', '--no-tags');
-            } catch (\Throwable) {
-            }
-
-            // Create or checkout dev branch from the base branch
-            // This ensures dev always starts from the latest base branch,
-            // avoiding history divergence caused by squash merges.
-            try {
-                $repo->execute('checkout', '-B', $gitBranch, $repoBranch);
-            } catch (\Throwable) {
                 $repo->execute('checkout', '-b', $gitBranch);
             }
 
@@ -685,7 +684,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                 return true;
             }
 
-            $repo->execute('push', '--force-with-lease', '-u', 'origin', $gitBranch, '--quiet');
+            $repo->execute('push', '-u', 'origin', $gitBranch, '--quiet');
         } catch (\Throwable $e) {
             Console::warning("  Git push failed: " . $e->getMessage());
             return false;


### PR DESCRIPTION
## Summary

- Replaced `git push --force-with-lease` with a regular `git push` in the SDK push task
- Changed the checkout strategy to fetch and build on top of the existing remote `dev` branch instead of resetting it from `main`
- This fixes SDK pushes failing on repos with branch protection rules that disallow force pushes (e.g. `sdk-for-flutter`, `sdk-for-android`)

## What changed

Previously the task would:
1. Fetch `main`, checkout `main`
2. `checkout -B dev main` — reset `dev` to `main`'s HEAD
3. Force-push `dev`

This broke on protected branches (`GH006: Cannot force-push to this branch`).

Now the task:
1. Fetch the remote `dev` branch if it exists, checkout it
2. If `dev` doesn't exist yet, create it from `main`
3. Regular push (always fast-forward since we're committing on top)

## Test plan

- [x] Tested by successfully pushing all 5 client SDKs (web, flutter, apple, android, react-native) with this fix applied to vendor