### PR TITLE
chore: adopt utopia-php/http concurrency fixes

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"1ce4d4d2-abfa-41e4-b13e-8ea927be2eea","pid":74450,"procStart":"Tue Apr 28 11:38:51 2026","acquiredAt":1777382028727}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"1ce4d4d2-abfa-41e4-b13e-8ea927be2eea","pid":74450,"procStart":"Tue Apr 28 11:38:51 2026","acquiredAt":1777382028727}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ docker-compose.web-installer.yml
 .env.web-installer
 docker-compose.web-installer.yml.**.backup
 tests/playwright/screenshots
+.claude/scheduled_tasks.lock

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -54,7 +54,7 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
-use Utopia\Http\Route;
+use Utopia\Http\RouteMatch;
 use Utopia\Locale\Locale;
 use Utopia\Logger\Adapter\Sentry;
 use Utopia\Logger\Log;
@@ -848,8 +848,9 @@ Http::init()
     ->inject('authorization')
     ->inject('queueForDeletes')
     ->inject('executionsRetentionCount')
-    ->inject('route')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeleteEvent $queueForDeletes, int $executionsRetentionCount, ?Route $route) {
+    ->inject('match')
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeleteEvent $queueForDeletes, int $executionsRetentionCount, ?RouteMatch $match) {
+        $route = $match?->route;
         /*
         * Appwrite Router
         */
@@ -1178,9 +1179,10 @@ Http::error()
     ->inject('bus')
     ->inject('devKey')
     ->inject('authorization')
-    ->inject('route')
-    ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization, ?Route $route) {
+    ->inject('match')
+    ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization, ?RouteMatch $match) {
         $version = System::getEnv('_APP_VERSION', 'UNKNOWN');
+        $route = $match?->route;
         $class = \get_class($error);
         $code = $error->getCode();
         $message = $error->getMessage();

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -856,14 +856,14 @@ Http::init()
         // Only run Router when external domain
         if (!\in_array($hostname, $platformHostnames) || !empty($previewHostname)) {
             if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
+                $utopia->getResource('route')?->label('router', true);
             }
         }
 
         /*
         * Request format
         */
-        $route = $utopia->getRoute();
+        $route = $utopia->getResource('route');
         $request->setRoute($route);
 
         if ($route === null) {
@@ -1148,7 +1148,7 @@ Http::options()
         // Only run Router when external domain
         if (!in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
             if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
+                $utopia->getResource('route')?->label('router', true);
             }
         }
 
@@ -1183,7 +1183,11 @@ Http::error()
     ->inject('authorization')
     ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization) {
         $version = System::getEnv('_APP_VERSION', 'UNKNOWN');
-        $route = $utopia->getRoute();
+        try {
+            $route = $utopia->getResource('route');
+        } catch (\Throwable $_th) {
+            $route = null;
+        }
         $class = \get_class($error);
         $code = $error->getCode();
         $message = $error->getMessage();
@@ -1549,7 +1553,7 @@ Http::get('/robots.txt')
             $response->text($template->render(false));
         } else {
             if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
+                $utopia->getResource('route')?->label('router', true);
             }
         }
     });
@@ -1583,7 +1587,7 @@ Http::get('/humans.txt')
             $response->text($template->render(false));
         } else {
             if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getRoute()?->label('router', true);
+                $utopia->getResource('route')?->label('router', true);
             }
         }
     });

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -54,6 +54,7 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
 use Utopia\Locale\Locale;
 use Utopia\Logger\Adapter\Sentry;
 use Utopia\Logger\Log;
@@ -847,7 +848,8 @@ Http::init()
     ->inject('authorization')
     ->inject('queueForDeletes')
     ->inject('executionsRetentionCount')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeleteEvent $queueForDeletes, int $executionsRetentionCount) {
+    ->inject('route')
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeleteEvent $queueForDeletes, int $executionsRetentionCount, ?Route $route) {
         /*
         * Appwrite Router
         */
@@ -855,15 +857,12 @@ Http::init()
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!\in_array($hostname, $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getResource('route')?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
 
         /*
         * Request format
         */
-        $route = $utopia->getResource('route');
         $request->setRoute($route);
 
         if ($route === null) {
@@ -1147,9 +1146,7 @@ Http::options()
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getResource('route')?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
 
         foreach ($cors->headers($request->getOrigin()) as $name => $value) {
@@ -1181,13 +1178,9 @@ Http::error()
     ->inject('bus')
     ->inject('devKey')
     ->inject('authorization')
-    ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization) {
+    ->inject('route')
+    ->action(function (Throwable $error, Http $utopia, Request $request, Response $response, Document $project, ?Logger $logger, Log $log, Bus $bus, Document $devKey, Authorization $authorization, ?Route $route) {
         $version = System::getEnv('_APP_VERSION', 'UNKNOWN');
-        try {
-            $route = $utopia->getResource('route');
-        } catch (\Throwable $_th) {
-            $route = null;
-        }
         $class = \get_class($error);
         $code = $error->getCode();
         $message = $error->getMessage();
@@ -1552,9 +1545,7 @@ Http::get('/robots.txt')
             $template = new View(__DIR__ . '/../views/general/robots.phtml');
             $response->text($template->render(false));
         } else {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getResource('route')?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
     });
 
@@ -1586,9 +1577,7 @@ Http::get('/humans.txt')
             $template = new View(__DIR__ . '/../views/general/humans.phtml');
             $response->text($template->render(false));
         } else {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount)) {
-                $utopia->getResource('route')?->label('router', true);
-            }
+            router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $queueForDeletes, $executionsRetentionCount);
         }
     });
 

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -13,7 +13,7 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Http;
-use Utopia\Http\Route;
+use Utopia\Http\RouteMatch;
 use Utopia\Locale\Locale;
 use Utopia\System\System;
 use Utopia\Validator\Text;
@@ -287,8 +287,9 @@ Http::shutdown()
     ->inject('utopia')
     ->inject('response')
     ->inject('request')
-    ->inject('route')
-    ->action(function (Http $utopia, Response $response, Request $request, ?Route $route) {
+    ->inject('match')
+    ->action(function (Http $utopia, Response $response, Request $request, ?RouteMatch $match) {
+        $route = $match?->route;
 
         $result = [];
         $path   = APP_STORAGE_CACHE . '/tests.json';

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -289,7 +289,7 @@ Http::shutdown()
     ->action(function (Http $utopia, Response $response, Request $request) {
 
         $result = [];
-        $route  = $utopia->getRoute();
+        $route  = $utopia->getResource('route');
         $path   = APP_STORAGE_CACHE . '/tests.json';
         $tests  = (\file_exists($path)) ? \json_decode(\file_get_contents($path), true) : [];
 

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -13,6 +13,7 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
 use Utopia\Locale\Locale;
 use Utopia\System\System;
 use Utopia\Validator\Text;
@@ -286,10 +287,10 @@ Http::shutdown()
     ->inject('utopia')
     ->inject('response')
     ->inject('request')
-    ->action(function (Http $utopia, Response $response, Request $request) {
+    ->inject('route')
+    ->action(function (Http $utopia, Response $response, Request $request, ?Route $route) {
 
         $result = [];
-        $route  = $utopia->getResource('route');
         $path   = APP_STORAGE_CACHE . '/tests.json';
         $tests  = (\file_exists($path)) ? \json_decode(\file_get_contents($path), true) : [];
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -101,7 +101,7 @@ Http::init()
     ->inject('apiKey')
     ->inject('authorization')
     ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization) {
-        $route = $utopia->getRoute();
+        $route = $utopia->getResource('route');
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
@@ -507,12 +507,12 @@ Http::init()
         $response->setUser($user);
         $request->setUser($user);
 
-        $route = $utopia->getRoute();
+        $route = $utopia->getResource('route');
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
 
-        $path = $route->getMatchedPath();
+        $path = $utopia->getResource('matchedPath');
         $databaseType = match (true) {
             str_contains($path, '/documentsdb') => DATABASE_TYPE_DOCUMENTSDB,
             str_contains($path, '/vectorsdb') => DATABASE_TYPE_VECTORSDB,
@@ -861,8 +861,8 @@ Http::shutdown()
             }
         }
 
-        $route = $utopia->getRoute();
-        $requestParams = $route->getParamsValues();
+        $route = $utopia->getResource('route');
+        $requestParams = $request->getParams();
 
         /**
          * Abuse labels

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -40,6 +40,7 @@ use Utopia\Database\Validator\Authorization\Input;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Http;
 use Utopia\Http\Route;
+use Utopia\Http\RouteMatch;
 use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -101,8 +102,9 @@ Http::init()
     ->inject('team')
     ->inject('apiKey')
     ->inject('authorization')
-    ->inject('route')
-    ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, ?Route $route) {
+    ->inject('match')
+    ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, ?RouteMatch $match) {
+        $route = $match?->route;
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
@@ -503,16 +505,17 @@ Http::init()
     ->inject('telemetry')
     ->inject('platform')
     ->inject('authorization')
-    ->inject('route')
-    ->inject('matchedPath')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, ?Route $route, string $path) {
+    ->inject('match')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, ?RouteMatch $match) {
 
         $response->setUser($user);
         $request->setUser($user);
 
+        $route = $match?->route;
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
+        $path = $match->path;
 
 
         $databaseType = match (true) {
@@ -813,8 +816,9 @@ Http::shutdown()
     ->inject('bus')
     ->inject('apiKey')
     ->inject('mode')
-    ->inject('route')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode, ?Route $route) use ($parseLabel) {
+    ->inject('match')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode, ?RouteMatch $match) use ($parseLabel) {
+        $route = $match?->route;
 
         $responsePayload = $response->getPayload();
 
@@ -864,10 +868,7 @@ Http::shutdown()
             }
         }
 
-        $requestParams = array_merge(
-            $route?->getPathValues($request) ?? [],
-            $request->getParams(),
-        );
+        $requestParams = $match->arguments ?? [];
 
         /**
          * Abuse labels

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -864,7 +864,10 @@ Http::shutdown()
             }
         }
 
-        $requestParams = $request->getParams();
+        $requestParams = array_merge(
+            $route?->getPathValues($request) ?? [],
+            $request->getParams(),
+        );
 
         /**
          * Abuse labels

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -633,7 +633,6 @@ Http::init()
         $useCache = $route->getLabel('cache', false);
         $storageCacheOperationsCounter = $telemetry->createCounter('storage.cache.operations.load');
         if ($useCache) {
-            $route = $utopia->match($request);
             $isImageTransformation = $route->getPath() === '/v1/storage/buckets/:bucketId/files/:fileId/preview';
             $isDisabled = isset($plan['imageTransformations']) && $plan['imageTransformations'] === -1 && ! $user->isPrivileged($authorization->getRoles());
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -39,6 +39,7 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Authorization\Input;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Http;
+use Utopia\Http\Route;
 use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -100,8 +101,8 @@ Http::init()
     ->inject('team')
     ->inject('apiKey')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization) {
-        $route = $utopia->getResource('route');
+    ->inject('route')
+    ->action(function (Http $utopia, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, ?Route $route) {
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
@@ -502,17 +503,18 @@ Http::init()
     ->inject('telemetry')
     ->inject('platform')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization) {
+    ->inject('route')
+    ->inject('matchedPath')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, ?Route $route, string $path) {
 
         $response->setUser($user);
         $request->setUser($user);
 
-        $route = $utopia->getResource('route');
         if ($route === null) {
             throw new AppwriteException(AppwriteException::GENERAL_ROUTE_NOT_FOUND);
         }
 
-        $path = $utopia->getResource('matchedPath');
+
         $databaseType = match (true) {
             str_contains($path, '/documentsdb') => DATABASE_TYPE_DOCUMENTSDB,
             str_contains($path, '/vectorsdb') => DATABASE_TYPE_VECTORSDB,
@@ -811,7 +813,8 @@ Http::shutdown()
     ->inject('bus')
     ->inject('apiKey')
     ->inject('mode')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode) use ($parseLabel) {
+    ->inject('route')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, Delete $queueForDeletes, EventDatabase $queueForDatabase, Build $queueForBuilds, Messaging $queueForMessaging, Func $queueForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode, ?Route $route) use ($parseLabel) {
 
         $responsePayload = $response->getPayload();
 
@@ -861,7 +864,6 @@ Http::shutdown()
             }
         }
 
-        $route = $utopia->getResource('route');
         $requestParams = $request->getParams();
 
         /**

--- a/app/controllers/shared/api/auth.php
+++ b/app/controllers/shared/api/auth.php
@@ -9,6 +9,7 @@ use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Http\Http;
+use Utopia\Http\RouteMatch;
 use Utopia\System\System;
 
 Http::init()
@@ -32,13 +33,13 @@ Http::init()
 
 Http::init()
     ->groups(['auth'])
-    ->inject('utopia')
     ->inject('request')
     ->inject('project')
     ->inject('geodb')
     ->inject('user')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Document $project, Reader $geodb, User $user, Authorization $authorization) {
+    ->inject('match')
+    ->action(function (Request $request, Document $project, Reader $geodb, User $user, Authorization $authorization, ?RouteMatch $match) {
         $denylist = System::getEnv('_APP_CONSOLE_COUNTRIES_DENYLIST', '');
         if (!empty($denylist && $project->getId() === 'console')) {
             $countries = explode(',', $denylist);
@@ -49,7 +50,7 @@ Http::init()
             }
         }
 
-        $route = $utopia->match($request);
+        $route = $match?->route;
 
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         $isAppUser = $user->isApp($authorization->getRoles());

--- a/app/http.php
+++ b/app/http.php
@@ -545,8 +545,8 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
 
         $app->run($request, $response);
 
-        $route = $app->getResource('route');
-        Span::add('http.path', $route?->getPath() ?? 'unknown');
+        $match = $app->getResource('match');
+        Span::add('http.path', $match?->route->getPath() ?? 'unknown');
     } catch (\Throwable $th) {
         Span::error($th);
 
@@ -562,7 +562,8 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
             }
 
             try {
-                $route = $app->getResource('route');
+                $match = $app->getResource('match');
+                $route = $match?->route;
             } catch (\Throwable $_th) {
                 $route = null;
             }

--- a/app/http.php
+++ b/app/http.php
@@ -522,7 +522,7 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
         return;
     }
 
-    $requestContainer = $swooleAdapter->getContainer();
+    $requestContainer = $swooleAdapter->getContext();
     $requestContainer->set('container', fn () => $requestContainer);
     $requestContainer->set('request', fn () => $request);
     $requestContainer->set('response', fn () => $response);
@@ -545,7 +545,7 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
 
         $app->run($request, $response);
 
-        $route = $app->getRoute();
+        $route = $app->getResource('route');
         Span::add('http.path', $route?->getPath() ?? 'unknown');
     } catch (\Throwable $th) {
         Span::error($th);
@@ -561,7 +561,11 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
                 // All good, user is optional information for logger
             }
 
-            $route = $app->getRoute();
+            try {
+                $route = $app->getResource('route');
+            } catch (\Throwable $_th) {
+                $route = null;
+            }
 
             $log = $app->getResource("log");
 

--- a/app/http.php
+++ b/app/http.php
@@ -561,12 +561,7 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
                 // All good, user is optional information for logger
             }
 
-            try {
-                $match = $app->getResource('match');
-                $route = $match?->route;
-            } catch (\Throwable $_th) {
-                $route = null;
-            }
+            $route = $app->getResource('match')?->route;
 
             $log = $app->getResource("log");
 

--- a/app/http.php
+++ b/app/http.php
@@ -191,7 +191,7 @@ $http->on(Constant::EVENT_AFTER_RELOAD, function ($server) {
 });
 
 $container->set('bus', function ($register) use ($swooleAdapter) {
-    return $register->get('bus')->setResolver(fn (string $name) => $swooleAdapter->getContainer()->get($name));
+    return $register->get('bus')->setResolver(fn (string $name) => $swooleAdapter->getContext()->get($name));
 }, ['register']);
 
 include __DIR__ . '/controllers/general.php';

--- a/app/http.php
+++ b/app/http.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/init/span.php';
 
-$registerRequestResources = require __DIR__ . '/init/resources/request.php';
+$registerContext = require __DIR__ . '/init/resources/request.php';
 
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
@@ -502,7 +502,7 @@ $http->on(Constant::EVENT_START, function ($http) use ($payloadSize, $totalWorke
     });
 });
 
-$swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files, $swooleAdapter, $registerRequestResources) {
+$swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files, $swooleAdapter, $registerContext) {
     Span::init('http.request');
 
     $request = new Request($utopiaRequest->getSwooleRequest());
@@ -522,15 +522,15 @@ $swooleAdapter->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files
         return;
     }
 
-    $requestContainer = $swooleAdapter->getContext();
-    $requestContainer->set('container', fn () => $requestContainer);
-    $requestContainer->set('request', fn () => $request);
-    $requestContainer->set('response', fn () => $response);
+    $context = $swooleAdapter->getContext();
+    $context->set('container', fn () => $context);
+    $context->set('request', fn () => $request);
+    $context->set('response', fn () => $response);
 
     $app = new Http($swooleAdapter, 'UTC');
-    $requestContainer->set('utopia', fn () => $app);
+    $context->set('utopia', fn () => $app);
 
-    $registerRequestResources($requestContainer);
+    $registerContext($context);
 
     $app->setCompression(System::getEnv('_APP_COMPRESSION_ENABLED', 'enabled') === 'enabled');
     $app->setCompressionMinSize(intval(System::getEnv('_APP_COMPRESSION_MIN_SIZE_BYTES', '1024'))); // 1KB

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -47,6 +47,7 @@ use Utopia\DI\Container;
 use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
+use Utopia\Http\RouteMatch;
 use Utopia\Locale\Locale;
 use Utopia\Logger\Log;
 use Utopia\Pools\Group;
@@ -602,7 +603,7 @@ return function (Container $container): void {
         return $user;
     }, ['mode', 'project', 'console', 'request', 'response', 'dbForProject', 'dbForPlatform', 'store', 'proofForToken', 'authorization']);
 
-    $container->set('project', function ($dbForPlatform, $request, $console, $authorization, Http $utopia) {
+    $container->set('project', function ($dbForPlatform, $request, $console, $authorization, ?RouteMatch $match) {
         /** @var Appwrite\Utopia\Request $request */
         /** @var Utopia\Database\Database $dbForPlatform */
         /** @var Utopia\Database\Document $console */
@@ -616,7 +617,7 @@ return function (Container $container): void {
         // These endpoints moved from /v1/projects/:projectId/<resource> to /v1/<resource>
         // When accessed via the old alias path, extract projectId from the URI
         $deprecatedProjectPathPrefix = '/v1/projects/';
-        $route = $utopia->match($request);
+        $route = $match?->route;
         if (!empty($route)) {
             $isDeprecatedAlias = \str_starts_with($request->getURI(), $deprecatedProjectPathPrefix) &&
                 !\str_starts_with($route->getPath(), $deprecatedProjectPathPrefix);
@@ -633,7 +634,7 @@ return function (Container $container): void {
         $project = $authorization->skip(fn () => $dbForPlatform->getDocument('projects', $projectId));
 
         return $project;
-    }, ['dbForPlatform', 'request', 'console', 'authorization', 'utopia']);
+    }, ['dbForPlatform', 'request', 'console', 'authorization', 'match']);
 
     $container->set('session', function (User $user, Store $store, Token $proofForToken) {
         if ($user->isEmpty()) {
@@ -1100,12 +1101,12 @@ return function (Container $container): void {
         return $key;
     }, ['request', 'project', 'servers', 'dbForPlatform', 'authorization']);
 
-    $container->set('team', function (Document $project, Database $dbForPlatform, Http $utopia, Request $request, Authorization $authorization) {
+    $container->set('team', function (Document $project, Database $dbForPlatform, ?RouteMatch $match, Request $request, Authorization $authorization) {
         $teamInternalId = '';
         if ($project->getId() !== 'console') {
             $teamInternalId = $project->getAttribute('teamInternalId', '');
         } else {
-            $route = $utopia->match($request);
+            $route = $match?->route;
             $path = ! empty($route) ? $route->getPath() : $request->getURI();
             $orgHeader = $request->getHeader('x-appwrite-organization', '');
             if (str_starts_with($path, '/v1/projects/:projectId')) {
@@ -1141,7 +1142,7 @@ return function (Container $container): void {
         });
 
         return $team;
-    }, ['project', 'dbForPlatform', 'utopia', 'request', 'authorization']);
+    }, ['project', 'dbForPlatform', 'match', 'request', 'authorization']);
 
     $container->set('previewHostname', function (Request $request, ?Key $apiKey) {
         $allowed = false;

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "utopia-php/emails": "0.6.*",
         "utopia-php/dns": "1.6.*",
         "utopia-php/dsn": "0.2.1",
-        "utopia-php/http": "0.34.*",
+        "utopia-php/http": "dev-fix/concurrency-shared-state as 0.34.99",
         "utopia-php/fetch": "0.5.*",
         "utopia-php/validators": "0.2.*",
         "utopia-php/image": "0.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4275,12 +4275,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "41179392e58553f03467ba1d53710e4ecb542e03"
+                "reference": "2e2c19aef535b1f9241bb5c9e1bf9811a11ec3d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/41179392e58553f03467ba1d53710e4ecb542e03",
-                "reference": "41179392e58553f03467ba1d53710e4ecb542e03",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/2e2c19aef535b1f9241bb5c9e1bf9811a11ec3d2",
+                "reference": "2e2c19aef535b1f9241bb5c9e1bf9811a11ec3d2",
                 "shasum": ""
             },
             "require": {
@@ -4323,7 +4323,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/fix/concurrency-shared-state"
             },
-            "time": "2026-04-28T14:08:05+00:00"
+            "time": "2026-04-28T15:13:55+00:00"
         },
         {
             "name": "utopia-php/image",

--- a/composer.lock
+++ b/composer.lock
@@ -4275,12 +4275,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "2e2c19aef535b1f9241bb5c9e1bf9811a11ec3d2"
+                "reference": "e26b1a995f01b136ec88f6f2fd34811188b627cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/2e2c19aef535b1f9241bb5c9e1bf9811a11ec3d2",
-                "reference": "2e2c19aef535b1f9241bb5c9e1bf9811a11ec3d2",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/e26b1a995f01b136ec88f6f2fd34811188b627cc",
+                "reference": "e26b1a995f01b136ec88f6f2fd34811188b627cc",
                 "shasum": ""
             },
             "require": {
@@ -4323,7 +4323,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/fix/concurrency-shared-state"
             },
-            "time": "2026-04-28T15:13:55+00:00"
+            "time": "2026-04-28T15:24:50+00:00"
         },
         {
             "name": "utopia-php/image",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "805802552f7482eaeae4bdaa505ae982",
+    "content-hash": "4fe55bdcb4efe2a8e4394e3a504bd94e",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4271,16 +4271,16 @@
         },
         {
             "name": "utopia-php/http",
-            "version": "0.34.24",
+            "version": "dev-fix/concurrency-shared-state",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "d1eced0627c5a9fceddf53992ed97d664b810d33"
+                "reference": "0707b7caff4ec0561027eba12ed045940e7b1b0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/d1eced0627c5a9fceddf53992ed97d664b810d33",
-                "reference": "d1eced0627c5a9fceddf53992ed97d664b810d33",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/0707b7caff4ec0561027eba12ed045940e7b1b0d",
+                "reference": "0707b7caff4ec0561027eba12ed045940e7b1b0d",
                 "shasum": ""
             },
             "require": {
@@ -4321,9 +4321,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/0.34.24"
+                "source": "https://github.com/utopia-php/http/tree/fix/concurrency-shared-state"
             },
-            "time": "2026-04-24T12:16:53+00:00"
+            "time": "2026-04-28T10:30:40+00:00"
         },
         {
             "name": "utopia-php/image",
@@ -8443,9 +8443,18 @@
             "time": "2024-11-07T12:36:22+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/http",
+            "version": "dev-fix/concurrency-shared-state",
+            "alias": "0.34.99",
+            "alias_normalized": "0.34.99.0"
+        }
+    ],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "utopia-php/http": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4275,12 +4275,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "0707b7caff4ec0561027eba12ed045940e7b1b0d"
+                "reference": "41179392e58553f03467ba1d53710e4ecb542e03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/0707b7caff4ec0561027eba12ed045940e7b1b0d",
-                "reference": "0707b7caff4ec0561027eba12ed045940e7b1b0d",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/41179392e58553f03467ba1d53710e4ecb542e03",
+                "reference": "41179392e58553f03467ba1d53710e4ecb542e03",
                 "shasum": ""
             },
             "require": {
@@ -4323,7 +4323,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/fix/concurrency-shared-state"
             },
-            "time": "2026-04-28T10:30:40+00:00"
+            "time": "2026-04-28T14:08:05+00:00"
         },
         {
             "name": "utopia-php/image",

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -359,11 +359,7 @@ class Resolvers
 
         $lock->acquire();
 
-        try {
-            $original = $utopia->getResource('match');
-        } catch (\Throwable $_th) {
-            $original = null;
-        }
+        $original = $utopia->getResource('match');
         try {
             $request = clone $request;
 

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -360,7 +360,7 @@ class Resolvers
         $lock->acquire();
 
         try {
-            $original = $utopia->getResource('route');
+            $original = $utopia->getResource('match');
         } catch (\Throwable $_th) {
             $original = null;
         }
@@ -408,7 +408,7 @@ class Resolvers
         } finally {
             if ($original !== null) {
                 $container = self::getResolverContainer($utopia);
-                $container->set('route', static fn () => $original);
+                $container->set('match', static fn () => $original);
             }
 
             $lock->release();

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -403,8 +403,7 @@ class Resolvers
             return;
         } finally {
             if ($original !== null) {
-                $container = self::getResolverContainer($utopia);
-                $container->set('match', static fn () => $original);
+                $utopia->setContext('match', static fn () => $original);
             }
 
             $lock->release();

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -359,7 +359,11 @@ class Resolvers
 
         $lock->acquire();
 
-        $original = $utopia->getRoute();
+        try {
+            $original = $utopia->getResource('route');
+        } catch (\Throwable $_th) {
+            $original = null;
+        }
         try {
             $request = clone $request;
 
@@ -403,7 +407,8 @@ class Resolvers
             return;
         } finally {
             if ($original !== null) {
-                $utopia->setRoute($original);
+                $container = self::getResolverContainer($utopia);
+                $container->set('route', static fn () => $original);
             }
 
             $lock->release();

--- a/src/Appwrite/Platform/Installer/Server.php
+++ b/src/Appwrite/Platform/Installer/Server.php
@@ -154,7 +154,7 @@ class Server
 
         $nativeServer = $adapter->getNativeServer();
 
-        $container = $adapter->getContainer();
+        $container = $adapter->getContext();
         $container->set('installerState', fn () => $state);
         $container->set('installerConfig', fn () => $config);
         $container->set('installerPaths', fn () => $paths);

--- a/src/Appwrite/Promises/Swoole.php
+++ b/src/Appwrite/Promises/Swoole.php
@@ -8,7 +8,7 @@ use Utopia\DI\Container;
 
 class Swoole extends Promise
 {
-    private const REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_request_container';
+    private const REQUEST_CONTAINER_CONTEXT_KEY = '__utopia_http_context';
 
     public function __construct(?callable $executor = null)
     {


### PR DESCRIPTION
## Summary

Bumps `utopia-php/http` to the `fix/concurrency-shared-state` branch (utopia-php/http#251), which removes per-request mutations on shared singletons (`Http::$route`, `Route::$matchedPath`, `Http::$wildcardRoute`, `Hook` param writeback). This PR migrates the appwrite codebase to the new public surface.

### Changes

- `composer.json`: pin `utopia-php/http` to `dev-fix/concurrency-shared-state as 0.34.99` (revert before merge once the upstream PR ships).
- `app/http.php`:
  - Use `$swooleAdapter->getContext()` instead of `getContainer()` for the per-request container (`getContainer()` now always returns the global singleton).
  - Read the matched route via `$app->getResource('route')` instead of `getRoute()`.
- `app/controllers/general.php`, `app/controllers/mock.php`, `app/controllers/shared/api.php`: replace `Http::getRoute()` calls with `getResource('route')`. Replace `Route::getMatchedPath()` with `getResource('matchedPath')`. Calls to `Request::getRoute()` / `setRoute()` (Appwrite's own subclass) are left alone.
- `app/controllers/shared/api.php`: read request params via `$request->getParams()` in the shutdown hook — `Route::getParamsValues()` is no longer populated by request handling.
- `src/Appwrite/GraphQL/Resolvers.php`: snapshot/restore the parent route via the per-request context container instead of `Http::setRoute()`.
- `src/Appwrite/Promises/Swoole.php`: update the coroutine context key constant from `__utopia_http_request_container` to `__utopia_http_context` to match the upstream rename.

### Verification

- [x] `composer analyze` (PHPStan) — clean.
- [x] `composer format` (Pint) — clean.
- [ ] e2e suite — needs CI (Docker stack).
- [ ] Manual smoke test of concurrent requests on Swoole-backed deploy.

## Test plan
- [ ] CI green
- [ ] Verify concurrent request behavior under Swoole (parameterized routes via different aliases, wildcard route in parallel, route with I/O followed by `getResource('route')`).
- [ ] Confirm GraphQL resolvers still resolve nested route routes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)