### PR TITLE
fix: prevent NotFoundException during console project maintenance

### DIFF
--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -416,19 +416,13 @@ class Deletes extends Action
             );
         };
 
-        $this->listByGroup(
-            'functions',
-            [],
-            $dbForProject,
-            $removalCallback
-        );
+        foreach (['functions', 'sites'] as $group) {
+            if ($dbForProject->getCollection($group)->isEmpty()) {
+                continue;
+            }
 
-        $this->listByGroup(
-            'sites',
-            [],
-            $dbForProject,
-            $removalCallback
-        );
+            $this->listByGroup($group, [], $dbForProject, $removalCallback);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR implements Option A from issue #12230. It adds a guard clause in deleteOldDeployments to skip the deletion process if the functions or sites collections do not exist in the project schema. This safely prevents the daily NotFound exception from firing on the console project.

Closes #12230