### PR TITLE
fix(auth): validate session expiry during JWT authentication

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -424,8 +424,14 @@ App::setResource('user', function (string $mode, Document $project, Document $co
         }
         $jwtSessionId = $payload['sessionId'] ?? '';
         if (!empty($jwtSessionId)) {
-            if (empty($user->find('$id', $jwtSessionId, 'sessions'))) { // Match JWT to active token
+            $jwtSession = $user->find('$id', $jwtSessionId, 'sessions');
+            if (empty($jwtSession)) {
                 $user = new User([]);
+            } else {
+                $session = reset($jwtSession);
+                if ($session->isSet('expire') && DatabaseDateTime::formatTz(DatabaseDateTime::format(new \DateTime($session->getAttribute('expire')))) < DatabaseDateTime::formatTz(DatabaseDateTime::now())) {
+                    $user = new User([]);
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes #8000 — JWT tokens were still valid after the associated session had timed out, because the JWT authentication block only verified the session exists but never checked if it had expired.

## Root Cause

In `app/init/resources.php`, the JWT authentication block only performed two checks:
1. JWT signature is cryptographically valid (`$jwt->decode()`)
2. The session still exists on the user document (`$user->find('$id', $jwtSessionId, 'sessions')`)

It did **not** compare the session's `expire` attribute against the current time.

By contrast, the regular session authentication block delegates to `User::sessionVerify()` (`src/Appwrite/Utopia/Database/Documents/User.php:161`), which explicitly checks session expiry.

## Changes

Added an expiry check in the JWT authentication block using the same pattern as `User::sessionVerify()`. After finding the session by ID, the code now:
1. Extracts the session document from the `find()` result
2. Checks if `expire` is set on the session
3. Compares the expiry timestamp against the current time
4. Sets user to empty/guest if the session has expired

## Test Plan

1. Set a short session length (e.g. 1 minute) in Auth > Security
2. Create a user and sign in
3. Create a JWT token via `account.createJWT()`
4. Verify `account.get()` with the JWT works immediately
5. Wait for the session to expire
6. Call `account.get()` again with the same JWT — should now return 401 instead of 200