### PR TITLE
[codex] Stabilize database e2e CI retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,8 @@ jobs:
         include:
           - service: Databases
             runner: blacksmith-4vcpu-ubuntu-2404
+            paratest_processes: 3
+            timeout_minutes: 30
           - service: Sites
             runner: blacksmith-4vcpu-ubuntu-2404
           - service: Functions
@@ -439,6 +441,10 @@ jobs:
             runner: blacksmith-4vcpu-ubuntu-2404
           - service: TablesDB
             runner: blacksmith-4vcpu-ubuntu-2404
+            paratest_processes: 3
+            timeout_minutes: 30
+          - service: Migrations
+            paratest_processes: 1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -499,7 +505,7 @@ jobs:
         with:
           max_attempts: 2
           retry_wait_seconds: 60
-          timeout_minutes: 20
+          timeout_minutes: ${{ matrix.timeout_minutes || 20 }}
           job_id: ${{ job.check_run_id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           test_dir: tests/e2e/Services/${{ matrix.service }}
@@ -512,9 +518,14 @@ jobs:
               Databases|TablesDB|Functions|Realtime|GraphQL|ProjectWebhooks) FUNCTIONAL_FLAG="" ;;
             esac
 
+            PARATEST_PROCESSES="${{ matrix.paratest_processes }}"
+            if [ -z "$PARATEST_PROCESSES" ]; then
+              PARATEST_PROCESSES="$(nproc)"
+            fi
+
             docker compose exec -T \
               -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
-              appwrite vendor/bin/paratest --processes $(nproc) $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service }}/junit.xml
+              appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service }}/junit.xml
 
       - name: Failure Logs
         if: failure()

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -4207,7 +4207,9 @@ trait MigrationsBase
         }, 30_000, 500);
 
         // Check that email was sent with download link
-        $lastEmail = $this->getLastEmail();
+        $lastEmail = $this->getLastEmail(probe: function ($email) {
+            $this->assertEquals('Your JSON export is ready', $email['subject']);
+        });
         $this->assertNotEmpty($lastEmail);
         $this->assertEquals('Your JSON export is ready', $lastEmail['subject']);
         $this->assertStringContainsStringIgnoringCase('Your data export has been completed successfully', $lastEmail['text']);


### PR DESCRIPTION
## What changed

- Limit the Databases and TablesDB E2E service jobs to 3 ParaTest workers instead of using every reported CPU.
- Give those two heavy schema-processing suites a 30 minute php-retry timeout while keeping the default 20 minute timeout for the rest of the service matrix.
- Run the Migrations E2E service job with 1 ParaTest worker.
- Make the Migrations JSON export email assertion search for the expected export email instead of assuming the newest Maildev email is the export notification.

## Why

The failed run in appwrite/appwrite#11974 showed Databases timing out in `itznotabug/php-retry@v3` after the job saturated the runner with 6 ParaTest workers while Appwrite, MongoDB, Redis, and database workers were also running. TablesDB also hit a schema polling failure where an attribute stayed `processing` long enough for the first attempt to fail, then the retry fell back to the full suite.

A follow-up Migrations run failed in `testExportVectordbCSV` while creating the first VectorsDB collection on Postgres. The server log shows `SQLSTATE[42704]: Undefined object: collation "utf8_ci_ai" for encoding "UTF8" does not exist` while creating the `_metadata` unique index. That points to a parallel first-bootstrap race where one worker sees the project schema before the Postgres adapter has finished creating the VectorsDB collation/extensions. Running this shared-state suite sequentially avoids concurrent first-time VectorsDB bootstrap inside the same project.

The next PR run confirmed Migrations was sequential, and exposed a separate mailbox-order flake in `testCreateJSONExport`: the test expected `Your JSON export is ready` but read a later `Test SMTP Connection` email. The JSON export test now uses the same subject probe pattern already used by the CSV export tests.

Leaving worker capacity for the database services should reduce schema queue starvation and API query timeouts. The longer wrapper timeout gives Databases and TablesDB enough room when php-retry has to rerun the full service directory.

## Validation

- Parsed `.github/workflows/ci.yml` with Ruby YAML.
- Ran `php -l tests/e2e/Services/Migrations/MigrationsBase.php`.
- Ran `git diff --check`.
- Rebasing onto current `origin/1.9.x` completed cleanly.