### PR TITLE
fix: use correct rule ID format and deployment values for chunked site deployments

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -160,7 +160,7 @@ class Create extends Action
         $fileSize = (\is_array($file['size']) && isset($file['size'][0])) ? $file['size'][0] : $file['size'];
 
         if (!$fileExt->isValid($file['name'])) { // Check if file type is allowed
-            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
+            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED, 'Only gzip compressed files (.tar.gz) are accepted for function deployments.');
         }
 
         $contentRange = $request->getHeader('content-range');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -160,7 +160,7 @@ class Create extends Action
         $fileSize = (\is_array($file['size']) && isset($file['size'][0])) ? $file['size'][0] : $file['size'];
 
         if (!$fileExt->isValid($file['name'])) { // Check if file type is allowed
-            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
+            throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED, 'Only gzip compressed files (.tar.gz) are accepted for site deployments.');
         }
 
         $contentRange = $request->getHeader('content-range');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -356,15 +356,18 @@ class Create extends Action
                     ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
                     ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
                 $dbForProject->updateDocument('sites', $site->getId(), new Document([
-                    'latestDeploymentId' => $site->getAttribute('latestDeploymentId'),
-                    'latestDeploymentInternalId' => $site->getAttribute('latestDeploymentInternalId'),
-                    'latestDeploymentCreatedAt' => $site->getAttribute('latestDeploymentCreatedAt'),
-                    'latestDeploymentStatus' => $site->getAttribute('latestDeploymentStatus'),
+                    'latestDeploymentId' => $deployment->getId(),
+                    'latestDeploymentInternalId' => $deployment->getSequence(),
+                    'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
+                    'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
                 ]));
 
                 $sitesDomain = $platform['sitesDomain'];
                 $domain = ID::unique() . "." . $sitesDomain;
-                $ruleId = md5($domain);
+
+                // TODO: (@Meldiron) Remove after 1.7.x migration
+                $isMd5 = System::getEnv('_APP_RULES_FORMAT') === 'md5';
+                $ruleId = $isMd5 ? md5($domain) : ID::unique();
                 $authorization->skip(
                     fn () => $dbForPlatform->createDocument('rules', new Document([
                         '$id' => $ruleId,


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistencies in the chunked site deployment upload flow in:

- `src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php`

### Fix 1 — Correct rule ID format handling

The single-chunk upload flow already respects `_APP_RULES_FORMAT` by conditionally using either:

- `md5($domain)` (legacy format)
- `ID::unique()` (current format)

However, the chunked upload path was hardcoded to always use `md5($domain)`, causing large/chunked site deployments to incorrectly generate legacy-format rule IDs regardless of environment configuration.

This PR updates the chunked upload flow to use the same `$isMd5` logic as the single-chunk implementation.

### Fix 2 — Consistent deployment value usage

The chunked upload flow updated site attributes using:

- `$site->getAttribute(...)`

immediately after setting those attributes from the deployment object.

The equivalent single-chunk flow directly used deployment values instead.

This PR aligns the chunked upload flow with the existing single-chunk implementation by using deployment values directly for consistency and clarity.

## Test Plan

- Verified chunked deployments now respect the configured `_APP_RULES_FORMAT`
- Confirmed large/chunked uploads correctly generate rule IDs using the same logic as single-chunk uploads
- Verified deployment attributes update correctly after deployment completion
- Compared behavior against the existing single-chunk upload flow to ensure consistency

## Related PRs and Issues

- Stacked on top of #12264

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?