### PR TITLE
fix: preserve function domain execution logs by using executor object-header format

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -592,7 +592,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
                 memory: $spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT,
                 logging: $resource->getAttribute('logging', true),
                 requestTimeout: 30,
-                responseFormat: Executor::RESPONSE_FORMAT_ARRAY_HEADERS
+                responseFormat: $type === 'function' ? Executor::RESPONSE_FORMAT_OBJECT_HEADERS : Executor::RESPONSE_FORMAT_ARRAY_HEADERS
             );
 
             $headerOverrides = [];

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -674,7 +674,10 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
 
             // Truncate logs if they exceed the limit
             $maxLogLength = APP_FUNCTION_LOG_LENGTH_LIMIT;
-            $logs = $executionResponse['logs'] ?? '';
+            $logs = $executionResponse['logs'] ?? $executionResponse['stdout'] ?? '';
+            if (\is_array($logs)) {
+                $logs = \implode("\n", $logs);
+            }
 
             if (\is_string($logs) && \strlen($logs) > $maxLogLength) {
                 $warningMessage = "[WARNING] Logs truncated. The output exceeded {$maxLogLength} characters.\n";
@@ -685,7 +688,10 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
 
             // Truncate errors if they exceed the limit
             $maxErrorLength = APP_FUNCTION_ERROR_LENGTH_LIMIT;
-            $errors = $executionResponse['errors'] ?? '';
+            $errors = $executionResponse['errors'] ?? $executionResponse['stderr'] ?? '';
+            if (\is_array($errors)) {
+                $errors = \implode("\n", $errors);
+            }
 
             if (\is_string($errors) && \strlen($errors) > $maxErrorLength) {
                 $warningMessage = "[WARNING] Errors truncated. The output exceeded {$maxErrorLength} characters.\n";

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -674,10 +674,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
 
             // Truncate logs if they exceed the limit
             $maxLogLength = APP_FUNCTION_LOG_LENGTH_LIMIT;
-            $logs = $executionResponse['logs'] ?? $executionResponse['stdout'] ?? '';
-            if (\is_array($logs)) {
-                $logs = \implode("\n", $logs);
-            }
+            $logs = $executionResponse['logs'] ?? '';
 
             if (\is_string($logs) && \strlen($logs) > $maxLogLength) {
                 $warningMessage = "[WARNING] Logs truncated. The output exceeded {$maxLogLength} characters.\n";
@@ -688,10 +685,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
 
             // Truncate errors if they exceed the limit
             $maxErrorLength = APP_FUNCTION_ERROR_LENGTH_LIMIT;
-            $errors = $executionResponse['errors'] ?? $executionResponse['stderr'] ?? '';
-            if (\is_array($errors)) {
-                $errors = \implode("\n", $errors);
-            }
+            $errors = $executionResponse['errors'] ?? '';
 
             if (\is_string($errors) && \strlen($errors) > $maxErrorLength) {
                 $warningMessage = "[WARNING] Errors truncated. The output exceeded {$maxErrorLength} characters.\n";

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -254,7 +254,19 @@ class Executor
         if (is_string($headers)) {
             $headers = \json_decode($headers, true);
         }
+        $logs = $response['body']['logs'] ?? $response['body']['stdout'] ?? '';
+        if (\is_array($logs)) {
+            $logs = \implode("\n", $logs);
+        }
+
+        $errors = $response['body']['errors'] ?? $response['body']['stderr'] ?? '';
+        if (\is_array($errors)) {
+            $errors = \implode("\n", $errors);
+        }
+
         $response['body']['headers'] = $headers;
+        $response['body']['logs'] = $logs;
+        $response['body']['errors'] = $errors;
         $response['body']['statusCode'] = \intval($response['body']['statusCode'] ?? 500);
         $response['body']['duration'] = \floatval($response['body']['duration'] ?? 0);
         $response['body']['startTime'] = \floatval($response['body']['startTime'] ?? \microtime(true));

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -254,19 +254,7 @@ class Executor
         if (is_string($headers)) {
             $headers = \json_decode($headers, true);
         }
-        $logs = $response['body']['logs'] ?? $response['body']['stdout'] ?? '';
-        if (\is_array($logs)) {
-            $logs = \implode("\n", $logs);
-        }
-
-        $errors = $response['body']['errors'] ?? $response['body']['stderr'] ?? '';
-        if (\is_array($errors)) {
-            $errors = \implode("\n", $errors);
-        }
-
         $response['body']['headers'] = $headers;
-        $response['body']['logs'] = $logs;
-        $response['body']['errors'] = $errors;
         $response['body']['statusCode'] = \intval($response['body']['statusCode'] ?? 500);
         $response['body']['duration'] = \floatval($response['body']['duration'] ?? 0);
         $response['body']['startTime'] = \floatval($response['body']['startTime'] ?? \microtime(true));


### PR DESCRIPTION
## What does this PR do?

This PR fixes missing logs/errors for function executions triggered via generated/custom domains.

The router path in `app/controllers/general.php` was always requesting `Executor::RESPONSE_FORMAT_ARRAY_HEADERS`.  
I updated it to use response format conditionally:

- `functions` → `Executor::RESPONSE_FORMAT_OBJECT_HEADERS`
- `sites` → `Executor::RESPONSE_FORMAT_ARRAY_HEADERS` (unchanged)

This aligns function domain executions with the existing function API execution flow, while keeping site behavior intact.

## Test Plan

1. Trigger a function through its generated/custom domain.
2. Open the related execution in Console (`Functions -> Executions`).
3. Verify `logs` and `errors` are present as expected.
4. Trigger a site deployment route and verify response headers continue to work normally.
5. Run syntax checks:
   - `php -l app/controllers/general.php`
   - `php -l src/Executor/Executor.php`
6. (Optional, if tooling is installed) run formatting/lint:
   - `composer lint app/controllers/general.php src/Executor/Executor.php`

## Related PRs and Issues

- Fixes #11944

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?