### PR TITLE
perf(teams): batch-fetch users in listTeamMemberships to remove N+1

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
@@ -140,10 +140,35 @@ class XList extends Action
             return $privacy || $isPrivilegedUser || $isAppUser;
         }, $membershipsPrivacy);
 
-        $memberships = array_map(function ($membership) use ($dbForProject, $team, $membershipsPrivacy) {
-            $memberUser = !empty(array_filter($membershipsPrivacy))
-                ? $dbForProject->getDocument('users', $membership->getAttribute('userId'))
-                : new Document();
+        // Batch-fetch users referenced by this page in a single query, instead of
+        // issuing one getDocument('users', ...) per membership row. Falls back to
+        // an empty Document for users that are missing or not visible to the caller.
+        $usersMap = [];
+        $needsUserLookup = !empty(array_filter($membershipsPrivacy));
+
+        if ($needsUserLookup) {
+            $userIds = [];
+            foreach ($memberships as $membership) {
+                $userId = $membership->getAttribute('userId');
+                if (!empty($userId)) {
+                    $userIds[] = $userId;
+                }
+            }
+            $userIds = \array_values(\array_unique($userIds));
+
+            if (!empty($userIds)) {
+                $fetchedUsers = $dbForProject->find('users', [
+                    Query::equal('$id', $userIds),
+                    Query::limit(\count($userIds)),
+                ]);
+                foreach ($fetchedUsers as $fetchedUser) {
+                    $usersMap[$fetchedUser->getId()] = $fetchedUser;
+                }
+            }
+        }
+
+        $memberships = array_map(function ($membership) use ($team, $membershipsPrivacy, $usersMap) {
+            $memberUser = $usersMap[$membership->getAttribute('userId')] ?? new Document();
 
             if ($membershipsPrivacy['mfa']) {
                 $mfa = $memberUser->getAttribute('mfa', false);


### PR DESCRIPTION
## Summary

Replaces the per-row `getDocument('users', ...)` call inside `listTeamMemberships` with a single batched `find('users', equal('\$id', \$userIds))`, removing the N+1 pattern.

## Before

[XList.php#L143-L186](https://github.com/appwrite/appwrite/blob/1.9.x/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php#L143-L186)

```php
$memberships = array_map(function (\$membership) use (\$dbForProject, \$team, \$membershipsPrivacy) {
    \$memberUser = !empty(array_filter(\$membershipsPrivacy))
        ? \$dbForProject->getDocument('users', \$membership->getAttribute('userId'))
        : new Document();
    // ... privacy-aware attribute copying
}, \$memberships);
```

For a page of N memberships that's N user lookups, each going through the document cache (Dragonfly hit) or MySQL on miss. With the default page size 25, that's 25 round trips per request.

## After

Collect the userIds once, fetch them in a single `find()` indexed by id, then look up per-row. Permission semantics are unchanged: `find()` respects the same authorization checks `getDocument()` does, so users not visible to the caller still fall back to an empty `Document` and the privacy attribute copying stays correct.

## Why this matters

`listTeamMemberships` is one of the most-called authenticated endpoints in the platform:
- Console 'Members' tab loads it on every team page view
- Customer team-roster UIs hit it on every page load
- Permission-check flows fan out to it indirectly

Cutting 25 round trips to 1 saves ~12-125ms per request depending on cache hit rate (Dragonfly hit ~0.5ms vs MySQL miss ~5ms per call). Compounds across the entire fleet.

## Test plan

- [ ] Existing PHPUnit e2e tests for Teams pass
- [ ] Manual: list memberships of a team with 50+ members, verify all user fields (name/email/phone/MFA) appear correctly
- [ ] Manual: list memberships where some users have been deleted, verify empty fallback works
- [ ] Manual: verify privacy settings still hide the right attributes when configured off
- [ ] Staging: confirm p99 on `/v1/teams/:teamId/memberships` drops post-deploy via http_server_request_duration_seconds histogram