### PR TITLE
Fix:GraphQL enum mapping for database attributes

### DIFF
--- a/src/Appwrite/GraphQL/Types/Mapper.php
+++ b/src/Appwrite/GraphQL/Types/Mapper.php
@@ -451,9 +451,11 @@ class Mapper
                 'email' => static::model("{$prefix}Email"),
                 'url' => static::model("{$prefix}Url"),
                 'ip' => static::model("{$prefix}Ip"),
+                APP_DATABASE_ATTRIBUTE_ENUM => static::model("{$prefix}Enum"),
                 default => static::model("{$prefix}String"),
             },
-            'enum' => static::model("{$prefix}String"), // TODO: Add enum type (breaking change if added)
+            // Keep supporting legacy responses where type is "enum".
+            'enum' => static::model("{$prefix}Enum"),
             'integer' => static::model("{$prefix}Integer"),
             'double' => static::model("{$prefix}Float"),
             'boolean' => static::model("{$prefix}Boolean"),

--- a/src/Appwrite/GraphQL/Types/Mapper.php
+++ b/src/Appwrite/GraphQL/Types/Mapper.php
@@ -454,7 +454,9 @@ class Mapper
                 APP_DATABASE_ATTRIBUTE_ENUM => static::model("{$prefix}Enum"),
                 default => static::model("{$prefix}String"),
             },
-            // Keep supporting legacy responses where type is "enum".
+
+            // Map type='enum' (legacy outer-match) to Enum model. Originally deferred as a breaking change;
+            // now applied. Existing GraphQL clients expecting String for enum fields will break.
             'enum' => static::model("{$prefix}Enum"),
             'integer' => static::model("{$prefix}Integer"),
             'double' => static::model("{$prefix}Float"),

--- a/tests/unit/GraphQL/BuilderTest.php
+++ b/tests/unit/GraphQL/BuilderTest.php
@@ -28,4 +28,30 @@ class BuilderTest extends TestCase
         $this->assertInstanceOf(NamedType::class, $type);
         $this->assertEquals('Table', $type->name());
     }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testEnumAttributeResolvesToEnumModel(): void
+    {
+        $method = new \ReflectionMethod(Mapper::class, 'getColumnImplementation');
+
+        $type = $method->invokeArgs(null, [['type' => 'string', 'format' => APP_DATABASE_ATTRIBUTE_ENUM], false]);
+
+        $this->assertInstanceOf(NamedType::class, $type);
+        $this->assertEquals('AttributeEnum', $type->name());
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testEnumColumnResolvesToEnumModel(): void
+    {
+        $method = new \ReflectionMethod(Mapper::class, 'getColumnImplementation');
+
+        $type = $method->invokeArgs(null, [['type' => 'string', 'format' => APP_DATABASE_ATTRIBUTE_ENUM], true]);
+
+        $this->assertInstanceOf(NamedType::class, $type);
+        $this->assertEquals('ColumnEnum', $type->name());
+    }
 }

--- a/tests/unit/GraphQL/BuilderTest.php
+++ b/tests/unit/GraphQL/BuilderTest.php
@@ -54,4 +54,30 @@ class BuilderTest extends TestCase
         $this->assertInstanceOf(NamedType::class, $type);
         $this->assertEquals('ColumnEnum', $type->name());
     }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testLegacyEnumTypeResolvesToEnumAttribute(): void
+    {
+        $method = new \ReflectionMethod(Mapper::class, 'getColumnImplementation');
+
+        $type = $method->invokeArgs(null, [['type' => 'enum'], false]);
+
+        $this->assertInstanceOf(NamedType::class, $type);
+        $this->assertEquals('AttributeEnum', $type->name());
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testLegacyEnumTypeResolvesToEnumColumn(): void
+    {
+        $method = new \ReflectionMethod(Mapper::class, 'getColumnImplementation');
+
+        $type = $method->invokeArgs(null, [['type' => 'enum'], true]);
+
+        $this->assertInstanceOf(NamedType::class, $type);
+        $this->assertEquals('ColumnEnum', $type->name());
+    }
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes GraphQL mapping for Appwrite database enum attributes and columns.
fixes: #12168 

Previously, enum-formatted schema fields were resolved as generic string models in GraphQL, causing the schema to lose enum-specific structure and preventing clients from accessing the actual allowed values.

This change updates the mapper to resolve these fields to `AttributeEnum` and `ColumnEnum` instead, allowing the GraphQL schema to accurately reflect the underlying data model.

## Test Plan

Verified using PHPUnit inside the Appwrite container:

```bash
docker compose exec appwrite vendor/bin/phpunit tests/unit/GraphQL/BuilderTest.php --filter=testEnumAttributeResolvesToEnumModel
```

The test passed successfully with 1 test and 2 assertions.

Additionally, I fixed a PHP 8.5 deprecation warning in the test by removing the deprecated `ReflectionMethod::setAccessible()` call, ensuring the test runs cleanly without warnings.

## Related PRs and Issues

None.

## Checklist

* [x] Have you read the [[Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
* [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?