### PR TITLE
chore: pin TablesDB e2e to 8cpu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,7 @@ jobs:
             paratest_processes: 3
             timeout_minutes: 30
           - service: TablesDB
+            runner: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/volume=120g/spot=false
             paratest_processes: 3
             timeout_minutes: 30
           - service: Migrations


### PR DESCRIPTION
## Summary

- Pin the TablesDB e2e_service matrix entry to the same `8cpu-linux-x64/volume=120g/spot=false` runner that Databases already uses.
- Restores headroom lost when #12274 removed `family=m7` from the default e2e_service runner.

## Why

After #12274 the default e2e runner went from `4cpu-linux-x64/family=m7/volume=120g/spot=false` to `4cpu-linux-x64/volume=120g/spot=false`. Databases kept its 8cpu override, but TablesDB has no override, so it inherits the bare 4cpu runner with no instance-family pinning.

Under `paratest_processes: 3` the databases worker can't create attributes fast enough for the schema-polling loop, and tests fail with `Expected 'available', Actual 'processing'`. Different test methods fail every rerun, and the same failure pattern is hitting unrelated PRs (e.g. branch `codex/fail-open-abuse-timelimit`) at the same time — a clear infra signature, not a test bug.

Mirroring Databases' runner override gets TablesDB the CPU/IO budget it needs.

## Test plan

- [ ] CI green on this PR
- [ ] TablesDB no longer flakes with attribute-polling timeouts across recent PRs