### PR TITLE
Update SDK generator cover image config

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5476,16 +5476,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "1.28.4",
+            "version": "1.29.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "38de925e8c9e7f0f720d45187be54a291aaf696b"
+                "reference": "31248a984a4d478d20a780dda8f5897984ee4e8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/38de925e8c9e7f0f720d45187be54a291aaf696b",
-                "reference": "38de925e8c9e7f0f720d45187be54a291aaf696b",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/31248a984a4d478d20a780dda8f5897984ee4e8f",
+                "reference": "31248a984a4d478d20a780dda8f5897984ee4e8f",
                 "shasum": ""
             },
             "require": {
@@ -5521,9 +5521,9 @@
             "description": "Appwrite PHP library for generating API SDKs for multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/1.28.4"
+                "source": "https://github.com/appwrite/sdk-generator/tree/1.29.2"
             },
-            "time": "2026-05-11T13:55:49+00:00"
+            "time": "2026-05-13T04:47:38+00:00"
         },
         {
             "name": "brianium/paratest",

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -493,7 +493,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                     ->setGitRepo($language['gitUrl'])
                     ->setGitRepoName($language['gitRepoName'])
                     ->setGitUserName($language['gitUserName'])
-                    ->setLogo($cover)
+                    ->setCoverImage($cover)
                     ->setURL('https://appwrite.io')
                     ->setShareText('Appwrite is a backend as a service for building web or mobile apps')
                     ->setShareURL('http://appwrite.io')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates `appwrite/sdk-generator` from `1.28.4` to `1.29.2` and switches SDK generation metadata from `setLogo($cover)` to `setCoverImage($cover)`. The CLI ASCII logo configuration remains unchanged.

## Test Plan

- `composer lint src/Appwrite/Platform/Tasks/SDKs.php`

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? N/A - this only updates SDK generation task metadata.

