### PR TITLE
Fix: Add deprecated function scopes

### DIFF
--- a/app/config/scopes/project.php
+++ b/app/config/scopes/project.php
@@ -214,15 +214,16 @@ return [
     'executions.write' => [
         'description' => 'Access to create function executions',
         'category' => 'Functions',
-        'deprecated' => true,
     ],
     'execution.read' => [
         'description' => 'Access to read function executions. This scope is deprecated for consistency purposes, and replaced by `executions.read`.',
         'category' => 'Functions',
+        'deprecated' => true,
     ],
     'execution.write' => [
         'description' => 'Access to create function executions. This scope is deprecated for consistency purposes, and replaced by `executions.write`.',
         'category' => 'Functions',
+        'deprecated' => true,
     ],
 
     // Sites

--- a/app/config/scopes/project.php
+++ b/app/config/scopes/project.php
@@ -210,9 +210,19 @@ return [
     'executions.read' => [
         'description' => 'Access to read function executions',
         'category' => 'Functions',
+        'deprecated' => true,
     ],
     'executions.write' => [
         'description' => 'Access to create function executions',
+        'category' => 'Functions',
+        'deprecated' => true,
+    ],
+    'execution.read' => [
+        'description' => 'Access to read function executions. This scope is deprecated for consistency purposes, and replaced by `executions.read`.',
+        'category' => 'Functions',
+    ],
+    'execution.write' => [
+        'description' => 'Access to create function executions. This scope is deprecated for consistency purposes, and replaced by `executions.write`.',
         'category' => 'Functions',
     ],
 

--- a/app/config/scopes/project.php
+++ b/app/config/scopes/project.php
@@ -210,7 +210,6 @@ return [
     'executions.read' => [
         'description' => 'Access to read function executions',
         'category' => 'Functions',
-        'deprecated' => true,
     ],
     'executions.write' => [
         'description' => 'Access to create function executions',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Re-adds singular execution scopes so they become visible in Console - so developer doesnt remove it unknowingly when adjusting other scopes.

## Test Plan

None

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
