### PR TITLE
fix: add missing deployment ownership check in duplicate endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -87,6 +87,10 @@ class Create extends Action
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
+        if ($deployment->getAttribute('resourceId') !== $function->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
         $path = $deployment->getAttribute('sourcePath');
         if (empty($path) || !$deviceForFunctions->exists($path)) {
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);


### PR DESCRIPTION
## Summary

The `createDuplicateDeployment` endpoint (`POST /v1/functions/:functionId/deployments/duplicate` with aliases for the build path) fetches a deployment by ID without verifying it belongs to the function in the URL. A caller with write access to one function could pass another function's `deploymentId` and the endpoint would duplicate the other function's source, attach the copy to the attacker's function, and kick off a build. The sibling `Get`, `Delete`, and `Download/Get` endpoints already guard this with `$deployment->getAttribute('resourceId') !== $function->getId()`; the duplicate endpoint was the one outlier.

This PR adds the same check after the `isEmpty` guard, returning `DEPLOYMENT_NOT_FOUND` to match sibling behavior and avoid leaking whether the foreign deployment ID exists.

File changed: `src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php`

## Test plan

- [ ] `docker compose exec appwrite test tests/e2e/Services/Functions --filter=FunctionsCustomServerTest` passes
- [ ] Manual: create two functions A and B under the same project, upload a deployment to A, call the duplicate endpoint with `functionId=B` and `deploymentId=<A's deployment>`, verify it now returns `404 DEPLOYMENT_NOT_FOUND` instead of duplicating A's source into B
- [ ] Regression: duplicating a deployment with the correct `functionId` still succeeds