### PR TITLE
fix: prevent enqueue drift in scheduled functions

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -49,7 +49,7 @@ class ScheduleFunctions extends ScheduleBase
         $elapsed = $this->lastEnqueueUpdate === null ? 0.0 : $timerStart - $this->lastEnqueueUpdate;
         $enqueueDiff = max(0.0, $elapsed - static::ENQUEUE_TIMER);
         $this->lastEnqueueUpdate = $timerStart;
-        $timeFrame = DateTime::addSeconds(new \DateTime(), static::ENQUEUE_TIMER + (int)$enqueueDiff);
+        $timeFrame = DateTime::addSeconds(new \DateTime(), static::ENQUEUE_TIMER + (int)ceil($enqueueDiff));
 
         Console::log("Enqueue tick: started at: $time (with diff $enqueueDiff)");
 

--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -21,6 +21,8 @@ class ScheduleFunctions extends ScheduleBase
     public const UPDATE_TIMER = 10; // seconds
     public const ENQUEUE_TIMER = 60; // seconds
 
+    private ?float $lastEnqueueUpdate = null;
+
     public static function getName(): string
     {
         return 'schedule-functions';
@@ -41,11 +43,13 @@ class ScheduleFunctions extends ScheduleBase
         $timerStart = \microtime(true);
         $time = DateTime::now();
 
-        // TODO: Track the last enqueue timestamp to subtract ENQUEUE_TIMER drift from
-        // the time frame. Previously this used $this->lastEnqueueUpdate as a property
-        // but enabling the assignment broke scheduling, so the diff stays 0.
-        $enqueueDiff = 0;
-        $timeFrame = DateTime::addSeconds(new \DateTime(), static::ENQUEUE_TIMER - $enqueueDiff);
+        // Widen the look-ahead window by how much the cycle ran late so that
+        // schedules cannot fall into the gap between two consecutive windows.
+        // Using max(0, ...) ensures an early wake-up never shrinks the window.
+        $elapsed = $this->lastEnqueueUpdate === null ? 0.0 : $timerStart - $this->lastEnqueueUpdate;
+        $enqueueDiff = max(0.0, $elapsed - static::ENQUEUE_TIMER);
+        $this->lastEnqueueUpdate = $timerStart;
+        $timeFrame = DateTime::addSeconds(new \DateTime(), static::ENQUEUE_TIMER + (int)$enqueueDiff);
 
         Console::log("Enqueue tick: started at: $time (with diff $enqueueDiff)");
 


### PR DESCRIPTION
## What does this PR do?

Fixes scheduling drift handling in `src/Appwrite/Platform/Tasks/ScheduleFunctions.php`.

Previously, `$lastEnqueueUpdate` logic was disabled because the original calculation:

```php
ENQUEUE_TIMER - elapsed
```

could collapse the scheduling window to zero when `elapsed` approached the enqueue interval duration.

This caused scheduled executions to drift and potentially miss the intended enqueue window during delayed scheduler cycles.

This PR restores the enqueue update logic using:

```php
ENQUEUE_TIMER + max(0, elapsed - ENQUEUE_TIMER)
```

This preserves the normal enqueue window during regular execution while safely widening the look-ahead window only when scheduler cycles run late.

## Why this matters

- Prevents schedule drift during delayed scheduler cycles
- Avoids enqueue window collapse
- Keeps normal scheduling behavior unchanged during healthy execution
- Aligns delayed-cycle behavior with intended scheduling semantics

## Test Plan

- Verified scheduler behavior with delayed execution cycles
- Confirmed enqueue windows no longer collapse when elapsed time approaches the timer interval
- Verified normal execution timing remains unaffected for non-delayed cycles

## Related PRs and Issues

- Fixes #11931

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?