### PR TITLE
fix: include project ID in storage preview cache key

### DIFF
--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -54,7 +54,7 @@ class Get extends Action
             ->label('cache', true)
             ->label('cache.resourceType', 'bucket/{request.bucketId}')
             ->label('cache.resource', 'file/{request.fileId}')
-            ->label('cache.params', ['width', 'height', 'gravity', 'quality', 'borderWidth', 'borderColor', 'borderRadius', 'opacity', 'rotation', 'background', 'output'])
+            ->label('cache.params', ['width', 'height', 'gravity', 'quality', 'borderWidth', 'borderColor', 'borderRadius', 'opacity', 'rotation', 'background', 'output', 'project'])
             ->label('sdk', new Method(
                 namespace: 'storage',
                 group: 'files',

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -238,10 +238,10 @@ class Request extends UtopiaRequest
         if ($allowedParams !== null) {
             $params = array_intersect_key($params, array_flip($allowedParams));
         }
-        ksort($params);
         if (!isset($params['project'])) {
             $params['project'] = $this->getHeader('x-appwrite-project', '');
         }
+        ksort($params);
         return md5($this->getURI() . '*' . serialize($params) . '*' . APP_CACHE_BUSTER);
     }
 

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -239,6 +239,9 @@ class Request extends UtopiaRequest
             $params = array_intersect_key($params, array_flip($allowedParams));
         }
         ksort($params);
+        if (!isset($params['project'])) {
+            $params['project'] = $this->getHeader('x-appwrite-project', '');
+        }
         return md5($this->getURI() . '*' . serialize($params) . '*' . APP_CACHE_BUSTER);
     }
 


### PR DESCRIPTION
## Summary

Cache key for storage preview never included the project ID, meaning two projects with the same `bucketId`, `fileId`, and transform params would share a cache key. On a cache hit, Appwrite re-validates the bucket using the cached `resourceType` (which belongs to a different project's bucket), finds nothing in the requesting project's DB, and throws `storage_bucket_not_found`.

- When `project` is passed as a query param (public URLs): added `project` to `cache.params` on the preview route so it's included in the key
- When project is passed as `X-Appwrite-Project` header: added header fallback in `cacheIdentifier()` so it's always captured

**Timeline of the vulnerability:**
- **Header-based requests** (`X-Appwrite-Project`): broken since the preview cache was first introduced — headers were never part of the cache key
- **Query-param-based requests** (`?project=...`): broken since the April 9 `cache.params` fix, which allowlisted only transform params and inadvertently dropped `project`

## Test plan

- [ ] Two projects with same bucketId/fileId/transform params no longer share a cache key
- [ ] Public preview URLs (`?project=...&output=avif`) return correct image, not another project's cached error
- [ ] Authenticated preview requests (`X-Appwrite-Project` header) cache independently per project

🤖 Generated with [Claude Code](https://claude.com/claude-code)