### PR TITLE
Chore: Dual read for google oauth secret

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Google.php
+++ b/src/Appwrite/Auth/OAuth2/Google.php
@@ -187,7 +187,7 @@ class Google extends OAuth2
     {
         $secret = $this->getAppSecret();
 
-        return $secret['clientSecret'] ?? '';
+        return $secret['clientSecret'] ?? $this->appSecret;
     }
 
     /**
@@ -201,6 +201,10 @@ class Google extends OAuth2
         try {
             $secret = \json_decode($this->appSecret, true, 512, JSON_THROW_ON_ERROR);
         } catch (\Throwable $th) {
+            return ['clientSecret' => $this->appSecret];
+        }
+
+        if (!\is_array($secret)) {
             return ['clientSecret' => $this->appSecret];
         }
 

--- a/src/Appwrite/Auth/OAuth2/Google.php
+++ b/src/Appwrite/Auth/OAuth2/Google.php
@@ -72,7 +72,7 @@ class Google extends OAuth2
                 'https://oauth2.googleapis.com/token?' . \http_build_query([
                     'code' => $code,
                     'client_id' => $this->appID,
-                    'client_secret' => $this->appSecret,
+                    'client_secret' => $this->getClientSecret(),
                     'redirect_uri' => $this->callback,
                     'scope' => null,
                     'grant_type' => 'authorization_code'
@@ -95,7 +95,7 @@ class Google extends OAuth2
             'https://oauth2.googleapis.com/token?' . \http_build_query([
                 'refresh_token' => $refreshToken,
                 'client_id' => $this->appID,
-                'client_secret' => $this->appSecret,
+                'client_secret' => $this->getClientSecret(),
                 'grant_type' => 'refresh_token'
             ])
         ), true);
@@ -176,5 +176,34 @@ class Google extends OAuth2
         }
 
         return $this->user;
+    }
+
+    /**
+     * Extracts the Client Secret from the JSON stored in appSecret
+     *
+     * @return string
+     */
+    protected function getClientSecret(): string
+    {
+        $secret = $this->getAppSecret();
+
+        return $secret['clientSecret'] ?? '';
+    }
+
+    /**
+     * Decode the JSON stored in appSecret.
+     * Falls back to treating the raw string as the client secret for backwards compatibility.
+     *
+     * @return array
+     */
+    protected function getAppSecret(): array
+    {
+        try {
+            $secret = \json_decode($this->appSecret, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $th) {
+            return ['clientSecret' => $this->appSecret];
+        }
+
+        return $secret;
     }
 }


### PR DESCRIPTION
Will allow future support for more params

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds dual reading - value as is, or JSON. Preparation for future support of custom extra parameters.

## Test Plan

None

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
