### PR TITLE
fix: honor _APP_WORKERS_NUM in realtime

### DIFF
--- a/app/realtime.php
+++ b/app/realtime.php
@@ -262,7 +262,9 @@ $stats->create();
 
 $containerId = uniqid();
 $statsDocument = null;
-$workerNumber = intval(System::getEnv('_APP_CPU_NUM', swoole_cpu_num())) * intval(System::getEnv('_APP_WORKER_PER_CORE', 6));
+
+$workerNumber = intval(System::getEnv('_APP_WORKERS_NUM', 0))
+    ?: intval(System::getEnv('_APP_CPU_NUM', swoole_cpu_num())) * intval(System::getEnv('_APP_WORKER_PER_CORE', 6));
 
 $adapter = new Adapter\Swoole(port: System::getEnv('PORT', 80));
 $adapter


### PR DESCRIPTION
## Summary
- Realtime ignored `_APP_WORKERS_NUM` and always computed workers as `_APP_CPU_NUM × _APP_WORKER_PER_CORE` (default CPU × 6), so on larger hosts it would spin up ~96 workers with no way to cap via the standard env var used by other workers.
- Prefer `_APP_WORKERS_NUM` when set, falling back to the existing CPU × per-core calculation.

## Test plan
- [ ] Start realtime with `_APP_WORKERS_NUM=4` and confirm it boots 4 workers
- [ ] Start realtime without `_APP_WORKERS_NUM` and confirm fallback to CPU × `_APP_WORKER_PER_CORE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)