### PR TITLE
Fix project delete platform cleanup ordering

### DIFF
--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -633,6 +633,57 @@ class Deletes extends Action
             $dsn = new DSN('mysql://' . $document->getAttribute('database', 'console'));
         }
 
+        // Delete Platforms
+        $this->deleteByGroup('platforms', [
+            Query::equal('projectInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
+        // Delete project and function rules
+        $this->deleteByGroup('rules', [
+            Query::equal('projectInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform, function (Document $document) use ($dbForPlatform, $certificates) {
+            $this->deleteRule($dbForPlatform, $document, $certificates);
+        });
+
+        // Delete Keys
+        $this->deleteByGroup('keys', [
+            Query::equal('resourceType', ['projects']),
+            Query::equal('resourceInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
+        // Delete Webhooks
+        $this->deleteByGroup('webhooks', [
+            Query::equal('projectInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
+        // Delete VCS Installations
+        $this->deleteByGroup('installations', [
+            Query::equal('projectInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
+        // Delete VCS Repositories
+        $this->deleteByGroup('repositories', [
+            Query::equal('projectInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
+        // Delete VCS comments
+        $this->deleteByGroup('vcsComments', [
+            Query::equal('projectInternalId', [$projectInternalId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
+        // Delete Schedules
+        $this->deleteByGroup('schedules', [
+            Query::equal('projectId', [$projectId]),
+            Query::orderAsc()
+        ], $dbForPlatform);
+
         /**
          * @var Database $dbForProject
          */
@@ -693,57 +744,6 @@ class Deletes extends Action
                 ),
                 $databasesToClean
             ));
-
-            // Delete Platforms
-            $this->deleteByGroup('platforms', [
-                Query::equal('projectInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
-
-            // Delete project and function rules
-            $this->deleteByGroup('rules', [
-                Query::equal('projectInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform, function (Document $document) use ($dbForPlatform, $certificates) {
-                $this->deleteRule($dbForPlatform, $document, $certificates);
-            });
-
-            // Delete Keys
-            $this->deleteByGroup('keys', [
-                Query::equal('resourceType', ['projects']),
-                Query::equal('resourceInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
-
-            // Delete Webhooks
-            $this->deleteByGroup('webhooks', [
-                Query::equal('projectInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
-
-            // Delete VCS Installations
-            $this->deleteByGroup('installations', [
-                Query::equal('projectInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
-
-            // Delete VCS Repositories
-            $this->deleteByGroup('repositories', [
-                Query::equal('projectInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
-
-            // Delete VCS comments
-            $this->deleteByGroup('vcsComments', [
-                Query::equal('projectInternalId', [$projectInternalId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
-
-            // Delete Schedules
-            $this->deleteByGroup('schedules', [
-                Query::equal('projectId', [$projectId]),
-                Query::orderAsc()
-            ], $dbForPlatform);
 
             // Delete metadata table
             if ($projectTables) {

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -634,55 +634,87 @@ class Deletes extends Action
         }
 
         // Delete Platforms
-        $this->deleteByGroup('platforms', [
-            Query::equal('projectInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('platforms', [
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete platforms: ' . $th->getMessage());
+        }
 
         // Delete project and function rules
-        $this->deleteByGroup('rules', [
-            Query::equal('projectInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform, function (Document $document) use ($dbForPlatform, $certificates) {
-            $this->deleteRule($dbForPlatform, $document, $certificates);
-        });
+        try {
+            $this->deleteByGroup('rules', [
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform, function (Document $document) use ($dbForPlatform, $certificates) {
+                $this->deleteRule($dbForPlatform, $document, $certificates);
+            });
+        } catch (Throwable $th) {
+            Console::error('Failed to delete rules: ' . $th->getMessage());
+        }
 
         // Delete Keys
-        $this->deleteByGroup('keys', [
-            Query::equal('resourceType', ['projects']),
-            Query::equal('resourceInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('keys', [
+                Query::equal('resourceType', ['projects']),
+                Query::equal('resourceInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete keys: ' . $th->getMessage());
+        }
 
         // Delete Webhooks
-        $this->deleteByGroup('webhooks', [
-            Query::equal('projectInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('webhooks', [
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete webhooks: ' . $th->getMessage());
+        }
 
         // Delete VCS Installations
-        $this->deleteByGroup('installations', [
-            Query::equal('projectInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('installations', [
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete installations: ' . $th->getMessage());
+        }
 
         // Delete VCS Repositories
-        $this->deleteByGroup('repositories', [
-            Query::equal('projectInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('repositories', [
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete repositories: ' . $th->getMessage());
+        }
 
         // Delete VCS comments
-        $this->deleteByGroup('vcsComments', [
-            Query::equal('projectInternalId', [$projectInternalId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('vcsComments', [
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete VCS comments: ' . $th->getMessage());
+        }
 
         // Delete Schedules
-        $this->deleteByGroup('schedules', [
-            Query::equal('projectId', [$projectId]),
-            Query::orderAsc()
-        ], $dbForPlatform);
+        try {
+            $this->deleteByGroup('schedules', [
+                Query::equal('projectId', [$projectId]),
+                Query::orderAsc()
+            ], $dbForPlatform);
+        } catch (Throwable $th) {
+            Console::error('Failed to delete schedules: ' . $th->getMessage());
+        }
 
         /**
          * @var Database $dbForProject
@@ -736,24 +768,35 @@ class Deletes extends Action
             };
 
             batch(array_map(
-                fn ($databaseDoc) => fn () => $this->cleanDatabase(
-                    $databaseDoc,
-                    $executionActionPerDatabase,
-                    $projectTables,
-                    $projectCollectionIds
-                ),
+                fn ($databaseDoc) => function () use ($databaseDoc, $executionActionPerDatabase, $projectTables, $projectCollectionIds) {
+                    try {
+                        $this->cleanDatabase(
+                            $databaseDoc,
+                            $executionActionPerDatabase,
+                            $projectTables,
+                            $projectCollectionIds
+                        );
+                    } catch (Throwable $th) {
+                        Console::error('Failed to delete database ' . $databaseDoc->getAttribute('database') . ': ' . $th->getMessage());
+                    }
+                },
                 $databasesToClean
             ));
 
             // Delete metadata table
             if ($projectTables) {
                 batch(array_map(
-                    fn ($databaseDoc) => fn () =>
-                        $executionActionPerDatabase(
-                            $databaseDoc,
-                            fn (Database $dbForDatabases) =>
-                                $dbForDatabases->deleteCollection(Database::METADATA)
-                        ),
+                    fn ($databaseDoc) => function () use ($databaseDoc, $executionActionPerDatabase) {
+                        try {
+                            $executionActionPerDatabase(
+                                $databaseDoc,
+                                fn (Database $dbForDatabases) =>
+                                    $dbForDatabases->deleteCollection(Database::METADATA)
+                            );
+                        } catch (Throwable $th) {
+                            Console::error('Failed to delete metadata table for database ' . $databaseDoc->getAttribute('database') . ': ' . $th->getMessage());
+                        }
+                    },
                     $databasesToClean
                 ));
             } else {
@@ -764,19 +807,47 @@ class Deletes extends Action
 
                 $queries[] = Query::orderAsc();
 
-                $this->deleteByGroup(
-                    Database::METADATA,
-                    $queries,
-                    $dbForProject
-                );
+                try {
+                    $this->deleteByGroup(
+                        Database::METADATA,
+                        $queries,
+                        $dbForProject
+                    );
+                } catch (Throwable $th) {
+                    Console::error('Failed to delete metadata documents: ' . $th->getMessage());
+                }
             }
 
             // Delete all storage directories
-            $deviceForFiles->delete($deviceForFiles->getRoot(), true);
-            $deviceForSites->delete($deviceForSites->getRoot(), true);
-            $deviceForFunctions->delete($deviceForFunctions->getRoot(), true);
-            $deviceForBuilds->delete($deviceForBuilds->getRoot(), true);
-            $deviceForCache->delete($deviceForCache->getRoot(), true);
+            try {
+                $deviceForFiles->delete($deviceForFiles->getRoot(), true);
+            } catch (Throwable $th) {
+                Console::error('Failed to delete files storage directory: ' . $th->getMessage());
+            }
+
+            try {
+                $deviceForSites->delete($deviceForSites->getRoot(), true);
+            } catch (Throwable $th) {
+                Console::error('Failed to delete sites storage directory: ' . $th->getMessage());
+            }
+
+            try {
+                $deviceForFunctions->delete($deviceForFunctions->getRoot(), true);
+            } catch (Throwable $th) {
+                Console::error('Failed to delete functions storage directory: ' . $th->getMessage());
+            }
+
+            try {
+                $deviceForBuilds->delete($deviceForBuilds->getRoot(), true);
+            } catch (Throwable $th) {
+                Console::error('Failed to delete builds storage directory: ' . $th->getMessage());
+            }
+
+            try {
+                $deviceForCache->delete($deviceForCache->getRoot(), true);
+            } catch (Throwable $th) {
+                Console::error('Failed to delete cache storage directory: ' . $th->getMessage());
+            }
 
         } finally {
             $dbForProject->enableValidation();


### PR DESCRIPTION
## What does this PR do?

Moves project-level platform cleanup earlier in the deletes worker, before project database cleanup begins.

When a project is deleted, the project document is removed first and the deletes worker later cleans related resources. Previously, platform-scoped cleanup for `platforms`, `rules`, `keys`, `webhooks`, `installations`, `repositories`, `vcsComments`, and `schedules` happened after the worker opened and cleaned the project database. If project database cleanup failed before that point, those platform rows could be left behind.

This is especially visible for proxy rules because `_console_rules.domain` is globally unique. An orphaned rule keeps the domain reserved and causes users to see `domain is already used` when adding the domain to a site in another project.

This PR does not add new cleanup behavior. It moves the existing cleanup blocks earlier so they run before the project DB cleanup failure point.

## Test Plan

- Ran formatting/lint check:

```bash
composer lint src/Appwrite/Platform/Workers/Deletes.php
```

Result:

```text
{"result":"pass"}
```

- Started the local Appwrite stack:

```bash
docker compose up -d --force-recreate --build
```

- Verified the original bug by temporarily restoring the old ordering, seeding a project and one matching `_console_rules` row, then invoking the real `Deletes::deleteProject()` path with a simulated project DB cleanup failure before the old platform cleanup section.

Old ordering result:

```text
mode=old
rules_before=1
worker_exception=RuntimeException: simulated project DB cleanup failure
rules_after=1
```

This confirms the rule was orphaned when project DB cleanup failed first.

- Restored the fixed ordering and repeated the same verification for proxy rules.

Fixed rule cleanup result:

```text
mode=fixed
rules_before=1
Deleted 1 documents by group
worker_exception=RuntimeException: simulated project DB cleanup failure
rules_after=0
```

This confirms the rule is removed before the project DB cleanup failure point.

- Broadened the verification by seeding one matching row in each moved platform collection, then invoking the real `Deletes::deleteProject()` path with the same simulated project DB cleanup failure.

Fixed platform cleanup result:

```text
mode=platform-cleanup-fixed
before={"platforms":1,"rules":1,"keys":1,"webhooks":1,"installations":1,"repositories":1,"vcsComments":1,"schedules":1}
worker_exception=RuntimeException: simulated project DB cleanup failure
after={"platforms":0,"rules":0,"keys":0,"webhooks":0,"installations":0,"repositories":0,"vcsComments":0,"schedules":0}
```

- Confirmed no temporary verification rows remained in MongoDB:

```text
{
  _console_platforms: 0,
  _console_rules: 0,
  _console_keys: 0,
  _console_webhooks: 0,
  _console_installations: 0,
  _console_repositories: 0,
  _console_vcsComments: 0,
  _console_schedules: 0,
  _console_projects: 0
}
```

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
