### PR TITLE
fix: add descriptive error message for unsupported file type in deployments

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -160,7 +160,7 @@ class Create extends Action
         $fileSize = (\is_array($file['size']) && isset($file['size'][0])) ? $file['size'][0] : $file['size'];
 
         if (!$fileExt->isValid($file['name'])) { // Check if file type is allowed
-            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
+            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED, 'Only gzip compressed files (.tar.gz) are accepted for function deployments.');
         }
 
         $contentRange = $request->getHeader('content-range');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -160,7 +160,7 @@ class Create extends Action
         $fileSize = (\is_array($file['size']) && isset($file['size'][0])) ? $file['size'][0] : $file['size'];
 
         if (!$fileExt->isValid($file['name'])) { // Check if file type is allowed
-            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
+            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED, 'Only gzip compressed files (.tar.gz) are accepted for site deployments.');
         }
 
         $contentRange = $request->getHeader('content-range');


### PR DESCRIPTION
## What does this PR do?

Adds explicit error messages for unsupported deployment file types in:

* `src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php`
* `src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php`

Previously these endpoints threw `STORAGE_FILE_TYPE_UNSUPPORTED` without a custom message, which caused the generic fallback message to appear:

> "The given file extension is not supported."

Function and site deployments specifically require `.tar.gz` gzip archives, so the generic message did not provide enough guidance for developers.

This PR aligns deployment endpoints with the existing precedent in `Storage/Files/Create.php`, where explicit error messages are already provided.

## Changes

Added descriptive validation messages explaining that only `.tar.gz` gzip archives are supported for deployments.

## Why this matters

* Improves developer experience
* Makes deployment constraints immediately clear
* Brings consistency across upload-related endpoints

## Testing

* Verified unsupported file uploads now return descriptive validation errors
* Confirmed existing deployment flow remains unchanged
