### PR TITLE
Remove /status from project endpoint paths; upgrade to platform 0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "utopia-php/logger": "0.6.*",
         "utopia-php/messaging": "0.22.*",
         "utopia-php/migration": "1.9.*",
-        "utopia-php/platform": "0.12.*",
+        "utopia-php/platform": "0.13.*",
         "utopia-php/pools": "1.*",
         "utopia-php/span": "1.1.*",
         "utopia-php/preloader": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6a87c1012b316e614258f8f57a28e48",
+    "content-hash": "c5ae97637fd0ec0a950044d1c33677ea",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4642,16 +4642,16 @@
         },
         {
             "name": "utopia-php/platform",
-            "version": "0.12.1",
+            "version": "0.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/platform.git",
-                "reference": "2a6b88168b3a99d4d7d3b37d927f2cb91da5e0fc"
+                "reference": "d23af5349a7ea9ee11f9920a13626226f985522e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/platform/zipball/2a6b88168b3a99d4d7d3b37d927f2cb91da5e0fc",
-                "reference": "2a6b88168b3a99d4d7d3b37d927f2cb91da5e0fc",
+                "url": "https://api.github.com/repos/utopia-php/platform/zipball/d23af5349a7ea9ee11f9920a13626226f985522e",
+                "reference": "d23af5349a7ea9ee11f9920a13626226f985522e",
                 "shasum": ""
             },
             "require": {
@@ -4687,9 +4687,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/platform/issues",
-                "source": "https://github.com/utopia-php/platform/tree/0.12.1"
+                "source": "https://github.com/utopia-php/platform/tree/0.13.0"
             },
-            "time": "2026-04-08T04:11:31+00:00"
+            "time": "2026-04-17T09:57:18+00:00"
         },
         {
             "name": "utopia-php/pools",

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Download/Get.php
@@ -31,7 +31,7 @@ class Get extends Action
         $this
             ->setHttpMethod(Action::HTTP_REQUEST_METHOD_GET)
             ->setHttpPath('/v1/functions/:functionId/deployments/:deploymentId/download')
-            ->httpAlias('/v1/functions/:functionId/deployments/:deploymentId/build/download', ['type' => 'output'])
+            ->httpAlias('/v1/functions/:functionId/deployments/:deploymentId/build/download')
             ->groups(['api', 'functions'])
             ->desc('Get deployment download')
             ->label('scope', 'functions.read')

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appwrite\Platform\Modules\Project\Http\Project\Services\Status;
+namespace Appwrite\Platform\Modules\Project\Http\Project\Protocols;
 
 use Appwrite\Event\Event;
 use Appwrite\Platform\Action;
@@ -22,27 +22,28 @@ class Update extends Action
 
     public static function getName()
     {
-        return 'updateProjectServiceStatus';
+        return 'updateProjectProtocol';
     }
 
     public function __construct()
     {
         $this
             ->setHttpMethod(Action::HTTP_REQUEST_METHOD_PATCH)
-            ->setHttpPath('/v1/project/services/:serviceId/status')
-            ->httpAlias('/v1/projects/:projectId/service')
-            ->desc('Update project service status')
+            ->setHttpPath('/v1/project/protocols/:protocolId')
+            ->httpAlias('/v1/project/protocols/:protocolId/status')
+            ->httpAlias('/v1/projects/:projectId/api')
+            ->desc('Update project protocol')
             ->groups(['api', 'project'])
             ->label('scope', 'project.write')
-            ->label('event', 'services.[serviceId].update')
-            ->label('audits.event', 'project.services.[serviceId].update')
-            ->label('audits.resource', 'project.services/{response.$id}')
+            ->label('event', 'protocols.[protocolId].update')
+            ->label('audits.event', 'project.protocols.[protocolId].update')
+            ->label('audits.resource', 'project.protocols/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,
-                name: 'updateServiceStatus',
+                name: 'updateProtocol',
                 description: <<<EOT
-                Update the status of a specific service. Use this endpoint to enable or disable a service in your project. 
+                Update properties of a specific protocol. Use this endpoint to enable or disable a protocol in your project. 
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
@@ -52,8 +53,8 @@ class Update extends Action
                     )
                 ],
             ))
-            ->param('serviceId', '', new WhiteList(array_keys(array_filter(Config::getParam('services'), fn ($element) => $element['optional'])), true), 'Service name. Can be one of: '.\implode(', ', array_keys(array_filter(Config::getParam('services'), fn ($element) => $element['optional']))))
-            ->param('enabled', null, new Boolean(), 'Service status.')
+            ->param('protocolId', '', new WhiteList(array_keys(Config::getParam('protocols')), true), 'Protocol name. Can be one of: ' . \implode(', ', array_keys(Config::getParam('protocols'))))
+            ->param('enabled', null, new Boolean(), 'Protocol status.')
             ->inject('response')
             ->inject('dbForPlatform')
             ->inject('project')
@@ -63,22 +64,22 @@ class Update extends Action
     }
 
     public function action(
-        string $serviceId,
+        string $protocolId,
         bool $enabled,
         Response $response,
         Database $dbForPlatform,
         Document $project,
         Authorization $authorization,
-        Event $queueForEvents
+        Event $queueForEvents,
     ): void {
-        $services = $project->getAttribute('services', []);
-        $services[$serviceId] = $enabled;
+        $protocols = $project->getAttribute('apis', []);
+        $protocols[$protocolId] = $enabled;
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-            'services' => $services,
+            'apis' => $protocols,
         ])));
 
-        $queueForEvents->setParam('serviceId', $serviceId);
+        $queueForEvents->setParam('protocolId', $protocolId);
 
         $response->dynamic($project, Response::MODEL_PROJECT);
     }

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Appwrite\Platform\Modules\Project\Http\Project\Protocols\Status;
+namespace Appwrite\Platform\Modules\Project\Http\Project\Services;
 
 use Appwrite\Event\Event;
 use Appwrite\Platform\Action;
@@ -22,27 +22,28 @@ class Update extends Action
 
     public static function getName()
     {
-        return 'updateProjectProtocolStatus';
+        return 'updateProjectService';
     }
 
     public function __construct()
     {
         $this
             ->setHttpMethod(Action::HTTP_REQUEST_METHOD_PATCH)
-            ->setHttpPath('/v1/project/protocols/:protocolId/status')
-            ->httpAlias('/v1/projects/:projectId/api')
-            ->desc('Update project protocol status')
+            ->setHttpPath('/v1/project/services/:serviceId')
+            ->httpAlias('/v1/project/services/:serviceId/status')
+            ->httpAlias('/v1/projects/:projectId/service')
+            ->desc('Update project service')
             ->groups(['api', 'project'])
             ->label('scope', 'project.write')
-            ->label('event', 'protocols.[protocolId].update')
-            ->label('audits.event', 'project.protocols.[protocolId].update')
-            ->label('audits.resource', 'project.protocols/{response.$id}')
+            ->label('event', 'services.[serviceId].update')
+            ->label('audits.event', 'project.services.[serviceId].update')
+            ->label('audits.resource', 'project.services/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,
-                name: 'updateProtocolStatus',
+                name: 'updateService',
                 description: <<<EOT
-                Update the status of a specific protocol. Use this endpoint to enable or disable a protocol in your project. 
+                Update properties of a specific service. Use this endpoint to enable or disable a service in your project. 
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
@@ -52,8 +53,8 @@ class Update extends Action
                     )
                 ],
             ))
-            ->param('protocolId', '', new WhiteList(array_keys(Config::getParam('protocols')), true), 'Protocol name. Can be one of: ' . \implode(', ', array_keys(Config::getParam('protocols'))))
-            ->param('enabled', null, new Boolean(), 'Protocol status.')
+            ->param('serviceId', '', new WhiteList(array_keys(array_filter(Config::getParam('services'), fn ($element) => $element['optional'])), true), 'Service name. Can be one of: '.\implode(', ', array_keys(array_filter(Config::getParam('services'), fn ($element) => $element['optional']))))
+            ->param('enabled', null, new Boolean(), 'Service status.')
             ->inject('response')
             ->inject('dbForPlatform')
             ->inject('project')
@@ -63,22 +64,22 @@ class Update extends Action
     }
 
     public function action(
-        string $protocolId,
+        string $serviceId,
         bool $enabled,
         Response $response,
         Database $dbForPlatform,
         Document $project,
         Authorization $authorization,
-        Event $queueForEvents,
+        Event $queueForEvents
     ): void {
-        $protocols = $project->getAttribute('apis', []);
-        $protocols[$protocolId] = $enabled;
+        $services = $project->getAttribute('services', []);
+        $services[$serviceId] = $enabled;
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-            'apis' => $protocols,
+            'services' => $services,
         ])));
 
-        $queueForEvents->setParam('protocolId', $protocolId);
+        $queueForEvents->setParam('serviceId', $serviceId);
 
         $response->dynamic($project, Response::MODEL_PROJECT);
     }

--- a/src/Appwrite/Platform/Modules/Project/Services/Http.php
+++ b/src/Appwrite/Platform/Modules/Project/Services/Http.php
@@ -22,8 +22,8 @@ use Appwrite\Platform\Modules\Project\Http\Project\Platforms\Web\Update as Updat
 use Appwrite\Platform\Modules\Project\Http\Project\Platforms\Windows\Create as CreateWindowsPlatform;
 use Appwrite\Platform\Modules\Project\Http\Project\Platforms\Windows\Update as UpdateWindowsPlatform;
 use Appwrite\Platform\Modules\Project\Http\Project\Platforms\XList as ListPlatforms;
-use Appwrite\Platform\Modules\Project\Http\Project\Protocols\Status\Update as UpdateProjectProtocolStatus;
-use Appwrite\Platform\Modules\Project\Http\Project\Services\Status\Update as UpdateProjectServiceStatus;
+use Appwrite\Platform\Modules\Project\Http\Project\Protocols\Update as UpdateProjectProtocol;
+use Appwrite\Platform\Modules\Project\Http\Project\Services\Update as UpdateProjectService;
 use Appwrite\Platform\Modules\Project\Http\Project\Variables\Create as CreateVariable;
 use Appwrite\Platform\Modules\Project\Http\Project\Variables\Delete as DeleteVariable;
 use Appwrite\Platform\Modules\Project\Http\Project\Variables\Get as GetVariable;
@@ -42,8 +42,8 @@ class Http extends Service
 
         // Project
         $this->addAction(UpdateProjectLabels::getName(), new UpdateProjectLabels());
-        $this->addAction(UpdateProjectProtocolStatus::getName(), new UpdateProjectProtocolStatus());
-        $this->addAction(UpdateProjectServiceStatus::getName(), new UpdateProjectServiceStatus());
+        $this->addAction(UpdateProjectProtocol::getName(), new UpdateProjectProtocol());
+        $this->addAction(UpdateProjectService::getName(), new UpdateProjectService());
 
         // Variables
         $this->addAction(CreateVariable::getName(), new CreateVariable());

--- a/src/Appwrite/Utopia/Request/Filters/V19.php
+++ b/src/Appwrite/Utopia/Request/Filters/V19.php
@@ -35,6 +35,13 @@ class V19 extends Filter
             case 'functions.updateVariable':
                 $content['secret'] = false;
                 break;
+            case 'functions.getDeploymentDownload':
+                // Pre-1.7.0 clients call the legacy alias
+                // `/v1/functions/:functionId/deployments/:deploymentId/build/download`,
+                // which always downloaded the build output. The merged 1.7.0 endpoint
+                // requires an explicit `type` param, so force it to `output` here.
+                $content['type'] = 'output';
+                break;
         }
         return $content;
     }

--- a/src/Appwrite/Utopia/Request/Filters/V22.php
+++ b/src/Appwrite/Utopia/Request/Filters/V22.php
@@ -73,10 +73,10 @@ class V22 extends Filter
     public function parse(array $content, string $model): array
     {
         switch ($model) {
-            case 'project.updateServiceStatus':
+            case 'project.updateService':
                 $content = $this->parseUpdateServiceStatus($content);
                 break;
-            case 'project.updateProtocolStatus':
+            case 'project.updateProtocol':
                 $content = $this->parseUpdateProtocolStatus($content);
                 break;
             case 'project.createKey':

--- a/tests/e2e/Services/Project/ProtocolsBase.php
+++ b/tests/e2e/Services/Project/ProtocolsBase.php
@@ -241,6 +241,33 @@ trait ProtocolsBase
         $this->assertSame(404, $response['headers']['status-code']);
     }
 
+    // Backwards compatibility
+
+    public function testUpdateProtocolLegacyStatusPath(): void
+    {
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+
+        // Disable via the legacy `/status` alias
+        $response = $this->client->call(Client::METHOD_PATCH, '/project/protocols/rest/status', $headers, [
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertNotEmpty($response['body']['$id']);
+        $this->assertSame(false, $response['body']['protocolStatusForRest']);
+
+        // Re-enable via the legacy `/status` alias
+        $response = $this->client->call(Client::METHOD_PATCH, '/project/protocols/rest/status', $headers, [
+            'enabled' => true,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(true, $response['body']['protocolStatusForRest']);
+    }
+
     // Helpers
 
     protected function updateProtocolStatus(string $protocolId, bool $enabled, bool $authenticated = true): mixed
@@ -254,7 +281,7 @@ trait ProtocolsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PATCH, '/project/protocols/' . $protocolId . '/status', $headers, [
+        return $this->client->call(Client::METHOD_PATCH, '/project/protocols/' . $protocolId, $headers, [
             'enabled' => $enabled,
         ]);
     }

--- a/tests/e2e/Services/Project/ServicesBase.php
+++ b/tests/e2e/Services/Project/ServicesBase.php
@@ -239,6 +239,33 @@ trait ServicesBase
         $this->assertSame(404, $response['headers']['status-code']);
     }
 
+    // Backwards compatibility
+
+    public function testUpdateServiceLegacyStatusPath(): void
+    {
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+
+        // Disable via the legacy `/status` alias
+        $response = $this->client->call(Client::METHOD_PATCH, '/project/services/teams/status', $headers, [
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertNotEmpty($response['body']['$id']);
+        $this->assertSame(false, $response['body']['serviceStatusForTeams']);
+
+        // Re-enable via the legacy `/status` alias
+        $response = $this->client->call(Client::METHOD_PATCH, '/project/services/teams/status', $headers, [
+            'enabled' => true,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(true, $response['body']['serviceStatusForTeams']);
+    }
+
     // Helpers
 
     protected function updateServiceStatus(string $serviceId, bool $enabled, bool $authenticated = true): mixed
@@ -252,7 +279,7 @@ trait ServicesBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PATCH, '/project/services/' . $serviceId . '/status', $headers, [
+        return $this->client->call(Client::METHOD_PATCH, '/project/services/' . $serviceId, $headers, [
             'enabled' => $enabled,
         ]);
     }


### PR DESCRIPTION
## Summary

- Upgrade utopia-php/platform from 0.12.* to 0.13.*
- Consolidate protocol and service update endpoints by removing `/status` segment from URLs:
  - `/v1/project/protocols/:protocolId/status` → `/v1/project/protocols/:protocolId`
  - `/v1/project/services/:serviceId/status` → `/v1/project/services/:serviceId`
- Register old `/status` paths as backwards-compatible aliases via `httpAlias()`
- Rename action methods: `updateProjectProtocolStatus` → `updateProjectProtocol`, `updateProjectServiceStatus` → `updateProjectService`
- Reorganize file structure: move `Status/Update.php` files up one directory level
- Fix deployment download alias to use new platform API (removed `type` parameter from alias, handled via V19 filter instead)
- Add V19 request filter to inject `type=output` for legacy clients calling build/download alias

## Testing

- Run unit and E2E tests for Project module: `docker compose exec appwrite test tests/e2e/Services/Project`
- Verify new endpoint paths work: `PATCH /v1/project/protocols/:protocolId` and `PATCH /v1/project/services/:serviceId`
- Verify backwards compatibility tests pass: `testUpdateProtocolLegacyStatusPath` and `testUpdateServiceLegacyStatusPath`
- Verify legacy `/status` aliases still work for existing clients
- Test deployment download with legacy path to confirm V19 filter injects `type=output` correctly