### PR TITLE
Add cached response cache-control callback

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -705,7 +705,6 @@ Http::init()
                             bucket: $bucket,
                             file: $file,
                             resourceToken: $resourceToken,
-                            isImageTransformation: $isImageTransformation,
                             fileSecurity: $fileSecurity,
                             cacheLog: $cacheLog,
                             route: $route,

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -20,6 +20,7 @@ use Appwrite\Extend\Exception;
 use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Functions\EventProcessor;
 use Appwrite\Platform\Modules\Storage\Config\CacheControl;
+use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Appwrite\SDK\Method;
 use Appwrite\Usage\Context;
 use Appwrite\Utopia\Database\Documents\User;
@@ -641,9 +642,7 @@ Http::init()
             $data = $cache->load($key, $timestamp);
 
             if (! empty($data) && ! $cacheLog->isEmpty()) {
-                $bucket = new Document();
-                $file = new Document();
-                $fileSecurity = null;
+                $storageCacheControl = null;
                 $parts = explode('/', $cacheLog->getAttribute('resourceType', ''));
                 $type = $parts[0];
 
@@ -696,6 +695,22 @@ Http::init()
                             ])));
                         }
                     }
+
+                    if ($isImageTransformation) {
+                        $storageCacheControl = new StorageCacheControl(
+                            source: CacheControl::SOURCE_CACHE,
+                            user: $user,
+                            maxAge: $timestamp,
+                            project: $project,
+                            bucket: $bucket,
+                            file: $file,
+                            resourceToken: $resourceToken,
+                            isImageTransformation: $isImageTransformation,
+                            fileSecurity: $fileSecurity,
+                            cacheLog: $cacheLog,
+                            route: $route,
+                        );
+                    }
                 }
 
                 $accessedAt = $cacheLog->getAttribute('accessedAt', '');
@@ -708,20 +723,8 @@ Http::init()
                 }
 
                 $cacheControl = \sprintf('private, max-age=%d', $timestamp);
-                if ($isImageTransformation) {
-                    $cacheControl = $cacheControlForStorage(new CacheControl(
-                        source: CacheControl::SOURCE_CACHE,
-                        project: $project,
-                        user: $user,
-                        bucket: $bucket,
-                        file: $file,
-                        resourceToken: $resourceToken,
-                        maxAge: $timestamp,
-                        isImageTransformation: $isImageTransformation,
-                        fileSecurity: $fileSecurity,
-                        cacheLog: $cacheLog,
-                        route: $route,
-                    ));
+                if ($storageCacheControl !== null) {
+                    $cacheControl = $cacheControlForStorage($storageCacheControl);
                 }
 
                 $response

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -642,7 +642,7 @@ Http::init()
             $data = $cache->load($key, $timestamp);
 
             if (! empty($data) && ! $cacheLog->isEmpty()) {
-                $storageCacheControl = null;
+                $cacheControl = \sprintf('private, max-age=%d', $timestamp);
                 $parts = explode('/', $cacheLog->getAttribute('resourceType', ''));
                 $type = $parts[0];
 
@@ -697,7 +697,7 @@ Http::init()
                     }
 
                     if ($isImageTransformation) {
-                        $storageCacheControl = new StorageCacheControl(
+                        $cacheControl = $cacheControlForStorage(new StorageCacheControl(
                             source: CacheControl::SOURCE_CACHE,
                             user: $user,
                             maxAge: $timestamp,
@@ -709,7 +709,7 @@ Http::init()
                             fileSecurity: $fileSecurity,
                             cacheLog: $cacheLog,
                             route: $route,
-                        );
+                        ));
                     }
                 }
 
@@ -720,11 +720,6 @@ Http::init()
                     ])));
                     // Refresh the filesystem file's mtime so TTL-based expiry in cache->load() stays valid
                     $cache->save($key, $data);
-                }
-
-                $cacheControl = \sprintf('private, max-age=%d', $timestamp);
-                if ($storageCacheControl !== null) {
-                    $cacheControl = $cacheControlForStorage($storageCacheControl);
                 }
 
                 $response

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -707,19 +707,22 @@ Http::init()
                     $cache->save($key, $data);
                 }
 
-                $cacheControl = $cacheControlForStorage(new CacheControl(
-                    source: CacheControl::SOURCE_CACHE,
-                    project: $project,
-                    user: $user,
-                    bucket: $bucket,
-                    file: $file,
-                    resourceToken: $resourceToken,
-                    maxAge: $timestamp,
-                    isImageTransformation: $isImageTransformation,
-                    fileSecurity: $fileSecurity,
-                    cacheLog: $cacheLog,
-                    route: $route,
-                ));
+                $cacheControl = \sprintf('private, max-age=%d', $timestamp);
+                if ($isImageTransformation) {
+                    $cacheControl = $cacheControlForStorage(new CacheControl(
+                        source: CacheControl::SOURCE_CACHE,
+                        project: $project,
+                        user: $user,
+                        bucket: $bucket,
+                        file: $file,
+                        resourceToken: $resourceToken,
+                        maxAge: $timestamp,
+                        isImageTransformation: $isImageTransformation,
+                        fileSecurity: $fileSecurity,
+                        cacheLog: $cacheLog,
+                        route: $route,
+                    ));
+                }
 
                 $response
                     ->addHeader('Cache-Control', $cacheControl)

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -501,7 +501,8 @@ Http::init()
     ->inject('telemetry')
     ->inject('platform')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization) {
+    ->inject('cacheControlForResponse')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, callable $cacheControlForResponse) {
 
         $response->setUser($user);
         $request->setUser($user);
@@ -639,6 +640,9 @@ Http::init()
             $data = $cache->load($key, $timestamp);
 
             if (! empty($data) && ! $cacheLog->isEmpty()) {
+                $bucket = new Document();
+                $file = new Document();
+                $fileSecurity = null;
                 $parts = explode('/', $cacheLog->getAttribute('resourceType', ''));
                 $type = $parts[0];
 
@@ -702,8 +706,22 @@ Http::init()
                     $cache->save($key, $data);
                 }
 
+                $cacheControl = $cacheControlForResponse([
+                    'route' => $route,
+                    'source' => 'cache',
+                    'project' => $project,
+                    'user' => $user,
+                    'bucket' => $bucket,
+                    'file' => $file,
+                    'fileSecurity' => $fileSecurity,
+                    'resourceToken' => $resourceToken,
+                    'cacheLog' => $cacheLog,
+                    'maxAge' => $timestamp,
+                    'isImageTransformation' => $isImageTransformation,
+                ]);
+
                 $response
-                    ->addHeader('Cache-Control', sprintf('private, max-age=%d', $timestamp))
+                    ->addHeader('Cache-Control', $cacheControl ?? sprintf('private, max-age=%d', $timestamp))
                     ->addHeader('X-Appwrite-Cache', 'hit')
                     ->setContentType($cacheLog->getAttribute('mimeType'));
                 $storageCacheOperationsCounter->add(1, ['result' => 'hit']);

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -19,6 +19,7 @@ use Appwrite\Event\Webhook;
 use Appwrite\Extend\Exception;
 use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Functions\EventProcessor;
+use Appwrite\Platform\Modules\Storage\Config\CacheControl;
 use Appwrite\SDK\Method;
 use Appwrite\Usage\Context;
 use Appwrite\Utopia\Database\Documents\User;
@@ -706,19 +707,19 @@ Http::init()
                     $cache->save($key, $data);
                 }
 
-                $cacheControl = $cacheControlForStorage([
-                    'route' => $route,
-                    'source' => 'cache',
-                    'project' => $project,
-                    'user' => $user,
-                    'bucket' => $bucket,
-                    'file' => $file,
-                    'fileSecurity' => $fileSecurity,
-                    'resourceToken' => $resourceToken,
-                    'cacheLog' => $cacheLog,
-                    'maxAge' => $timestamp,
-                    'isImageTransformation' => $isImageTransformation,
-                ]);
+                $cacheControl = $cacheControlForStorage(new CacheControl(
+                    source: CacheControl::SOURCE_CACHE,
+                    project: $project,
+                    user: $user,
+                    bucket: $bucket,
+                    file: $file,
+                    resourceToken: $resourceToken,
+                    maxAge: $timestamp,
+                    isImageTransformation: $isImageTransformation,
+                    fileSecurity: $fileSecurity,
+                    cacheLog: $cacheLog,
+                    route: $route,
+                ));
 
                 $response
                     ->addHeader('Cache-Control', $cacheControl)

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -501,8 +501,8 @@ Http::init()
     ->inject('telemetry')
     ->inject('platform')
     ->inject('authorization')
-    ->inject('cacheControlForResponse')
-    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, callable $cacheControlForResponse) {
+    ->inject('cacheControlForStorage')
+    ->action(function (Http $utopia, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, Messaging $queueForMessaging, AuditContext $auditContext, Delete $queueForDeletes, EventDatabase $queueForDatabase, Context $usage, Func $queueForFunctions, Mail $queueForMails, Database $dbForProject, callable $timelimit, Document $resourceToken, string $mode, ?Key $apiKey, array $plan, Document $devKey, Telemetry $telemetry, array $platform, Authorization $authorization, callable $cacheControlForStorage) {
 
         $response->setUser($user);
         $request->setUser($user);
@@ -706,7 +706,7 @@ Http::init()
                     $cache->save($key, $data);
                 }
 
-                $cacheControl = $cacheControlForResponse([
+                $cacheControl = $cacheControlForStorage([
                     'route' => $route,
                     'source' => 'cache',
                     'project' => $project,
@@ -721,7 +721,7 @@ Http::init()
                 ]);
 
                 $response
-                    ->addHeader('Cache-Control', $cacheControl ?? sprintf('private, max-age=%d', $timestamp))
+                    ->addHeader('Cache-Control', $cacheControl)
                     ->addHeader('X-Appwrite-Cache', 'hit')
                     ->setContentType($cacheLog->getAttribute('mimeType'));
                 $storageCacheOperationsCounter->add(1, ['result' => 'hit']);

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -203,8 +203,10 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
     return $cache;
 }, ['pools', 'telemetry']);
 
-$container->set('cacheControlForResponse', fn () => function (array $context): ?string {
-    return null;
+$container->set('cacheControlForStorage', fn () => function (array $context): string {
+    $maxAge = $context['maxAge'] ?? 0;
+
+    return \sprintf('private, max-age=%d', \is_int($maxAge) ? $maxAge : 0);
 });
 
 $container->set('redis', function () {

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -9,7 +9,6 @@ use Appwrite\Event\Publisher\Migration as MigrationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
-use Appwrite\Platform\Modules\Storage\Config\CacheControl;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Appwrite\Utopia\Database\Documents\User;
 use Executor\Executor;
@@ -206,10 +205,6 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
 }, ['pools', 'telemetry']);
 
 $container->set('cacheControlForStorage', fn () => function (StorageCacheControl $config): string {
-    if ($config->source === CacheControl::SOURCE_CACHE) {
-        return 'private, max-age=15552000';
-    }
-
     return \sprintf('private, max-age=%d', $config->maxAge);
 });
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -9,7 +9,7 @@ use Appwrite\Event\Publisher\Migration as MigrationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
-use Appwrite\Platform\Modules\Storage\Config\CacheControl;
+use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Appwrite\Utopia\Database\Documents\User;
 use Executor\Executor;
 use Utopia\Abuse\Adapters\TimeLimit\Redis as TimeLimitRedis;
@@ -204,7 +204,7 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
     return $cache;
 }, ['pools', 'telemetry']);
 
-$container->set('cacheControlForStorage', fn () => function (CacheControl $config): string {
+$container->set('cacheControlForStorage', fn () => function (StorageCacheControl $config): string {
     return \sprintf('private, max-age=%d', $config->maxAge);
 });
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -9,6 +9,7 @@ use Appwrite\Event\Publisher\Migration as MigrationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
+use Appwrite\Platform\Modules\Storage\Config\CacheControl;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Appwrite\Utopia\Database\Documents\User;
 use Executor\Executor;
@@ -205,6 +206,10 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
 }, ['pools', 'telemetry']);
 
 $container->set('cacheControlForStorage', fn () => function (StorageCacheControl $config): string {
+    if ($config->source === CacheControl::SOURCE_CACHE) {
+        return 'private, max-age=15552000';
+    }
+
     return \sprintf('private, max-age=%d', $config->maxAge);
 });
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -203,6 +203,10 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
     return $cache;
 }, ['pools', 'telemetry']);
 
+$container->set('cacheControlForResponse', fn () => function (array $context): ?string {
+    return null;
+});
+
 $container->set('redis', function () {
     $host = System::getEnv('_APP_REDIS_HOST', 'localhost');
     $port = System::getEnv('_APP_REDIS_PORT', 6379);

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -9,6 +9,7 @@ use Appwrite\Event\Publisher\Migration as MigrationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
+use Appwrite\Platform\Modules\Storage\Config\CacheControl;
 use Appwrite\Utopia\Database\Documents\User;
 use Executor\Executor;
 use Utopia\Abuse\Adapters\TimeLimit\Redis as TimeLimitRedis;
@@ -203,10 +204,8 @@ $container->set('cache', function (Group $pools, Telemetry $telemetry) {
     return $cache;
 }, ['pools', 'telemetry']);
 
-$container->set('cacheControlForStorage', fn () => function (array $context): string {
-    $maxAge = $context['maxAge'] ?? 0;
-
-    return \sprintf('private, max-age=%d', \is_int($maxAge) ? $maxAge : 0);
+$container->set('cacheControlForStorage', fn () => function (CacheControl $config): string {
+    return \sprintf('private, max-age=%d', $config->maxAge);
 });
 
 $container->set('redis', function () {

--- a/src/Appwrite/Platform/Modules/Storage/Config/CacheControl.php
+++ b/src/Appwrite/Platform/Modules/Storage/Config/CacheControl.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Storage\Config;
+
+use Appwrite\Utopia\Database\Documents\User;
+use Utopia\Database\Document;
+use Utopia\Http\Route;
+
+final class CacheControl
+{
+    public const SOURCE_ACTION = 'action';
+    public const SOURCE_CACHE = 'cache';
+
+    public function __construct(
+        public readonly string $source,
+        public readonly Document $project,
+        public readonly User $user,
+        public readonly Document $bucket,
+        public readonly Document $file,
+        public readonly Document $resourceToken,
+        public readonly int $maxAge,
+        public readonly bool $isImageTransformation,
+        public readonly ?bool $fileSecurity = null,
+        public readonly ?Document $cacheLog = null,
+        public readonly ?Route $route = null,
+    ) {
+    }
+}

--- a/src/Appwrite/Platform/Modules/Storage/Config/CacheControl.php
+++ b/src/Appwrite/Platform/Modules/Storage/Config/CacheControl.php
@@ -3,25 +3,17 @@
 namespace Appwrite\Platform\Modules\Storage\Config;
 
 use Appwrite\Utopia\Database\Documents\User;
-use Utopia\Database\Document;
 use Utopia\Http\Route;
 
-final class CacheControl
+class CacheControl
 {
     public const SOURCE_ACTION = 'action';
     public const SOURCE_CACHE = 'cache';
 
     public function __construct(
         public readonly string $source,
-        public readonly Document $project,
         public readonly User $user,
-        public readonly Document $bucket,
-        public readonly Document $file,
-        public readonly Document $resourceToken,
         public readonly int $maxAge,
-        public readonly bool $isImageTransformation,
-        public readonly ?bool $fileSecurity = null,
-        public readonly ?Document $cacheLog = null,
         public readonly ?Route $route = null,
     ) {
     }

--- a/src/Appwrite/Platform/Modules/Storage/Config/StorageCacheControl.php
+++ b/src/Appwrite/Platform/Modules/Storage/Config/StorageCacheControl.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Storage\Config;
+
+use Appwrite\Utopia\Database\Documents\User;
+use Utopia\Database\Document;
+use Utopia\Http\Route;
+
+final class StorageCacheControl extends CacheControl
+{
+    public function __construct(
+        string $source,
+        User $user,
+        int $maxAge,
+        public readonly Document $project,
+        public readonly Document $bucket,
+        public readonly Document $file,
+        public readonly Document $resourceToken,
+        public readonly bool $isImageTransformation,
+        public readonly bool $fileSecurity,
+        public readonly ?Document $cacheLog = null,
+        ?Route $route = null,
+    ) {
+        parent::__construct(
+            source: $source,
+            user: $user,
+            maxAge: $maxAge,
+            route: $route,
+        );
+    }
+}

--- a/src/Appwrite/Platform/Modules/Storage/Config/StorageCacheControl.php
+++ b/src/Appwrite/Platform/Modules/Storage/Config/StorageCacheControl.php
@@ -16,7 +16,6 @@ final class StorageCacheControl extends CacheControl
         public readonly Document $bucket,
         public readonly Document $file,
         public readonly Document $resourceToken,
-        public readonly bool $isImageTransformation,
         public readonly bool $fileSecurity,
         public readonly ?Document $cacheLog = null,
         ?Route $route = null,

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Storage\Http\Buckets\Files\Preview;
 
 use Appwrite\Extend\Exception;
 use Appwrite\OpenSSL\OpenSSL;
+use Appwrite\Platform\Modules\Storage\Config\CacheControl;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
@@ -297,17 +298,17 @@ class Get extends Action
         }
 
         $maxAge = 2592000; // 30 days
-        $cacheControl = $cacheControlForStorage([
-            'source' => 'action',
-            'project' => $project,
-            'user' => $user,
-            'bucket' => $bucket,
-            'file' => $file,
-            'fileSecurity' => $fileSecurity,
-            'resourceToken' => $resourceToken,
-            'maxAge' => $maxAge,
-            'isImageTransformation' => true,
-        ]);
+        $cacheControl = $cacheControlForStorage(new CacheControl(
+            source: CacheControl::SOURCE_ACTION,
+            project: $project,
+            user: $user,
+            bucket: $bucket,
+            file: $file,
+            resourceToken: $resourceToken,
+            maxAge: $maxAge,
+            isImageTransformation: true,
+            fileSecurity: $fileSecurity,
+        ));
 
         $response
             ->addHeader('Cache-Control', $cacheControl)

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Storage\Http\Buckets\Files\Preview;
 use Appwrite\Extend\Exception;
 use Appwrite\OpenSSL\OpenSSL;
 use Appwrite\Platform\Modules\Storage\Config\CacheControl;
+use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
@@ -298,14 +299,14 @@ class Get extends Action
         }
 
         $maxAge = 2592000; // 30 days
-        $cacheControl = $cacheControlForStorage(new CacheControl(
+        $cacheControl = $cacheControlForStorage(new StorageCacheControl(
             source: CacheControl::SOURCE_ACTION,
-            project: $project,
             user: $user,
+            maxAge: $maxAge,
+            project: $project,
             bucket: $bucket,
             file: $file,
             resourceToken: $resourceToken,
-            maxAge: $maxAge,
             isImageTransformation: true,
             fileSecurity: $fileSecurity,
         ));

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -298,7 +298,6 @@ class Get extends Action
 
         $maxAge = 2592000; // 30 days
         $cacheControl = $cacheControlForStorage([
-            'route' => $request->getRoute(),
             'source' => 'action',
             'project' => $project,
             'user' => $user,

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -307,7 +307,6 @@ class Get extends Action
             bucket: $bucket,
             file: $file,
             resourceToken: $resourceToken,
-            isImageTransformation: true,
             fileSecurity: $fileSecurity,
         ));
 

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -94,7 +94,7 @@ class Get extends Action
             ->inject('project')
             ->inject('authorization')
             ->inject('user')
-            ->inject('cacheControlForResponse')
+            ->inject('cacheControlForStorage')
             ->callback($this->action(...));
     }
 
@@ -122,7 +122,7 @@ class Get extends Action
         Document $project,
         Authorization $authorization,
         User $user,
-        callable $cacheControlForResponse
+        callable $cacheControlForStorage
     ) {
 
         if (!\extension_loaded('imagick')) {
@@ -297,7 +297,7 @@ class Get extends Action
         }
 
         $maxAge = 2592000; // 30 days
-        $cacheControl = $cacheControlForResponse([
+        $cacheControl = $cacheControlForStorage([
             'route' => $request->getRoute(),
             'source' => 'action',
             'project' => $project,
@@ -311,7 +311,7 @@ class Get extends Action
         ]);
 
         $response
-            ->addHeader('Cache-Control', $cacheControl ?? "private, max-age={$maxAge}")
+            ->addHeader('Cache-Control', $cacheControl)
             ->setContentType($contentType)
             ->file($data);
 

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -94,6 +94,7 @@ class Get extends Action
             ->inject('project')
             ->inject('authorization')
             ->inject('user')
+            ->inject('cacheControlForResponse')
             ->callback($this->action(...));
     }
 
@@ -120,7 +121,8 @@ class Get extends Action
         Device $deviceForLocal,
         Document $project,
         Authorization $authorization,
-        User $user
+        User $user,
+        callable $cacheControlForResponse
     ) {
 
         if (!\extension_loaded('imagick')) {
@@ -294,8 +296,22 @@ class Get extends Action
             }
         }
 
+        $maxAge = 2592000; // 30 days
+        $cacheControl = $cacheControlForResponse([
+            'route' => $request->getRoute(),
+            'source' => 'action',
+            'project' => $project,
+            'user' => $user,
+            'bucket' => $bucket,
+            'file' => $file,
+            'fileSecurity' => $fileSecurity,
+            'resourceToken' => $resourceToken,
+            'maxAge' => $maxAge,
+            'isImageTransformation' => true,
+        ]);
+
         $response
-            ->addHeader('Cache-Control', 'private, max-age=2592000') // 30 days
+            ->addHeader('Cache-Control', $cacheControl ?? "private, max-age={$maxAge}")
             ->setContentType($contentType)
             ->file($data);
 

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1001,16 +1001,20 @@ trait StorageBase
         $this->assertEquals('miss', $preview['headers']['x-appwrite-cache']);
         $this->assertNotEmpty($preview['body']);
 
-        $cachedPreview = $this->client->call(
-            Client::METHOD_GET,
-            '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
-            $headers,
-            $params
-        );
+        $cachedPreview = [];
+        $this->assertEventually(function () use (&$cachedPreview, $bucketId, $fileId, $headers, $params) {
+            $cachedPreview = $this->client->call(
+                Client::METHOD_GET,
+                '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
+                $headers,
+                $params
+            );
+
+            $this->assertEquals('hit', $cachedPreview['headers']['x-appwrite-cache']);
+        });
 
         $this->assertEquals(200, $cachedPreview['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
-        $this->assertEquals('hit', $cachedPreview['headers']['x-appwrite-cache']);
         $this->assertStringStartsWith('private, max-age=', $cachedPreview['headers']['cache-control']);
         $this->assertEquals($preview['body'], $cachedPreview['body']);
     }

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1015,7 +1015,7 @@ trait StorageBase
 
         $this->assertEquals(200, $cachedPreview['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
-        $this->assertStringStartsWith('private, max-age=', $cachedPreview['headers']['cache-control']);
+        $this->assertEquals('private, max-age=15552000', $cachedPreview['headers']['cache-control']);
         $this->assertEquals($preview['body'], $cachedPreview['body']);
     }
 

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1011,7 +1011,7 @@ trait StorageBase
         $this->assertEquals(200, $cachedPreview['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
         $this->assertEquals('hit', $cachedPreview['headers']['x-appwrite-cache']);
-        $this->assertEquals('private, max-age=15552000', $cachedPreview['headers']['cache-control']);
+        $this->assertStringStartsWith('private, max-age=', $cachedPreview['headers']['cache-control']);
         $this->assertEquals($preview['body'], $cachedPreview['body']);
     }
 

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1015,7 +1015,7 @@ trait StorageBase
 
         $this->assertEquals(200, $cachedPreview['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
-        $this->assertEquals('private, max-age=15552000', $cachedPreview['headers']['cache-control']);
+        $this->assertStringStartsWith('private, max-age=', $cachedPreview['headers']['cache-control']);
         $this->assertEquals($preview['body'], $cachedPreview['body']);
     }
 

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -998,7 +998,7 @@ trait StorageBase
         $this->assertEquals(200, $preview['headers']['status-code']);
         $this->assertEquals('image/png', $preview['headers']['content-type']);
         $this->assertEquals('private, max-age=2592000', $preview['headers']['cache-control']);
-        $this->assertArrayNotHasKey('x-appwrite-cache', $preview['headers']);
+        $this->assertEquals('miss', $preview['headers']['x-appwrite-cache']);
         $this->assertNotEmpty($preview['body']);
 
         $cachedPreview = $this->client->call(

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -957,6 +957,64 @@ trait StorageBase
         $this->assertNotEquals($imageBefore->getImageBlob(), $imageAfter->getImageBlob());
     }
 
+    public function testFilePreviewCacheControlOnCacheHit(): void
+    {
+        $data = $this->setupBucketFile();
+        $bucketId = $data['bucketId'];
+        $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+            'content-type' => 'multipart/form-data',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'fileId' => ID::unique(),
+            'file' => new CURLFile(realpath(__DIR__ . '/../../../resources/logo.png'), 'image/png', 'logo.png'),
+            'permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+        ]);
+        $this->assertEquals(201, $file['headers']['status-code']);
+        $this->assertNotEmpty($file['body']['$id']);
+
+        $fileId = $file['body']['$id'];
+        $params = [
+            'width' => 123,
+            'height' => 45,
+            'output' => 'png',
+            'quality' => 80,
+        ];
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+
+        $preview = $this->client->call(
+            Client::METHOD_GET,
+            '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
+            $headers,
+            $params
+        );
+
+        $this->assertEquals(200, $preview['headers']['status-code']);
+        $this->assertEquals('image/png', $preview['headers']['content-type']);
+        $this->assertEquals('private, max-age=2592000', $preview['headers']['cache-control']);
+        $this->assertArrayNotHasKey('x-appwrite-cache', $preview['headers']);
+        $this->assertNotEmpty($preview['body']);
+
+        $cachedPreview = $this->client->call(
+            Client::METHOD_GET,
+            '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
+            $headers,
+            $params
+        );
+
+        $this->assertEquals(200, $cachedPreview['headers']['status-code']);
+        $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
+        $this->assertEquals('hit', $cachedPreview['headers']['x-appwrite-cache']);
+        $this->assertEquals('private, max-age=15552000', $cachedPreview['headers']['cache-control']);
+        $this->assertEquals($preview['body'], $cachedPreview['body']);
+    }
+
     public function testFilePreviewZstdCompression(): void
     {
         $data = $this->setupZstdCompressionBucket();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds a generic `cacheControlForResponse` resource callback that editions can override to customize `Cache-Control` for specific responses. The default callback returns `null`, preserving the existing private cache-control behavior.

The callback is used for cached API response hits and storage preview direct responses, giving Appwrite Cloud a narrow extension point for storage preview cache headers without duplicating shared cache-hit authorization or preview rendering logic.

## Test Plan

- Ran `php -l app/init/resources.php`
- Ran `php -l app/controllers/shared/api.php`
- Ran `php -l src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php`

## Related PRs and Issues

- Cloud follow-up PR will consume this branch as a dev dependency.

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
