### PR TITLE
fix(auth): resolve session alert localization for non-English locales

### DIFF
--- a/app/config/locale/terms.json
+++ b/app/config/locale/terms.json
@@ -110,6 +110,56 @@
         "reference": ""
     },
     {
+        "term": "emails.sessionAlert.subject",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.preview",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.hello",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.body",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.listDevice",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.listIpAddress",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.listCountry",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.footer",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.thanks",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
+        "term": "emails.sessionAlert.signature",
+        "comment": "These strings are used in the session alert templates.",
+        "reference": ""
+    },
+    {
         "term": "locale.country.unknown",
         "comment": "This string is used as the country name in case of a missing [ country_code => country_name ] mapping.",
         "reference": ""

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -77,7 +77,6 @@ use Utopia\Validator\WhiteList;
 $oauthDefaultSuccess = '/console/auth/oauth2/success';
 $oauthDefaultFailure = '/console/auth/oauth2/failure';
 
-
 $createSession = function (string $userId, string $secret, Request $request, Response $response, User $user, Database $dbForProject, Document $project, array $platform, Locale $locale, Reader $geodb, Event $queueForEvents, Bus $bus, Store $store, ProofsToken $proofForToken, ProofsCode $proofForCode, bool $domainVerification, ?string $cookieDomain, Authorization $authorization) {
 
     // Attempt to decode secret as a JWT (used by OAuth2 token flow to carry provider info)

--- a/src/Appwrite/Bus/Listeners/Mails.php
+++ b/src/Appwrite/Bus/Listeners/Mails.php
@@ -62,6 +62,15 @@ class Mails extends Listener
         }
 
         $locale->setDefault($event->locale);
+        $translate = static function (string $key) use ($locale): string {
+            $value = $locale->getText($key);
+
+            if (\preg_match('/^\{\{(.+)\}\}$/', $value, $matches) === 1) {
+                return $locale->getText($matches[1], $value);
+            }
+
+            return $value;
+        };
 
         $session = new Document($event->session);
         $smtp = $project->getAttribute('smtp', []);
@@ -74,19 +83,19 @@ class Mails extends Listener
         $customTemplate = $project->getAttribute('templates', [])["email.sessionAlert-$event->locale"] ?? [];
         $isBranded = $smtpBaseTemplate === APP_BRANDED_EMAIL_BASE_TEMPLATE;
 
-        $subject = $customTemplate['subject'] ?? $locale->getText('emails.sessionAlert.subject');
-        $preview = $locale->getText('emails.sessionAlert.preview');
+        $subject = $customTemplate['subject'] ?? $translate('emails.sessionAlert.subject');
+        $preview = $translate('emails.sessionAlert.preview');
 
         $body = empty($customTemplate['message'])
             ? Template::fromFile(__DIR__ . '/../../../../app/config/locale/templates/email-session-alert.tpl')
-                ->setParam('{{hello}}', $locale->getText('emails.sessionAlert.hello'))
-                ->setParam('{{body}}', $locale->getText('emails.sessionAlert.body'))
-                ->setParam('{{listDevice}}', $locale->getText('emails.sessionAlert.listDevice'))
-                ->setParam('{{listIpAddress}}', $locale->getText('emails.sessionAlert.listIpAddress'))
-                ->setParam('{{listCountry}}', $locale->getText('emails.sessionAlert.listCountry'))
-                ->setParam('{{footer}}', $locale->getText('emails.sessionAlert.footer'))
-                ->setParam('{{thanks}}', $locale->getText('emails.sessionAlert.thanks'))
-                ->setParam('{{signature}}', $locale->getText('emails.sessionAlert.signature'))
+                ->setParam('{{hello}}', $translate('emails.sessionAlert.hello'))
+                ->setParam('{{body}}', $translate('emails.sessionAlert.body'))
+                ->setParam('{{listDevice}}', $translate('emails.sessionAlert.listDevice'))
+                ->setParam('{{listIpAddress}}', $translate('emails.sessionAlert.listIpAddress'))
+                ->setParam('{{listCountry}}', $translate('emails.sessionAlert.listCountry'))
+                ->setParam('{{footer}}', $translate('emails.sessionAlert.footer'))
+                ->setParam('{{thanks}}', $translate('emails.sessionAlert.thanks'))
+                ->setParam('{{signature}}', $translate('emails.sessionAlert.signature'))
                 ->render()
             : $customTemplate['message'];
 

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -2159,6 +2159,67 @@ class AccountCustomClientTest extends Scope
         $this->assertEquals($lastEmailId, $lastEmail['id']);
     }
 
+    public function testSessionAlertWithLocaleHeader(): void
+    {
+        $email = uniqid() . 'session-alert-locale@appwrite.io';
+        $password = 'password123';
+
+        $response = $this->client->call(Client::METHOD_PATCH, '/projects/' . $this->getProject()['$id'] . '/auth/session-alerts', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => 'console',
+            'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+        ]), [
+            'alerts' => true,
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/account', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-dev-key' => $this->getProject()['devKey'] ?? '',
+        ]), [
+            'userId' => ID::unique(),
+            'email' => $email,
+            'password' => $password,
+            'name' => 'Locale Session Alert Tester',
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $headers = [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-locale' => 'es',
+            'user-agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+        ];
+
+        $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', $headers, [
+            'email' => $email,
+            'password' => $password,
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', $headers, [
+            'email' => $email,
+            'password' => $password,
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $lastEmail = $this->getLastEmailByAddress($email);
+
+        $this->assertNotEmpty($lastEmail, 'Email not found for address: ' . $email);
+        $this->assertStringNotContainsString('{{emails.sessionAlert.', $lastEmail['subject']);
+        $this->assertStringNotContainsString('{{emails.sessionAlert.', $lastEmail['text']);
+        $this->assertStringContainsString($response['body']['ip'], $lastEmail['text']);
+        $this->assertStringContainsString($response['body']['clientName'], $lastEmail['text']);
+    }
+
     public function testCreateOAuth2AccountSession(): void
     {
         // Just ensure we have a session set up


### PR DESCRIPTION
## Problem
Session alert emails render raw `{{emails.sessionAlert.*}}` placeholders when a non-English locale is used.

## Solution
- Added missing localization terms for session alert templates.
- Implemented translation normalization in `sendSessionAlert()`.
- Ensured fallback handling for unresolved placeholders.
- Added an end-to-end regression test using the `X-Appwrite-Locale` header.

## Testing
- Ran `docker compose exec appwrite test tests/e2e/Services/Account --filter=testSessionAlertWithLocaleHeader`.

Fixes #8659