### PR TITLE
fix(auth): correct PasswordDictionary description text

### DIFF
--- a/src/Appwrite/Auth/Validator/PasswordDictionary.php
+++ b/src/Appwrite/Auth/Validator/PasswordDictionary.php
@@ -28,7 +28,7 @@ class PasswordDictionary extends Password
      */
     public function getDescription(): string
     {
-        return 'Password must be between 8 and 265 characters long, and should not be one of the commonly used password.';
+        return 'Password must be between 8 and 256 characters long, and should not be one of the commonly used passwords.';
     }
 
     /**


### PR DESCRIPTION
## Summary

`PasswordDictionary::getDescription()` returns a message that is shown to API clients when password validation fails. The current text has two small problems:

- It reports the maximum length as **265 characters**, but the actual limit enforced by the parent `Password::isValid()` is **256 characters**. The unit test in `tests/unit/Auth/Validator/PasswordDictionaryTest.php` confirms the real limit by asserting that a 256-character password is accepted while a 257-character password is rejected.
- The sentence ends with `"one of the commonly used password"` (singular), which is ungrammatical; it should be `"passwords"` (plural) to agree with `"one of the"`.

### Before

```
Password must be between 8 and 265 characters long, and should not be one of the commonly used password.
```

### After

```
Password must be between 8 and 256 characters long, and should not be one of the commonly used passwords.
```

No behaviour changes — this only fixes user-facing copy in the description method.

## Test plan

- [x] Grepped the codebase for other occurrences of the `"265 characters"` string to ensure nothing else depends on the previous wording. Only this one file contained it.
- [x] Confirmed via `tests/unit/Auth/Validator/PasswordDictionaryTest.php::testValues()` that the enforced limit is 256, not 265.
- [x] No logic changes; the returned string is only read by callers that surface validation errors.