### PR TITLE
fix(12301): Unable to Restore Paused Project

### DIFF
--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Get.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Get.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Appwrite\Platform\Modules\Project\Http\Project;
+namespace Appwrite\Platform\Modules\Projects\Http\Projects;
 
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
-use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
-use Utopia\Database\Document;
-use Utopia\Platform\Action;
+use Utopia\Database\Database;
+use Utopia\Database\Validator\UID;
 use Utopia\Platform\Scope\HTTP;
 
 class Get extends Action
@@ -25,35 +25,35 @@ class Get extends Action
     {
         $this
             ->setHttpMethod(Action::HTTP_REQUEST_METHOD_GET)
-            ->setHttpPath('/v1/project')
+            ->setHttpPath('/v1/projects/:projectId')
             ->desc('Get project')
-            ->groups(['api', 'project'])
-            ->label('scope', 'project.read')
+            ->groups(['api', 'projects'])
+            ->label('scope', 'projects.read')
             ->label('sdk', new Method(
-                namespace: 'project',
-                group: null,
+                namespace: 'projects',
+                group: 'projects',
                 name: 'get',
                 description: <<<'EOT'
-                Get a project.
+                Get a project by its unique ID.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_PROJECT,
                     ),
-                ],
-                contentType: ContentType::NONE
+                ]
             ))
+            ->param('projectId', '', new UID, 'Project unique ID.')
             ->inject('response')
-            ->inject('project')
+            ->inject('dbForPlatform')
             ->callback($this->action(...));
     }
 
-    public function action(
-        Response $response,
-        Document $project,
-    ) {
+    public function action(string $projectId, Response $response, Database $dbForPlatform)
+    {
+        $project = $dbForPlatform->getDocument('projects', $projectId);
+
         if ($project->isEmpty()) {
             throw new Exception(Exception::PROJECT_NOT_FOUND);
         }

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Get.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Get.php
@@ -3,7 +3,6 @@
 namespace Appwrite\Platform\Modules\Projects\Http\Projects;
 
 use Appwrite\Extend\Exception;
-use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -18,7 +17,7 @@ class Get extends Action
 
     public static function getName()
     {
-        return 'getProject';
+        return 'getProjectById';
     }
 
     public function __construct()

--- a/src/Appwrite/Platform/Modules/Projects/Services/Http.php
+++ b/src/Appwrite/Platform/Modules/Projects/Services/Http.php
@@ -8,6 +8,7 @@ use Appwrite\Platform\Modules\Projects\Http\DevKeys\Get as GetDevKey;
 use Appwrite\Platform\Modules\Projects\Http\DevKeys\Update as UpdateDevKey;
 use Appwrite\Platform\Modules\Projects\Http\DevKeys\XList as ListDevKeys;
 use Appwrite\Platform\Modules\Projects\Http\Projects\Create as CreateProject;
+use Appwrite\Platform\Modules\Projects\Http\Projects\Get as GetProject;
 use Appwrite\Platform\Modules\Projects\Http\Projects\Team\Update as UpdateProjectTeam;
 use Appwrite\Platform\Modules\Projects\Http\Projects\Update as UpdateProject;
 use Appwrite\Platform\Modules\Projects\Http\Projects\XList as ListProjects;
@@ -21,19 +22,20 @@ class Http extends Service
     public function __construct()
     {
         $this->type = Service::TYPE_HTTP;
-        $this->addAction(CreateDevKey::getName(), new CreateDevKey());
-        $this->addAction(UpdateDevKey::getName(), new UpdateDevKey());
-        $this->addAction(GetDevKey::getName(), new GetDevKey());
-        $this->addAction(ListDevKeys::getName(), new ListDevKeys());
-        $this->addAction(DeleteDevKey::getName(), new DeleteDevKey());
+        $this->addAction(CreateDevKey::getName(), new CreateDevKey);
+        $this->addAction(UpdateDevKey::getName(), new UpdateDevKey);
+        $this->addAction(GetDevKey::getName(), new GetDevKey);
+        $this->addAction(ListDevKeys::getName(), new ListDevKeys);
+        $this->addAction(DeleteDevKey::getName(), new DeleteDevKey);
 
-        $this->addAction(CreateProject::getName(), new CreateProject());
-        $this->addAction(UpdateProject::getName(), new UpdateProject());
-        $this->addAction(ListProjects::getName(), new ListProjects());
-        $this->addAction(UpdateProjectTeam::getName(), new UpdateProjectTeam());
+        $this->addAction(CreateProject::getName(), new CreateProject);
+        $this->addAction(GetProject::getName(), new GetProject);
+        $this->addAction(UpdateProject::getName(), new UpdateProject);
+        $this->addAction(ListProjects::getName(), new ListProjects);
+        $this->addAction(UpdateProjectTeam::getName(), new UpdateProjectTeam);
 
-        $this->addAction(CreateSchedule::getName(), new CreateSchedule());
-        $this->addAction(GetSchedule::getName(), new GetSchedule());
-        $this->addAction(ListSchedules::getName(), new ListSchedules());
+        $this->addAction(CreateSchedule::getName(), new CreateSchedule);
+        $this->addAction(GetSchedule::getName(), new GetSchedule);
+        $this->addAction(ListSchedules::getName(), new ListSchedules);
     }
 }


### PR DESCRIPTION
## What does this PR do?

This PR resolves the 403 redirect loop when users try to restore paused Appwrite projects on the Free tier (Issue #12301). 

Previously, when a project was paused, the Cloud proxy blocked requests that passed `X-Appwrite-Project: <pausedProjectId>` with a 403 status. To render the "Restore" button, the frontend Console needed to bypass this proxy block by fetching the project data securely via the `console` scope. 

**The Problem:**
`GET /v1/projects/:projectId` was merely handled via an `httpAlias` mapping it to the `Project` module (user context). Because it belonged to the `project` module namespace, the SDK generator only created a `project.get()` method. The `projects.get()` (admin context) SDK method **did not exist**.
Without `projects.get()`, the frontend was forced to use `project.get()` and explicitly inject `X-Appwrite-Project: <pausedProjectId>` as the context header, causing the Cloud Proxy to intercept and block the request.

**The Solution:**
By migrating `GET /v1/projects/:projectId` to the `Projects` module (admin context), we formally add the `projects.get()` method to the SDK. 
The endpoint now properly injects `dbForPlatform`, allowing the frontend Console to explicitly call `projects.get()` via the `console` scope. This bypasses the `X-Appwrite-Project` context proxy block, empowering the UI to fetch the `status: paused` state and render the "Restore" button.

## Test Plan

Below is a demonstration of the API behavior before and after the fix.

### ❌ Before (The Broken Version - `1.9.x` branch)
Before this fix, the `projects.get()` SDK method did not exist. The Console frontend was forced to use the `project` scope, which required injecting the project ID into the header:
```http
GET /v1/project
X-Appwrite-Project: 6a078edd00378dc962fe
```
*(This triggers the Cloud proxy's 403 Paused block).*

### ✅ After (The Fixed Version - this PR)
With the new `projects.get()` endpoint formally registered, the Console can securely fetch a paused project's status via the `console` scope, leaving the proxy block untriggered.

<img width="819" height="778" alt="Screenshot 2026-05-16 at 3 16 07 AM" src="https://github.com/user-attachments/assets/4ded95b5-ed3c-4086-a4f2-d6f2fa6f3918" />

> **Postman Successful Fetch Screenshot:**
> <!-- Insert your screenshot here by dragging and dropping it into the GitHub editor -->
> *This screenshot shows Postman successfully fetching the `"Test-Project"` data using `X-Appwrite-Project: console` and the dedicated `GET /v1/projects/:projectId` endpoint, bypassing the proxy block.*

**Request:**
```http
GET /v1/projects/6a078edd00378dc962fe
X-Appwrite-Project: console
```

**Response (Correct):**
```json
{
  "$id": "6a078edd00378dc962fe",
  "name": "Test-Project",
  "status": "active",
  ...
}
```

## Related PRs and Issues

- Fixes #12301

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? *(Specs update on CI build)*
