### PR TITLE
Refactor auth role checks

### DIFF
--- a/app/controllers/shared/api/auth.php
+++ b/app/controllers/shared/api/auth.php
@@ -36,9 +36,8 @@ Http::init()
     ->inject('request')
     ->inject('project')
     ->inject('geodb')
-    ->inject('user')
     ->inject('authorization')
-    ->action(function (Http $utopia, Request $request, Document $project, Reader $geodb, User $user, Authorization $authorization) {
+    ->action(function (Http $utopia, Request $request, Document $project, Reader $geodb, Authorization $authorization) {
         $denylist = System::getEnv('_APP_CONSOLE_COUNTRIES_DENYLIST', '');
         if (!empty($denylist && $project->getId() === 'console')) {
             $countries = explode(',', $denylist);
@@ -51,8 +50,8 @@ Http::init()
 
         $route = $utopia->match($request);
 
-        $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
-        $isAppUser = $user->isApp($authorization->getRoles());
+        $isPrivilegedUser = User::isPrivileged($authorization->getRoles());
+        $isAppUser = User::isApp($authorization->getRoles());
 
         if ($isAppUser || $isPrivilegedUser) { // Skip limits for app and console devs
             return;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1333,7 +1333,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 10
-      start_period: 30s
+      start_period: 60s
 
   postgresql:
     image: appwrite/postgres:0.1.0

--- a/src/Appwrite/Utopia/Database/Documents/User.php
+++ b/src/Appwrite/Utopia/Database/Documents/User.php
@@ -101,7 +101,7 @@ class User extends Document
      *
      * @return bool
      */
-    public function isPrivileged(array $roles): bool
+    public static function isPrivileged(array $roles): bool
     {
         if (
             in_array(self::ROLE_OWNER, $roles) ||
@@ -121,7 +121,7 @@ class User extends Document
      *
      * @return bool
      */
-    public function isApp(array $roles): bool
+    public static function isApp(array $roles): bool
     {
         if (in_array(self::ROLE_APPS, $roles)) {
             return true;

--- a/tests/e2e/Services/Proxy/ProxyBase.php
+++ b/tests/e2e/Services/Proxy/ProxyBase.php
@@ -171,8 +171,8 @@ trait ProxyBase
 
         $siteId = $this->setupSite()['siteId'];
 
-        $ruleId = $this->setupRedirectRule($domain, 'https://jsonplaceholder.typicode.com/todos/1', 301, 'site', $siteId);
-        $this->assertNotEmpty($ruleId);
+        $redirectRuleId = $this->setupRedirectRule($domain, 'https://jsonplaceholder.typicode.com/todos/1', 301, 'site', $siteId);
+        $this->assertNotEmpty($redirectRuleId);
 
         $response = $proxyClient->call(Client::METHOD_GET, '/todos/1');
         $this->assertEquals(200, $response['headers']['status-code']);
@@ -187,8 +187,8 @@ trait ProxyBase
         $this->assertEquals('https://jsonplaceholder.typicode.com/todos/1', $response['headers']['location']);
 
         $domain = \uniqid() . '-redirect-307.custom.localhost';
-        $ruleId = $this->setupRedirectRule($domain, 'https://jsonplaceholder.typicode.com/todos/1', 307, 'site', $siteId);
-        $this->assertNotEmpty($ruleId);
+        $temporaryRedirectRuleId = $this->setupRedirectRule($domain, 'https://jsonplaceholder.typicode.com/todos/1', 307, 'site', $siteId);
+        $this->assertNotEmpty($temporaryRedirectRuleId);
 
         $proxyClient = new Client();
         $proxyClient->setEndpoint('http://appwrite.test');
@@ -209,8 +209,9 @@ trait ProxyBase
         $this->assertEquals(200, $rules['headers']['status-code']);
         $this->assertEquals(2, $rules['body']['total']);
 
+        $this->cleanupRule($redirectRuleId);
+        $this->cleanupRule($temporaryRedirectRuleId);
         $this->cleanupSite($siteId);
-        $this->cleanupRule($ruleId);
     }
 
     public function testCreateFunctionRule(): void


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Refactors the shared auth init to avoid injecting `user` when it only needs to check authorization roles.

The auth init previously resolved `user` and then called `User::isPrivileged()` / `User::isApp()` with roles from `Authorization::getRoles()`. Since those helpers only inspect the roles array, the user document is not needed at this call site.

This PR makes the auth init depend directly on `Authorization` for the role data it needs. It also makes `User::isPrivileged()` and `User::isApp()` static, matching how these helpers are used on `main`, so the role-checking logic stays centralized instead of being duplicated in the auth init.

This also includes two CI/test stability cleanups:

- `ProxyCustomServerTest::testCreateRedirectRule` now tracks both redirect rules it creates and deletes them before deleting the parent site. That avoids racing explicit rule cleanup against the async site-delete cleanup worker.
- The MongoDB healthcheck start period in the dev compose file now matches the install compose template. This gives cold MongoDB startup more time before `docker compose --wait` can mark the service unhealthy.

## Test Plan

- `php -l app/controllers/shared/api/auth.php && php -l src/Appwrite/Utopia/Database/Documents/User.php`
- `php -l tests/e2e/Services/Proxy/ProxyBase.php`
- `composer lint app/controllers/shared/api/auth.php src/Appwrite/Utopia/Database/Documents/User.php`
- `composer lint tests/e2e/Services/Proxy/ProxyBase.php`
- `vendor/bin/phpunit tests/unit/Utopia/Database/Documents/UserTest.php`
- `docker compose config --quiet`
- `git diff --check`

The specific Proxy E2E test was not run locally because the Appwrite Docker stack is not currently running in this checkout.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? Not applicable.
