### PR TITLE
chore: bump base image to 1.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:1.3.1 AS base
+FROM appwrite/base:1.4.1 AS base
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
## Summary
- Bump `appwrite/base` Docker image from 1.3.1 to 1.4.1 in the Dockerfile.

## Test plan
- [ ] CI build passes
- [ ] `docker compose up -d --force-recreate --build` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)