### PR TITLE
fix: return fresh devKey document from update endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Projects/Http/DevKeys/Update.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/DevKeys/Update.php
@@ -70,11 +70,7 @@ class Update extends Action
             throw new Exception(Exception::KEY_NOT_FOUND);
         }
 
-        $key
-            ->setAttribute('name', $name)
-            ->setAttribute('expire', $expire);
-
-        $dbForPlatform->updateDocument('devKeys', $key->getId(), new Document(['name' => $name, 'expire' => $expire]));
+        $key = $dbForPlatform->updateDocument('devKeys', $key->getId(), new Document(['name' => $name, 'expire' => $expire]));
 
         $dbForPlatform->purgeCachedDocument('projects', $project->getId());
 


### PR DESCRIPTION
## Summary

`PUT /v1/projects/:projectId/dev-keys/:keyId` (`Projects/Http/DevKeys/Update.php`) currently mutates the in-memory `$key` via `setAttribute('name')`/`setAttribute('expire')` **and** issues a sparse `updateDocument()`, but does not capture the updated document that `updateDocument()` returns. The response is then rendered from the pre-update `$key`, so the client receives a stale `$updatedAt` (and any other server-maintained fields like internal sequences would be out of date as well).

This assigns the `updateDocument()` return back to `$key` and drops the now-redundant `setAttribute` chain, matching the pattern already used by `Project/Http/Project/Keys/Update.php`, every `Project/Http/Project/Platforms/*/Update.php`, and the cloud/account variants that were aligned during #11465.

### Before
```php
$key
    ->setAttribute('name', $name)
    ->setAttribute('expire', $expire);

$dbForPlatform->updateDocument('devKeys', $key->getId(), new Document(['name' => $name, 'expire' => $expire]));
```

### After
```php
$key = $dbForPlatform->updateDocument('devKeys', $key->getId(), new Document(['name' => $name, 'expire' => $expire]));
```

## Test plan

- [ ] `PUT /v1/projects/:projectId/dev-keys/:keyId` returns a `$updatedAt` that reflects the write (no longer equal to `$createdAt` / last value from `getDocument`).
- [ ] Response `name` and `expire` still reflect the request payload.
- [ ] `$dbForPlatform->purgeCachedDocument('projects', $project->getId())` is still called after the update.