### PR TITLE
fix(migrations): write _APP_MIGRATION_HOST in the installer-generated .env

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -1337,6 +1337,15 @@ return [
         'description' => '',
         'variables' => [
             [
+                'name' => '_APP_MIGRATION_HOST',
+                'description' => 'Internal hostname the migrations worker uses to reach this instance\'s API (for migrations and CSV/JSON imports & exports). Defaults to \'appwrite\', the API service name in the standard Docker Compose setup. Only change this for non-standard deployments.',
+                'introduction' => '1.9.0',
+                'default' => 'appwrite',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
                 'name' => '_APP_MIGRATIONS_FIREBASE_CLIENT_ID',
                 'description' => 'Google OAuth client ID. You can find it in your GCP application settings.',
                 'introduction' => '1.4.0',


### PR DESCRIPTION
## What does this PR do?

On a fresh self-hosted install, the first Appwrite→Appwrite migration or CSV/JSON import/export **hangs forever** — the console sits on "Preparing export…" with no error (#11853).

### Root cause

The migrations worker reads `_APP_MIGRATION_HOST` to call back into this instance's REST API. That var was introduced in #11229 (in both 1.8.x and 1.9.x) — it replaced a hardcoded `$endpoint = 'http://appwrite/v1'` — but it was **never added to `app/config/variables.php`**. So `appwrite install` / `appwrite upgrade` don't write it into the generated `.env`, the worker gets an empty value, and the migration fails before its status can be updated → the record stays `pending` and the console spins.

Contributors and CI never see it because the repo's hand-maintained `.env` already has `_APP_MIGRATION_HOST=appwrite`; only the **installer-generated** `.env` is missing it.

### The fix

Add `_APP_MIGRATION_HOST` to `app/config/variables.php` with default `appwrite` — the API service name in the standard Docker Compose setup (what the repo's own `.env` and the cloud Helm charts already use, and what the migration endpoint was hardcoded to before #11229). `appwrite install` and `appwrite upgrade` now write it into the generated `.env`, so fresh installs and upgrades have it set and the migration / import / export flows work.

| Scenario | `_APP_MIGRATION_HOST` in generated `.env`? |
|---|---|
| `appwrite install` (fresh) | ✅ `appwrite` — written by the installer |
| `appwrite upgrade` | ✅ `appwrite` — merged in on upgrade |

### Scope

This PR addresses the **install & upgrade paths only** — it deliberately does not touch the worker code. (The worker still throws `'_APP_MIGRATION_HOST is not set'` if the var is somehow still empty — e.g. an instance that pulls a new image without re-running `appwrite upgrade`. Making that failure terminal instead of stuck is a separate change.)

## Test Plan

1. `appwrite install` on a clean host.
2. Verify the generated `.env` contains `_APP_MIGRATION_HOST=appwrite`.
3. Console → any database table → Export → CSV → Export → completes and downloads.
4. Same after `appwrite upgrade` from an older version.

## Related PRs and Issues

- Fixes #11853
- `_APP_MIGRATION_HOST` was introduced in #11229; it's missing from `variables.php` in 1.8.x too, so the same gap exists there.
- Overlaps with #12214 (which adds a `_APP_MIGRATION_HOST` → `"appwrite"` fallback in the worker, and a separate `DestinationCSV`/`DestinationJSON` double-extension fix) — both orthogonal to this config-only change.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
