### PR TITLE
feat: use buildTimeout from message payload in build worker

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -596,8 +596,7 @@ class Builds extends Action
             $memory = max($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT, $minMemory);
             $timeout = $buildTimeout;
 
-            $jwtExpiry = $timeout;
-            $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $jwtExpiry, 0);
+            $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $timeout, 0);
 
             $apiKey = $jwtObj->encode([
                 'projectId' => $project->getId(),

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -145,7 +145,7 @@ class Builds extends Action
                     $executor,
                     $plan,
                     $platform,
-                    (int) ($payload['buildTimeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900))
+                    (int) ($payload['timeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900))
                 );
                 break;
 
@@ -181,7 +181,7 @@ class Builds extends Action
         Executor $executor,
         array $plan,
         array $platform,
-        int $buildTimeout = 900
+        int $timeout
     ): void {
         Console::info('Deployment action started');
 
@@ -594,8 +594,6 @@ class Builds extends Action
 
             $cpus = $spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT;
             $memory = max($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT, $minMemory);
-            $timeout = $buildTimeout;
-
             $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $timeout, 0);
 
             $apiKey = $jwtObj->encode([

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -592,9 +592,9 @@ class Builds extends Action
 
             $cpus = $spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT;
             $memory = max($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT, $minMemory);
-            $timeout = (int) System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900);
+            $timeout = (int) ($payload['buildTimeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900));
 
-            $jwtExpiry = (int) System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900);
+            $jwtExpiry = $timeout;
             $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $jwtExpiry, 0);
 
             $apiKey = $jwtObj->encode([

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -144,7 +144,8 @@ class Builds extends Action
                     $log,
                     $executor,
                     $plan,
-                    $platform
+                    $platform,
+                    (int) ($payload['buildTimeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900))
                 );
                 break;
 
@@ -179,7 +180,8 @@ class Builds extends Action
         Log $log,
         Executor $executor,
         array $plan,
-        array $platform
+        array $platform,
+        int $buildTimeout = 900
     ): void {
         Console::info('Deployment action started');
 
@@ -592,7 +594,7 @@ class Builds extends Action
 
             $cpus = $spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT;
             $memory = max($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT, $minMemory);
-            $timeout = (int) ($payload['buildTimeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900));
+            $timeout = $buildTimeout;
 
             $jwtExpiry = $timeout;
             $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $jwtExpiry, 0);


### PR DESCRIPTION
## Summary

- Build worker now reads `buildTimeout` from the message payload instead of always using `_APP_COMPUTE_BUILD_TIMEOUT` env var
- `$jwtExpiry` reuses `$timeout` instead of re-reading the env var
- Falls back to `_APP_COMPUTE_BUILD_TIMEOUT` (default 900s) when `buildTimeout` is absent, keeping self-hosted deployments unchanged

## Test plan

- [ ] Verify free-tier builds respect the 15-minute (900s) timeout sent in the payload
- [ ] Verify Pro/Scale builds respect the 45-minute (2700s) timeout sent in the payload
- [ ] Verify self-hosted deployments without `buildTimeout` in the payload still use `_APP_COMPUTE_BUILD_TIMEOUT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)