### PR TITLE
fix: do not cache error responses for storage preview, bump utopia-php/image to 0.8.5

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -971,7 +971,8 @@ Http::shutdown()
         if ($useCache) {
             $resource = $resourceType = null;
             $data = $response->getPayload();
-            if (! empty($data['payload'])) {
+            $statusCode = $response->getStatusCode();
+            if (! empty($data['payload']) && $statusCode >= 200 && $statusCode < 300) {
                 $pattern = $route->getLabel('cache.resource', null);
                 if (! empty($pattern)) {
                     $resource = $parseLabel($pattern, $responsePayload, $requestParams, $user);

--- a/composer.lock
+++ b/composer.lock
@@ -4325,16 +4325,16 @@
         },
         {
             "name": "utopia-php/image",
-            "version": "0.8.4",
+            "version": "0.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/image.git",
-                "reference": "ce788ff0121a79286fdbe3ef3eba566de646df65"
+                "reference": "9af2fcff028a42550465e2ccad88e3b31c3584f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/image/zipball/ce788ff0121a79286fdbe3ef3eba566de646df65",
-                "reference": "ce788ff0121a79286fdbe3ef3eba566de646df65",
+                "url": "https://api.github.com/repos/utopia-php/image/zipball/9af2fcff028a42550465e2ccad88e3b31c3584f3",
+                "reference": "9af2fcff028a42550465e2ccad88e3b31c3584f3",
                 "shasum": ""
             },
             "require": {
@@ -4343,10 +4343,12 @@
                 "php": ">=8.1"
             },
             "require-dev": {
-                "laravel/pint": "1.2.*",
-                "phpstan/phpstan": "^1.10.0",
-                "phpunit/phpunit": "^9.3",
-                "vimeo/psalm": "4.13.1"
+                "laravel/pint": "1.24.*",
+                "phpstan/phpstan": "2.1.*",
+                "phpunit/phpunit": "10.5.*"
+            },
+            "suggest": {
+                "ext-imagick": "Imagick extension is required for Imagick adapter"
             },
             "type": "library",
             "autoload": {
@@ -4368,9 +4370,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/image/issues",
-                "source": "https://github.com/utopia-php/image/tree/0.8.4"
+                "source": "https://github.com/utopia-php/image/tree/0.8.5"
             },
-            "time": "2025-06-03T08:32:20+00:00"
+            "time": "2026-04-17T15:02:49+00:00"
         },
         {
             "name": "utopia-php/locale",

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1050,6 +1050,28 @@ trait StorageBase
         $this->assertEquals(404, $file['headers']['status-code']);
     }
 
+    public function testFilePreviewAvifPublic(): void
+    {
+        $data = $this->setupBucketFile();
+        $bucketId = $data['bucketId'];
+        $fileId = $data['fileId'];
+        $projectId = $this->getProject()['$id'];
+
+        // Matches the customer's URL pattern: no headers, project + output in query string only
+        $preview = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview', [
+            'content-type' => 'application/json',
+        ], [
+            'project' => $projectId,
+            'width' => 1080,
+            'quality' => 40,
+            'output' => 'avif',
+        ]);
+
+        $this->assertEquals(200, $preview['headers']['status-code']);
+        $this->assertEquals('image/avif', $preview['headers']['content-type']);
+        $this->assertNotEmpty($preview['body']);
+    }
+
     public function testFilePreview(): void
     {
         $data = $this->setupBucketFile();
@@ -1069,6 +1091,49 @@ trait StorageBase
         $this->assertEquals(200, $preview['headers']['status-code']);
         $this->assertEquals('image/webp', $preview['headers']['content-type']);
         $this->assertNotEmpty($preview['body']);
+
+        // Preview PNG as avif
+        $avifPreview = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'width' => 1080,
+            'quality' => 40,
+            'output' => 'avif',
+        ]);
+
+        $this->assertEquals(200, $avifPreview['headers']['status-code']);
+        $this->assertEquals('image/avif', $avifPreview['headers']['content-type']);
+        $this->assertNotEmpty($avifPreview['body']);
+
+        // Preview JPEG as avif
+        $jpegFile = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+            'content-type' => 'multipart/form-data',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'fileId' => ID::unique(),
+            'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/disk-a/kitten-1.jpg'), 'image/jpeg', 'kitten-1.jpg'),
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $jpegFile['headers']['status-code']);
+
+        $avifFromJpeg = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files/' . $jpegFile['body']['$id'] . '/preview', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'width' => 1080,
+            'quality' => 40,
+            'output' => 'avif',
+        ]);
+
+        $this->assertEquals(200, $avifFromJpeg['headers']['status-code']);
+        $this->assertEquals('image/avif', $avifFromJpeg['headers']['content-type']);
+        $this->assertNotEmpty($avifFromJpeg['body']);
     }
 
     public function testDeletePartiallyUploadedFile(): void


### PR DESCRIPTION
## Summary

- **Root cause 1 (library):** `utopia-php/image` was using the deprecated `magick convert` shell command for AVIF/HEIC output, which fails on ImageMagick 7. Fixed upstream in [utopia-php/image#43](https://github.com/utopia-php/image/pull/43) and released as `0.8.5`. This PR bumps to that version.
- **Root cause 2 (caching):** The cache write hook in `app/controllers/shared/api.php` was writing any non-empty response payload to cache, including error responses. When AVIF conversion failed (first request), the error JSON was cached, and subsequent requests with the same cache key would serve the cached error — manifesting as `storage_bucket_not_found` on cloud.
- **Fix:** Cache write hook now checks `$statusCode >= 200 && $statusCode < 300` before writing to cache.
- **Tests:** Added `testFilePreviewAvifPublic()` for the customer's URL pattern (project in query params, no auth headers), and AVIF assertions in `testFilePreview()` for PNG→AVIF and JPEG→AVIF conversions.

## Test plan

- [ ] `docker compose exec appwrite test tests/e2e/Services/Storage/StorageCustom`
- [ ] `docker compose exec appwrite test tests/e2e/Services/Storage/StorageServer`
- [ ] Verify `GET /v1/storage/buckets/{id}/files/{id}/preview?output=avif` returns `200 image/avif`
- [ ] Verify a previously cached error for `output=avif` no longer blocks subsequent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)