### PR TITLE
fix: add missing deployment ownership checks in Sites endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -95,6 +95,10 @@ class Create extends Action
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
+        if ($deployment->getAttribute('resourceId') !== $site->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
         $path = $deployment->getAttribute('sourcePath');
         if (empty($path) || !$deviceForSites->exists($path)) {
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -85,6 +85,10 @@ class Update extends Base
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
+        if ($deployment->getAttribute('resourceId') !== $site->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
         if ($deployment->getAttribute('status') !== 'ready') {
             throw new Exception(Exception::BUILD_NOT_READY);
         }


### PR DESCRIPTION
## Summary

Two Sites deployment endpoints fetched a deployment by ID without verifying it belonged to the site referenced in the URL path:

- `PATCH /v1/sites/:siteId/deployment` (`updateSiteDeployment`) in `src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php`
- `POST /v1/sites/:siteId/deployments/duplicate` (`createDuplicateDeployment`) in `src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php`

Because only `isEmpty()` was checked, a caller with `sites.write` access to *any* site could pass a `deploymentId` belonging to a *different* site. For `updateSiteDeployment` this activates the foreign deployment on the caller's site (updating `deploymentId`, screenshots, and propagating the change into the matching platform `rules` documents). For `createDuplicateDeployment` it transfers the foreign deployment's source bundle into a brand-new deployment attached to the caller's site and kicks off a build.

Sibling endpoints (`Sites/Http/Deployments/Get.php`, `Delete.php`, `Download/Get.php`) already reject this with `DEPLOYMENT_NOT_FOUND` when `$deployment->getAttribute('resourceId') !== $site->getId()`. This PR adds the same guard to the two endpoints that were missing it.

The check is placed directly after the `isEmpty()` check so the error is raised before any mutation (document update, rule rewrite, file transfer, or build queue).

## Test plan

- [ ] `PATCH /v1/sites/:siteA/deployment` with a `deploymentId` that belongs to site B now responds `404 deployment_not_found` instead of silently switching site A's active deployment.
- [ ] `POST /v1/sites/:siteA/deployments/duplicate` with a `deploymentId` that belongs to site B now responds `404 deployment_not_found` and does not create a new deployment or transfer the source bundle.
- [ ] Both endpoints continue to work unchanged when `deploymentId` belongs to the site referenced in the URL.
- [ ] Existing E2E tests under `tests/e2e/Services/Sites` pass.