### PR TITLE
Update appwrite runtimes to 0.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ext-openssl": "*",
         "ext-zlib": "*",
         "ext-sockets": "*",
-        "appwrite/php-runtimes": "0.19.*",
+        "appwrite/php-runtimes": "0.20.*",
         "appwrite/php-clamav": "2.0.*",
         "utopia-php/abuse": "1.2.*",
         "utopia-php/agents": "1.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bee36b21a57e754d2b3417e72dc9599",
+    "content-hash": "bd45829c252971301370d62300be106d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -161,16 +161,16 @@
         },
         {
             "name": "appwrite/php-runtimes",
-            "version": "0.19.5",
+            "version": "0.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/runtimes.git",
-                "reference": "aa2f7760cd0493c0880209b92df812c9386b3546"
+                "reference": "7d9b7f4eef5c0a142a60907b06de2219d025c5c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/runtimes/zipball/aa2f7760cd0493c0880209b92df812c9386b3546",
-                "reference": "aa2f7760cd0493c0880209b92df812c9386b3546",
+                "url": "https://api.github.com/repos/appwrite/runtimes/zipball/7d9b7f4eef5c0a142a60907b06de2219d025c5c3",
+                "reference": "7d9b7f4eef5c0a142a60907b06de2219d025c5c3",
                 "shasum": ""
             },
             "require": {
@@ -210,9 +210,9 @@
             ],
             "support": {
                 "issues": "https://github.com/appwrite/runtimes/issues",
-                "source": "https://github.com/appwrite/runtimes/tree/0.19.5"
+                "source": "https://github.com/appwrite/runtimes/tree/0.20.0"
             },
-            "time": "2026-04-01T01:39:23+00:00"
+            "time": "2026-05-01T07:47:07+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
## What does this PR do?

Updates `appwrite/php-runtimes` from `0.19.*` / `0.19.5` to `0.20.*` / `0.20.0`.

## Test Plan

- `composer validate --strict --no-check-publish`
- `git diff --check`

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
