### PR TITLE
fix: prevent state mutation in PersonalData validator

### DIFF
--- a/src/Appwrite/Auth/Validator/PersonalData.php
+++ b/src/Appwrite/Auth/Validator/PersonalData.php
@@ -43,35 +43,40 @@ class PersonalData extends Password
             return false;
         }
 
+        $userId = $this->userId ?? '';
+        $email = $this->email ?? '';
+        $name = $this->name ?? '';
+        $phone = $this->phone ?? '';
+
         if (!$this->strict) {
             $password = strtolower($password);
-            $this->userId = strtolower($this->userId ?? '');
-            $this->email = strtolower($this->email ?? '');
-            $this->name = strtolower($this->name ?? '');
-            $this->phone = strtolower($this->phone ?? '');
+            $userId = strtolower($userId);
+            $email = strtolower($email);
+            $name = strtolower($name);
+            $phone = strtolower($phone);
         }
 
-        if ($this->userId && strpos($password, $this->userId) !== false) {
+        if ($userId && strpos($password, $userId) !== false) {
             return false;
         }
 
-        if ($this->email && strpos($password, $this->email) !== false) {
+        if ($email && strpos($password, $email) !== false) {
             return false;
         }
 
-        if ($this->email && strpos($password, explode('@', $this->email)[0]) !== false) {
+        if ($email && strpos($password, explode('@', $email)[0]) !== false) {
             return false;
         }
 
-        if ($this->name && strpos($password, $this->name) !== false) {
+        if ($name && strpos($password, $name) !== false) {
             return false;
         }
 
-        if ($this->phone && strpos($password, str_replace('+', '', $this->phone)) !== false) {
+        if ($phone && strpos($password, str_replace('+', '', $phone)) !== false) {
             return false;
         }
 
-        if ($this->phone && strpos($password, $this->phone) !== false) {
+        if ($phone && strpos($password, $phone) !== false) {
             return false;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes unintended internal state mutation in `PersonalData::isValid()`.

Previously, `isValid()` wrote lowercase-transformed values back to instance properties such as:

- `$this->userId`
- `$this->email`

This caused repeated calls on the same validator instance to operate on already-mutated state, which could break strict case-sensitive validation behavior.

This PR avoids mutating validator state by using local lowercase variables during comparison instead of overwriting instance properties.

## Test Plan

- Verified repeated `isValid()` calls now behave consistently
- Confirmed strict case-sensitive validation no longer depends on previous calls
- Verified existing validation behavior remains unchanged for valid inputs

## Related PRs and Issues

- Fixes #11895

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?