### PR TITLE
fix: add CORS headers to GraphQL responses

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -975,7 +975,7 @@ Http::init()
  * @see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
  */
 Http::init()
-    ->groups(['api', 'web'])
+    ->groups(['api', 'web', 'graphql'])
     ->inject('request')
     ->inject('response')
     ->inject('cors')

--- a/tests/e2e/Services/GraphQL/ContentTypeTest.php
+++ b/tests/e2e/Services/GraphQL/ContentTypeTest.php
@@ -7,6 +7,7 @@ use Tests\E2E\Client;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideServer;
+use Utopia\Config\Config;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
@@ -43,6 +44,28 @@ class ContentTypeTest extends Scope
             'x-appwrite-project' => $projectId,
         ], $this->getHeaders()), $graphQLPayload);
 
+        $this->assertIsArray($response['body']['data']);
+        $this->assertArrayNotHasKey('errors', $response['body']);
+        $response = $response['body']['data']['localeListCountries'];
+        $this->assertEquals(197, $response['total']);
+    }
+
+    public function testSingleQueryJSONContentTypeIncludesCorsHeaders()
+    {
+        $projectId = $this->getProject()['$id'];
+        $query = 'query { localeListCountries { total countries { code } } }';
+        $graphQLPayload = ['query' => $query];
+        $response = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
+            'content-type' => 'application/json',
+            'origin' => 'http://localhost',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders()), $graphQLPayload);
+
+        $corsConfig = Config::getParam('cors');
+
+        $this->assertEquals('http://localhost', $response['headers']['access-control-allow-origin'] ?? null);
+        $this->assertEquals('true', $response['headers']['access-control-allow-credentials'] ?? null);
+        $this->assertEquals(\implode(', ', $corsConfig['exposedHeaders']), $response['headers']['access-control-expose-headers'] ?? null);
         $this->assertIsArray($response['body']['data']);
         $this->assertArrayNotHasKey('errors', $response['body']);
         $response = $response['body']['data']['localeListCountries'];

--- a/tests/e2e/Services/GraphQL/ContentTypeTest.php
+++ b/tests/e2e/Services/GraphQL/ContentTypeTest.php
@@ -63,9 +63,11 @@ class ContentTypeTest extends Scope
 
         $corsConfig = Config::getParam('cors');
 
+        $this->assertNotNull($corsConfig, 'CORS configuration was not loaded in the test environment.');
+
         $this->assertEquals('http://localhost', $response['headers']['access-control-allow-origin'] ?? null);
         $this->assertEquals('true', $response['headers']['access-control-allow-credentials'] ?? null);
-        $this->assertEquals(\implode(', ', $corsConfig['exposedHeaders']), $response['headers']['access-control-expose-headers'] ?? null);
+        $this->assertEquals(\implode(', ', $corsConfig['exposedHeaders'] ?? []), $response['headers']['access-control-expose-headers'] ?? null);
         $this->assertIsArray($response['body']['data']);
         $this->assertArrayNotHasKey('errors', $response['body']);
         $response = $response['body']['data']['localeListCountries'];


### PR DESCRIPTION
## What does this PR do?

Fixes GraphQL POST responses so they include the same CORS/security headers already returned by the preflight path.

Root cause:
- the global security/CORS init hook in `app/controllers/general.php` only applied to the `api` and `web` groups
- GraphQL routes are registered under the `graphql` group, so successful `/v1/graphql` POST responses skipped that header injection path

This PR:
- includes the `graphql` group in the global CORS/security init hook
- adds a focused GraphQL E2E regression test asserting CORS headers are present on a successful POST `/graphql` response

## Test Plan

- Verified the edited files have no editor diagnostics in this environment.
- Full Docker E2E execution could not be run here because the `docker` CLI is unavailable.
- Recommended focused validation in a full local Appwrite environment:

  docker compose exec appwrite test tests/e2e/Services/GraphQL/ContentTypeTest.php --filter=IncludesCorsHeaders

## Related PRs and Issues

Closes #11959