### PR TITLE
chore: bump utopia-php/audit to 2.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "utopia-php/abuse": "1.3.*",
         "utopia-php/agents": "1.2.*",
         "utopia-php/analytics": "0.15.*",
-        "utopia-php/audit": "2.2.*",
+        "utopia-php/audit": "2.3.*",
         "utopia-php/auth": "0.5.*",
         "utopia-php/cache": "^2.1",
         "utopia-php/cli": "0.23.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3510,16 +3510,16 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "2.3.1",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "56b0250c01397145e431f838ab76ca764b45bd77"
+                "reference": "e7b4049fc2ee9be34bcc18771fa593db3b0e9fe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/56b0250c01397145e431f838ab76ca764b45bd77",
-                "reference": "56b0250c01397145e431f838ab76ca764b45bd77",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/e7b4049fc2ee9be34bcc18771fa593db3b0e9fe3",
+                "reference": "e7b4049fc2ee9be34bcc18771fa593db3b0e9fe3",
                 "shasum": ""
             },
             "require": {
@@ -3554,9 +3554,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/2.3.1"
+                "source": "https://github.com/utopia-php/audit/tree/2.3.2"
             },
-            "time": "2026-05-08T10:14:04+00:00"
+            "time": "2026-05-14T04:00:37+00:00"
         },
         {
             "name": "utopia-php/auth",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4a706c346d59204264c4a4734564d64",
+    "content-hash": "9377e1b56bca8dbaf213ee3572ca15c0",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3510,22 +3510,23 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "2.2.3",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "95e9961fa286d2fdb6bf3eaa198f21d51bf58d9c"
+                "reference": "56b0250c01397145e431f838ab76ca764b45bd77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/95e9961fa286d2fdb6bf3eaa198f21d51bf58d9c",
-                "reference": "95e9961fa286d2fdb6bf3eaa198f21d51bf58d9c",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/56b0250c01397145e431f838ab76ca764b45bd77",
+                "reference": "56b0250c01397145e431f838ab76ca764b45bd77",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
+                "php": ">=8.4",
                 "utopia-php/database": "5.*",
                 "utopia-php/fetch": "^1.1",
+                "utopia-php/query": "0.1.*",
                 "utopia-php/validators": "0.2.*"
             },
             "require-dev": {
@@ -3553,9 +3554,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/2.2.3"
+                "source": "https://github.com/utopia-php/audit/tree/2.3.1"
             },
-            "time": "2026-05-08T10:38:23+00:00"
+            "time": "2026-05-08T10:14:04+00:00"
         },
         {
             "name": "utopia-php/auth",
@@ -4875,6 +4876,52 @@
                 "source": "https://github.com/utopia-php/preloader/tree/0.2.4"
             },
             "time": "2020-10-24T07:04:59+00:00"
+        },
+        {
+            "name": "utopia-php/query",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/utopia-php/query.git",
+                "reference": "964a10ed3185490505f4c0062f2eb7b89287fb27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/query/zipball/964a10ed3185490505f4c0062f2eb7b89287fb27",
+                "reference": "964a10ed3185490505f4c0062f2eb7b89287fb27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "laravel/pint": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Utopia\\Query\\": "src/Query"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A simple library providing a query abstraction for filtering, ordering, and pagination",
+            "keywords": [
+                "framework",
+                "php",
+                "query",
+                "upf",
+                "utopia"
+            ],
+            "support": {
+                "issues": "https://github.com/utopia-php/query/issues",
+                "source": "https://github.com/utopia-php/query/tree/0.1.1"
+            },
+            "time": "2026-03-03T09:05:14+00:00"
         },
         {
             "name": "utopia-php/queue",


### PR DESCRIPTION
## Summary

- Bump `utopia-php/audit` constraint from `2.2.*` to `2.3.*` (resolves to `2.3.1`).
- Pulls in `utopia-php/query 0.1.x` as a new transitive dependency.

The 2.3 line adds cursor pagination (`cursorAfter` / `cursorBefore`) and `count(max)` support to audit queries, which currently fail at the activities endpoint with `Invalid query method: cursorAfter` on prod.

`utopia-php/audit 2.3.x` requires PHP 8.4, satisfied by the `appwrite/base:1.4.1` runtime image used on this branch (PHP 8.5).

## Test plan

- [ ] CI passes (lint, PHPStan, unit, e2e)
- [ ] Local: `composer lint` and `composer analyze` pass (verified locally)
- [ ] Activities endpoint accepts `Query.cursorAfter(...)` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)