### PR TITLE
Fix 1.9.x CI code scanning and retry image cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,29 +871,3 @@ jobs:
       - name: Fail benchmark
         if: always() && steps.benchmark_after.outcome != 'success'
         run: exit 1
-
-  cleanup:
-    name: Cleanup GHCR Image
-    if: ${{ always() && github.event_name == 'pull_request' }}
-    needs: [build, unit, e2e_general, e2e_service, e2e_abuse, e2e_screenshots, benchmark]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Delete CI image from GHCR
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          package_path="${GITHUB_REPOSITORY#*/}/appwrite-dev"
-          encoded_path="$(printf '%s' "$package_path" | jq -Rr @uri)"
-          version_id=$(gh api -H "Accept: application/vnd.github+json" \
-            "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${encoded_path}/versions" \
-            --jq ".[] | select(.metadata.container.tags | index(\"${GITHUB_SHA}\")) | .id")
-          if [ -n "$version_id" ]; then
-            gh api --method DELETE -H "Accept: application/vnd.github+json" \
-              "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${encoded_path}/versions/${version_id}"
-            echo "Deleted ${package_path}:${GITHUB_SHA} (version ${version_id})"
-          else
-            echo "No GHCR version found for SHA ${GITHUB_SHA}"
-          fi

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -5,6 +5,11 @@ on:
     types:
       - closed
 
+permissions:
+  actions: write
+  contents: read
+  packages: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -33,6 +38,31 @@ jobs:
             for cacheKey in $cacheKeysForPR
             do
               gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+            done
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup GHCR image
+        continue-on-error: true
+        run: |
+          package_path="${GITHUB_REPOSITORY#*/}/appwrite-dev"
+          encoded_path="$(printf '%s' "$package_path" | jq -Rr @uri)"
+
+          gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/commits" --jq '.[].sha' | while read -r sha; do
+            version_ids=$(gh api --paginate -H "Accept: application/vnd.github+json" \
+              "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${encoded_path}/versions" \
+              --jq ".[] | select(.metadata.container.tags | index(\"${sha}\")) | .id")
+
+            if [ -z "$version_ids" ]; then
+              echo "No GHCR version found for SHA ${sha}"
+              continue
+            fi
+
+            echo "$version_ids" | while read -r version_id; do
+              gh api --method DELETE -H "Accept: application/vnd.github+json" \
+                "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${encoded_path}/versions/${version_id}"
+              echo "Deleted ${package_path}:${sha} (version ${version_id})"
             done
           done
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,9 +24,10 @@ jobs:
           ignore-unfixed: 'false'
           severity: 'CRITICAL,HIGH'
       - name: Upload Docker Image Scan Results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-image-results.sarif'
+          category: 'trivy-image'
 
   scan-code:
     name: Scan Code
@@ -42,6 +43,7 @@ jobs:
           output: 'trivy-fs-results.sarif'
           severity: 'CRITICAL,HIGH'
       - name: Upload Code Scan Results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-fs-results.sarif'
+          category: 'trivy-source'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
       - name: Upload Docker Image Scan Results
         uses: github/codeql-action/upload-sarif@v4
+        if: always() && hashFiles('trivy-image-results.sarif') != ''
         with:
           sarif_file: 'trivy-image-results.sarif'
           category: 'trivy-image'
@@ -44,6 +45,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
       - name: Upload Code Scan Results
         uses: github/codeql-action/upload-sarif@v4
+        if: always() && hashFiles('trivy-fs-results.sarif') != ''
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-source'


### PR DESCRIPTION
## What does this PR do?

Fixes two CI issues on `1.9.x`.

First, it aligns the nightly Trivy SARIF upload configuration with the PR CI Trivy uploads. The base branch currently publishes Trivy code scanning results from `.github/workflows/nightly.yml` without explicit categories, so GitHub records them as `.github/workflows/nightly.yml:scan-image` and `.github/workflows/nightly.yml:scan-code`. PR CI publishes Trivy results from `.github/workflows/ci.yml:security` with `trivy-image` and `trivy-source` categories. Because those configurations do not match, GitHub Advanced Security reports the PR Trivy check as neutral with "2 configurations not found".

Second, it preserves the GHCR CI image while a PR is open. The CI workflow currently deletes `ghcr.io/appwrite/appwrite/appwrite-dev:<sha>` at the end of each PR run. Retrying an individual job reuses the same SHA tag but does not rerun the `build` job, so the retry fails while pulling the deleted image with `manifest unknown`. This moves GHCR cleanup to the existing `pull_request.closed` cleanup workflow and deletes images for the PR commit SHAs after the PR is closed.

## Test Plan

- Parsed `.github/workflows/nightly.yml`, `.github/workflows/ci.yml`, and `.github/workflows/cleanup-cache.yml` locally with Ruby YAML parser.

## Related PRs and Issues

- Related to #12174

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
