### PR TITLE
Fix: remove invalid event label from project delete action

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php
@@ -33,7 +33,6 @@ class Delete extends Action
             ->desc('Delete project')
             ->groups(['api', 'project'])
             ->label('scope', 'project.write')
-            ->label('event', 'project.delete')
             ->label('audits.event', 'project.delete')
             ->label('audits.resource', 'project/{project.$id}')
             ->label('sdk', new Method(


### PR DESCRIPTION
## Summary

`DELETE /v1/project` (alias `DELETE /v1/projects/:projectId`) was crashing with `InvalidArgumentException: delete is missing from the params` inside `Appwrite\Event\Event::generateEvents()`.

The action declared `->label('event', 'project.delete')`. `Event::generateEvents()` parses that pattern as `type=project, resource=delete` and then requires a `delete` key in the route params; the route has no `:delete` placeholder, so every call threw.

## Root cause

Commit b99139661e ("Migrate delete project endpoint") migrated this route from `app/controllers/api/projects.php` to the new module pattern and added an `event` label that was never present before. The pre-migration `Http::delete()` route declared only `audits.event`, so functions and webhooks were intentionally not triggered for project deletion (an admin teardown operation should not fire user-facing webhooks for the project being deleted).

## Fix

Single-line removal in `src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php`: drop `->label('event', 'project.delete')`. The `audits.event` label is preserved so audit logs still record the deletion.

## Test plan

- [x] `composer lint` on the modified file — Pint passes
- [x] `composer analyze` — PHPStan level 3, no errors
- [ ] Existing E2E suite for the Project service covers the success path; full E2E run requires the multi-MySQL docker compose stack and was not executed locally
- [ ] Manual: `DELETE /v1/project` against a running instance returns 204 and no longer raises `InvalidArgumentException`