### PR TITLE
feat(locale): add sign language

### DIFF
--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -719,6 +719,11 @@ return [
         "nativeName" => "Sängö"
     ],
     [
+        'name' => 'Sign Language',
+        'code' => 'sgn',
+        'nativeName' => 'Sign Language',
+    ],
+    [
         "code" => "sh",
         "name" => "Serbo-Croatian",
         "nativeName" => "Srpskohrvatski / Српскохрватски"
@@ -727,11 +732,6 @@ return [
         "code" => "si",
         "name" => "Sinhalese",
         "nativeName" => "සිංහල"
-    ],
-    [
-    'name' => 'Sign Language',
-    'code' => 'sgn',
-    'nativeName' => 'Sign Language',
     ],
     [
         "code" => "sk",

--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -729,6 +729,11 @@ return [
         "nativeName" => "සිංහල"
     ],
     [
+    'name' => 'Sign Language',
+    'code' => 'sgn',
+    'nativeName' => 'Sign Language',
+    ],
+    [
         "code" => "sk",
         "name" => "Slovak",
         "nativeName" => "Slovenčina"


### PR DESCRIPTION
## What does this PR do?

Adds Sign Language (`sgn`) to the list of supported locales.

This allows the Locale API to return Sign Language as one of the available language options.

## Test Plan

- Verified the language entry follows the existing locale structure
- Checked that the relevant language list remains valid

## Related PRs and Issues

- Closes #8201

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?