### PR TITLE
Return project_not_found when project region does not match _APP_REGION

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -153,6 +153,13 @@ function router(App $utopia, Database $dbForPlatform, callable $getProjectDB, Sw
             }
         }
 
+        if (!$project->isEmpty() && $project->getId() !== 'console') {
+            $localRegion = System::getEnv('_APP_REGION', 'default');
+            if ($project->getAttribute('region', 'default') !== $localRegion) {
+                throw new AppwriteException(AppwriteException::PROJECT_NOT_FOUND, view: $errorView);
+            }
+        }
+
         /** @var Database $dbForProject */
         $dbForProject = $getProjectDB($project);
 
@@ -903,6 +910,12 @@ App::init()
                 $request->addFilter(new RequestV19());
             }
             if (version_compare($requestFormat, '1.8.0', '<')) {
+                if (!$project->isEmpty() && $project->getId() !== 'console') {
+                    $localRegion = System::getEnv('_APP_REGION', 'default');
+                    if ($project->getAttribute('region', 'default') !== $localRegion) {
+                        throw new AppwriteException(AppwriteException::PROJECT_NOT_FOUND);
+                    }
+                }
                 $dbForProject = $getProjectDB($project);
                 $request->addFilter(new RequestV20($dbForProject, $route->getPathValues($request)));
             }
@@ -1154,7 +1167,7 @@ App::options()
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $queueForStatsUsage, $queueForFunctions, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $apiKey)) {
+            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $queueForStatsUsage, $queueForFunctions, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey)) {
                 $utopia->getRoute()?->label('router', true);
             }
         }

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -515,6 +515,11 @@ App::setResource('dbForProject', function (Group $pools, Database $dbForPlatform
         return $dbForPlatform;
     }
 
+    $localRegion = System::getEnv('_APP_REGION', 'default');
+    if ($project->getAttribute('region', 'default') !== $localRegion) {
+        throw new Exception(Exception::PROJECT_NOT_FOUND);
+    }
+
     try {
         $dsn = new DSN($project->getAttribute('database'));
     } catch (\InvalidArgumentException) {
@@ -574,6 +579,11 @@ App::setResource('getProjectDB', function (Group $pools, Database $dbForPlatform
     return function (Document $project) use ($pools, $dbForPlatform, $cache, $authorization, &$databases) {
         if ($project->isEmpty() || $project->getId() === 'console') {
             return $dbForPlatform;
+        }
+
+        $localRegion = System::getEnv('_APP_REGION', 'default');
+        if ($project->getAttribute('region', 'default') !== $localRegion) {
+            throw new Exception(Exception::PROJECT_NOT_FOUND);
         }
 
         try {


### PR DESCRIPTION
Reject opening the project database on the wrong regional node (router deployment path, legacy request format filter, and shared dbForProject / getProjectDB resources). Compares project region to System::_APP_REGION with default "default".

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
