### PR TITLE
feat(realtime): add telemetry counter for Redis pub/sub reconnection …

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -398,7 +398,7 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
     $register->set('telemetry.connectionCounter', fn () => $telemetry->createUpDownCounter('realtime.server.open_connections'));
     $register->set('telemetry.connectionCreatedCounter', fn () => $telemetry->createCounter('realtime.server.connection.created'));
     $register->set('telemetry.messageSentCounter', fn () => $telemetry->createCounter('realtime.server.message.sent'));
-    $register->set('telemetry.pubsubReconnectionCounter', fn () => $telemetry->createCounter('realtime.server.pubsub.reconnection'));
+    $register->set('telemetry.pubsubReconnectionCounter', fn () => $telemetry->createCounter('realtime.server.pubsub.reconnection.attempt'));
     $register->set('telemetry.deliveryDelayHistogram', fn () => $telemetry->createHistogram(
         name: 'realtime.server.delivery_delay',
         unit: 'ms',

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -398,6 +398,7 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
     $register->set('telemetry.connectionCounter', fn () => $telemetry->createUpDownCounter('realtime.server.open_connections'));
     $register->set('telemetry.connectionCreatedCounter', fn () => $telemetry->createCounter('realtime.server.connection.created'));
     $register->set('telemetry.messageSentCounter', fn () => $telemetry->createCounter('realtime.server.message.sent'));
+    $register->set('telemetry.pubsubReconnectionCounter', fn () => $telemetry->createCounter('realtime.server.pubsub.reconnection'));
     $register->set('telemetry.deliveryDelayHistogram', fn () => $telemetry->createHistogram(
         name: 'realtime.server.delivery_delay',
         unit: 'ms',
@@ -632,6 +633,7 @@ $server->onWorkerStart(function (int $workerId) use ($server, $register, $stats,
 
             Console::error('Pub/sub error: ' . $th->getMessage());
             $attempts++;
+            $register->get('telemetry.pubsubReconnectionCounter')->add(1);
             sleep(DATABASE_RECONNECT_SLEEP);
             continue;
         }


### PR DESCRIPTION
## Resolves - #11943

## What does this PR do?

This PR adds a telemetry counter `telemetry.pubsubReconnectionCounter` to track Redis pub/sub connection reconnection attempts in the realtime service. 

Realtime functionality depends entirely on Redis pub/sub for message distribution. When pub/sub connections fail, the system automatically retries, but there was previously no metric to monitor the frequency or pattern of these reconnections. This enhancement provides:

- **Infrastructure visibility**: Operators can detect Redis instability before it impacts users
- **Alerting capability**: Spikes in reconnection attempts can trigger infrastructure alerts
- **Low overhead**: Single counter increment per failed connection attempt
- **Consistent pattern**: Follows existing telemetry patterns already in the file

The implementation adds:
1. Telemetry counter registration in `onWorkerStart` callback (line 401)
2. Counter increment in the pub/sub connection error catch block (line 636)

## Test Plan

This change adds telemetry instrumentation and does not modify existing functionality. Verification steps:

1. **Code Review**: 
   - Confirmed the counter registration follows the exact same pattern as existing telemetry counters (lines 398-400)
   - Confirmed the increment is placed in the correct catch block handling pub/sub connection errors (lines 631-639)
   - Verified metric name follows naming convention: `realtime.server.pubsub.reconnection`

2. **Syntax Check**:
   - Changes are minimal (2 lines of code)
   - No breaking changes to existing code
   - Backward compatible (telemetry system already in place)

3. **Runtime Verification** (when deployed):
   - The counter will automatically increment when pub/sub connection errors occur
   - Metrics will be available in the telemetry backend for monitoring
   - No changes required to existing tests as this is pure instrumentation

## Related PRs and Issues

- Addresses enhancement request to add telemetry for Redis pub/sub reconnection attempts

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (N/A - this is internal telemetry instrumentation, no API changes)