### PR TITLE
fix: resolve query syntax errors and improve error handling in Reques…

### DIFF
--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -89,7 +89,7 @@ class Request extends UtopiaRequest
             // intended 400.
             $code = $e->getCode();
             if (\is_int($code) && $code >= 400 && $code < 500) {
-                $this->filteredParams = parent::getParams();
+                $this->filteredParams = $parameters;
             }
             throw $e;
         }

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -80,13 +80,15 @@ class Request extends UtopiaRequest
                 $parameters = $filter->parse($parameters, $id);
             }
         } catch (\Throwable $e) {
-            // 4xx filter throws are user-input errors that the action layer
-            // revalidates and reports. Cache the raw, pre-filter parameters
-            // so a subsequent getParams() — e.g. when the framework builds
-            // arguments for an error hook — returns without re-running
-            // filters. Otherwise the second throw gets wrapped as
-            // "Error handler had an error: ..." (HTTP 500), masking the
-            // intended 400.
+            /*
+            * 4xx filter throws are user-input errors that the action layer
+            * revalidates and reports. Cache the raw, pre-filter parameters
+            * so a subsequent getParams() — e.g. when the framework builds
+            * arguments for an error hook — returns without re-running
+            * filters. Otherwise the second throw gets wrapped as
+            * "Error handler had an error: ..." (HTTP 500), masking the
+            * intended 400.
+            */
             $code = $e->getCode();
             if (\is_int($code) && $code >= 400 && $code < 500) {
                 $this->filteredParams = $parameters;

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -51,38 +51,47 @@ class Request extends UtopiaRequest
 
         if (!\is_array($methods)) {
             $id = $methods->getNamespace() . '.' . $methods->getMethodName();
+        } else {
+            $matched = null;
+            foreach ($methods as $method) {
+                /** @var Method|null $method */
+                if ($method === null) {
+                    continue;
+                }
+
+                // Find the method that matches the parameters passed
+                $methodParamNames = \array_map(fn ($param) => $param->getName(), $method->getParameters());
+                $invalidParams = \array_diff(\array_keys($parameters), $methodParamNames);
+
+                // No params defined, or all params are valid
+                if (empty($methodParamNames) || empty($invalidParams)) {
+                    $matched = $method;
+                    break;
+                }
+            }
+
+            $id = $matched !== null
+                ? $matched->getNamespace() . '.' . $matched->getMethodName()
+                : 'unknown.unknown';
+        }
+
+        try {
             foreach ($this->getFilters() as $filter) {
                 $parameters = $filter->parse($parameters, $id);
             }
-            $this->filteredParams = $parameters;
-            return $parameters;
-        }
-
-        $matched = null;
-        foreach ($methods as $method) {
-            /** @var Method|null $method */
-            if ($method === null) {
-                continue;
+        } catch (\Throwable $e) {
+            // 4xx filter throws are user-input errors that the action layer
+            // revalidates and reports. Cache the raw, pre-filter parameters
+            // so a subsequent getParams() — e.g. when the framework builds
+            // arguments for an error hook — returns without re-running
+            // filters. Otherwise the second throw gets wrapped as
+            // "Error handler had an error: ..." (HTTP 500), masking the
+            // intended 400.
+            $code = $e->getCode();
+            if (\is_int($code) && $code >= 400 && $code < 500) {
+                $this->filteredParams = parent::getParams();
             }
-
-            // Find the method that matches the parameters passed
-            $methodParamNames = \array_map(fn ($param) => $param->getName(), $method->getParameters());
-            $invalidParams = \array_diff(\array_keys($parameters), $methodParamNames);
-
-            // No params defined, or all params are valid
-            if (empty($methodParamNames) || empty($invalidParams)) {
-                $matched = $method;
-                break;
-            }
-        }
-
-        $id = $matched !== null
-            ? $matched->getNamespace() . '.' . $matched->getMethodName()
-            : 'unknown.unknown';
-
-        // Apply filters
-        foreach ($this->getFilters() as $filter) {
-            $parameters = $filter->parse($parameters, $id);
+            throw $e;
         }
 
         $this->filteredParams = $parameters;

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -4339,51 +4339,6 @@ trait DatabasesBase
         // $this->assertEquals('Invalid query: Cannot query search on attribute "actors" because it is an array.', $documents['body']['message']);
     }
 
-    public function testDocumentsListInvalidQuerySyntax(): void
-    {
-        $data = $this->setupDocuments();
-        $databaseId = $data['databaseId'];
-
-        // Each entry in `queries` must be a JSON-encoded object (e.g.
-        // `{"method":"limit","values":[5]}`). Anything else — including the
-        // legacy SDK shorthand `limit(5)`, a hand-rolled non-JSON string, or a
-        // JSON value that isn't an object — must be rejected by Query::parse
-        // with the same `Invalid query: Syntax error` message so callers get
-        // a consistent 400.
-        $invalidQueries = [
-            'legacy shorthand'   => 'limit(5)',
-            'plain string'       => 'not-json',
-            'json non-object'    => '"limit"',
-            'malformed json'     => '{"method":"limit","values":[5}',
-            'unquoted attribute' => '{method:"limit",values:[5]}',
-        ];
-
-        foreach ($invalidQueries as $label => $rawQuery) {
-            $documents = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $data['moviesId']), array_merge([
-                'content-type' => 'application/json',
-                'x-appwrite-project' => $this->getProject()['$id'],
-            ], $this->getHeaders()), [
-                'queries' => [$rawQuery],
-            ]);
-
-            $this->assertEquals(400, $documents['headers']['status-code'], "Expected 400 for [$label]: $rawQuery");
-            $this->assertEquals('Invalid query: Syntax error', $documents['body']['message'], "Wrong error for [$label]: $rawQuery");
-        }
-
-        // Sanity check: the JSON form the SDK actually emits still works.
-        $documents = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $data['moviesId']), array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()), [
-            'queries' => [
-                Query::limit(5)->toString(),
-            ],
-        ]);
-
-        $this->assertEquals(200, $documents['headers']['status-code']);
-        $this->assertLessThanOrEqual(5, count($documents['body'][$this->getRecordResource()]));
-    }
-
     public function testUpdateDocument(): void
     {
         $data = $this->setupDocuments();

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -4339,6 +4339,51 @@ trait DatabasesBase
         // $this->assertEquals('Invalid query: Cannot query search on attribute "actors" because it is an array.', $documents['body']['message']);
     }
 
+    public function testDocumentsListInvalidQuerySyntax(): void
+    {
+        $data = $this->setupDocuments();
+        $databaseId = $data['databaseId'];
+
+        // Each entry in `queries` must be a JSON-encoded object (e.g.
+        // `{"method":"limit","values":[5]}`). Anything else — including the
+        // legacy SDK shorthand `limit(5)`, a hand-rolled non-JSON string, or a
+        // JSON value that isn't an object — must be rejected by Query::parse
+        // with the same `Invalid query: Syntax error` message so callers get
+        // a consistent 400.
+        $invalidQueries = [
+            'legacy shorthand'   => 'limit(5)',
+            'plain string'       => 'not-json',
+            'json non-object'    => '"limit"',
+            'malformed json'     => '{"method":"limit","values":[5}',
+            'unquoted attribute' => '{method:"limit",values:[5]}',
+        ];
+
+        foreach ($invalidQueries as $label => $rawQuery) {
+            $documents = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $data['moviesId']), array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()), [
+                'queries' => [$rawQuery],
+            ]);
+
+            $this->assertEquals(400, $documents['headers']['status-code'], "Expected 400 for [$label]: $rawQuery");
+            $this->assertEquals('Invalid query: Syntax error', $documents['body']['message'], "Wrong error for [$label]: $rawQuery");
+        }
+
+        // Sanity check: the JSON form the SDK actually emits still works.
+        $documents = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $data['moviesId']), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [
+                Query::limit(5)->toString(),
+            ],
+        ]);
+
+        $this->assertEquals(200, $documents['headers']['status-code']);
+        $this->assertLessThanOrEqual(5, count($documents['body'][$this->getRecordResource()]));
+    }
+
     public function testUpdateDocument(): void
     {
         $data = $this->setupDocuments();

--- a/tests/unit/Utopia/Request/Filters/ThrowingFilter.php
+++ b/tests/unit/Utopia/Request/Filters/ThrowingFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Utopia\Request\Filters;
+
+use Appwrite\Utopia\Request\Filter;
+
+/**
+ * Test fixture: a filter that always throws, with a configurable code.
+ * Used to assert how Request::getParams() reacts to filter exceptions.
+ */
+class ThrowingFilter extends Filter
+{
+    public int $calls = 0;
+
+    public function __construct(private int $code, private string $reason)
+    {
+    }
+
+    public function parse(array $content, string $model): array
+    {
+        $this->calls++;
+        throw new \Exception($this->reason, $this->code);
+    }
+}

--- a/tests/unit/Utopia/RequestTest.php
+++ b/tests/unit/Utopia/RequestTest.php
@@ -196,15 +196,17 @@ class RequestTest extends TestCase
 
     public function testGetParamsCachesRawParamsWhenFilterThrows4xx(): void
     {
-        // Regression: when a request filter throws a 4xx exception during
-        // Request::getParams() (e.g. RequestV20 rejecting an unparseable
-        // queries[]), the framework's error path calls getParams() again to
-        // build error-hook arguments. Without caching, that second call
-        // re-runs the filter and re-throws, which the framework wraps as
-        // "Error handler had an error: ..." (HTTP 500), masking the intended
-        // 400. This test pins that behavior: the first call throws (so the
-        // action's argument resolution aborts), but the second call returns
-        // the raw, pre-filter params without re-invoking filters.
+        /*
+        * Regression: when a request filter throws a 4xx exception during
+        * Request::getParams() (e.g. RequestV20 rejecting an unparseable
+        * queries[]), the framework's error path calls getParams() again to
+        * build error-hook arguments. Without caching, that second call
+        * re-runs the filter and re-throws, which the framework wraps as
+        * "Error handler had an error: ..." (HTTP 500), masking the intended
+        * 400. This test pins that behavior: the first call throws (so the
+        * action's argument resolution aborts), but the second call returns
+        * the raw, pre-filter params without re-invoking filters.
+        */
         $filter = new ThrowingFilter(400, 'invalid input');
 
         $this->setupSingleMethodRoute($filter);

--- a/tests/unit/Utopia/RequestTest.php
+++ b/tests/unit/Utopia/RequestTest.php
@@ -5,10 +5,12 @@ namespace Tests\Unit\Utopia;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Parameter;
 use Appwrite\Utopia\Request;
+use Appwrite\Utopia\Request\Filter;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Request as SwooleRequest;
 use Tests\Unit\Utopia\Request\Filters\First;
 use Tests\Unit\Utopia\Request\Filters\Second;
+use Tests\Unit\Utopia\Request\Filters\ThrowingFilter;
 use Utopia\Http\Route;
 
 class RequestTest extends TestCase
@@ -190,6 +192,105 @@ class RequestTest extends TestCase
         $request = new Request($swoole);
 
         $this->assertSame('fallback', $request->getHeader('referer', 'fallback'));
+    }
+
+    public function testGetParamsCachesRawParamsWhenFilterThrows4xx(): void
+    {
+        // Regression: when a request filter throws a 4xx exception during
+        // Request::getParams() (e.g. RequestV20 rejecting an unparseable
+        // queries[]), the framework's error path calls getParams() again to
+        // build error-hook arguments. Without caching, that second call
+        // re-runs the filter and re-throws, which the framework wraps as
+        // "Error handler had an error: ..." (HTTP 500), masking the intended
+        // 400. This test pins that behavior: the first call throws (so the
+        // action's argument resolution aborts), but the second call returns
+        // the raw, pre-filter params without re-invoking filters.
+        $filter = new ThrowingFilter(400, 'invalid input');
+
+        $this->setupSingleMethodRoute($filter);
+        $this->request->setQueryString(['foo' => 'bar']);
+
+        $threw = false;
+        try {
+            $this->request->getParams();
+        } catch (\Throwable $e) {
+            $threw = true;
+            $this->assertSame(400, $e->getCode());
+            $this->assertSame('invalid input', $e->getMessage());
+        }
+        $this->assertTrue($threw, 'First getParams() call must rethrow the filter exception.');
+        $this->assertSame(1, $filter->calls, 'Filter ran once on the first call.');
+
+        // Second call: framework's error hook arg resolution. Must return raw
+        // params without re-invoking the filter.
+        $params = $this->request->getParams();
+        $this->assertSame(['foo' => 'bar'], $params);
+        $this->assertSame(1, $filter->calls, 'Filter must not run again after a cached 4xx failure.');
+    }
+
+    public function testGetParamsDoesNotCacheRawParamsForServerError(): void
+    {
+        // 5xx filter throws indicate genuine server-side problems, not
+        // user-input mistakes. They must keep rethrowing on every call so
+        // the framework's normal error handling sees the failure each time
+        // — caching raw params would silently swallow real bugs.
+        $filter = new ThrowingFilter(500, 'boom');
+
+        $this->setupSingleMethodRoute($filter);
+        $this->request->setQueryString(['foo' => 'bar']);
+
+        for ($attempt = 1; $attempt <= 2; $attempt++) {
+            $threw = false;
+            try {
+                $this->request->getParams();
+            } catch (\Throwable $e) {
+                $threw = true;
+                $this->assertSame(500, $e->getCode());
+            }
+            $this->assertTrue($threw, "Call #$attempt must rethrow.");
+            $this->assertSame($attempt, $filter->calls, "Filter must run on call #$attempt.");
+        }
+    }
+
+    public function testGetParamsDoesNotCacheRawParamsForUncodedException(): void
+    {
+        // \Exception with the default code of 0 is treated as "unknown" and
+        // must propagate every call — same reasoning as 5xx.
+        $filter = new ThrowingFilter(0, 'unknown');
+
+        $this->setupSingleMethodRoute($filter);
+        $this->request->setQueryString(['foo' => 'bar']);
+
+        for ($attempt = 1; $attempt <= 2; $attempt++) {
+            $threw = false;
+            try {
+                $this->request->getParams();
+            } catch (\Throwable) {
+                $threw = true;
+            }
+            $this->assertTrue($threw, "Call #$attempt must rethrow.");
+            $this->assertSame($attempt, $filter->calls, "Filter must run on call #$attempt.");
+        }
+    }
+
+    /**
+     * Helper to attach a route with a single SDK method and one filter.
+     */
+    private function setupSingleMethodRoute(Filter $filter): void
+    {
+        $route = new Route(Request::METHOD_GET, '/single');
+        $route->label('sdk', new Method(
+            namespace: 'namespace',
+            group: 'group',
+            name: 'method',
+            description: 'description',
+            auth: [],
+            responses: [],
+        ));
+
+        $this->request->addHeader('EXAMPLE', 'VALUE');
+        $this->request->setRoute($route);
+        $this->request->addFilter($filter);
     }
 
     /**

--- a/tests/unit/Utopia/RequestTest.php
+++ b/tests/unit/Utopia/RequestTest.php
@@ -232,10 +232,12 @@ class RequestTest extends TestCase
 
     public function testGetParamsDoesNotCacheRawParamsForServerError(): void
     {
-        // 5xx filter throws indicate genuine server-side problems, not
-        // user-input mistakes. They must keep rethrowing on every call so
-        // the framework's normal error handling sees the failure each time
-        // — caching raw params would silently swallow real bugs.
+        /*
+        * 5xx filter throws indicate genuine server-side problems, not
+        * user-input mistakes. They must keep rethrowing on every call so
+        * the framework's normal error handling sees the failure each time
+        * — caching raw params would silently swallow real bugs.
+        */
         $filter = new ThrowingFilter(500, 'boom');
 
         $this->setupSingleMethodRoute($filter);


### PR DESCRIPTION
…t class

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Solving cascading failures in the request filters

Reproducing
```
ENDPOINT="${ENDPOINT:-http://localhost:8080}"
PROJECT_ID="69f8402500298b3be1d5"
API_KEY="standard_7e31dd6357424680fe4223b5a5264e9d1796f1befaa856d72cfde7794a72f71f8b37f7038aa4937d7c5b447271c0a997b37e5a1db68ad3dcc5605ee83cec296ff8517000ea9d0f561d3de7fd95443848f936e818c685c0f1f59e70eb00c53fe16742dd81f5c8c24538d1c6291473d2cc00ff00e93595d77408ade0279e958b71"
DB_ID="test"
COLL_ID="test"

echo
echo "===================================================================="
echo "Case 1: 1.7.0 client (activates V20 filter — the cascade path)"
echo "===================================================================="
curl -i -sS -X GET \
  "${ENDPOINT}/v1/databases/${DB_ID}/collections/${COLL_ID}/documents?queries%5B0%5D=limit%285%29" \
  -H "Accept: */*" \
  -H "User-Agent: AppwritePythonSDK/11.1.0" \
  -H "X-Appwrite-Project: ${PROJECT_ID}" \
  -H "X-Appwrite-Key: ${API_KEY}" \
  -H "X-Appwrite-Response-Format: 1.7.0"
echo

echo
echo "===================================================================="
echo "Case 2: modern client (no V20) — for comparison, should also be 400"
echo "===================================================================="
curl -i -sS -X GET \
  "${ENDPOINT}/v1/databases/${DB_ID}/collections/${COLL_ID}/documents?queries%5B0%5D=limit%285%29" \
  -H "Accept: */*" \
  -H "X-Appwrite-Project: ${PROJECT_ID}" \
  -H "X-Appwrite-Key: ${API_KEY}"
echo

echo
echo "===================================================================="
echo "Case 3: 1.7.0 client + valid JSON queries — should be 200"
echo "===================================================================="
# queries[0]={"method":"limit","values":[5]}
ENCODED='%7B%22method%22%3A%22limit%22%2C%22values%22%3A%5B5%5D%7D'
curl -i -sS -X GET \
  "${ENDPOINT}/v1/databases/${DB_ID}/collections/${COLL_ID}/documents?queries%5B0%5D=${ENCODED}" \
  -H "Accept: */*" \
  -H "X-Appwrite-Project: ${PROJECT_ID}" \
  -H "X-Appwrite-Key: ${API_KEY}" \
  -H "X-Appwrite-Response-Format: 1.7.0"
echo
```

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
