### PR TITLE
feat: use per-build timeout from queue message payload

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -592,9 +592,9 @@ class Builds extends Action
 
             $cpus = $spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT;
             $memory = max($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT, $minMemory);
-            $timeout = (int) System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900);
+            $timeout = (int) ($payload['buildTimeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900));
 
-            $jwtExpiry = (int) System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900);
+            $jwtExpiry = $timeout;
             $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $jwtExpiry, 0);
 
             $apiKey = $jwtObj->encode([


### PR DESCRIPTION
## Summary
- Reads `buildTimeout` from the build queue message payload instead of always using the global `_APP_COMPUTE_BUILD_TIMEOUT` env var
- Falls back to the env var when `buildTimeout` is absent, so self-hosted deployments are unaffected
- Companion to appwrite-labs/cloud#3823, which adds `buildTimeout` to plan config (900s free, 2700s paid) and includes it in the message payload

## Test plan
- [ ] Trigger a build on a free-tier project — confirm timeout is 900s
- [ ] Trigger a build on a Pro/Scale project — confirm timeout is 2700s
- [ ] Trigger a build without `buildTimeout` in payload (e.g. self-hosted) — confirm env var fallback applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)