### PR TITLE
feat: add reset param to email template update endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
@@ -7,15 +7,18 @@ use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Template\Template;
 use Appwrite\Utopia\Response;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Emails\Validator\Email;
+use Utopia\Locale\Locale;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\System\System;
+use Utopia\Validator\Boolean;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
@@ -46,7 +49,7 @@ class Update extends Action
                 group: 'templates',
                 name: 'updateEmailTemplate',
                 description: <<<EOT
-                Update a custom email template for the specified locale and type. Use this endpoint to modify the content of your email templates.
+                Update a custom email template for the specified locale and type. Use this endpoint to modify the content of your email templates. Pass `reset=true` to remove all customisations and restore Appwrite defaults.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
@@ -64,6 +67,7 @@ class Update extends Action
             ->param('senderEmail', null, new Nullable(new Email()), 'Email of the sender.', optional: true)
             ->param('replyToEmail', null, new Nullable(new Email()), 'Reply to email.', optional: true)
             ->param('replyToName', null, new Nullable(new Text(255, 0)), 'Reply to name.', optional: true)
+            ->param('reset', false, new Boolean(), 'Reset template to Appwrite defaults. Removes all customisations for the given template and locale. When set to true, all other parameters are ignored.', optional: true)
             ->inject('response')
             ->inject('queueForEvents')
             ->inject('dbForPlatform')
@@ -81,6 +85,7 @@ class Update extends Action
         ?string $senderEmail,
         ?string $replyToEmail,
         ?string $replyToName,
+        bool $reset,
         Response $response,
         QueueEvent $queueForEvents,
         Database $dbForPlatform,
@@ -89,6 +94,34 @@ class Update extends Action
     ) {
         $locale = $locale ?: System::getEnv('_APP_LOCALE', 'en');
 
+        $templates = $project->getAttribute('templates', []);
+
+        if ($reset) {
+            // Remove custom override — no SMTP check needed to restore defaults
+            unset($templates['email.' . $templateId . '-' . $locale]);
+
+            $updates = new Document(['templates' => $templates]);
+            $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+
+            $queueForEvents->setParam('templateId', $templateId);
+
+            $localeObj = new Locale($locale);
+            $localeObj->setFallback(System::getEnv('_APP_LOCALE', 'en'));
+
+            $response->dynamic(new Document([
+                'templateId'   => $templateId,
+                'locale'       => $locale,
+                'subject'      => $localeObj->getText('emails.' . $templateId . '.subject'),
+                'message'      => $this->getDefaultMessage($templateId, $localeObj),
+                'senderName'   => '',
+                'senderEmail'  => '',
+                'replyToEmail' => '',
+                'replyToName'  => '',
+            ]), Response::MODEL_EMAIL_TEMPLATE);
+
+            return;
+        }
+
         // Prevent template update if custom SMTP is not configured
         $smtp = $project->getAttribute('smtp', []);
         if (($smtp['enabled'] ?? false) !== true) {
@@ -96,7 +129,6 @@ class Update extends Action
         }
 
         // Fetch current configuration
-        $templates = $project->getAttribute('templates', []);
         $template = $templates['email.' . $templateId . '-' . $locale] ?? [];
 
         // Apply changes
@@ -140,5 +172,52 @@ class Update extends Action
             'replyToEmail' => $template['replyToEmail'] ?? '',
             'replyToName' => $template['replyToName'] ?? '',
         ]), Response::MODEL_EMAIL_TEMPLATE);
+    }
+
+    private function getDefaultMessage(string $templateId, Locale $localeObj): string
+    {
+        $templateConfigs = [
+            'magicSession' => [
+                'file' => 'email-magic-url.tpl',
+                'placeholders' => ['optionButton', 'buttonText', 'optionUrl', 'clientInfo', 'securityPhrase']
+            ],
+            'mfaChallenge' => [
+                'file' => 'email-mfa-challenge.tpl',
+                'placeholders' => ['description', 'clientInfo']
+            ],
+            'otpSession' => [
+                'file' => 'email-otp.tpl',
+                'placeholders' => ['description', 'clientInfo', 'securityPhrase']
+            ],
+            'sessionAlert' => [
+                'file' => 'email-session-alert.tpl',
+                'placeholders' => ['body', 'listDevice', 'listIpAddress', 'listCountry', 'footer']
+            ],
+        ];
+
+        $config = $templateConfigs[$templateId] ?? [
+            'file' => 'email-inner-base.tpl',
+            'placeholders' => ['buttonText', 'body', 'footer']
+        ];
+
+        $templateString = file_get_contents(APP_CE_CONFIG_DIR . '/locale/templates/' . $config['file']);
+        $message = Template::fromString($templateString);
+
+        foreach ($config['placeholders'] as $param) {
+            $escapeHtml = !in_array($param, ['clientInfo', 'body', 'footer', 'description']);
+            if ($templateId === 'magicSession' && $param === 'securityPhrase') {
+                $message->setParam('{{securityPhrase}}', '');
+                continue;
+            }
+
+            $message->setParam("{{{$param}}}", $localeObj->getText("emails.{$templateId}.{$param}"), escapeHtml: $escapeHtml);
+        }
+
+        $message
+            ->setParam('{{hello}}', $localeObj->getText("emails.{$templateId}.hello"))
+            ->setParam('{{thanks}}', $localeObj->getText("emails.{$templateId}.thanks"))
+            ->setParam('{{signature}}', $localeObj->getText("emails.{$templateId}.signature"));
+
+        return $message->render(useContent: true);
     }
 }

--- a/tests/e2e/Services/Project/TemplatesBase.php
+++ b/tests/e2e/Services/Project/TemplatesBase.php
@@ -1242,6 +1242,274 @@ trait TemplatesBase
         $this->assertSame(400, $response['headers']['status-code']);
     }
 
+    // Reset email template tests
+
+    public function testResetEmailTemplateRestoresDefaults(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        // Capture Appwrite's built-in defaults before touching the project template.
+        $defaults = $this->getConsoleEmailTemplate('verification', 'en');
+        $this->assertSame(200, $defaults['headers']['status-code']);
+        $defaultSubject = $defaults['body']['subject'];
+
+        // Seed a fully custom template.
+        $seed = $this->updateEmailTemplate(
+            templateId: 'verification',
+            locale: 'en',
+            subject: 'Custom subject ' . \uniqid(),
+            message: 'Custom message ' . \uniqid(),
+            senderName: 'Custom Sender',
+            senderEmail: 'custom@appwrite.io',
+            replyToEmail: 'custom-reply@appwrite.io',
+            replyToName: 'Custom Reply',
+        );
+        $this->assertSame(200, $seed['headers']['status-code']);
+
+        // Reset to default.
+        $reset = $this->resetEmailTemplate('verification', 'en');
+
+        $this->assertSame(200, $reset['headers']['status-code']);
+        $this->assertSame('verification', $reset['body']['templateId']);
+        $this->assertSame('en', $reset['body']['locale']);
+        $this->assertSame($defaultSubject, $reset['body']['subject']);
+        $this->assertNotEmpty($reset['body']['message']);
+        $this->assertSame('', $reset['body']['senderName']);
+        $this->assertSame('', $reset['body']['senderEmail']);
+        $this->assertSame('', $reset['body']['replyToEmail']);
+        $this->assertSame('', $reset['body']['replyToName']);
+    }
+
+    public function testResetEmailTemplatePersists(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        // Seed a custom template.
+        $this->updateEmailTemplate(
+            templateId: 'recovery',
+            locale: 'en',
+            subject: 'Should be wiped',
+            message: 'Should also be wiped',
+            senderEmail: 'wiped@appwrite.io',
+        );
+
+        // Reset it.
+        $reset = $this->resetEmailTemplate('recovery', 'en');
+        $this->assertSame(200, $reset['headers']['status-code']);
+
+        // A subsequent GET must reflect the reset — confirming the unset was
+        // actually persisted to the project document, not just returned transiently.
+        $get = $this->getEmailTemplate('recovery', 'en');
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertNotSame('Should be wiped', $get['body']['subject']);
+        $this->assertSame('', $get['body']['senderEmail']);
+    }
+
+    public function testResetEmailTemplateDoesNotRequireSMTP(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        // Seed so there is something to reset.
+        $this->updateEmailTemplate(
+            templateId: 'invitation',
+            locale: 'en',
+            subject: 'To be reset',
+            message: 'To be reset body',
+        );
+
+        // Disable SMTP.
+        $disable = $this->client->call(
+            Client::METHOD_PATCH,
+            '/project/smtp',
+            \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()),
+            ['enabled' => false],
+        );
+        $this->assertSame(200, $disable['headers']['status-code']);
+
+        try {
+            // Reset must succeed even without SMTP enabled.
+            $reset = $this->resetEmailTemplate('invitation', 'en');
+            $this->assertSame(200, $reset['headers']['status-code']);
+            $this->assertSame('invitation', $reset['body']['templateId']);
+            $this->assertSame('', $reset['body']['senderEmail']);
+        } finally {
+            $this->ensureSMTPEnabled();
+        }
+    }
+
+    public function testResetEmailTemplateDefaultLocale(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        // Seed with an explicit locale then reset without one — server falls back to 'en'.
+        $this->updateEmailTemplate(
+            templateId: 'otpSession',
+            locale: 'en',
+            subject: 'OTP seed subject',
+            message: 'OTP seed body',
+        );
+
+        $reset = $this->resetEmailTemplate('otpSession');
+
+        $this->assertSame(200, $reset['headers']['status-code']);
+        $this->assertSame('en', $reset['body']['locale']);
+        $this->assertNotEmpty($reset['body']['subject']);
+    }
+
+    public function testResetEmailTemplateIsLocaleScoped(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        $enSubject = 'EN before reset ' . \uniqid();
+        $frSubject = 'FR before reset ' . \uniqid();
+
+        $this->assertSame(200, $this->updateEmailTemplate(
+            templateId: 'mfaChallenge',
+            locale: 'en',
+            subject: $enSubject,
+            message: 'EN body',
+        )['headers']['status-code']);
+
+        $this->assertSame(200, $this->updateEmailTemplate(
+            templateId: 'mfaChallenge',
+            locale: 'fr',
+            subject: $frSubject,
+            message: 'FR body',
+        )['headers']['status-code']);
+
+        // Reset only the 'en' locale.
+        $reset = $this->resetEmailTemplate('mfaChallenge', 'en');
+        $this->assertSame(200, $reset['headers']['status-code']);
+
+        // 'en' is back to Appwrite defaults.
+        $en = $this->getEmailTemplate('mfaChallenge', 'en');
+        $this->assertNotSame($enSubject, $en['body']['subject']);
+
+        // 'fr' must remain untouched.
+        $fr = $this->getEmailTemplate('mfaChallenge', 'fr');
+        $this->assertSame($frSubject, $fr['body']['subject']);
+    }
+
+    public function testResetEmailTemplateRemovedFromList(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        $marker = 'Reset-from-list ' . \uniqid();
+        $this->updateEmailTemplate(
+            templateId: 'sessionAlert',
+            locale: 'en',
+            subject: $marker,
+            message: 'Body',
+        );
+
+        // Confirm it is in the list before reset.
+        $before = $this->listEmailTemplates();
+        $this->assertSame(200, $before['headers']['status-code']);
+        $found = \array_filter(
+            $before['body']['templates'],
+            fn ($t) => $t['templateId'] === 'sessionAlert' && $t['locale'] === 'en' && $t['subject'] === $marker,
+        );
+        $this->assertNotEmpty($found, 'seeded template must appear in list before reset');
+
+        // Reset it.
+        $this->resetEmailTemplate('sessionAlert', 'en');
+
+        // Must no longer appear in the list — the entire entry was unset.
+        $after = $this->listEmailTemplates();
+        $this->assertSame(200, $after['headers']['status-code']);
+        $stillThere = \array_filter(
+            $after['body']['templates'],
+            fn ($t) => $t['templateId'] === 'sessionAlert' && $t['locale'] === 'en' && $t['subject'] === $marker,
+        );
+        $this->assertEmpty($stillThere, 'reset template must not appear in list after reset');
+    }
+
+    public function testResetEmailTemplateOtherParamsIgnored(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        $this->updateEmailTemplate(
+            templateId: 'magicSession',
+            locale: 'en',
+            subject: 'Custom subject',
+            message: 'Custom body',
+            senderEmail: 'custom@appwrite.io',
+        );
+
+        // Pass reset=true alongside other fields — those fields must be ignored.
+        $reset = $this->client->call(
+            Client::METHOD_PATCH,
+            '/project/templates/email',
+            \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()),
+            [
+                'templateId' => 'magicSession',
+                'locale'     => 'en',
+                'subject'    => 'Should be ignored',
+                'message'    => 'Should also be ignored',
+                'reset'      => true,
+            ],
+        );
+
+        $this->assertSame(200, $reset['headers']['status-code']);
+        $this->assertNotSame('Should be ignored', $reset['body']['subject']);
+        $this->assertSame('', $reset['body']['senderEmail']);
+    }
+
+    public function testResetEmailTemplateResponseModel(): void
+    {
+        $this->ensureSMTPEnabled();
+
+        $this->updateEmailTemplate(
+            templateId: 'verification',
+            locale: 'en',
+            subject: 'Before reset',
+            message: 'Before reset body',
+            senderName: 'Sender',
+            senderEmail: 'sender@appwrite.io',
+            replyToEmail: 'reply@appwrite.io',
+            replyToName: 'Reply',
+        );
+
+        $reset = $this->resetEmailTemplate('verification', 'en');
+
+        $this->assertSame(200, $reset['headers']['status-code']);
+        $this->assertArrayHasKey('templateId', $reset['body']);
+        $this->assertArrayHasKey('locale', $reset['body']);
+        $this->assertArrayHasKey('subject', $reset['body']);
+        $this->assertArrayHasKey('message', $reset['body']);
+        $this->assertArrayHasKey('senderName', $reset['body']);
+        $this->assertArrayHasKey('senderEmail', $reset['body']);
+        $this->assertArrayHasKey('replyToEmail', $reset['body']);
+        $this->assertArrayHasKey('replyToName', $reset['body']);
+    }
+
+    public function testResetEmailTemplateInvalidType(): void
+    {
+        $reset = $this->resetEmailTemplate('notATemplate', 'en');
+
+        $this->assertSame(400, $reset['headers']['status-code']);
+    }
+
+    public function testResetEmailTemplateInvalidLocale(): void
+    {
+        $reset = $this->resetEmailTemplate('verification', 'not-a-locale');
+
+        $this->assertSame(400, $reset['headers']['status-code']);
+    }
+
+    public function testResetEmailTemplateWithoutAuthentication(): void
+    {
+        $reset = $this->resetEmailTemplate('verification', 'en', authenticated: false);
+
+        $this->assertSame(401, $reset['headers']['status-code']);
+    }
+
     protected function getConsoleEmailTemplate(string $templateId, ?string $locale = null): mixed
     {
         $params = [];
@@ -1254,6 +1522,29 @@ trait TemplatesBase
             'x-appwrite-project' => 'console',
             'cookie' => 'a_session_console=' . $this->getRoot()['session'],
         ], $params);
+    }
+
+    protected function resetEmailTemplate(string $templateId, ?string $locale = null, bool $authenticated = true): mixed
+    {
+        $headers = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ];
+
+        if ($authenticated) {
+            $headers = \array_merge($headers, $this->getHeaders());
+        }
+
+        $params = [
+            'templateId' => $templateId,
+            'reset'      => true,
+        ];
+
+        if ($locale !== null) {
+            $params['locale'] = $locale;
+        }
+
+        return $this->client->call(Client::METHOD_PATCH, '/project/templates/email', $headers, $params);
     }
 
     protected function ensureSMTPEnabled(): void


### PR DESCRIPTION
Adds `reset=true` to PATCH /project/templates/email. When set, the endpoint unsets the entire custom template entry for the given templateId/locale, bypassing the SMTP check, and returns the Appwrite built-in defaults. This allows the console to restore all fields — including senderEmail/replyToEmail — without needing a valid SMTP configuration. Covers 11 new e2e test cases in TemplatesBase.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
