### PR TITLE
chore(deps): bump utopia-php/cache to 2.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "utopia-php/analytics": "0.15.*",
         "utopia-php/audit": "2.2.*",
         "utopia-php/auth": "0.5.*",
-        "utopia-php/cache": "1.0.*",
+        "utopia-php/cache": "2.0.*",
         "utopia-php/cli": "0.23.*",
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",


### PR DESCRIPTION
## Summary

- Bumps `utopia-php/cache` constraint from `1.0.*` to `2.0.*` in `composer.json`.
- Brings in the new [`CircuitBreaker` adapter](https://github.com/utopia-php/cache/pull/69) and `Feature\Telemetry` propagation contract introduced in [cache 2.0.0](https://github.com/utopia-php/cache/releases/tag/2.0.0).

## Status

**Draft — blocked on upstream constraint widenings.** Cache 2.0.0 is released, but several utopia-php packages currently locked here pin to `cache 1.*`. PRs to widen those constraints:

- utopia-php/database#875 — widens `1.*` → `1.* || 2.*`
- utopia-php/domains#64 — widens `1.0.*` → `1.0.* || 2.0.*`
- utopia-php/vcs#100 — widens `1.0.*` → `1.0.* || 2.0.*`

`utopia-php/migration` depends on `utopia-php/database 5.*` transitively, so it's covered by the database update.

Once each upstream PR is merged and tagged, run `composer update -W utopia-php/cache utopia-php/database utopia-php/domains utopia-php/vcs utopia-php/migration` here and push the regenerated `composer.lock`.

## Test plan

- [ ] All three upstream PRs merged + tagged releases cut
- [ ] `composer update -W` succeeds locally with the new tags
- [ ] CI green