### PR TITLE
Upgrade utopia-php/http to coroutine-safe dispatch

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -52,6 +52,8 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
+use Utopia\Http\Router;
 use Utopia\Locale\Locale;
 use Utopia\Logger\Adapter\Sentry;
 use Utopia\Logger\Log;
@@ -848,7 +850,8 @@ Http::init()
     ->inject('authorization')
     ->inject('queueForDeletes')
     ->inject('executionsRetentionCount')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeleteEvent $queueForDeletes, int $executionsRetentionCount) {
+    ->inject('route')
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeleteEvent $queueForDeletes, int $executionsRetentionCount, ?Route $route) {
         /*
         * Appwrite Router
         */
@@ -862,7 +865,6 @@ Http::init()
         /*
         * Request format
         */
-        $route = $utopia->getRoute();
         $request->setRoute($route);
 
         if ($route === null) {
@@ -1172,9 +1174,9 @@ Http::error()
     ->inject('bus')
     ->inject('devKey')
     ->inject('authorization')
-    ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization) {
+    ->inject('route')
+    ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization, ?Route $route) {
         $version = System::getEnv('_APP_VERSION', 'UNKNOWN');
-        $route = $utopia->getRoute();
         $class = \get_class($error);
         $code = $error->getCode();
         $message = $error->getMessage();

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -856,9 +856,7 @@ Http::init()
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!\in_array($hostname, $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
 
         /*
@@ -1142,9 +1140,7 @@ Http::options()
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
 
         foreach ($cors->headers($request->getOrigin()) as $name => $value) {
@@ -1543,9 +1539,7 @@ Http::get('/robots.txt')
             $template = new View(__DIR__ . '/../views/general/robots.phtml');
             $response->text($template->render(false));
         } else {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
     });
 
@@ -1577,9 +1571,7 @@ Http::get('/humans.txt')
             $template = new View(__DIR__ . '/../views/general/humans.phtml');
             $response->text($template->render(false));
         } else {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
     });
 

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -13,6 +13,7 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
 use Utopia\Locale\Locale;
 use Utopia\System\System;
 use Utopia\Validator\Text;
@@ -283,13 +284,12 @@ Http::get('/v1/mock/github/callback')
 
 Http::shutdown()
     ->groups(['mock'])
-    ->inject('utopia')
     ->inject('response')
     ->inject('request')
-    ->action(function (Http $utopia, Response $response, Request $request) {
+    ->inject('route')
+    ->action(function (Response $response, Request $request, ?Route $route) {
 
         $result = [];
-        $route  = $utopia->getRoute();
         $path   = APP_STORAGE_CACHE . '/tests.json';
         $tests  = (\file_exists($path)) ? \json_decode(\file_get_contents($path), true) : [];
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -515,7 +515,7 @@ Http::init()
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
 
-        $path = $route->getMatchedPath();
+        $path = $route->getPath();
         $databaseType = match (true) {
             str_contains($path, '/documentsdb') => DATABASE_TYPE_DOCUMENTSDB,
             str_contains($path, '/vectorsdb') => DATABASE_TYPE_VECTORSDB,

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -39,6 +39,8 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Authorization\Input;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
+use Utopia\Http\Router;
 use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -99,8 +101,8 @@ Http::init()
     ->inject('team')
     ->inject('apiKey')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization) {
-        $route = $utopia->getRoute();
+    ->inject('route')
+    ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, ?Route $route) {
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
@@ -505,12 +507,12 @@ Http::init()
     ->inject('telemetry')
     ->inject('platform')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization) {
+    ->inject('route')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, ?Route $route) {
 
         $response->setUser($user);
         $request->setUser($user);
 
-        $route = $utopia->getRoute();
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
@@ -631,7 +633,6 @@ Http::init()
         $useCache = $route->getLabel('cache', false);
         $storageCacheOperationsCounter = $telemetry->createCounter('storage.cache.operations.load');
         if ($useCache) {
-            $route = $utopia->match($request);
             $isImageTransformation = $route->getPath() === '/v1/storage/buckets/:bucketId/files/:fileId/preview';
             $isDisabled = isset($plan['imageTransformations']) && $plan['imageTransformations'] === -1 && ! $user->isPrivileged($authorization->getRoles());
 
@@ -809,7 +810,8 @@ Http::shutdown()
     ->inject('bus')
     ->inject('apiKey')
     ->inject('mode')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode) use ($parseLabel) {
+    ->inject('route')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode, ?Route $route) use ($parseLabel) {
 
         $responsePayload = $response->getPayload();
 
@@ -859,7 +861,10 @@ Http::shutdown()
             }
         }
 
-        $route = $utopia->getRoute();
+        if ($route === null) {
+            return;
+        }
+
         $requestParams = $route->getParamsValues();
 
         /**

--- a/app/controllers/shared/api/auth.php
+++ b/app/controllers/shared/api/auth.php
@@ -9,6 +9,7 @@ use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
 use Utopia\System\System;
 
 Http::init()
@@ -32,13 +33,13 @@ Http::init()
 
 Http::init()
     ->groups(['auth'])
-    ->inject('utopia')
     ->inject('request')
     ->inject('project')
     ->inject('geodb')
     ->inject('user')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Document $project, Reader $geodb, User $user, Authorization $authorization) {
+    ->inject('route')
+    ->action(function (Request $request, Document $project, Reader $geodb, User $user, Authorization $authorization, ?Route $route) {
         $denylist = System::getEnv('_APP_CONSOLE_COUNTRIES_DENYLIST', '');
         if (!empty($denylist && $project->getId() === 'console')) {
             $countries = explode(',', $denylist);
@@ -49,8 +50,6 @@ Http::init()
             }
         }
 
-        $route = $utopia->match($request);
-
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         $isAppUser = $user->isApp($authorization->getRoles());
 
@@ -59,7 +58,7 @@ Http::init()
         }
 
         $auths = $project->getAttribute('auths', []);
-        switch ($route->getLabel('auth.type', '')) {
+        switch ($route?->getLabel('auth.type', '')) {
             case 'email-password':
                 if (($auths[Config::getParam('auth')['email-password']['key']] ?? true) === false) {
                     throw new Exception(Exception::USER_AUTH_METHOD_UNSUPPORTED, 'Email / Password authentication is disabled for this project');

--- a/app/http.php
+++ b/app/http.php
@@ -545,7 +545,11 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
 
         $app->run($request, $response);
 
-        $route = $app->getRoute();
+        try {
+            $route = $app->getResource('routeMatch')?->route;
+        } catch (\Throwable) {
+            $route = null;
+        }
         Span::add('http.path', $route?->getPath() ?? 'unknown');
     } catch (\Throwable $th) {
         Span::error($th);
@@ -561,7 +565,11 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
                 // All good, user is optional information for logger
             }
 
-            $route = $app->getRoute();
+            try {
+                $route = $app->getResource('routeMatch')?->route;
+            } catch (\Throwable) {
+                $route = null;
+            }
 
             $log = $app->getResource("log");
 

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -47,6 +47,7 @@ use Utopia\DI\Container;
 use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
+use Utopia\Http\Router;
 use Utopia\Locale\Locale;
 use Utopia\Logger\Log;
 use Utopia\Pools\Group;
@@ -620,10 +621,12 @@ return function (Container $container): void {
         // These endpoints moved from /v1/projects/:projectId/<resource> to /v1/<resource>
         // When accessed via the old alias path, extract projectId from the URI
         $deprecatedProjectPathPrefix = '/v1/projects/';
-        $route = $utopia->match($request);
-        if (!empty($route)) {
+        $urlPath = \parse_url($request->getURI(), PHP_URL_PATH);
+        $urlPath = \is_string($urlPath) ? ($urlPath === '' ? '/' : $urlPath) : '/';
+        $match = Router::matchRoute($request->getMethod(), $urlPath);
+        if ($match !== null) {
             $isDeprecatedAlias = \str_starts_with($request->getURI(), $deprecatedProjectPathPrefix) &&
-                !\str_starts_with($route->getPath(), $deprecatedProjectPathPrefix);
+                !\str_starts_with($match->route->getPath(), $deprecatedProjectPathPrefix);
 
             if ($isDeprecatedAlias) {
                 $projectId = \explode('/', $request->getURI(), 5)[3] ?? '';
@@ -1109,8 +1112,10 @@ return function (Container $container): void {
         if ($project->getId() !== 'console') {
             $teamInternalId = $project->getAttribute('teamInternalId', '');
         } else {
-            $route = $utopia->match($request);
-            $path = ! empty($route) ? $route->getPath() : $request->getURI();
+            $urlPath = \parse_url($request->getURI(), PHP_URL_PATH);
+            $urlPath = \is_string($urlPath) ? ($urlPath === '' ? '/' : $urlPath) : '/';
+            $match = Router::matchRoute($request->getMethod(), $urlPath);
+            $path = $match !== null ? $match->route->getPath() : $request->getURI();
             $orgHeader = $request->getHeader('x-appwrite-organization', '');
             if (str_starts_with($path, '/v1/projects/:projectId')) {
                 $uri = $request->getURI();

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "utopia-php/emails": "0.6.*",
         "utopia-php/dns": "1.6.*",
         "utopia-php/dsn": "0.2.1",
-        "utopia-php/http": "0.34.*",
+        "utopia-php/http": "dev-refactor/coroutine-safe-dispatch as 0.34.99",
         "utopia-php/fetch": "0.5.*",
         "utopia-php/image": "0.8.*",
         "utopia-php/locale": "0.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5ae97637fd0ec0a950044d1c33677ea",
+    "content-hash": "847532ec8f650852450fec3d6e806f4e",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4271,21 +4271,20 @@
         },
         {
             "name": "utopia-php/http",
-            "version": "0.34.21",
+            "version": "dev-refactor/coroutine-safe-dispatch",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "49a6bd3ea0d2966aa19cf707255d442675288a24"
+                "reference": "4f5d41aac517ec43c1319598c00c90adc6d5407c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/49a6bd3ea0d2966aa19cf707255d442675288a24",
-                "reference": "49a6bd3ea0d2966aa19cf707255d442675288a24",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/4f5d41aac517ec43c1319598c00c90adc6d5407c",
+                "reference": "4f5d41aac517ec43c1319598c00c90adc6d5407c",
                 "shasum": ""
             },
             "require": {
-                "ext-swoole": "*",
-                "php": ">=8.2",
+                "php": ">=8.3",
                 "utopia-php/compression": "0.1.*",
                 "utopia-php/di": "0.3.*",
                 "utopia-php/servers": "0.3.*",
@@ -4295,10 +4294,13 @@
             "require-dev": {
                 "doctrine/instantiator": "^1.5",
                 "laravel/pint": "1.*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "1.*",
-                "phpunit/phpunit": "^9.5.25",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^12.0",
+                "rector/rector": "^2.4",
                 "swoole/ide-helper": "4.8.3"
+            },
+            "suggest": {
+                "ext-swoole": "Required to use the Swoole server adapter (\\Utopia\\Http\\Adapter\\Swoole\\Server)."
             },
             "type": "library",
             "autoload": {
@@ -4319,9 +4321,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/0.34.21"
+                "source": "https://github.com/utopia-php/http/tree/refactor/coroutine-safe-dispatch"
             },
-            "time": "2026-04-19T19:44:04+00:00"
+            "time": "2026-04-24T14:01:56+00:00"
         },
         {
             "name": "utopia-php/image",
@@ -8441,9 +8443,18 @@
             "time": "2024-11-07T12:36:22+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/http",
+            "version": "dev-refactor/coroutine-safe-dispatch",
+            "alias": "0.34.99",
+            "alias_normalized": "0.34.99.0"
+        }
+    ],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "utopia-php/http": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4275,12 +4275,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "4f5d41aac517ec43c1319598c00c90adc6d5407c"
+                "reference": "07087af8f0e8976a143507e3fd8123ae065cc91a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/4f5d41aac517ec43c1319598c00c90adc6d5407c",
-                "reference": "4f5d41aac517ec43c1319598c00c90adc6d5407c",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/07087af8f0e8976a143507e3fd8123ae065cc91a",
+                "reference": "07087af8f0e8976a143507e3fd8123ae065cc91a",
                 "shasum": ""
             },
             "require": {
@@ -4323,7 +4323,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/refactor/coroutine-safe-dispatch"
             },
-            "time": "2026-04-24T14:01:56+00:00"
+            "time": "2026-04-24T15:49:39+00:00"
         },
         {
             "name": "utopia-php/image",

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -10,6 +10,7 @@ use Utopia\DI\Container;
 use Utopia\Http\Exception;
 use Utopia\Http\Http;
 use Utopia\Http\Route;
+use Utopia\Http\Router;
 use Utopia\System\System;
 
 class Resolvers
@@ -359,7 +360,11 @@ class Resolvers
 
         $lock->acquire();
 
-        $original = $utopia->getRoute();
+        try {
+            $originalMatch = $utopia->getResource('routeMatch');
+        } catch (\Throwable) {
+            $originalMatch = null;
+        }
         try {
             $request = clone $request;
 
@@ -380,7 +385,13 @@ class Resolvers
             $resolverResponse->setContentType(Response::CONTENT_TYPE_NULL);
             $resolverResponse->setSent(false);
 
-            $route = $utopia->match($request, fresh: true);
+            $urlPath = \parse_url($request->getURI(), PHP_URL_PATH);
+            $urlPath = \is_string($urlPath) ? ($urlPath === '' ? '/' : $urlPath) : '/';
+            $match = Router::matchRoute($request->getMethod(), $urlPath);
+            if ($match === null) {
+                throw new Exception('Route not found: ' . $request->getMethod() . ' ' . $urlPath, 404);
+            }
+            $route = $match->route;
             $request->setRoute($route);
 
             $utopia->execute($route, $request, $resolverResponse);
@@ -402,9 +413,9 @@ class Resolvers
             $reject($e);
             return;
         } finally {
-            if ($original !== null) {
-                $utopia->setRoute($original);
-            }
+            $container = self::getResolverContainer($utopia);
+            $container->set('route', static fn () => $originalMatch?->route);
+            $container->set('routeMatch', static fn () => $originalMatch);
 
             $lock->release();
             unset(self::$locks[\spl_object_hash($utopia)]);


### PR DESCRIPTION
## Summary

- Pin `utopia-php/http` to `refactor/coroutine-safe-dispatch`, which extracts per-request state into a `Dispatcher` + immutable `RouteMatch` so the shared `Http`/`Router`/`Route` objects are no longer mutated under concurrent Swoole coroutines.
- `app/controllers/shared/api.php`: `Route::getMatchedPath()` was removed; switch to `Route::getPath()` for the `/documentsdb` vs `/vectorsdb` substring check. Both the registered pattern and the matched path contain the literal segment, so behaviour is preserved.
- `app/controllers/general.php`: drop four orphaned `$route->label('router', true)` writes. The sole reader in the wildcard 404 handler was deleted in 40beecdddc (Feb 2025); the writes mutated the shared Route definition, which is now frozen under the new dispatch model.

Deprecated shims for `Http::match()`, `Http::getRoute()`, `Http::setRoute()` are still honoured by the library; the ~16 remaining call sites can migrate in a follow-up pass.

## Test plan

- [x] `composer analyze` — 0 errors across 1324 files
- [x] `vendor/bin/phpunit tests/unit/Utopia` — 223/223 pass
- [ ] Full CI
- [ ] E2E smoke against `_APP_ENV=development` stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)