### PR TITLE
Stop user-data errors leaking to Sentry from migrations worker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "utopia-php/locale": "0.8.*",
         "utopia-php/logger": "0.6.*",
         "utopia-php/messaging": "0.22.*",
-        "utopia-php/migration": "1.9.*",
+        "utopia-php/migration": "dev-fix-migration-sentry-leak as 1.9.999",
         "utopia-php/platform": "0.13.*",
         "utopia-php/pools": "1.*",
         "utopia-php/span": "1.1.*",
@@ -118,5 +118,11 @@
             "php-http/discovery": true,
             "tbachert/spi": true
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/utopia-php/migration"
+        }
+    ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4bee36b21a57e754d2b3417e72dc9599",
+    "content-hash": "0e8cd1a2446dfb54015d25fa130d081a",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2708,16 +2708,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "01933e626c3de76bea1e22641e205e78f6a34342"
+                "reference": "7e941c6abf4e3bf7dca160bf0e11ef36a9f832f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/01933e626c3de76bea1e22641e205e78f6a34342",
-                "reference": "01933e626c3de76bea1e22641e205e78f6a34342",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/7e941c6abf4e3bf7dca160bf0e11ef36a9f832f6",
+                "reference": "7e941c6abf4e3bf7dca160bf0e11ef36a9f832f6",
                 "shasum": ""
             },
             "require": {
@@ -2785,7 +2785,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -2805,7 +2805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T12:55:43+00:00"
+            "time": "2026-04-29T13:25:15+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -3850,22 +3850,23 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "5.4.1",
+            "version": "5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "688d9422b5ff42ac2ecc29397d94891cfd772e93"
+                "reference": "609ebcd64be1ec6fab00c5f46fce54acb0031b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/688d9422b5ff42ac2ecc29397d94891cfd772e93",
-                "reference": "688d9422b5ff42ac2ecc29397d94891cfd772e93",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/609ebcd64be1ec6fab00c5f46fce54acb0031b3c",
+                "reference": "609ebcd64be1ec6fab00c5f46fce54acb0031b3c",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "ext-mongodb": "*",
                 "ext-pdo": "*",
+                "ext-redis": "*",
                 "php": ">=8.4",
                 "utopia-php/cache": "1.*",
                 "utopia-php/console": "0.1.*",
@@ -3903,9 +3904,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/5.4.1"
+                "source": "https://github.com/utopia-php/database/tree/5.6.0"
             },
-            "time": "2026-04-29T07:32:59+00:00"
+            "time": "2026-05-01T01:28:07+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -4530,16 +4531,16 @@
         },
         {
             "name": "utopia-php/migration",
-            "version": "1.9.5",
+            "version": "dev-fix-migration-sentry-leak",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "952a4dfe232702f80e45c35129466a8d8cb4c599"
+                "reference": "276e7c25077a4dee670a806f715869f11367d932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/952a4dfe232702f80e45c35129466a8d8cb4c599",
-                "reference": "952a4dfe232702f80e45c35129466a8d8cb4c599",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/276e7c25077a4dee670a806f715869f11367d932",
+                "reference": "276e7c25077a4dee670a806f715869f11367d932",
                 "shasum": ""
             },
             "require": {
@@ -4565,7 +4566,25 @@
                     "Utopia\\Migration\\": "src/Migration"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Utopia\\Tests\\": "tests/Migration"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "./vendor/bin/phpunit"
+                ],
+                "lint": [
+                    "./vendor/bin/pint --test"
+                ],
+                "format": [
+                    "./vendor/bin/pint"
+                ],
+                "check": [
+                    "./vendor/bin/phpstan analyse --level 3 src tests --memory-limit 2G"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -4578,10 +4597,10 @@
                 "utopia"
             ],
             "support": {
-                "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/1.9.5"
+                "source": "https://github.com/utopia-php/migration/tree/fix-migration-sentry-leak",
+                "issues": "https://github.com/utopia-php/migration/issues"
             },
-            "time": "2026-04-29T11:19:13+00:00"
+            "time": "2026-05-04T07:20:31+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -8442,9 +8461,18 @@
             "time": "2024-11-07T12:36:22+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/migration",
+            "version": "dev-fix-migration-sentry-leak",
+            "alias": "1.9.999",
+            "alias_normalized": "1.9.999.0"
+        }
+    ],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "utopia-php/migration": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -8465,5 +8493,5 @@
     "platform-dev": {
         "ext-fileinfo": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4535,12 +4535,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "276e7c25077a4dee670a806f715869f11367d932"
+                "reference": "da8205e8f3e927b2b860dddc2efca0e408171116"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/276e7c25077a4dee670a806f715869f11367d932",
-                "reference": "276e7c25077a4dee670a806f715869f11367d932",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/da8205e8f3e927b2b860dddc2efca0e408171116",
+                "reference": "da8205e8f3e927b2b860dddc2efca0e408171116",
                 "shasum": ""
             },
             "require": {
@@ -4600,7 +4600,7 @@
                 "source": "https://github.com/utopia-php/migration/tree/fix-migration-sentry-leak",
                 "issues": "https://github.com/utopia-php/migration/issues"
             },
-            "time": "2026-05-04T07:20:31+00:00"
+            "time": "2026-05-05T15:50:58+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -5039,16 +5039,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "8a2e3a86fd01aaed675884146665308c2122264e"
+                "reference": "64e132a3768e22243eda36fe4262da22fd204f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/8a2e3a86fd01aaed675884146665308c2122264e",
-                "reference": "8a2e3a86fd01aaed675884146665308c2122264e",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/64e132a3768e22243eda36fe4262da22fd204f3c",
+                "reference": "64e132a3768e22243eda36fe4262da22fd204f3c",
                 "shasum": ""
             },
             "require": {
@@ -5085,22 +5085,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/2.0.1"
+                "source": "https://github.com/utopia-php/storage/tree/2.0.2"
             },
-            "time": "2026-04-29T09:05:48+00:00"
+            "time": "2026-05-01T15:06:16+00:00"
         },
         {
             "name": "utopia-php/system",
-            "version": "0.10.1",
+            "version": "0.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/system.git",
-                "reference": "7c1669533bb9c285de19191270c8c1439161a78a"
+                "reference": "04229a822b147c1abaf1a92fb42c2d7aad4625df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/system/zipball/7c1669533bb9c285de19191270c8c1439161a78a",
-                "reference": "7c1669533bb9c285de19191270c8c1439161a78a",
+                "url": "https://api.github.com/repos/utopia-php/system/zipball/04229a822b147c1abaf1a92fb42c2d7aad4625df",
+                "reference": "04229a822b147c1abaf1a92fb42c2d7aad4625df",
                 "shasum": ""
             },
             "require": {
@@ -5141,9 +5141,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/system/issues",
-                "source": "https://github.com/utopia-php/system/tree/0.10.1"
+                "source": "https://github.com/utopia-php/system/tree/0.10.2"
             },
-            "time": "2026-03-15T21:07:41+00:00"
+            "time": "2026-05-05T14:33:41+00:00"
         },
         {
             "name": "utopia-php/telemetry",

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -536,14 +536,9 @@ class Migrations extends Action
             $migration->setAttribute('status', 'failed');
             $migration->setAttribute('stage', 'finished');
 
-            // Remember the bubbled exception so the finally block can include it in the
-            // migration's errors attribute — otherwise setup-time failures (e.g. invalid
-            // credentials) would leave the user looking at status='failed' with no message.
             $caughtError = $th;
 
-            // User-facing failures (validation, not found, conflict) are routed through
-            // MigrationException and stay in the migration report only. Anything else is
-            // a bug or infra failure and goes to Sentry with the full trace.
+            // MigrationException is reserved for user-facing failures and stays in the migration report only.
             if (!$th instanceof MigrationException) {
                 call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), [
                     'migrationId' => $migration->getId(),
@@ -569,7 +564,6 @@ class Migrations extends Action
                     $destinationErrors[] = $bubbled;
                 }
 
-                // Persist the consolidated error list regardless of which code path fired.
                 $migration->setAttribute('errors', $this->sanitizeErrors(
                     $sourceErrors,
                     $destinationErrors,

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -428,6 +428,7 @@ class Migrations extends Action
 
         $transfer = $source = $destination = null;
         $aggregatedResources = [];
+        $caughtError = null;
 
         $host = System::getEnv('_APP_MIGRATION_HOST');
         if (empty($host)) {
@@ -535,6 +536,11 @@ class Migrations extends Action
             $migration->setAttribute('status', 'failed');
             $migration->setAttribute('stage', 'finished');
 
+            // Remember the bubbled exception so the finally block can include it in the
+            // migration's errors attribute — otherwise setup-time failures (e.g. invalid
+            // credentials) would leave the user looking at status='failed' with no message.
+            $caughtError = $th;
+
             // User-facing failures (validation, not found, conflict) are routed through
             // MigrationException and stay in the migration report only. Anything else is
             // a bug or infra failure and goes to Sentry with the full trace.
@@ -547,10 +553,26 @@ class Migrations extends Action
             }
         } finally {
             try {
+                $sourceErrors = $source?->getErrors() ?? [];
+                $destinationErrors = $destination?->getErrors() ?? [];
+
+                if ($caughtError !== null) {
+                    $bubbled = $caughtError instanceof MigrationException
+                        ? $caughtError
+                        : new MigrationException(
+                            resourceName: '',
+                            resourceGroup: '',
+                            message: $caughtError->getMessage(),
+                            code: $caughtError->getCode(),
+                            previous: $caughtError,
+                        );
+                    $destinationErrors[] = $bubbled;
+                }
+
                 // Persist the consolidated error list regardless of which code path fired.
                 $migration->setAttribute('errors', $this->sanitizeErrors(
-                    $source?->getErrors() ?? [],
-                    $destination?->getErrors() ?? [],
+                    $sourceErrors,
+                    $destinationErrors,
                 ));
 
                 $this->updateMigrationDocument($migration, $project, $queueForRealtime);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -857,7 +857,7 @@ class Migrations extends Action
     }
 
     /**
-     * Sanitize migration errors, removing sensitive information like stack traces
+     * Encode migration errors as JSON strings for storage on the migration document.
      *
      * @param array $sourceErrors
      * @param array $destinationErrors
@@ -867,20 +867,10 @@ class Migrations extends Action
         array $sourceErrors,
         array $destinationErrors,
     ): array {
-        $errors = [];
-        foreach ([...$sourceErrors, ...$destinationErrors] as $error) {
-            $encoded = \json_decode(\json_encode($error), true);
-            if (\is_array($encoded)) {
-                if (isset($encoded['trace'])) {
-                    unset($encoded['trace']);
-                }
-                $errors[] = \json_encode($encoded);
-            } else {
-                $errors[] = \json_encode($error);
-            }
-        }
-
-        return $errors;
+        return \array_map(
+            fn ($error) => \json_encode($error),
+            [...$sourceErrors, ...$destinationErrors],
+        );
     }
 
     private function processMigrationResourceStats(array $resources, Context $usage, Document $projectDocument, UsagePublisher $publisherForUsage, string $source, Authorization $authorization, ?string $resourceId)

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -196,13 +196,13 @@ class Migrations extends Action
         $projectDB = null;
         $useAppwriteApiSource = false;
         if ($source === SourceAppwrite::getName() && empty($credentials['projectId'])) {
-            throw new \Exception('Source projectId is required for Appwrite migrations');
+            throw new MigrationException('', '', message: 'Source projectId is required for Appwrite migrations', code: MigrationException::CODE_VALIDATION);
         }
 
         if (! empty($credentials['projectId'])) {
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
             if ($this->sourceProject->isEmpty()) {
-                throw new \Exception('Source project not found for provided projectId');
+                throw new MigrationException('', '', message: 'Source project not found for provided projectId', code: MigrationException::CODE_NOT_FOUND);
             }
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
@@ -265,7 +265,7 @@ class Migrations extends Action
                 $this->deviceForMigrations,
                 $this->dbForProject,
             ),
-            default => throw new \Exception('Invalid source type'),
+            default => throw new MigrationException('', '', message: 'Invalid source type', code: MigrationException::CODE_VALIDATION),
         };
 
         $resources = $migration->getAttribute('resources', []);
@@ -310,7 +310,7 @@ class Migrations extends Action
                 $options['filename'],
                 $options['columns'] ?? [],
             ),
-            default => throw new \Exception('Invalid destination type'),
+            default => throw new MigrationException('', '', message: 'Invalid destination type', code: MigrationException::CODE_VALIDATION),
         };
     }
 
@@ -521,7 +521,6 @@ class Migrations extends Action
             if (!empty($sourceErrors) || ! empty($destinationErrors)) {
                 $migration->setAttribute('status', 'failed');
                 $migration->setAttribute('stage', 'finished');
-                $migration->setAttribute('errors', $this->sanitizeErrors($sourceErrors, $destinationErrors));
                 return;
             }
 
@@ -536,34 +535,28 @@ class Migrations extends Action
             $migration->setAttribute('status', 'failed');
             $migration->setAttribute('stage', 'finished');
 
-            call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), [
-                'migrationId' => $migration->getId(),
-                'source' => $migration->getAttribute('source') ?? '',
-                'destination' => $migration->getAttribute('destination') ?? '',
-            ]);
-
+            // User-facing failures (validation, not found, conflict) are routed through
+            // MigrationException and stay in the migration report only. Anything else is
+            // a bug or infra failure and goes to Sentry with the full trace.
+            if (!$th instanceof MigrationException) {
+                call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), [
+                    'migrationId' => $migration->getId(),
+                    'source' => $migration->getAttribute('source') ?? '',
+                    'destination' => $migration->getAttribute('destination') ?? '',
+                ]);
+            }
         } finally {
             try {
+                // Persist the consolidated error list regardless of which code path fired.
+                $migration->setAttribute('errors', $this->sanitizeErrors(
+                    $source?->getErrors() ?? [],
+                    $destination?->getErrors() ?? [],
+                ));
+
                 $this->updateMigrationDocument($migration, $project, $queueForRealtime);
 
                 if ($migration->getAttribute('status', '') === 'failed') {
                     Console::error('Migration(' . $migration->getSequence() . ':' . $migration->getId() . ') failed, Project(' . $this->project->getSequence() . ':' . $this->project->getId() . ')');
-
-                    $sourceErrors = $source?->getErrors() ?? [];
-                    $destinationErrors = $destination?->getErrors() ?? [];
-
-                    foreach ([...$sourceErrors, ...$destinationErrors] as $error) {
-                        /** @var MigrationException $error */
-                        if ($error->getCode() === 0 || $error->getCode() >= 500) {
-                            ($this->logError)($error, 'appwrite-worker', 'appwrite-queue-' . self::getName(), [
-                                'migrationId' => $migration->getId(),
-                                'source' => $migration->getAttribute('source') ?? '',
-                                'destination' => $migration->getAttribute('destination') ?? '',
-                                'resourceName' => $error->getResourceName(),
-                                'resourceGroup' => $error->getResourceGroup(),
-                            ]);
-                        }
-                    }
 
                     $source?->error();
                     $destination?->error();

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -873,7 +873,7 @@ class Migrations extends Action
     }
 
     /**
-     * Encode migration errors as JSON strings for storage on the migration document.
+     * Sanitize migration errors, removing sensitive information like stack traces
      *
      * @param array $sourceErrors
      * @param array $destinationErrors
@@ -883,10 +883,20 @@ class Migrations extends Action
         array $sourceErrors,
         array $destinationErrors,
     ): array {
-        return \array_map(
-            fn ($error) => \json_encode($error),
-            [...$sourceErrors, ...$destinationErrors],
-        );
+        $errors = [];
+        foreach ([...$sourceErrors, ...$destinationErrors] as $error) {
+            $encoded = \json_decode(\json_encode($error), true);
+            if (\is_array($encoded)) {
+                if (isset($encoded['trace'])) {
+                    unset($encoded['trace']);
+                }
+                $errors[] = \json_encode($encoded);
+            } else {
+                $errors[] = \json_encode($error);
+            }
+        }
+
+        return $errors;
     }
 
     private function processMigrationResourceStats(array $resources, Context $usage, Document $projectDocument, UsagePublisher $publisherForUsage, string $source, Authorization $authorization, ?string $resourceId)


### PR DESCRIPTION
## Summary

Migrations worker was paging on every user-data condition (duplicate column, invalid document structure, missing required field, bad credentials, etc.) because the `code === 0 || >= 500` heuristic in the per-batch loop matched almost everything.

- Outer `catch (\Throwable $th)` gates `logError` with `if (!$th instanceof MigrationException)` — single, type-based routing decision.
- Deleted the foreach loop that re-published collected errors with the bad code heuristic.
- Hoisted `setAttribute('errors', sanitizeErrors(...))` into `finally` so the migration document always reflects the failure (including the bubbled exception's message via a new `\$caughtError` capture).
- 4 setup-time bare `\Exception` throws (Source projectId required, Source project not found, Invalid source/destination type) converted to `MigrationException` with appropriate codes — so the gate classifies them as user errors.

Pairs with library-side fixes in [utopia-php/migration#fix-migration-sentry-leak](https://github.com/utopia-php/migration/tree/fix-migration-sentry-leak).

## ⚠️ Cross-repo dependency — revert before merge

`composer.json` and `composer.lock` pin `utopia-php/migration` to the dev branch `dev-fix-migration-sentry-leak` for end-to-end testing. **These must be reverted to a versioned dependency (e.g. `1.9.*`) once the utopia-php/migration PR is merged and tagged.**

## Test plan

- [ ] Migration with duplicate row → *"Document already exists"* in migration report, **no** Sentry event
- [ ] Migration with bad source projectId → *"Source project not found"* in report, no Sentry
- [ ] Migration with invalid source type → *"Invalid source type"* in report, no Sentry
- [ ] Synthetic library bug (TypeError) → recorded in report AND reaches Sentry with full trace
- [ ] Missing `_APP_MIGRATION_HOST` env var → still reaches Sentry (config bug, intentionally not converted)