### PR TITLE
fix: add missing installation ownership check in VCS delete endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Delete.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Delete.php
@@ -11,6 +11,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Validator\Text;
 
@@ -48,6 +49,7 @@ class Delete extends Action
             ))
             ->param('installationId', '', new Text(256), 'Installation Id')
             ->inject('response')
+            ->inject('project')
             ->inject('dbForPlatform')
             ->inject('queueForDeletes')
             ->callback($this->action(...));
@@ -56,12 +58,17 @@ class Delete extends Action
     public function action(
         string $installationId,
         Response $response,
+        Document $project,
         Database $dbForPlatform,
         DeleteEvent $queueForDeletes
     ) {
         $installation = $dbForPlatform->getDocument('installations', $installationId);
 
         if ($installation->isEmpty()) {
+            throw new Exception(Exception::INSTALLATION_NOT_FOUND);
+        }
+
+        if ($installation->getAttribute('projectInternalId') !== $project->getSequence()) {
             throw new Exception(Exception::INSTALLATION_NOT_FOUND);
         }
 


### PR DESCRIPTION
## Summary

- Added missing project scoping check to `DELETE /v1/vcs/installations/:installationId`
- The delete endpoint previously only verified that the installation document existed; it did not verify that the installation belonged to the current project
- The corresponding `GET /v1/vcs/installations/:installationId` endpoint already performs this check (`$installation->getAttribute('projectInternalId') !== $project->getSequence()`), and the `listInstallations` endpoint scopes its query by `projectInternalId` — so this was an oversight in the delete endpoint
- Without this check, a caller with admin credentials in project A could delete an installation belonging to project B by passing its installation ID, breaking tenant isolation for VCS installations

## Test plan

- [ ] Verify that deleting an installation that belongs to the current project returns `204 No Content` as before
- [ ] Verify that attempting to delete an installation ID that belongs to a different project returns a 404 (`INSTALLATION_NOT_FOUND`) instead of succeeding
- [ ] Verify that the installation document in the other project is not deleted in the unauthorized case
- [ ] Verify `getInstallation` and `listInstallations` behavior is unchanged