### PR TITLE
fix(account): validate null user name

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1,5 +1,5 @@
 <?php
-
+use Appwrite\Extend\Exception;
 use Ahc\Jwt\JWT;
 use Appwrite\Auth\MFA\Type;
 use Appwrite\Auth\OAuth2\Exception as OAuth2Exception;
@@ -383,7 +383,16 @@ Http::post('/v1/account')
             ]);
 
             $user->removeAttribute('$sequence');
-            $user = $authorization->skip(fn () => $dbForProject->createDocument('users', $user));
+            if ($name === null || trim($name) === '') {
+    throw new Exception(
+        Exception::GENERAL_ARGUMENT_INVALID,
+        'Invalid "name" param'
+    );
+}
+
+$user = $authorization->skip(
+    fn () => $dbForProject->createDocument('users', $user)
+);
             try {
                 $target = $authorization->skip(fn () => $dbForProject->createDocument('targets', new Document([
                     '$permissions' => [


### PR DESCRIPTION
## What does this PR do?

Adds validation for null or empty user names before user document creation.

## Why?

Previously, sending a null name could trigger an internal server error instead of returning a proper validation response.

## Changes

* Added validation for null/empty `name`
* Throws `GENERAL_ARGUMENT_INVALID`
* Prevents invalid values from reaching database creation

## Testing

Tested with:

```json
{
  "email": "test@test.com",
  "password": "12345678",
  "name": null
}
```

Now returns a proper HTTP 400 validation error.
