### PR TITLE
fix: tighten scheduled execution E2E coverage

### DIFF
--- a/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
+++ b/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
@@ -117,7 +117,9 @@ class FunctionsScheduleTest extends Scope
         $executionId = $execution['body']['$id'];
 
         $this->assertEquals(202, $execution['headers']['status-code']);
+        $this->assertEquals('schedule', $execution['body']['trigger']);
         $this->assertEquals('scheduled', $execution['body']['status']);
+        $this->assertEquals($futureTime->format(\DateTime::ATOM), (new \DateTime($execution['body']['scheduledAt']))->format(\DateTime::ATOM));
         $this->assertEquals('PATCH', $execution['body']['requestMethod']);
         $this->assertEquals('/custom-path', $execution['body']['requestPath']);
         $this->assertCount(1, $execution['body']['requestHeaders']);
@@ -148,6 +150,7 @@ class FunctionsScheduleTest extends Scope
             'scheduledAt' =>  $futureTime->format(\DateTime::ATOM),
         ]);
         $this->assertEquals(400, $execution['headers']['status-code']);
+        $this->assertEquals('Scheduled executions must run asynchronously. Set scheduledAt to a future date, or set async to true.', $execution['body']['message']);
 
         // Execution with seconds precision
         $execution = $this->createExecution($functionId, [
@@ -163,12 +166,16 @@ class FunctionsScheduleTest extends Scope
         ]);
         $this->assertEquals(400, $execution['headers']['status-code']);
 
-        // Execution too soon
+        // Execution with minute precision but less than 1 minute in the future
+        $tooSoonTime = (new \DateTime())->modify('+1 minute');
+        $tooSoonTime->setTime((int) $tooSoonTime->format('H'), (int) $tooSoonTime->format('i'), 0, 0);
+
         $execution = $this->createExecution($functionId, [
             'async' => true,
-            'scheduledAt' => (new \DateTime())->add(new \DateInterval('PT1S'))->format(\DateTime::ATOM)
+            'scheduledAt' => $tooSoonTime->format(\DateTime::ATOM)
         ]);
         $this->assertEquals(400, $execution['headers']['status-code']);
+        $this->assertEquals('Execution schedule must be a valid date, and at least 1 minute from now', $execution['body']['message']);
 
         $this->cleanupFunction($functionId);
     }

--- a/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
+++ b/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
@@ -158,6 +158,7 @@ class FunctionsScheduleTest extends Scope
             'scheduledAt' => (new \DateTime("2100-12-08 16:12:02"))->format(\DateTime::ATOM)
         ]);
         $this->assertEquals(400, $execution['headers']['status-code']);
+        $this->assertEquals('Execution schedule must be a valid date, and at least 1 minute from now', $execution['body']['message']);
 
         // Execution with milliseconds precision
         $execution = $this->createExecution($functionId, [
@@ -165,10 +166,14 @@ class FunctionsScheduleTest extends Scope
             'scheduledAt' => (new \DateTime("2100-12-08 16:12:02.255"))->format(\DateTime::ATOM)
         ]);
         $this->assertEquals(400, $execution['headers']['status-code']);
+        $this->assertEquals('Execution schedule must be a valid date, and at least 1 minute from now', $execution['body']['message']);
 
-        // Execution with minute precision but less than 1 minute in the future
-        $tooSoonTime = (new \DateTime())->modify('+1 minute');
-        $tooSoonTime->setTime((int) $tooSoonTime->format('H'), (int) $tooSoonTime->format('i'), 0, 0);
+        // Minute precision still fails when the execution is not more than 1 minute ahead.
+        $now = new \DateTimeImmutable();
+        $tooSoonTime = $now->modify('+1 minute');
+        $tooSoonTime = $tooSoonTime->setTime((int) $tooSoonTime->format('H'), (int) $tooSoonTime->format('i'), 0, 0);
+
+        $this->assertLessThanOrEqual(60, $tooSoonTime->getTimestamp() - $now->getTimestamp());
 
         $execution = $this->createExecution($functionId, [
             'async' => true,


### PR DESCRIPTION
## What does this PR do?

Adds end-to-end coverage for the createExecution scheduledAt boundary rules without changing production behavior.

This updates the scheduled execution E2E test to cover the contract described in the issue more explicitly:
- verifies the successful async scheduled execution path returns the expected schedule trigger and scheduledAt value
- verifies scheduled executions are rejected when async=false
- verifies minute-precision scheduledAt values that are less than 1 minute ahead are rejected with the expected validation message

The goal here is to protect the existing API behavior against regression, not to change runtime behavior.

## Test Plan

- Verified the updated test file is clean in editor diagnostics.
- Full Docker/PHP execution could not be run in this environment because the required CLIs were unavailable.
- Recommended validation command in a full local Appwrite environment:

  docker compose exec appwrite test tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php --filter=ScheduledExecution

## Related PRs and Issues

Closes #11984