### PR TITLE
fix: coerce non-string header values in Request::getHeader

### DIFF
--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -209,7 +209,11 @@ class Request extends UtopiaRequest
     public function getHeader(string $key, string $default = ''): string
     {
         $headers = $this->getHeaders();
-        return $headers[$key] ?? $default;
+        $value = $headers[$key] ?? $default;
+        if (\is_array($value)) {
+            $value = $value[0] ?? $default;
+        }
+        return \is_string($value) ? $value : $default;
     }
 
     /**

--- a/tests/unit/Utopia/RequestTest.php
+++ b/tests/unit/Utopia/RequestTest.php
@@ -161,6 +161,37 @@ class RequestTest extends TestCase
         $this->assertSame($secondRoute, $secondRequest->getRoute());
     }
 
+    public function testGetHeaderReturnsStringValue(): void
+    {
+        $this->request->addHeader('referer', 'https://example.com');
+
+        $this->assertSame('https://example.com', $this->request->getHeader('referer'));
+    }
+
+    public function testGetHeaderReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame('', $this->request->getHeader('referer'));
+        $this->assertSame('fallback', $this->request->getHeader('referer', 'fallback'));
+    }
+
+    public function testGetHeaderCoercesArrayToFirstElement(): void
+    {
+        $swoole = new SwooleRequest();
+        $swoole->header = ['referer' => ['https://a.example', 'https://b.example']];
+        $request = new Request($swoole);
+
+        $this->assertSame('https://a.example', $request->getHeader('referer'));
+    }
+
+    public function testGetHeaderReturnsDefaultWhenValueNotString(): void
+    {
+        $swoole = new SwooleRequest();
+        $swoole->header = ['referer' => 123];
+        $request = new Request($swoole);
+
+        $this->assertSame('fallback', $request->getHeader('referer', 'fallback'));
+    }
+
     /**
      * Helper to attach a route with multiple SDK methods to the request.
      */


### PR DESCRIPTION
## Summary

When duplicate headers (notably `Referer`) arrive on a request, Swoole exposes them as an array in `$swoole->header`. `Request::getHeader()` then returns that array, but its strict `: string` return type triggers a `TypeError`.

This crashes anonymous CORS rule resolution because `app/init/resources/request.php` (`$container->set('rule', ...)`) calls `$request->getReferer()` -> `getHeader('referer', '')` for every request without an `Origin`.

## Fix

Defensively coerce the header value:
- if it arrives as an array, take the first element (falling back to `$default`),
- if it is still not a string, return `$default`.

This keeps the `: string` contract intact and prevents the CORS resolution crash.

Closes CLO-4280

## Test plan

- [ ] Send a request with duplicate `Referer` headers and confirm no `TypeError` is thrown.
- [ ] Verify CORS rule resolution proceeds normally for anonymous requests.