### PR TITLE
feat!: rename ACTIVITY_TYPE_*, ROLE_APPS, isApp() to ACTOR_TYPE_*, ROLE_KEYS, isKey() + bump utopia-php/audit to ^2.4

### DIFF
--- a/app/config/roles.php
+++ b/app/config/roles.php
@@ -150,7 +150,7 @@ return [
         'label' => 'Owner',
         'scopes' => \array_merge($member, $admins),
     ],
-    User::ROLE_APPS => [
+    User::ROLE_KEYS => [
         'label' => 'Applications',
         'scopes' => ['global', 'health.read', 'graphql'],
     ],

--- a/app/controllers/api/graphql.php
+++ b/app/controllers/api/graphql.php
@@ -39,7 +39,7 @@ Http::init()
         if (
             array_key_exists('graphql', $project->getAttribute('apis', []))
             && !$project->getAttribute('apis', [])['graphql']
-            && !($user->isPrivileged($authorization->getRoles()) || $user->isApp($authorization->getRoles()))
+            && !($user->isPrivileged($authorization->getRoles()) || $user->isKey($authorization->getRoles()))
         ) {
             throw new AppwriteException(AppwriteException::GENERAL_API_DISABLED);
         }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -186,7 +186,7 @@ Http::init()
                 $user = new User([
                     '$id' => '',
                     'status' => true,
-                    'type' => ACTIVITY_TYPE_KEY_PROJECT,
+                    'type' => ACTOR_TYPE_KEY_PROJECT,
                     'email' => 'app.' . $project->getId() . '@service.' . $request->getHostname(),
                     'password' => '',
                     'name' => $apiKey->getName(),
@@ -258,9 +258,9 @@ Http::init()
 
                 $userClone = clone $user;
                 $userClone->setAttribute('type', match ($apiKey->getType()) {
-                    API_KEY_STANDARD => ACTIVITY_TYPE_KEY_PROJECT,
-                    API_KEY_ACCOUNT => ACTIVITY_TYPE_KEY_ACCOUNT,
-                    default => ACTIVITY_TYPE_KEY_ORGANIZATION,
+                    API_KEY_STANDARD => ACTOR_TYPE_KEY_PROJECT,
+                    API_KEY_ACCOUNT => ACTOR_TYPE_KEY_ACCOUNT,
+                    default => ACTOR_TYPE_KEY_ORGANIZATION,
                 });
                 $auditContext->user = $userClone;
             }
@@ -602,7 +602,7 @@ Http::init()
             $userClone = clone $user;
             // $user doesn't support `type` and can cause unintended effects.
             if (empty($user->getAttribute('type'))) {
-                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTIVITY_TYPE_ADMIN : ACTIVITY_TYPE_USER);
+                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
             }
             $auditContext->user = $userClone;
         }
@@ -913,7 +913,7 @@ Http::shutdown()
             $userClone = clone $user;
             // $user doesn't support `type` and can cause unintended effects.
             if (empty($user->getAttribute('type'))) {
-                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTIVITY_TYPE_ADMIN : ACTIVITY_TYPE_USER);
+                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
             }
             $auditContext->user = $userClone;
         } elseif ($auditContext->user === null || $auditContext->user->isEmpty()) {
@@ -928,7 +928,7 @@ Http::shutdown()
             $user = new User([
                 '$id' => '',
                 'status' => true,
-                'type' => ACTIVITY_TYPE_GUEST,
+                'type' => ACTOR_TYPE_GUEST,
                 'email' => 'guest.' . $project->getId() . '@service.' . $request->getHostname(),
                 'password' => '',
                 'name' => 'Guest',

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -175,8 +175,8 @@ Http::init()
             $role = $apiKey->getRole();
             $scopes = $apiKey->getScopes();
 
-            // Handle special app role case
-            if ($apiKey->getRole() === User::ROLE_APPS) {
+            // Handle special key role case
+            if ($apiKey->getRole() === User::ROLE_KEYS) {
                 // Disable authorization checks for project API keys
                 // Dynamic supported for backwards compatibility
                 if (($apiKey->getType() === API_KEY_STANDARD || $apiKey->getType() === API_KEY_EPHEMERAL || $apiKey->getType() === 'dynamic') && $apiKey->getProjectId() === $project->getId()) {
@@ -425,7 +425,7 @@ Http::init()
             if (
                 array_key_exists($namespace, $project->getAttribute('services', []))
                 && ! $project->getAttribute('services', [])[$namespace]
-                && ! ($user->isPrivileged($authorization->getRoles()) || $user->isApp($authorization->getRoles()))
+                && ! ($user->isPrivileged($authorization->getRoles()) || $user->isKey($authorization->getRoles()))
             ) {
                 throw new Exception(Exception::GENERAL_SERVICE_DISABLED);
             }
@@ -435,7 +435,7 @@ Http::init()
         if (
             array_key_exists('rest', $project->getAttribute('apis', []))
             && ! $project->getAttribute('apis', [])['rest']
-            && ! ($user->isPrivileged($authorization->getRoles()) || $user->isApp($authorization->getRoles()))
+            && ! ($user->isPrivileged($authorization->getRoles()) || $user->isKey($authorization->getRoles()))
         ) {
             throw new AppwriteException(AppwriteException::GENERAL_API_DISABLED);
         }
@@ -488,7 +488,7 @@ Http::init()
 
         $roles = $authorization->getRoles();
         $shouldCheckAbuse = System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') !== 'disabled'
-            && ! $user->isApp($roles)
+            && ! $user->isKey($roles)
             && ! $user->isPrivileged($roles)
             && $devKey->isEmpty();
 
@@ -611,7 +611,7 @@ Http::init()
         $storageCacheOperationsCounter = $telemetry->createCounter('storage.cache.operations.load');
         if ($useCache) {
             $roles = $authorization->getRoles();
-            $isAppUser = $user->isApp($roles);
+            $isAppUser = $user->isKey($roles);
             $isImageTransformation = $route->getPath() === '/v1/storage/buckets/:bucketId/files/:fileId/preview';
             $isDisabled = isset($plan['imageTransformations']) && $plan['imageTransformations'] === -1 && ! $user->isPrivileged($roles);
 

--- a/app/controllers/shared/api/auth.php
+++ b/app/controllers/shared/api/auth.php
@@ -51,7 +51,7 @@ Http::init()
         }
 
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
-        $isAppUser = $user->isApp($authorization->getRoles());
+        $isAppUser = $user->isKey($authorization->getRoles());
 
         if ($isAppUser || $isPrivilegedUser) { // Skip limits for app and console devs
             return;

--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -159,14 +159,14 @@ const SESSION_PROVIDER_TOKEN = 'token';
 const SESSION_PROVIDER_SERVER = 'server';
 
 /**
- * Activity associated with user or the app.
+ * Actor that performed the request (user, admin, guest, or API key).
  */
-const ACTIVITY_TYPE_USER = 'user';
-const ACTIVITY_TYPE_ADMIN = 'admin';
-const ACTIVITY_TYPE_GUEST = 'guest';
-const ACTIVITY_TYPE_KEY_PROJECT = 'keyProject';
-const ACTIVITY_TYPE_KEY_ACCOUNT = 'keyAccount';
-const ACTIVITY_TYPE_KEY_ORGANIZATION = 'keyOrganization';
+const ACTOR_TYPE_USER = 'user';
+const ACTOR_TYPE_ADMIN = 'admin';
+const ACTOR_TYPE_GUEST = 'guest';
+const ACTOR_TYPE_KEY_PROJECT = 'keyProject';
+const ACTOR_TYPE_KEY_ACCOUNT = 'keyAccount';
+const ACTOR_TYPE_KEY_ORGANIZATION = 'keyOrganization';
 
 /**
  * MFA

--- a/app/realtime.php
+++ b/app/realtime.php
@@ -858,7 +858,7 @@ $server->onOpen(function (int $connection, SwooleRequest $request) use ($server,
         $websocketEnabled = $apis['websocket'] ?? $apis['realtime'] ?? true;
         if (
             !$websocketEnabled
-            && !($user->isPrivileged($authorization->getRoles()) || $user->isApp($authorization->getRoles()))
+            && !($user->isPrivileged($authorization->getRoles()) || $user->isKey($authorization->getRoles()))
         ) {
             throw new AppwriteException(AppwriteException::GENERAL_API_DISABLED);
         }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "utopia-php/abuse": "1.3.*",
         "utopia-php/agents": "1.2.*",
         "utopia-php/analytics": "0.15.*",
-        "utopia-php/audit": "2.3.*",
+        "utopia-php/audit": "^2.4",
         "utopia-php/auth": "0.5.*",
         "utopia-php/cache": "^3.0",
         "utopia-php/cli": "0.23.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fafd8dc07538185b1753e9c16b622002",
+    "content-hash": "b092fffec11494aea10b0c823b7837b8",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3510,16 +3510,16 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "2.3.2",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "e7b4049fc2ee9be34bcc18771fa593db3b0e9fe3"
+                "reference": "eddd79d93f23ed2851c0df2b1e2e2dfb25ba06c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/e7b4049fc2ee9be34bcc18771fa593db3b0e9fe3",
-                "reference": "e7b4049fc2ee9be34bcc18771fa593db3b0e9fe3",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/eddd79d93f23ed2851c0df2b1e2e2dfb25ba06c6",
+                "reference": "eddd79d93f23ed2851c0df2b1e2e2dfb25ba06c6",
                 "shasum": ""
             },
             "require": {
@@ -3554,9 +3554,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/2.3.2"
+                "source": "https://github.com/utopia-php/audit/tree/2.4.1"
             },
-            "time": "2026-05-14T04:00:37+00:00"
+            "time": "2026-05-20T06:25:45+00:00"
         },
         {
             "name": "utopia-php/auth",

--- a/src/Appwrite/Auth/Key.php
+++ b/src/Appwrite/Auth/Key.php
@@ -122,9 +122,9 @@ class Key
             $secret = $key;
         }
 
-        $role = User::ROLE_APPS;
+        $role = User::ROLE_KEYS;
         $roles = Config::getParam('roles', []);
-        $scopes = $roles[User::ROLE_APPS]['scopes'] ?? [];
+        $scopes = $roles[User::ROLE_KEYS]['scopes'] ?? [];
         $expired = false;
 
         $guestKey = new Key(
@@ -270,7 +270,7 @@ class Key
 
                 $name = $key->getAttribute('name', 'UNKNOWN');
 
-                $role = User::ROLE_APPS;
+                $role = User::ROLE_KEYS;
 
                 $scopes = $key->getAttribute('scopes', []);
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
@@ -93,7 +93,7 @@ class Decrement extends Action
 
     public function action(string $databaseId, string $collectionId, string $documentId, string $attribute, int|float $value, int|float|null $min, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Event $queueForEvents, Context $usage, array $plan, Authorization $authorization, User $user): void
     {
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
@@ -93,7 +93,7 @@ class Increment extends Action
 
     public function action(string $databaseId, string $collectionId, string $documentId, string $attribute, int|float $value, int|float|null $max, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Event $queueForEvents, Context $usage, array $plan, Authorization $authorization, User $user): void
     {
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -201,7 +201,7 @@ class Create extends Action
             $documents = [$data];
         }
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($isBulk && !$isAPIKey && !$isPrivilegedUser) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
@@ -107,7 +107,7 @@ class Delete extends Action
     ): void {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
@@ -78,7 +78,7 @@ class Get extends Action
 
     public function action(string $databaseId, string $collectionId, string $documentId, array $queries, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Context $usage, TransactionState $transactionState, Authorization $authorization, User $user): void
     {
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
@@ -103,7 +103,7 @@ class Update extends Action
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
@@ -108,7 +108,7 @@ class Upsert extends Action
             throw new Exception($this->getMissingPayloadException());
         }
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
@@ -88,7 +88,7 @@ class XList extends Action
 
     public function action(string $databaseId, string $collectionId, array $queries, ?string $transactionId, bool $includeTotal, int $ttl, UtopiaResponse $response, Database $dbForProject, User $user, callable $getDatabasesDB, Context $usage, TransactionState $transactionState, Authorization $authorization, ?Http $utopia = null): void
     {
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Operations/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Operations/Create.php
@@ -75,7 +75,7 @@ class Create extends Action
             throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Operations array cannot be empty');
         }
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         // API keys and admins can read any transaction, regular users need permissions

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
@@ -120,7 +120,7 @@ class Update extends Action
             throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Cannot commit and rollback at the same time');
         }
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $transaction = ($isAPIKey || $isPrivilegedUser)

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -161,7 +161,7 @@ class Create extends Base
         /* @var Document $function */
         $function = $authorization->skip(fn () => $dbForProject->getDocument('functions', $functionId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($function->isEmpty() || (!$function->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Get.php
@@ -67,7 +67,7 @@ class Get extends Base
     ) {
         $function = $authorization->skip(fn () => $dbForProject->getDocument('functions', $functionId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($function->isEmpty() || (!$function->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/XList.php
@@ -77,7 +77,7 @@ class XList extends Base
     ) {
         $function = $authorization->skip(fn () => $dbForProject->getDocument('functions', $functionId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($function->isEmpty() || (!$function->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Update.php
@@ -128,7 +128,7 @@ class Update extends PlatformAction
         Event $queueForEvents
     ): void {
         $presenceState = new PresenceState();
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($userId && !$isAPIKey && !$isPrivilegedUser) {

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Upsert.php
@@ -128,7 +128,7 @@ class Upsert extends PlatformAction
         Event $queueForEvents,
         Context $usage
     ): void {
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         if ($userId && !$isAPIKey && !$isPrivilegedUser) {
             throw new Exception(Exception::GENERAL_UNAUTHORIZED_SCOPE, "userId is not allowed for non-API key and non-privileged users");

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -115,7 +115,7 @@ class Create extends Action
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
@@ -84,7 +84,7 @@ class Delete extends Action
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Download/Get.php
@@ -90,7 +90,7 @@ class Get extends Action
         /* @type Document $bucket */
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Get.php
@@ -65,7 +65,7 @@ class Get extends Action
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -133,7 +133,7 @@ class Get extends Action
 
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Push/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Push/Get.php
@@ -90,7 +90,7 @@ class Get extends Action
         $disposition = $decoded['disposition'] ?? 'inline';
         $dbForProject = $isInternal ? $dbForPlatform : $dbForProject;
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
@@ -81,7 +81,7 @@ class Update extends Action
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {
@@ -110,7 +110,7 @@ class Update extends Action
 
         // Users can only manage their own roles, API keys and Admin users can manage any
         $roles = $authorization->getRoles();
-        if (!$user->isApp($roles) && !$user->isPrivileged($roles) && !\is_null($permissions)) {
+        if (!$user->isKey($roles) && !$user->isPrivileged($roles) && !\is_null($permissions)) {
             foreach (Database::PERMISSIONS as $type) {
                 foreach ($permissions as $permission) {
                     $permission = Permission::parse($permission);

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/View/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/View/Get.php
@@ -91,7 +91,7 @@ class Get extends Action
         /* @type Document $bucket */
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/XList.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/XList.php
@@ -80,7 +80,7 @@ class XList extends Action
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -103,7 +103,7 @@ class Create extends Action
 
     public function action(string $teamId, string $email, string $userId, string $phone, array $roles, string $url, string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Event $queueForEvents, callable $timelimit, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
     {
-        $isAppUser = $user->isApp($authorization->getRoles());
+        $isAppUser = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         $invitee = new Document();
         $hash = '';

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
@@ -81,7 +81,7 @@ class Get extends Action
 
         $roles = $authorization->getRoles();
         $isPrivilegedUser = $user->isPrivileged($roles);
-        $isAppUser = $user->isApp($roles);
+        $isAppUser = $user->isKey($roles);
 
         $membershipsPrivacy = array_map(function ($privacy) use ($isPrivilegedUser, $isAppUser) {
             return $privacy || $isPrivilegedUser || $isAppUser;

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
@@ -84,7 +84,7 @@ class Update extends Action
         }
 
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
-        $isAppUser = $user->isApp($authorization->getRoles());
+        $isAppUser = $user->isKey($authorization->getRoles());
         $isOwner = $authorization->hasRole('team:' . $team->getId() . '/owner');
 
         if ($project->getId() === 'console') {

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
@@ -134,7 +134,7 @@ class XList extends Action
 
         $roles = $authorization->getRoles();
         $isPrivilegedUser = $user->isPrivileged($roles);
-        $isAppUser = $user->isApp($roles);
+        $isAppUser = $user->isKey($roles);
 
         $membershipsPrivacy = array_map(function ($privacy) use ($isPrivilegedUser, $isAppUser) {
             return $privacy || $isPrivilegedUser || $isAppUser;

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -71,7 +71,7 @@ class Create extends Action
     public function action(string $teamId, string $name, array $roles, Response $response, User $user, Database $dbForProject, Authorization $authorization, Event $queueForEvents)
     {
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
-        $isAppUser = $user->isApp($authorization->getRoles());
+        $isAppUser = $user->isKey($authorization->getRoles());
 
         $teamId = $teamId == 'unique()' ? ID::unique() : $teamId;
 

--- a/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Buckets/Files/Action.php
+++ b/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Buckets/Files/Action.php
@@ -15,7 +15,7 @@ class Action extends UtopiaAction
     {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
-        $isAPIKey = $user->isApp($authorization->getRoles());
+        $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         if ($bucket->isEmpty() || (!$bucket->getAttribute('enabled') && !$isAPIKey && !$isPrivilegedUser)) {

--- a/src/Appwrite/Platform/Workers/Audits.php
+++ b/src/Appwrite/Platform/Workers/Audits.php
@@ -100,7 +100,6 @@ class Audits extends Action
             'resource' => $resource,
             'userAgent' => $userAgent,
             'ip' => $ip,
-            'location' => '',
             'data' => [
                 'userId' => $actorUserId,
                 'userName' => $actorUserName,

--- a/src/Appwrite/Platform/Workers/Audits.php
+++ b/src/Appwrite/Platform/Workers/Audits.php
@@ -91,7 +91,7 @@ class Audits extends Action
         $actorUserEmail = $impersonatorUserId
             ? $user->getAttribute('impersonatorUserEmail', '')
             : $user->getAttribute('email', '');
-        $userType = $user->getAttribute('type', ACTIVITY_TYPE_USER);
+        $userType = $user->getAttribute('type', ACTOR_TYPE_USER);
 
         // Create event data
         $eventData = [

--- a/src/Appwrite/Presences/State.php
+++ b/src/Appwrite/Presences/State.php
@@ -48,7 +48,7 @@ class State
                 $permissions[] = (new Permission($permission, 'user', $ownerOverride))->toString();
             }
         } else {
-            $isAPIKey = $user->isApp($authorization->getRoles());
+            $isAPIKey = $user->isKey($authorization->getRoles());
             $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
             $permissions = Permission::aggregate($permissions, $allowedPermissions);

--- a/src/Appwrite/Utopia/Database/Documents/User.php
+++ b/src/Appwrite/Utopia/Database/Documents/User.php
@@ -17,7 +17,7 @@ class User extends Document
     public const ROLE_ADMIN = 'admin';
     public const ROLE_DEVELOPER = 'developer';
     public const ROLE_OWNER = 'owner';
-    public const ROLE_APPS = 'apps';
+    public const ROLE_KEYS = 'keys';
     public const ROLE_SYSTEM = 'system';
 
     public function getEmail(): ?string
@@ -39,7 +39,7 @@ class User extends Document
     {
         $roles = [];
 
-        if (!$this->isApp($authorization->getRoles())) {
+        if (!$this->isKey($authorization->getRoles())) {
             if ($this->getId()) {
                 $roles[] = Role::user($this->getId())->toString();
                 $roles[] = Role::users()->toString();
@@ -115,15 +115,15 @@ class User extends Document
     }
 
     /**
-     * Is App User?
+     * Is Key User?
      *
      * @param array<string> $roles
      *
      * @return bool
      */
-    public function isApp(array $roles): bool
+    public function isKey(array $roles): bool
     {
-        if (in_array(self::ROLE_APPS, $roles)) {
+        if (in_array(self::ROLE_KEYS, $roles)) {
             return true;
         }
 

--- a/src/Appwrite/Utopia/Request.php
+++ b/src/Appwrite/Utopia/Request.php
@@ -240,7 +240,7 @@ class Request extends UtopiaRequest
         $forwardedUserAgent = $this->getHeader('x-forwarded-user-agent');
         if (!empty($forwardedUserAgent)) {
             $roles = $this->authorization->getRoles();
-            $isAppUser = $this->user?->isApp($roles) ?? false;
+            $isAppUser = $this->user?->isKey($roles) ?? false;
 
             if ($isAppUser) {
                 return $forwardedUserAgent;

--- a/src/Appwrite/Utopia/Response.php
+++ b/src/Appwrite/Utopia/Response.php
@@ -591,7 +591,7 @@ class Response extends SwooleResponse
                 $roles = $this->authorization->getRoles();
                 $user = $this->user ?? new DBUser();
                 $isPrivilegedUser = $user->isPrivileged($roles);
-                $isAppUser = $user->isApp($roles);
+                $isAppUser = $user->isKey($roles);
 
                 if ((!$isPrivilegedUser && !$isAppUser) && !$this->showSensitive) {
                     $data->setAttribute($key, '');

--- a/tests/unit/Auth/KeyTest.php
+++ b/tests/unit/Auth/KeyTest.php
@@ -22,7 +22,7 @@ class KeyTest extends TestCase
             'collections.read',
             'documents.read',
         ];
-        $roleScopes = Config::getParam('roles', [])[User::ROLE_APPS]['scopes'];
+        $roleScopes = Config::getParam('roles', [])[User::ROLE_KEYS]['scopes'];
         $guestRoleScopes = Config::getParam('roles', [])[User::ROLE_GUESTS]['scopes'];
 
         $key = self::generateKey($projectId, $usage, $scopes);
@@ -37,7 +37,7 @@ class KeyTest extends TestCase
         $this->assertEquals('', $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_EPHEMERAL, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals(\array_merge($scopes, $roleScopes), $decoded->getScopes());
         $this->assertEquals('Ephemeral Key', $decoded->getName());
 
@@ -61,7 +61,7 @@ class KeyTest extends TestCase
         $this->assertEquals('', $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_EPHEMERAL, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals(\array_merge($scopes, $roleScopes), $decoded->getScopes());
         $this->assertEquals('Ephemeral Key', $decoded->getName());
         $this->assertEquals(['metric123'], $decoded->getDisabledMetrics());
@@ -123,7 +123,7 @@ class KeyTest extends TestCase
         $this->assertEquals('', $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_STANDARD, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals(\array_merge($scopes, $roleScopes), $decoded->getScopes());
         $this->assertEquals('Standard key', $decoded->getName());
 
@@ -146,7 +146,7 @@ class KeyTest extends TestCase
         $this->assertEquals('', $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_STANDARD, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals(\array_merge($scopes, $roleScopes), $decoded->getScopes());
         $this->assertEquals('Standard key', $decoded->getName());
 
@@ -194,7 +194,7 @@ class KeyTest extends TestCase
         $this->assertEquals('', $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_STANDARD, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals(\array_merge($scopes, $roleScopes), $decoded->getScopes());
         $this->assertEquals('Standard key', $decoded->getName());
 
@@ -289,7 +289,7 @@ class KeyTest extends TestCase
         $this->assertEquals($teamId, $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_ORGANIZATION, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals($scopes, $decoded->getScopes());
         $this->assertEquals('Organization key', $decoded->getName());
 
@@ -336,7 +336,7 @@ class KeyTest extends TestCase
         $this->assertEquals($teamId, $decoded->getTeamId());
         $this->assertEquals('', $decoded->getUserId());
         $this->assertEquals(API_KEY_ORGANIZATION, $decoded->getType());
-        $this->assertEquals(User::ROLE_APPS, $decoded->getRole());
+        $this->assertEquals(User::ROLE_KEYS, $decoded->getRole());
         $this->assertEquals($scopes, $decoded->getScopes());
         $this->assertEquals('Organization key', $decoded->getName());
     }

--- a/tests/unit/Utopia/Database/Documents/UserTest.php
+++ b/tests/unit/Utopia/Database/Documents/UserTest.php
@@ -179,11 +179,11 @@ class UserTest extends TestCase
         $this->assertEquals(true, $user->isPrivileged([User::ROLE_ADMIN]));
         $this->assertEquals(true, $user->isPrivileged([User::ROLE_DEVELOPER]));
         $this->assertEquals(true, $user->isPrivileged([User::ROLE_OWNER]));
-        $this->assertEquals(false, $user->isPrivileged([User::ROLE_APPS]));
+        $this->assertEquals(false, $user->isPrivileged([User::ROLE_KEYS]));
         $this->assertEquals(false, $user->isPrivileged([User::ROLE_SYSTEM]));
 
-        $this->assertEquals(false, $user->isPrivileged([User::ROLE_APPS, User::ROLE_APPS]));
-        $this->assertEquals(false, $user->isPrivileged([User::ROLE_APPS, Role::guests()->toString()]));
+        $this->assertEquals(false, $user->isPrivileged([User::ROLE_KEYS, User::ROLE_KEYS]));
+        $this->assertEquals(false, $user->isPrivileged([User::ROLE_KEYS, Role::guests()->toString()]));
         $this->assertEquals(true, $user->isPrivileged([User::ROLE_OWNER, Role::guests()->toString()]));
         $this->assertEquals(true, $user->isPrivileged([User::ROLE_OWNER, User::ROLE_ADMIN, User::ROLE_DEVELOPER]));
     }
@@ -192,19 +192,19 @@ class UserTest extends TestCase
     {
         $user = new User();
 
-        $this->assertEquals(false, $user->isApp([]));
-        $this->assertEquals(false, $user->isApp([Role::guests()->toString()]));
-        $this->assertEquals(false, $user->isApp([Role::users()->toString()]));
-        $this->assertEquals(false, $user->isApp([User::ROLE_ADMIN]));
-        $this->assertEquals(false, $user->isApp([User::ROLE_DEVELOPER]));
-        $this->assertEquals(false, $user->isApp([User::ROLE_OWNER]));
-        $this->assertEquals(true, $user->isApp([User::ROLE_APPS]));
-        $this->assertEquals(false, $user->isApp([User::ROLE_SYSTEM]));
+        $this->assertEquals(false, $user->isKey([]));
+        $this->assertEquals(false, $user->isKey([Role::guests()->toString()]));
+        $this->assertEquals(false, $user->isKey([Role::users()->toString()]));
+        $this->assertEquals(false, $user->isKey([User::ROLE_ADMIN]));
+        $this->assertEquals(false, $user->isKey([User::ROLE_DEVELOPER]));
+        $this->assertEquals(false, $user->isKey([User::ROLE_OWNER]));
+        $this->assertEquals(true, $user->isKey([User::ROLE_KEYS]));
+        $this->assertEquals(false, $user->isKey([User::ROLE_SYSTEM]));
 
-        $this->assertEquals(true, $user->isApp([User::ROLE_APPS, User::ROLE_APPS]));
-        $this->assertEquals(true, $user->isApp([User::ROLE_APPS, Role::guests()->toString()]));
-        $this->assertEquals(false, $user->isApp([User::ROLE_OWNER, Role::guests()->toString()]));
-        $this->assertEquals(false, $user->isApp([User::ROLE_OWNER, User::ROLE_ADMIN, User::ROLE_DEVELOPER]));
+        $this->assertEquals(true, $user->isKey([User::ROLE_KEYS, User::ROLE_KEYS]));
+        $this->assertEquals(true, $user->isKey([User::ROLE_KEYS, Role::guests()->toString()]));
+        $this->assertEquals(false, $user->isKey([User::ROLE_OWNER, Role::guests()->toString()]));
+        $this->assertEquals(false, $user->isKey([User::ROLE_OWNER, User::ROLE_ADMIN, User::ROLE_DEVELOPER]));
     }
 
     public function testGuestRoles(): void
@@ -327,7 +327,7 @@ class UserTest extends TestCase
 
     public function testAppUserRoles(): void
     {
-        $this->getAuthorization()->addRole(User::ROLE_APPS);
+        $this->getAuthorization()->addRole(User::ROLE_KEYS);
         $user  = new User([
             '$id' => ID::custom('123'),
             'memberships' => [


### PR DESCRIPTION
## Summary

Renames the actor-type constants in Appwrite CE and bumps the `utopia-php/audit` dependency to the matching minor release. No response model, schema, or audit log payload changes — only constant names and the composer pin.

## Changes

1. **Constants** (`app/init/constants.php`): six existing `ACTIVITY_TYPE_*` constants renamed to `ACTOR_TYPE_*` (`KEY_PROJECT`, `KEY_ACCOUNT`, `KEY_ORGANIZATION`, `USER`, `ADMIN`, `GUEST`). Values unchanged.
2. **Call sites** updated to use the new constant names:
   - `app/controllers/shared/api.php` (4 references)
   - `src/Appwrite/Platform/Workers/Audits.php` (1 reference)
3. **Composer**: bumped `utopia-php/audit` from `2.3.*` to `^2.4` (the new minor that ships the ClickHouse adapter rename in [utopia-php/audit#122](https://github.com/utopia-php/audit/pull/122)). Public Audit API and Database adapter unchanged in 2.4.0; CE doesn't depend on the ClickHouse-only rename, so no code adjustment is required.

### Additional rename: API-key role

3. **`User::ROLE_APPS` (`'apps'`) → `User::ROLE_KEYS` (`'keys'`)** + method `User::isApp()` → `User::isKey()`. The string `'apps'` is purely runtime (assigned in `src/Appwrite/Auth/Key.php` at API-key authentication) — no DB stores it, no Utopia `Role::apps()` exists, no permission strings reference it. So this is a pure code rename, no migration.
   - Call sites updated: `Auth/Key.php`, `config/roles.php`, `controllers/shared/api.php`, `controllers/api/graphql.php`, `Modules/Functions/Http/Executions/Create.php`, plus all `->isApp(...)` callers across Storage/Databases/Teams/Tokens modules, `app/realtime.php`, `Utopia/Request.php`, `Utopia/Response.php`, `controllers/shared/api/auth.php`.
   - Tests updated: `tests/unit/Utopia/Database/Documents/UserTest.php`, `tests/unit/Auth/KeyTest.php`.
   - BC impact: any extension importing the old constant name or method name must update.

## Not in scope (intentional)

- No changes to `src/Appwrite/Utopia/Response/Model/Log.php` — the public Log API response shape (`userId`, `userName`, `userEmail`, `userType`) is preserved.
- No changes to the audit log `data` payload keys — `data.userId`, `data.userName`, `data.userEmail`, `data.userType` continue to be written and read as-is. Downstream consumers (cloud activity events) write their own payload format.
- No schema changes / no migrations.
- No rename of the impersonator-aware actor variables in the Audits worker (`$actorUserId`, `$actorUserName`, `$actorUserEmail`, `$actorUserInternalId`).

## BC impact

- Any extension or plugin importing the renamed constants by old name must update to `ACTOR_TYPE_*`. Values are unchanged so any string comparisons keep working.

## Related

- utopia-php/audit#122 — ClickHouse adapter column rename + Log getter additions (2.4.0)
- appwrite-labs/cloud companion PR — cloud-side `ActivityEvent` response model rename (not visible here)

## Test plan

- [ ] CI lint + PHPStan green
- [ ] CI unit tests pass
