### PR TITLE
perf: memoize request filter chain and V20 schema lookups

### DIFF
--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -18,6 +18,7 @@ class Request extends UtopiaRequest
      */
     private array $filters = [];
     private ?Route $route = null;
+    private ?array $filteredParams = null;
 
     public function __construct(SwooleRequest $request)
     {
@@ -32,6 +33,10 @@ class Request extends UtopiaRequest
      */
     public function getParams(): array
     {
+        if ($this->filteredParams !== null) {
+            return $this->filteredParams;
+        }
+
         $parameters = parent::getParams();
 
         if (!$this->hasFilters() || !$this->hasRoute()) {
@@ -49,6 +54,7 @@ class Request extends UtopiaRequest
             foreach ($this->getFilters() as $filter) {
                 $parameters = $filter->parse($parameters, $id);
             }
+            $this->filteredParams = $parameters;
             return $parameters;
         }
 
@@ -79,6 +85,7 @@ class Request extends UtopiaRequest
             $parameters = $filter->parse($parameters, $id);
         }
 
+        $this->filteredParams = $parameters;
         return $parameters;
     }
 
@@ -92,6 +99,7 @@ class Request extends UtopiaRequest
     public function addFilter(Filter $filter): void
     {
         $this->filters[] = $filter;
+        $this->filteredParams = null;
     }
 
     /**
@@ -112,6 +120,7 @@ class Request extends UtopiaRequest
     public function resetFilters(): void
     {
         $this->filters = [];
+        $this->filteredParams = null;
     }
 
     /**
@@ -134,6 +143,7 @@ class Request extends UtopiaRequest
     public function setRoute(?Route $route): void
     {
         $this->route = $route;
+        $this->filteredParams = null;
     }
 
     /**

--- a/src/Appwrite/Utopia/Request/Filters/V20.php
+++ b/src/Appwrite/Utopia/Request/Filters/V20.php
@@ -10,6 +10,18 @@ use Utopia\Database\Query;
 
 class V20 extends Filter
 {
+    /**
+     * Per-instance (request-scoped) memo of the `attributes` array for a given
+     * `(databaseNamespace, collectionId)`. Avoids re-fetching the same collection
+     * document when multiple relationships in the same schema point at it, and
+     * when `parse()` is re-entered before `Request::getParams()` memoization warms.
+     *
+     * A `null` value means we already tried and the collection was missing or errored.
+     *
+     * @var array<string, array<int, array<string, mixed>>|null>
+     */
+    private array $collectionAttributesCache = [];
+
     // Convert 1.7 params to 1.8
     public function parse(array $content, string $model): array
     {
@@ -106,36 +118,21 @@ class V20 extends Filter
      * Recursively includes nested relationships up to 3 levels deep.
      * Prevents infinite loops by tracking all visited collections in the current path.
      */
-    private function getRelatedCollectionKeys(
-        ?string $databaseId = null,
-        ?string $collectionId = null,
-        ?string $prefix = null,
-        int $depth = 1,
-        array $visited = []
-    ): array {
-        $databaseId ??= $this->getParamValue('databaseId');
-        $collectionId ??= $this->getParamValue('collectionId');
+    private function getRelatedCollectionKeys(): array
+    {
+        $databaseId = $this->getParamValue('databaseId');
+        $collectionId = $this->getParamValue('collectionId');
 
-        if (
-            empty($databaseId) ||
-            empty($collectionId) ||
-            $depth > Database::RELATION_MAX_DEPTH
-        ) {
+        if (empty($databaseId) || empty($collectionId)) {
             return [];
         }
-
-        // Check if we've already visited this collection in the current path to prevent cycles
-        if (in_array($collectionId, $visited)) {
-            return [];
-        }
-
-        $visited[] = $collectionId;
 
         $dbForProject = $this->getDbForProject();
         if ($dbForProject === null) {
             return [];
         }
 
+        // Resolve the database namespace once, outside the recursion.
         try {
             $database = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument(
                 'databases',
@@ -148,19 +145,42 @@ class V20 extends Filter
             return [];
         }
 
-        try {
-            $collection = $database = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument(
-                'database_' . $database->getSequence(),
-                $collectionId
-            ));
-            if ($collection->isEmpty()) {
-                return [];
-            }
-        } catch (\Throwable) {
+        $databaseNamespace = 'database_' . $database->getSequence();
+
+        return $this->walkRelatedCollectionKeys(
+            $dbForProject,
+            $databaseNamespace,
+            $collectionId,
+            null,
+            1,
+            []
+        );
+    }
+
+    private function walkRelatedCollectionKeys(
+        Database $dbForProject,
+        string $databaseNamespace,
+        string $collectionId,
+        ?string $prefix,
+        int $depth,
+        array $visited
+    ): array {
+        if ($depth > Database::RELATION_MAX_DEPTH) {
             return [];
         }
 
-        $attributes = $collection->getAttribute('attributes', []);
+        // Check if we've already visited this collection in the current path to prevent cycles
+        if (in_array($collectionId, $visited, true)) {
+            return [];
+        }
+
+        $attributes = $this->getCollectionAttributes($dbForProject, $databaseNamespace, $collectionId);
+        if ($attributes === null) {
+            return [];
+        }
+
+        $visited[] = $collectionId;
+
         $relationshipKeys = [];
 
         foreach ($attributes as $attr) {
@@ -176,27 +196,54 @@ class V20 extends Filter
             $relatedCollectionId = $attr['relatedCollection'] ?? null;
 
             // Skip this relationship entirely if it points to an already visited collection
-            if ($relatedCollectionId && in_array($relatedCollectionId, $visited)) {
+            if ($relatedCollectionId && in_array($relatedCollectionId, $visited, true)) {
                 continue;
             }
 
-            // Add the wildcard select for this relationship
             $relationshipKeys[] = $fullKey . '.*';
 
-            // Continue recursively if we have a related collection
             if ($relatedCollectionId) {
-                $nestedKeys = $this->getRelatedCollectionKeys(
-                    $databaseId,
+                $nestedKeys = $this->walkRelatedCollectionKeys(
+                    $dbForProject,
+                    $databaseNamespace,
                     $relatedCollectionId,
                     $fullKey,
                     $depth + 1,
                     $visited
                 );
-
                 $relationshipKeys = \array_merge($relationshipKeys, $nestedKeys);
             }
         }
 
         return \array_values(\array_unique($relationshipKeys));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function getCollectionAttributes(
+        Database $dbForProject,
+        string $databaseNamespace,
+        string $collectionId
+    ): ?array {
+        $cacheKey = $databaseNamespace . ':' . $collectionId;
+        if (\array_key_exists($cacheKey, $this->collectionAttributesCache)) {
+            return $this->collectionAttributesCache[$cacheKey];
+        }
+
+        try {
+            $collection = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument(
+                $databaseNamespace,
+                $collectionId
+            ));
+        } catch (\Throwable) {
+            return $this->collectionAttributesCache[$cacheKey] = null;
+        }
+
+        if ($collection->isEmpty()) {
+            return $this->collectionAttributesCache[$cacheKey] = null;
+        }
+
+        return $this->collectionAttributesCache[$cacheKey] = $collection->getAttribute('attributes', []);
     }
 }


### PR DESCRIPTION
## Summary

A 30-second phpspy profile (1000 Hz) of a production worker showed the V20 backwards-compat request filter dominating in-request samples: **~40% of non-idle samples** touched it.

From the 24,841 leaf samples (2,851 in-request):

- `V20::getRelatedCollectionKeys` — 1,594 inclusive (the two recursive closures account for ~960 of those)
- `V20::manageSelectQueries` — 1,015 inclusive
- `V20::parse` — 1,007 inclusive

The workload was dominated by `Databases\Collections\Documents\XList` (504 inclusive samples — `databases.listDocuments`).

## Root cause

Two compounding problems, one in the framework glue and one in the filter itself:

### 1. `Request::getParams()` re-ran the full filter chain on every call

[`Request::getParams()`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/src/Appwrite/Utopia/Request.php#L34-L90) iterated `$this->filters` and invoked `parse()` every single time it was called. But `getParams()` is called many times per request. Known in-repo call sites:

- [`src/Appwrite/Utopia/Request.php#L246`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/src/Appwrite/Utopia/Request.php#L246) — `Request::cacheIdentifier()` (cache key computation)
- [`app/controllers/shared/api.php#L552`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/shared/api.php#L552) — abuse-key derivation (request hook, runs on every API request)
- [`app/controllers/shared/api.php#L890`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/shared/api.php#L890) — second abuse-key pass
- [`app/controllers/api/account.php#L1334`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/api/account.php#L1334) and [`#L1370`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/api/account.php#L1370) — account endpoints re-reading params
- [`app/controllers/api/graphql.php#L123`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/api/graphql.php#L123) and [`#L174`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/api/graphql.php#L174) — GraphQL query extraction
- [`src/Appwrite/Platform/Modules/Console/Http/Redirects/Base.php#L41`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/src/Appwrite/Platform/Modules/Console/Http/Redirects/Base.php#L41) — console redirects

Plus implicit calls from the utopia-http framework itself during route-action parameter binding (not linked — external package).

So V20's recursive schema walk executed **N times per request** with identical inputs. This amplified the raw cost of the filter before anything else even mattered.

### 2. V20's schema walk did redundant DB work per call

Inside [`V20::getRelatedCollectionKeys`](https://github.com/appwrite/appwrite/blob/7568964b7c/src/Appwrite/Utopia/Request/Filters/V20.php#L109-L201) (pre-fix, recursive, up to `RELATION_MAX_DEPTH = 3`):

- The `databases/$databaseId` document was re-fetched **at every recursion frame**, even though `$databaseId` is constant across the walk.
- Each sibling relationship pointing at the same related collection did its own independent `getDocument` call.
- Nothing was memoized, not even within a single walk.

### Why the filter runs at all

V20 is installed only when the request advertises `X-Appwrite-Response-Format < 1.8.0` (see [`app/controllers/general.php#L889-L892`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/controllers/general.php#L889-L892)). It's gated to two models — `databases.getDocument` and `databases.listDocuments` — which is exactly the hot endpoint. Pre-1.8 SDKs are still common enough in production that this is a meaningful share of traffic.

## Changes

### `src/Appwrite/Utopia/Request.php` — memoize `getParams()`

- Added `private ?array $filteredParams = null`.
- `getParams()` returns the cached post-filter result on subsequent calls.
- `addFilter()`, `resetFilters()`, and `setRoute()` invalidate the cache (these are the only state changes that could affect the output).
- `Request` is constructed fresh per HTTP request in [`app/http.php#L508`](https://github.com/appwrite/appwrite/blob/3ea12e0f79fc5903caee4d1592f93e3be5ae5c07/app/http.php#L508), so the memo is naturally request-scoped — no cross-request leak risk.
- Helps **every** request filter version (V16–V23), not just V20.

### `src/Appwrite/Utopia/Request/Filters/V20.php` — hoist + memoize

- Split into `getRelatedCollectionKeys()` (resolves the database namespace once via a single `databases/$databaseId` lookup) and `walkRelatedCollectionKeys()` (pure recursion over the pre-resolved namespace).
- Added `getCollectionAttributes()` with an instance cache keyed on `(databaseNamespace, collectionId)`. Sibling/cousin relationships pointing at the same related collection now share a single `getDocument` call. Misses/errors are cached as `null` so we don't retry on every frame.
- Removed a confusing `$collection = $database = ...` double-assignment (benign but misleading).

## Expected impact

- On pre-1.8 `listDocuments`/`getDocument` traffic: per-request V20 cost should drop by the factor of `getParams()` re-entries (typically 3–5×), plus further savings on any schema that has nested or shared relationships. Given this filter was ~40% of non-idle samples on the profiled worker, this should translate to a noticeable drop in total CPU time for the databases worker.
- Zero behavior change for callers: same `queries` are produced. Memoization is invalidated whenever the inputs that could affect the output change.

### Redis round-trip reduction (per request)

Each `$dbForProject->getDocument()` is ~1 Redis GET on warm cache — more on a miss, since the miss also drags a MariaDB/Mongo query behind it. Assuming `Request::getParams()` is called ~4 times per request (cacheIdentifier + two abuse-key passes in `app/controllers/shared/api.php` + framework route binding):

| Scenario | Before | After | Reduction |
|---|---|---|---|
| Collection with no relationships | 8 | 2 | 4× |
| 3 sibling rels to distinct collections, no nesting | 32 | 5 | ~6× |
| 2 rels both pointing at `users`, `users` has 2 rels (shared-FK case) | 56 | 5 | ~11× |
| 3-level chain A→B→C, no branching | 24 | 4 | 6× |

The shared-FK case is where the instance-level collection cache shines most — savings grow roughly linearly with the number of duplicate references in a schema.

## Test plan

- [ ] `docker compose exec appwrite test tests/unit/` passes
- [ ] `docker compose exec appwrite test tests/e2e/Services/Databases` passes (covers the V20-affected paths)
- [ ] Manual: request `GET /v1/databases/:dbId/collections/:colId/documents` with `X-Appwrite-Response-Format: 1.7.0` against a collection with relationship attributes — verify the response still includes related documents, and select-query combinations still resolve wildcards the same way
- [ ] Manual: request the same endpoint with `X-Appwrite-Response-Format: 1.8.0` (or newer) — V20 should not be installed, behavior unchanged
- [ ] Re-run phpspy on a databases worker post-deploy; confirm `V20::*` shrinks meaningfully in the flamegraph

## Follow-ups (not in this PR)

- Worker-scoped schema cache keyed on `(projectId, databaseId, collectionId)` with event-based invalidation — would eliminate the `getDocument` calls across requests entirely. Higher effort, needs an invalidation story.
- Consider skipping V20 installation for routes whose model isn't `databases.getDocument`/`databases.listDocuments` — saves the constructor + `dbForProject` resolution on unaffected routes.

