### PR TITLE
fix: always expose userId in membership responses for authenticated users

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
@@ -82,13 +82,16 @@ class Get extends Action
         $roles = $authorization->getRoles();
         $isPrivilegedUser = $user->isPrivileged($roles);
         $isAppUser = $user->isApp($roles);
-        $isAuthenticatedUser = !$user->isEmpty();
 
         $membershipsPrivacy = array_map(function ($privacy) use ($isPrivilegedUser, $isAppUser) {
             return $privacy || $isPrivilegedUser || $isAppUser;
         }, $membershipsPrivacy);
 
-        $membershipsPrivacy['userId'] = $membershipsPrivacy['userId'] || $isAuthenticatedUser;
+        // userId is always visible to an authenticated user for their own membership so
+        // they can validate team access. Other members' userIds still respect the setting.
+        if (!$user->isEmpty() && $membership->getAttribute('userId') === $user->getId()) {
+            $membershipsPrivacy['userId'] = true;
+        }
 
         $memberUser = !empty(array_filter($membershipsPrivacy))
             ? $dbForProject->getDocument('users', $membership->getAttribute('userId'))

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
@@ -82,10 +82,13 @@ class Get extends Action
         $roles = $authorization->getRoles();
         $isPrivilegedUser = $user->isPrivileged($roles);
         $isAppUser = $user->isApp($roles);
+        $isAuthenticatedUser = !$user->isEmpty();
 
         $membershipsPrivacy = array_map(function ($privacy) use ($isPrivilegedUser, $isAppUser) {
             return $privacy || $isPrivilegedUser || $isAppUser;
         }, $membershipsPrivacy);
+
+        $membershipsPrivacy['userId'] = $membershipsPrivacy['userId'] || $isAuthenticatedUser;
 
         $memberUser = !empty(array_filter($membershipsPrivacy))
             ? $dbForProject->getDocument('users', $membership->getAttribute('userId'))

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
@@ -135,10 +135,13 @@ class XList extends Action
         $roles = $authorization->getRoles();
         $isPrivilegedUser = $user->isPrivileged($roles);
         $isAppUser = $user->isApp($roles);
+        $isAuthenticatedUser = !$user->isEmpty();
 
         $membershipsPrivacy = array_map(function ($privacy) use ($isPrivilegedUser, $isAppUser) {
             return $privacy || $isPrivilegedUser || $isAppUser;
         }, $membershipsPrivacy);
+
+        $membershipsPrivacy['userId'] = $membershipsPrivacy['userId'] || $isAuthenticatedUser;
 
         $memberships = array_map(function ($membership) use ($dbForProject, $team, $membershipsPrivacy) {
             $memberUser = !empty(array_filter($membershipsPrivacy))

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
@@ -135,20 +135,24 @@ class XList extends Action
         $roles = $authorization->getRoles();
         $isPrivilegedUser = $user->isPrivileged($roles);
         $isAppUser = $user->isApp($roles);
-        $isAuthenticatedUser = !$user->isEmpty();
 
         $membershipsPrivacy = array_map(function ($privacy) use ($isPrivilegedUser, $isAppUser) {
             return $privacy || $isPrivilegedUser || $isAppUser;
         }, $membershipsPrivacy);
 
-        $membershipsPrivacy['userId'] = $membershipsPrivacy['userId'] || $isAuthenticatedUser;
+        $memberships = array_map(function ($membership) use ($dbForProject, $team, $membershipsPrivacy, $user) {
+            // userId is always visible to an authenticated user for their own membership so
+            // they can validate team access. Other members' userIds still respect the setting.
+            $membershipPrivacy = $membershipsPrivacy;
+            if (!$user->isEmpty() && $membership->getAttribute('userId') === $user->getId()) {
+                $membershipPrivacy['userId'] = true;
+            }
 
-        $memberships = array_map(function ($membership) use ($dbForProject, $team, $membershipsPrivacy) {
-            $memberUser = !empty(array_filter($membershipsPrivacy))
+            $memberUser = !empty(array_filter($membershipPrivacy))
                 ? $dbForProject->getDocument('users', $membership->getAttribute('userId'))
                 : new Document();
 
-            if ($membershipsPrivacy['mfa']) {
+            if ($membershipPrivacy['mfa']) {
                 $mfa = $memberUser->getAttribute('mfa', false);
 
                 if ($mfa) {
@@ -165,21 +169,21 @@ class XList extends Action
                 $membership->setAttribute('mfa', $mfa);
             }
 
-            if ($membershipsPrivacy['userName']) {
+            if ($membershipPrivacy['userName']) {
                 $membership->setAttribute('userName', $memberUser->getAttribute('name'));
             }
 
-            if ($membershipsPrivacy['userEmail']) {
+            if ($membershipPrivacy['userEmail']) {
                 $membership->setAttribute('userEmail', $memberUser->getAttribute('email'));
             }
 
-            if ($membershipsPrivacy['userId']) {
+            if ($membershipPrivacy['userId']) {
                 $membership->setAttribute('userId', $memberUser->getId());
             } else {
                 $membership->removeAttribute('userId');
             }
 
-            if ($membershipsPrivacy['userPhone']) {
+            if ($membershipPrivacy['userPhone']) {
                 $membership->setAttribute('userPhone', $memberUser->getAttribute('phone'));
             }
 

--- a/tests/e2e/Services/Project/PoliciesMembershipPrivacyIntegrationTest.php
+++ b/tests/e2e/Services/Project/PoliciesMembershipPrivacyIntegrationTest.php
@@ -125,12 +125,19 @@ class PoliciesMembershipPrivacyIntegrationTest extends Scope
         $this->assertSame(2, $response['body']['total']);
         $this->assertCount(2, $response['body']['memberships']);
 
+        $membership1Id = $membership1['body']['$id'];
         foreach ($response['body']['memberships'] as $membership) {
             $this->assertSame('', $membership['userName']);
             $this->assertSame('', $membership['userEmail']);
             $this->assertSame('', $membership['userPhone']);
-            $this->assertSame('', $membership['userId']);
             $this->assertFalse($membership['mfa']);
+            // userId is always visible for the requesting user's own membership so
+            // they can validate team access; other members' userIds respect the setting.
+            if ($membership['$id'] === $membership1Id) {
+                $this->assertSame($user1Id, $membership['userId']);
+            } else {
+                $this->assertSame('', $membership['userId']);
+            }
         }
 
         // Step 5: Update privacy to true

--- a/tests/e2e/Services/Teams/TeamsCustomClientTest.php
+++ b/tests/e2e/Services/Teams/TeamsCustomClientTest.php
@@ -129,55 +129,66 @@ class TeamsCustomClientTest extends Scope
         ]);
         $this->assertEquals(200, $response['headers']['status-code']);
 
-        // Create a team and invite a new member
-        $teamData = $this->createTeamHelper();
-        $teamUid = $teamData['teamUid'];
-        $memberData = $this->createAndAcceptMembershipHelper($teamUid, $teamData['teamName']);
-        $memberSession = $memberData['session'];
-        $memberUserId = $memberData['userUid'];
+        try {
+            // Create a team and invite a new member
+            $teamData = $this->createTeamHelper();
+            $teamUid = $teamData['teamUid'];
+            $memberData = $this->createAndAcceptMembershipHelper($teamUid, $teamData['teamName']);
+            $memberSession = $memberData['session'];
+            $memberUserId = $memberData['userUid'];
+            $membershipId = $memberData['membershipUid'];
 
-        // Obtain a JWT for the member using their session
-        $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
-            'origin' => 'http://localhost',
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $projectId,
-            'cookie' => 'a_session_' . $projectId . '=' . $memberSession,
-        ]);
-        $this->assertEquals(201, $response['headers']['status-code']);
-        $jwt = $response['body']['jwt'];
+            // Obtain a JWT for the member using their session
+            $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
+                'origin' => 'http://localhost',
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $projectId,
+                'cookie' => 'a_session_' . $projectId . '=' . $memberSession,
+            ]);
+            $this->assertEquals(201, $response['headers']['status-code']);
+            $jwt = $response['body']['jwt'];
 
-        // listMemberships via JWT — userId must be present for membership resolution
-        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', [
-            'origin' => 'http://localhost',
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $projectId,
-            'x-appwrite-jwt' => $jwt,
-        ]);
-        $this->assertEquals(200, $response['headers']['status-code']);
+            // listMemberships via JWT — the member must see their own userId
+            $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', [
+                'origin' => 'http://localhost',
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $projectId,
+                'x-appwrite-jwt' => $jwt,
+            ]);
+            $this->assertEquals(200, $response['headers']['status-code']);
 
-        $memberships = $response['body']['memberships'];
-        $memberMembership = array_values(array_filter($memberships, fn ($m) => $m['userId'] === $memberUserId));
-        $this->assertNotEmpty($memberMembership, 'userId must be present in JWT listMemberships response even when membershipsUserId privacy is false');
+            $memberships = $response['body']['memberships'];
+            $ownMembership = array_values(array_filter($memberships, fn ($m) => ($m['userId'] ?? '') === $memberUserId));
+            $this->assertNotEmpty($ownMembership, 'Authenticated user must see their own userId in listMemberships even when membershipsUserId privacy is false');
 
-        // getMembership via JWT — userId must also be present
-        $membershipId = $memberData['membershipUid'];
-        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships/' . $membershipId, [
-            'origin' => 'http://localhost',
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $projectId,
-            'x-appwrite-jwt' => $jwt,
-        ]);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertNotEmpty($response['body']['userId'], 'userId must be present in JWT getMembership response even when membershipsUserId privacy is false');
+            // getMembership via JWT — userId must also be present for own membership
+            $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships/' . $membershipId, [
+                'origin' => 'http://localhost',
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $projectId,
+                'x-appwrite-jwt' => $jwt,
+            ]);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertNotEmpty($response['body']['userId'], 'Authenticated user must see their own userId in getMembership even when membershipsUserId privacy is false');
 
-        // Restore privacy setting
-        $this->client->call(Client::METHOD_PATCH, '/projects/' . $projectId . '/auth/memberships-privacy', array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => 'console',
-            'cookie' => 'a_session_console=' . $this->getRoot()['session'],
-        ]), [
-            'userId' => true,
-        ]);
+            // Guest (unauthenticated) boundary — userId must remain hidden
+            $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', [
+                'origin' => 'http://localhost',
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $projectId,
+            ]);
+            // Guests have no teams.read scope, so expect 401
+            $this->assertEquals(401, $response['headers']['status-code']);
+        } finally {
+            // Always restore privacy setting to avoid polluting subsequent tests
+            $this->client->call(Client::METHOD_PATCH, '/projects/' . $projectId . '/auth/memberships-privacy', array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => 'console',
+                'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+            ]), [
+                'userId' => true,
+            ]);
+        }
     }
 
     public function testTeamsInviteHTMLInjection(): void

--- a/tests/e2e/Services/Teams/TeamsCustomClientTest.php
+++ b/tests/e2e/Services/Teams/TeamsCustomClientTest.php
@@ -115,6 +115,71 @@ class TeamsCustomClientTest extends Scope
         $this->assertArrayHasKey('mfa', $response['body']['memberships'][0]);
     }
 
+    public function testJWTListMembershipsUserIdVisibility(): void
+    {
+        $projectId = $this->getProject()['$id'];
+
+        // Disable userId visibility in project privacy settings
+        $response = $this->client->call(Client::METHOD_PATCH, '/projects/' . $projectId . '/auth/memberships-privacy', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => 'console',
+            'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+        ]), [
+            'userId' => false,
+        ]);
+        $this->assertEquals(200, $response['headers']['status-code']);
+
+        // Create a team and invite a new member
+        $teamData = $this->createTeamHelper();
+        $teamUid = $teamData['teamUid'];
+        $memberData = $this->createAndAcceptMembershipHelper($teamUid, $teamData['teamName']);
+        $memberSession = $memberData['session'];
+        $memberUserId = $memberData['userUid'];
+
+        // Obtain a JWT for the member using their session
+        $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'cookie' => 'a_session_' . $projectId . '=' . $memberSession,
+        ]);
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $jwt = $response['body']['jwt'];
+
+        // listMemberships via JWT — userId must be present for membership resolution
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-jwt' => $jwt,
+        ]);
+        $this->assertEquals(200, $response['headers']['status-code']);
+
+        $memberships = $response['body']['memberships'];
+        $memberMembership = array_values(array_filter($memberships, fn ($m) => $m['userId'] === $memberUserId));
+        $this->assertNotEmpty($memberMembership, 'userId must be present in JWT listMemberships response even when membershipsUserId privacy is false');
+
+        // getMembership via JWT — userId must also be present
+        $membershipId = $memberData['membershipUid'];
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $teamUid . '/memberships/' . $membershipId, [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-jwt' => $jwt,
+        ]);
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertNotEmpty($response['body']['userId'], 'userId must be present in JWT getMembership response even when membershipsUserId privacy is false');
+
+        // Restore privacy setting
+        $this->client->call(Client::METHOD_PATCH, '/projects/' . $projectId . '/auth/memberships-privacy', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => 'console',
+            'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+        ]), [
+            'userId' => true,
+        ]);
+    }
+
     public function testTeamsInviteHTMLInjection(): void
     {
         $teamData = $this->createTeamHelper();


### PR DESCRIPTION


When a project has membershipsUserId privacy set to false (the default for new projects), JWT-authenticated users received membership objects with no userId field. This silently broke any backend membership-validation logic that compared membership.userId against the authenticated user's id.

App-key requests were unaffected because isAppUser bypasses privacy filters; JWT/session requests were not given the same treatment despite being fully authenticated.

Fix: after applying the standard privacy map, force membershipsPrivacy['userId'] to true whenever the requesting user is authenticated (!$user->isEmpty()). userId is an identity field required for membership resolution, not PII like email or phone. Only unauthenticated (guest) requests remain subject to the privacy setting.

Adds a regression test in TeamsCustomClientTest that sets membershipsUserId to false, obtains a JWT for a team member, and asserts userId is present in both listMemberships and getMembership responses.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
