### PR TITLE
Throw Migration\Exception from migrations worker instead of HTTP error catalog

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1246,26 +1246,6 @@ return [
         'description' => 'The specified database type is not supported for CSV import or export operations.',
         'code' => 400,
     ],
-    Exception::MIGRATION_SOURCE_PROJECT_ID_REQUIRED => [
-        'name' => Exception::MIGRATION_SOURCE_PROJECT_ID_REQUIRED,
-        'description' => 'A source projectId is required for Appwrite migrations. Provide it in the migration credentials.',
-        'code' => 400,
-    ],
-    Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND => [
-        'name' => Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND,
-        'description' => 'The source project for the provided projectId was not found. Verify the projectId and the API key has access to it.',
-        'code' => 404,
-    ],
-    Exception::MIGRATION_SOURCE_TYPE_INVALID => [
-        'name' => Exception::MIGRATION_SOURCE_TYPE_INVALID,
-        'description' => 'The migration source type is invalid. Use one of the supported source types.',
-        'code' => 400,
-    ],
-    Exception::MIGRATION_DESTINATION_TYPE_INVALID => [
-        'name' => Exception::MIGRATION_DESTINATION_TYPE_INVALID,
-        'description' => 'The migration destination type is invalid. Use one of the supported destination types.',
-        'code' => 400,
-    ],
 
     /** Realtime */
     Exception::REALTIME_MESSAGE_FORMAT_INVALID => [

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -348,10 +348,6 @@ class Exception extends \Exception
     public const string MIGRATION_IN_PROGRESS = 'migration_in_progress';
     public const string MIGRATION_PROVIDER_ERROR = 'migration_provider_error';
     public const string MIGRATION_DATABASE_TYPE_UNSUPPORTED = 'migration_database_type_unsupported';
-    public const string MIGRATION_SOURCE_PROJECT_ID_REQUIRED = 'migration_source_project_id_required';
-    public const string MIGRATION_SOURCE_PROJECT_NOT_FOUND = 'migration_source_project_not_found';
-    public const string MIGRATION_SOURCE_TYPE_INVALID = 'migration_source_type_invalid';
-    public const string MIGRATION_DESTINATION_TYPE_INVALID = 'migration_destination_type_invalid';
 
     /** Realtime */
     public const string REALTIME_MESSAGE_FORMAT_INVALID = 'realtime_message_format_invalid';

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -197,13 +197,23 @@ class Migrations extends Action
         $projectDB = null;
         $useAppwriteApiSource = false;
         if ($source === SourceAppwrite::getName() && empty($credentials['projectId'])) {
-            throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_ID_REQUIRED);
+            throw new MigrationException(
+                resourceName: '',
+                resourceGroup: '',
+                message: 'A source projectId is required for Appwrite migrations. Provide it in the migration credentials.',
+                code: MigrationException::CODE_VALIDATION,
+            );
         }
 
         if (! empty($credentials['projectId'])) {
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
             if ($this->sourceProject->isEmpty()) {
-                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
+                throw new MigrationException(
+                    resourceName: '',
+                    resourceGroup: '',
+                    message: 'Source project for the provided projectId could not be found.',
+                    code: MigrationException::CODE_NOT_FOUND,
+                );
             }
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
@@ -266,7 +276,12 @@ class Migrations extends Action
                 $this->deviceForMigrations,
                 $this->dbForProject,
             ),
-            default => throw new Exception(Exception::MIGRATION_SOURCE_TYPE_INVALID),
+            default => throw new MigrationException(
+                resourceName: '',
+                resourceGroup: '',
+                message: 'The migration source type is invalid. Use one of the supported source types.',
+                code: MigrationException::CODE_VALIDATION,
+            ),
         };
 
         $resources = $migration->getAttribute('resources', []);
@@ -312,7 +327,12 @@ class Migrations extends Action
                 $options['filename'],
                 $options['columns'] ?? [],
             ),
-            default => throw new Exception(Exception::MIGRATION_DESTINATION_TYPE_INVALID),
+            default => throw new MigrationException(
+                resourceName: '',
+                resourceGroup: '',
+                message: 'The migration destination type is invalid. Use one of the supported destination types.',
+                code: MigrationException::CODE_VALIDATION,
+            ),
         };
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #12226. The migrations worker is a queue worker, not an HTTP endpoint — its errors never become HTTP responses — so its setup-validation failures shouldn't be drawn from the HTTP error registry (`app/config/errors.php` / `Appwrite\Extend\Exception`). Per review feedback, those throws now use `Utopia\Migration\Exception`, which is the domain-appropriate type for a migration worker.

The worker's outer-catch gate already handles `Migration\Exception` (it's library-thrown / user-facing → not published to Sentry, but recorded on the migration document), so the Sentry-suppression behavior #12226 introduced is preserved — it just no longer needs HTTP-catalog entries to do it.

## What changed

`src/Appwrite/Platform/Workers/Migrations.php` — four setup throws converted:

```php
// before
throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_ID_REQUIRED);
// after
throw new MigrationException(
    resourceName: '',
    resourceGroup: '',
    message: 'A source projectId is required for Appwrite migrations. Provide it in the migration credentials.',
    code: MigrationException::CODE_VALIDATION,
);
```

| Throw site | Old constant | New code |
|---|---|---|
| empty `credentials.projectId` | `MIGRATION_SOURCE_PROJECT_ID_REQUIRED` | `CODE_VALIDATION` (400) |
| source project not found | `MIGRATION_SOURCE_PROJECT_NOT_FOUND` | `CODE_NOT_FOUND` (404) |
| unknown source type | `MIGRATION_SOURCE_TYPE_INVALID` | `CODE_VALIDATION` (400) |
| unknown destination type | `MIGRATION_DESTINATION_TYPE_INVALID` | `CODE_VALIDATION` (400) |

`src/Appwrite/Extend/Exception.php` — removed the four now-unused constants.

`app/config/errors.php` — removed the four now-unused registry entries.

## Why

`Appwrite\Extend\Exception` + `app/config/errors.php` are the **HTTP error catalog** — entries map to HTTP status codes, response descriptions, and the `general.php` handler. A background queue worker has no HTTP response. Putting worker errors there was a category mismatch. `Migration\Exception` is the right type, and the gate already routes it correctly.

Empty `resourceName`/`resourceGroup` on these `MigrationException`s is consistent with the worker's existing bubbled-error wrap, which uses the same for setup-time (pre-resource) failures.

## Gate unchanged

```php
if ($th instanceof Exception) {                  // Appwrite\Extend\Exception (HTTP errors that bubbled)
    $publish = $th->isPublishable();
} elseif ($th instanceof MigrationException) {   // ← these now land here → not published, recorded in errors[]
    $publish = false;
} else {
    $publish = true;
}
```

## Companion

- `appwrite-labs/cloud#3962` — the same change applied to cloud's `processSource` overrides (drops `Appwrite\Cloud\Exception` `MIGRATION_SOURCE_*` constants + cloud `errors.php` entries).
