### PR TITLE
feat(specs): unify auth securityDefinitions across platforms

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -163,6 +163,12 @@ class Specs extends Action
                     'description' => 'Your secret dev API key',
                     'in' => 'header',
                 ],
+                'Cookie' => [
+                    'type' => 'apiKey',
+                    'name' => 'Cookie',
+                    'description' => 'The user cookie to authenticate with. Used by SDKs that forward an incoming Cookie header in server-side runtimes.',
+                    'in' => 'header',
+                ],
                 'ImpersonateUserId' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Id',
@@ -219,6 +225,18 @@ class Specs extends Action
                     'description' => 'The user agent string of the client that made the request',
                     'in' => 'header',
                 ],
+                'DevKey' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Dev-Key',
+                    'description' => 'Your secret dev API key',
+                    'in' => 'header',
+                ],
+                'Cookie' => [
+                    'type' => 'apiKey',
+                    'name' => 'Cookie',
+                    'description' => 'The user cookie to authenticate with. Used by SDKs that forward an incoming Cookie header in server-side runtimes.',
+                    'in' => 'header',
+                ],
                 'ImpersonateUserId' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Impersonate-User-Id',
@@ -273,6 +291,18 @@ class Specs extends Action
                     'type' => 'apiKey',
                     'name' => 'Cookie',
                     'description' => 'The user cookie to authenticate with',
+                    'in' => 'header',
+                ],
+                'Session' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Session',
+                    'description' => 'The user session to authenticate with',
+                    'in' => 'header',
+                ],
+                'DevKey' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Dev-Key',
+                    'description' => 'Your secret dev API key',
                     'in' => 'header',
                 ],
                 'ImpersonateUserId' => [

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -290,7 +290,7 @@ class Specs extends Action
                 'Cookie' => [
                     'type' => 'apiKey',
                     'name' => 'Cookie',
-                    'description' => 'The user cookie to authenticate with',
+                    'description' => 'The user cookie to authenticate with. Used by SDKs that forward an incoming Cookie header in server-side runtimes.',
                     'in' => 'header',
                 ],
                 'Session' => [


### PR DESCRIPTION
## What does this PR do?

Make every platform spec's `securityDefinitions` declare the **union** of auth headers, not just the subset referenced by that platform's endpoints.

### Why

The unified web SDK (sdk-generator [#1481](https://github.com/appwrite/sdk-generator/pull/1481)) emits a single typed `Client` class with cross-platform auth factories — `fromSession`, `fromCookie`, `fromDevKey`, etc. The factory surface is intentionally identical across `client`, `server`, and `console` builds so the same `appwrite` package can be used in browser, SSR, and console contexts.

Today each platform spec exposes only the auth headers its own endpoints accept:

| Platform | securityDefinitions today | Needed by unified web SDK |
|---|---|---|
| client  | Project, JWT, Locale, Session, DevKey, Impersonate*               | + **Cookie** (SSR cookie forwarding) |
| server  | Project, Key, JWT, Locale, Session, ForwardedUserAgent, Impersonate* | + **Cookie**, **DevKey** |
| console | Project, Key, JWT, Locale, Mode, Cookie, Impersonate*             | + **Session**, **DevKey** |

Because each platform spec is missing some headers the unified client needs, the SDK generator currently augments the parsed spec inside `Web.php::webClientHeaders()` to fill in the gaps. That works but encodes the union in the wrong place — the spec is the natural source of truth, not a per-SDK fallback table.

### What changes

`Specs::getKeys()` (`src/Appwrite/Platform/Tasks/Specs.php`) gains five entries:

- `client`: + `Cookie`
- `server`: + `Cookie`, `DevKey`
- `console`: + `Session`, `DevKey`

`securityDefinitions` is the registry of auth schemes the API knows about, not a list of "schemes this endpoint accepts." Per-endpoint applicability stays unchanged — it's expressed in each operation's `security: [{ Session: [] }]` requirement, which continues to be filtered per platform exactly as today. Only the registry expands.

### Downstream effect

After this PR ships and specs regenerate, [appwrite/sdk-generator#1481](https://github.com/appwrite/sdk-generator/pull/1481) can delete its `webClientHeaders` augmentation and the registered Twig filter (~35 lines of PHP). The web template's spec-driven setter loop will then have everything it needs from `spec.global.headers` directly, with no per-SDK fallback.

Other SDK templates (Python, Dart, Kotlin, etc.) consume `securityDefinitions` to generate `set_*` / `setX` / `set*` methods. They will start emitting setters for the newly-declared schemes — e.g. Python client SDK will gain `set_cookie`, server SDK will gain `set_dev_key`. These methods exist as platform-agnostic setters; whether they functionally authenticate is determined by per-endpoint `security` requirements (unchanged), not by their presence in the setter list. This matches the model the unified web SDK already uses and provides a path for other SDKs to adopt cross-platform factory patterns later.

## Test Plan

- [ ] Regenerate specs: `docker compose exec appwrite specs --version=1.9.x`
- [ ] Verify each platform JSON's `securityDefinitions` now contains the additions:
  - `swagger2-1.9.x-client.json` includes `Cookie`
  - `swagger2-1.9.x-server.json` includes `Cookie` and `DevKey`
  - `swagger2-1.9.x-console.json` includes `Session` and `DevKey`
- [ ] Verify per-endpoint `security` requirements are unchanged (no endpoint suddenly accepts a new auth scheme; only the registry expanded).
- [ ] Spot-check a generated SDK (e.g. Python client) gains the corresponding `set_cookie` method without affecting endpoint behaviour.

## Related PRs and Issues

- [appwrite/sdk-generator#1481](https://github.com/appwrite/sdk-generator/pull/1481) — Unified web SDK Client auth factories (depends on this change to drop the `webClientHeaders` augmentation)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata, does it also include updated API specs and example docs? — Spec metadata only; specs will be regenerated by the existing pipeline. No endpoint metadata or example docs change.