### PR TITLE
fix(tests): swap flaky appwrite.io image URL for github avatar CDN in Avatars E2E

### DIFF
--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -204,7 +204,7 @@ trait AvatarsBase
             $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://avatars.githubusercontent.com/u/25003669?v=4&size=200',
             ]);
 
             $this->assertEquals(200, $response['headers']['status-code']);
@@ -216,7 +216,7 @@ trait AvatarsBase
             $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://avatars.githubusercontent.com/u/25003669?v=4&size=200',
                 'width' => 200,
                 'height' => 200,
             ]);
@@ -230,7 +230,7 @@ trait AvatarsBase
             $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
-                'url' => 'https://appwrite.io/images/open-graph/website.avif',
+                'url' => 'https://avatars.githubusercontent.com/u/25003669?v=4&size=200',
                 'width' => 300,
                 'height' => 300,
                 'quality' => 30,
@@ -258,7 +258,7 @@ trait AvatarsBase
         $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
             'x-appwrite-project' => $this->getProject()['$id'],
         ], [
-            'url' => 'https://appwrite.io/images/open-graph/website.avif',
+            'url' => 'https://avatars.githubusercontent.com/u/25003669?v=4&size=200',
             'width' => 2001,
             'height' => 300,
             'quality' => 30,


### PR DESCRIPTION
`AvatarsBase::testGetImage` fetches an external image through the `/v1/avatars/image` endpoint to validate the success path. The hardcoded `https://appwrite.io/images/open-graph/website.avif` URL has been flaking on CI runners for multiple PRs (e.g. appwrite-labs/cloud#3619, #4006, #4004) — the runners get a non-200 from the CDN, the endpoint throws `AVATAR_IMAGE_NOT_FOUND`, and the test fails with `Failed asserting that 404 matches expected 200` repeatedly even with the existing 30s `assertEventually` retry.

This swaps to `https://avatars.githubusercontent.com/u/25003669?v=4&size=200` (Appwrite org's GitHub avatar):

- Globally distributed CDN with no geofencing / per-region rate limiting from CI providers
- Returns `200 image/png` directly (no decode-format risk like AVIF can have, depending on the runner's Imagick build)
- Stable target (GitHub org avatar) — unlike a marketing asset that may be renamed or have its extension changed

The failure-case assertion at line 261 (width=2001 → expected 400 from the `Range(0, 2000)` validator) also moves to the new URL — the 400 comes from the validator before the fetch happens, so the URL choice doesn't affect that assertion.