### PR TITLE
fix: use documentId parameter instead of document->getId() in updateDocument

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
@@ -325,7 +325,7 @@ class Update extends Action
                 $requestTimestamp,
                 fn () => $dbForDatabases->withPreserveDates(fn () => $dbForDatabases->updateDocument(
                     'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),
-                    $document->getId(),
+                    $documentId,
                     $newDocument
                 ))
             );


### PR DESCRIPTION
Fixes #9215

## What does this PR do?
In the updateDocument handler, the document is first fetched via getDocument() 
and stored in $document. Later, the update uses $document->getId() instead of 
the original $documentId parameter. If the cached document object becomes 
inconsistent between the read and the write, getId() can return an unexpected 
value, causing a 404 document_not_found error.

## Fix
Replace $document->getId() with $documentId in the updateDocument call, 
since $documentId is the original parameter from the request and does not 
depend on the cached object.

## Test Plan
Ran 50 consecutive PATCH requests to the same document using curl against 
a local Appwrite instance. All 50 returned HTTP 200 with no 404 errors.