### PR TITLE
fix(users): send full user object in updatePrefs event payload

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1679,7 +1679,8 @@ App::patch('/v1/users/:userId/prefs')
         $user = $dbForProject->updateDocument('users', $user->getId(), $user->setAttribute('prefs', $prefs));
 
         $queueForEvents
-            ->setParam('userId', $user->getId());
+            ->setParam('userId', $user->getId())
+            ->setPayload($response->output($user, Response::MODEL_USER));
 
         $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
     });


### PR DESCRIPTION
## What does this PR do?

Fixes #7234 — The `users.*.update.prefs` trigger function event payload now contains the full user document, matching the behavior of other update endpoints like `updateName` and `updateEmail`.

## Root Cause

The `updatePrefs` endpoint had two related issues:

1. The action handler only called `$queueForEvents->setParam('userId', ...)` without explicitly setting an event payload.
2. The response payload returned `MODEL_PREFERENCES` (only the preferences key-value pairs).

The shutdown hook in `app/controllers/shared/api.php` copies the **response payload** into the event payload when no explicit event payload is set. Since the response for `updatePrefs` contains only preferences, trigger functions received just the preference object instead of the full user.

By contrast, `updateName`, `updateEmail`, `updatePhone`, and other update endpoints all return `MODEL_USER` (full user document), so their trigger payloads consistently contain the complete user.

## Changes

Added an explicit `$queueForEvents->setPayload($response->output($user, Response::MODEL_USER))` call in the `updatePrefs` action handler. This ensures:

- **Trigger functions** receive the full user document in their event payload
- **HTTP response** still returns `MODEL_PREFERENCES` as per the API specification
- The change is **backwards compatible** — the HTTP API response format is unchanged

## Test Plan

1. Create a Cloud Function triggered by `users.*.update` event
2. Update user email via API — verify function receives full user object in payload
3. Update user name via API — verify function receives full user object in payload
4. Update user preferences via API — verify function now receives **full user object** (not just preferences)
5. Confirm the HTTP response to `PATCH /v1/users/:userId/prefs` still returns preferences only