### PR TITLE
chore: bump base image to 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:1.2.1 AS base
+FROM appwrite/base:1.3.1 AS base
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
## Summary
- Bumps the `appwrite/base` Docker image from 1.2.1 to 1.3.1.

## Test plan
- [ ] `docker compose up -d --force-recreate --build` succeeds
- [ ] Container starts cleanly and serves traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)