### PR TITLE
fix(api): support shorthand query syntax in REST

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -25,7 +25,6 @@ use Appwrite\Utopia\Database\Validator\Queries\Identities;
 use Appwrite\Utopia\Database\Validator\Queries\Memberships;
 use Appwrite\Utopia\Database\Validator\Queries\Targets;
 use Appwrite\Utopia\Database\Validator\Queries\Users;
-use Appwrite\Utopia\Request\Filters\V17;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use MaxMind\Db\Reader;
@@ -255,32 +254,6 @@ function createUser(Hash $hash, string $userId, ?string $email, ?string $passwor
     }
 
     return $user;
-}
-
-/**
- * Normalize shorthand query strings like limit(1) to JSON query format.
- *
- * @param array<mixed> $queries
- * @return array<mixed>
- */
-function normalizeLegacyShorthandQueries(array $queries): array
-{
-    $filter = new V17();
-
-    foreach ($queries as $index => $query) {
-        if (!\is_string($query)) {
-            continue;
-        }
-
-        try {
-            $parsed = $filter->parseQuery($query);
-            $queries[$index] = \json_encode(\array_filter($parsed->toArray()));
-        } catch (\Throwable) {
-            // Keep existing query values untouched when shorthand parsing fails.
-        }
-    }
-
-    return $queries;
 }
 
 Http::post('/v1/users')
@@ -730,7 +703,6 @@ Http::get('/v1/users')
     ->action(function (array $queries, string $search, bool $includeTotal, Response $response, Database $dbForProject) {
 
         try {
-            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -956,7 +928,6 @@ Http::get('/v1/users/:userId/memberships')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
         try {
-            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -1014,7 +985,6 @@ Http::get('/v1/users/:userId/logs')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
         try {
-            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -1100,7 +1070,6 @@ Http::get('/v1/users/:userId/targets')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
         try {
-            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -1159,7 +1128,6 @@ Http::get('/v1/users/identities')
     ->action(function (array $queries, string $search, bool $includeTotal, Response $response, Database $dbForProject) {
 
         try {
-            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -25,6 +25,7 @@ use Appwrite\Utopia\Database\Validator\Queries\Identities;
 use Appwrite\Utopia\Database\Validator\Queries\Memberships;
 use Appwrite\Utopia\Database\Validator\Queries\Targets;
 use Appwrite\Utopia\Database\Validator\Queries\Users;
+use Appwrite\Utopia\Request\Filters\V17;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use MaxMind\Db\Reader;
@@ -254,6 +255,32 @@ function createUser(Hash $hash, string $userId, ?string $email, ?string $passwor
     }
 
     return $user;
+}
+
+/**
+ * Normalize shorthand query strings like limit(1) to JSON query format.
+ *
+ * @param array<mixed> $queries
+ * @return array<mixed>
+ */
+function normalizeLegacyShorthandQueries(array $queries): array
+{
+    $filter = new V17();
+
+    foreach ($queries as $index => $query) {
+        if (!\is_string($query)) {
+            continue;
+        }
+
+        try {
+            $parsed = $filter->parseQuery($query);
+            $queries[$index] = \json_encode(\array_filter($parsed->toArray()));
+        } catch (\Throwable) {
+            // Keep existing query values untouched when shorthand parsing fails.
+        }
+    }
+
+    return $queries;
 }
 
 Http::post('/v1/users')
@@ -703,6 +730,7 @@ Http::get('/v1/users')
     ->action(function (array $queries, string $search, bool $includeTotal, Response $response, Database $dbForProject) {
 
         try {
+            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -928,6 +956,7 @@ Http::get('/v1/users/:userId/memberships')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
         try {
+            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -985,6 +1014,7 @@ Http::get('/v1/users/:userId/logs')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
         try {
+            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -1070,6 +1100,7 @@ Http::get('/v1/users/:userId/targets')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
         try {
+            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
@@ -1128,6 +1159,7 @@ Http::get('/v1/users/identities')
     ->action(function (array $queries, string $search, bool $includeTotal, Response $response, Database $dbForProject) {
 
         try {
+            $queries = normalizeLegacyShorthandQueries($queries);
             $queries = Query::parseQueries($queries);
         } catch (QueryException $e) {
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());

--- a/src/Appwrite/Utopia/Request/Filters/V17.php
+++ b/src/Appwrite/Utopia/Request/Filters/V17.php
@@ -67,6 +67,36 @@ class V17 extends Filter
         $parsed = [];
         foreach ($content['queries'] as $query) {
             try {
+                if (is_string($query)) {
+                    $query = trim($query);
+
+                    if (preg_match('/^(\w+)\(([^)]*)\)$/', $query, $matches)) {
+                        $method = $matches[1];
+
+                        // Handle empty values safely
+                        $values = $matches[2] === ''
+                            ? []
+                            : array_map('trim', explode(',', $matches[2]));
+
+                        // Convert numeric values properly
+                        $values = array_map(function ($value) {
+                        if (is_numeric($value)) return (int)$value;
+
+                        if (is_string($value)) {
+                           $lower = strtolower($value);
+                           if ($lower === 'true') return true;
+                           if ($lower === 'false') return false;
+                           }
+                           return $value;
+                        }, $values);
+
+                        $query = [
+                            'method' => $method,
+                            'values' => $values
+                        ];
+                    }
+                }
+
                 $query = $this->parseQuery($query);
                 $parsed[] = \json_encode(\array_filter($query->toArray()));
             } catch (\Throwable $th) {


### PR DESCRIPTION
## What does this PR do?

This PR fixes an inconsistency in the Appwrite REST API where shorthand query syntax (e.g. `limit(1)`) results in a syntax error.

<img width="1917" height="835" alt="Screenshot 2026-04-17 135324" src="https://github.com/user-attachments/assets/87e94f16-db0f-4b4a-875c-5260fd6a5a4d" />
Currently, REST requests like:
GET /v1/users?queries[]=limit(1)

return:
"Invalid query: Syntax error"

However, the equivalent JSON query format works correctly:
queries[]={"method":"limit","values":[1]}

This PR adds preprocessing logic in `V17.php` to detect and convert shorthand query strings into the structured format expected by the backend parser.

This aligns REST API behavior with SDK shorthand query support and improves developer experience.

## Test Plan
### Reproduction

Send the following request:

GET /v1/users?queries[]=limit(1)

Response:
400 Bad Request → "Invalid queries param: Invalid query: Syntax error"

This shows that shorthand query syntax is not handled correctly.

---

### Verification

- Added preprocessing logic in `V17.php` to parse shorthand queries like `limit(1)`
- Extracted method and values using regex:
  - `limit(1)` → `{ method: "limit", values: [1] }`
- Converted values to correct types (int, boolean)
- Passed structured query to existing `parseQuery()` method

This ensures compatibility with existing query handling while enabling shorthand syntax support.

---
### Note

Full API-level testing could not be completed due to local environment issues. The change has been validated at the request parsing level.


## Related PRs and Issues

-Fixes #11857

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
