### PR TITLE
Fix GraphQL preview test assertions

### DIFF
--- a/tests/e2e/Services/GraphQL/Base.php
+++ b/tests/e2e/Services/GraphQL/Base.php
@@ -4,6 +4,7 @@ namespace Tests\E2E\Services\GraphQL;
 
 use CURLFile;
 use Utopia\Console;
+use Utopia\Image\Image;
 
 trait Base
 {
@@ -515,6 +516,21 @@ trait Base
             }
         }
     ';
+
+    protected function assertFilePreviewResponse(array $file): void
+    {
+        $this->assertEquals(200, $file['headers']['status-code']);
+        $this->assertEquals('image/png', $file['headers']['content-type']);
+        $this->assertNotEmpty($file['body']);
+
+        $image = new Image($file['body']);
+        $dimensions = \getimagesizefromstring($file['body']);
+
+        $this->assertNotEmpty($image->output('png'));
+        $this->assertIsArray($dimensions);
+        $this->assertEquals(100, $dimensions[0]);
+        $this->assertEquals(100, $dimensions[1]);
+    }
 
     public function getQuery(string $name): string
     {
@@ -2388,8 +2404,8 @@ trait Base
                     }
                 }';
             case self::GET_FILE_PREVIEW:
-                return 'query getFilePreview($bucketId: String!, $fileId: String!) {
-                    storageGetFilePreview(bucketId: $bucketId, fileId: $fileId) {
+                return 'query getFilePreview($bucketId: String!, $fileId: String!, $width: Int, $height: Int) {
+                    storageGetFilePreview(bucketId: $bucketId, fileId: $fileId, width: $width, height: $height) {
                         status
                     }
                 }';

--- a/tests/e2e/Services/GraphQL/StorageClientTest.php
+++ b/tests/e2e/Services/GraphQL/StorageClientTest.php
@@ -200,7 +200,7 @@ class StorageClientTest extends Scope
             'x-appwrite-project' => $projectId,
         ], $this->getHeaders()), $gqlPayload);
 
-        $this->assertEquals(46719, \strlen($file['body']));
+        $this->assertFilePreviewResponse($file);
 
         return $file;
     }

--- a/tests/e2e/Services/GraphQL/StorageServerTest.php
+++ b/tests/e2e/Services/GraphQL/StorageServerTest.php
@@ -262,7 +262,7 @@ class StorageServerTest extends Scope
             'x-appwrite-project' => $projectId,
         ], $this->getHeaders()), $gqlPayload);
 
-        $this->assertEquals(46719, \strlen($file['body']));
+        $this->assertFilePreviewResponse($file);
 
         return $file;
     }


### PR DESCRIPTION
## What does this PR do?

Updates the GraphQL storage preview E2E tests to assert the response contract instead of an exact Imagick-generated PNG byte length.

The failing CI job on #12246 consistently returned a valid preview body with a different PNG size (`46952` instead of `46719`). Exact encoded image size is brittle across image pipeline/runtime changes, so these tests now assert:

- HTTP 200 response
- `image/png` content type
- non-empty body
- decoded 100x100 PNG dimensions

This also wires the existing `width` and `height` test variables into the GraphQL preview query.

## Test Plan

- `composer format tests/e2e/Services/GraphQL/Base.php tests/e2e/Services/GraphQL/StorageClientTest.php tests/e2e/Services/GraphQL/StorageServerTest.php`
- `composer lint tests/e2e/Services/GraphQL/Base.php tests/e2e/Services/GraphQL/StorageClientTest.php tests/e2e/Services/GraphQL/StorageServerTest.php`
- `php -l tests/e2e/Services/GraphQL/Base.php && php -l tests/e2e/Services/GraphQL/StorageClientTest.php && php -l tests/e2e/Services/GraphQL/StorageServerTest.php`
- `git diff --check -- tests/e2e/Services/GraphQL/Base.php tests/e2e/Services/GraphQL/StorageClientTest.php tests/e2e/Services/GraphQL/StorageServerTest.php`

The targeted E2E tests were not run locally because the appwrite Docker service is not currently running in this workspace.

## Related PRs and Issues

- Split out from CI investigation on #12246

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
