### PR TITLE
fix: guard DOMDocument::loadHTML against empty body in favicon endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
@@ -94,9 +94,12 @@ class Get extends Action
             throw new Exception(Exception::AVATAR_REMOTE_URL_FAILED);
         }
 
+        $body = $res->getBody();
         $doc = new DOMDocument();
         $doc->strictErrorChecking = false;
-        @$doc->loadHTML($res->getBody());
+        if ($body !== '') {
+            @$doc->loadHTML($body);
+        }
 
         $links = $doc->getElementsByTagName('link');
         $outputHref = '';

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php
@@ -97,7 +97,7 @@ class Get extends Action
         $body = $res->getBody();
         $doc = new DOMDocument();
         $doc->strictErrorChecking = false;
-        if ($body !== '') {
+        if (!empty($body)) {
             @$doc->loadHTML($body);
         }
 


### PR DESCRIPTION
## Summary

Fix a 500 in the favicon endpoint when the upstream URL returns an empty response body.

`DOMDocument::loadHTML()` on PHP 8+ throws `ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty` when given an empty string. The `@` error-suppression operator does NOT suppress `ValueError`, so the request 500s instead of falling back gracefully.

The existing fallback at the end of the action already handles "no `<link>` tags found" by defaulting to `/favicon.ico`, so when the body is empty we can simply skip the parsing step and let the existing fallback path handle it.

## Change

In `src/Appwrite/Platform/Modules/Avatars/Http/Favicon/Get.php`, capture the response body once and only call `loadHTML()` when it is non-empty.

## Test plan

- [ ] Manual: hit `/v1/avatars/favicon?url=<url returning 200 with empty body>` — should return `/favicon.ico` instead of 500.
- [ ] Manual: hit `/v1/avatars/favicon?url=<normal url>` — should still resolve favicon as before.

Closes CLO-4279