### PR TITLE
fix: security hardening — OAuth2, HMAC, MFA timing, cURL, PRNG

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -103,7 +103,7 @@ function dispatch(\Swoole\Http\Server $server, int $fd, int $type, $data = null)
                     return $i;
                 }
             }
-            return rand(0, $totalWorkers - 1);
+            return random_int(0, $totalWorkers - 1);
         }
 
         $riskyWorkersPercent = intval(System::getEnv('_APP_RISKY_WORKERS_PERCENT', 80)) / 100; // Decimal form 0 to 1
@@ -151,7 +151,7 @@ function dispatch(\Swoole\Http\Server $server, int $fd, int $type, $data = null)
             }
 
             // If no idle workers, give to random risky worker
-            $worker = rand($riskyWorkers, $totalWorkers - 1);
+            $worker = random_int($riskyWorkers, $totalWorkers - 1);
             Console::warning("swoole_dispatch: Risky branch: did not find a idle worker, picking random worker {$worker}");
             return $worker;
         }
@@ -166,7 +166,7 @@ function dispatch(\Swoole\Http\Server $server, int $fd, int $type, $data = null)
 
         // If no idle worker found, give to random safe worker
         // We avoid risky workers here, as it could be in work - not idle. Thats exactly when they are risky.
-        $worker = rand(0, $riskyWorkers - 1);
+        $worker = random_int(0, $riskyWorkers - 1);
         Console::warning("swoole_dispatch: Non-risky branch: did not find a idle worker, picking random worker {$worker}");
         return $worker;
     };

--- a/src/Appwrite/Auth/OAuth2/Etsy.php
+++ b/src/Appwrite/Auth/OAuth2/Etsy.php
@@ -40,7 +40,7 @@ class Etsy extends OAuth2
     private function getPKCE(): string
     {
         if (empty($this->pkce)) {
-            $this->pkce = \bin2hex(\random_bytes(rand(43, 128)));
+            $this->pkce = \bin2hex(\random_bytes(64));
         }
 
         return $this->pkce;
@@ -188,6 +188,7 @@ class Etsy extends OAuth2
         $this->user = \json_decode($this->request(
             'GET',
             'https://api.etsy.com/v3/application/users/' . $this->getUserID($accessToken),
+            $headers
         ), true);
 
         return $this->user;

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -113,7 +113,14 @@ class Update extends Action
                 $challenge->getAttribute('type') === Type::RECOVERY_CODE
             ) {
                 $mfaRecoveryCodes = $user->getAttribute('mfaRecoveryCodes', []);
-                if (\in_array($otp, $mfaRecoveryCodes)) {
+                $found = false;
+                foreach ($mfaRecoveryCodes as $code) {
+                    if (\hash_equals($code, $otp)) {
+                        $found = true;
+                        break;
+                    }
+                }
+                if ($found) {
                     $mfaRecoveryCodes = \array_diff($mfaRecoveryCodes, [$otp]);
                     $mfaRecoveryCodes = \array_values($mfaRecoveryCodes);
                     $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);

--- a/src/Appwrite/Platform/Modules/Console/Http/Assistant/Create.php
+++ b/src/Appwrite/Platform/Modules/Console/Http/Assistant/Create.php
@@ -54,7 +54,7 @@ class Create extends Action
         $ch = curl_init('http://appwrite-assistant:3003/v1/models/assistant/prompt');
         $responseHeaders = [];
         $query = json_encode(['prompt' => $prompt]);
-        $headers = ['accept: text/event-stream'];
+        $headers = ['accept: text/event-stream', 'Content-Type: application/json'];
         $handleEvent = function ($ch, $data) use ($response) {
             $response->chunk($data);
 
@@ -67,7 +67,7 @@ class Create extends Action
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 9000);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 300);
         curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
             $len = strlen($header);
             $header = explode(':', $header, 2);

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -102,7 +102,7 @@ class Webhooks extends Action
 
         $url = \rawurldecode($webhook->getAttribute('url'));
         $signatureKey = $webhook->getAttribute('signatureKey');
-        $signature = base64_encode(hash_hmac('sha1', $url . $payload, $signatureKey, true));
+        $signature = base64_encode(hash_hmac('sha256', $url . $payload, $signatureKey, true));
         $httpUser = $webhook->getAttribute('httpUser');
         $httpPass = $webhook->getAttribute('httpPass');
         $ch = \curl_init($webhook->getAttribute('url'));
@@ -135,7 +135,7 @@ class Webhooks extends Action
         \curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
 
         if (!$webhook->getAttribute('security', true)) {
-            \curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            \curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
             \curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         }
 

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -371,7 +371,7 @@ class Executor
 
         // Allow self signed certificates
         if ($this->selfSigned) {
-            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         }
 


### PR DESCRIPTION
## What does this PR do?

This PR implements multiple security hardening improvements and bug fixes identified during a comprehensive codebase audit:

1. **Fixed Etsy OAuth2 implementation (Critical)**
   - `getUser()` constructed an Authorization header but never passed it to the HTTP request, causing all profile API calls to fail.
   - The PKCE verifier generation used `rand()` for its length and produced verifiers up to 256 characters long, violating the RFC 7636 maximum of 128 characters. Fixed to use a deterministic cryptographically secure 64 bytes (128 hex chars).
2. **Upgraded Webhook HMAC to SHA-256 (Security)**
   - Replaced the deprecated `sha1` hashing algorithm with `sha256` for webhook signatures in `Webhooks.php`, aligning with industry standards (GitHub, Stripe, etc.).
3. **Prevented MFA Timing Attacks (Security)**
   - Replaced `in_array()` with a timing-safe `hash_equals()` loop for MFA recovery code comparison in `Update.php`.
4. **Hardened Assistant Endpoint (Bug/Security)**
   - Added missing `Content-Type: application/json` header to the SSE request.
   - Reduced excessive 9000-second (2.5 hour) cURL timeout to 300 seconds to prevent potential resource exhaustion / DoS.
5. **General Hardening**
   - Corrected `CURLOPT_SSL_VERIFYHOST` from boolean `false` to integer `0` per cURL specifications in `Webhooks.php` and `Executor.php`.
   - Replaced `rand()` with `random_int()` in `app/http.php` for uniform worker dispatch distribution.

## Test Plan

1. **Etsy OAuth2:** Trigger the Etsy OAuth flow and verify that user information is successfully retrieved without authentication errors, and that the PKCE challenge strictly meets RFC length requirements.
2. **Webhooks:** Create a webhook and trigger it. Verify the `X-Appwrite-Webhook-Signature` header validates correctly using `hash_hmac('sha256', ...)` on the receiving end.
3. **MFA Recovery:** Attempt to use an MFA recovery code and ensure successful login on match, and rejection on mismatch.
4. **Assistant:** Trigger an assistant prompt and verify that the request succeeds (now sending the correct content type).
5. **Worker Dispatch:** Ensure Appwrite boots normally and routes requests correctly to Swoole workers without errors.

## Related PRs and Issues

- Resolves security audit findings.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
