### PR TITLE
Consolidate shared DI resources

### DIFF
--- a/app/cli.php
+++ b/app/cli.php
@@ -2,18 +2,10 @@
 
 require_once __DIR__ . '/init.php';
 
-use Appwrite\Event\Event;
-use Appwrite\Event\Publisher\Certificate as CertificatePublisher;
-use Appwrite\Event\Publisher\Database as DatabasePublisher;
-use Appwrite\Event\Publisher\Delete as DeletePublisher;
-use Appwrite\Event\Publisher\Func as FunctionPublisher;
-use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
-use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Platform\Appwrite;
 use Appwrite\Runtimes\Runtimes;
 use Appwrite\Usage\Context as UsageContext;
 use Appwrite\Utopia\Database\Documents\User;
-use Executor\Executor;
 use Swoole\Runtime;
 use Swoole\Timer;
 use Utopia\Cache\Adapter\Pool as CachePool;
@@ -27,17 +19,12 @@ use Utopia\Database\Adapter\Pool as DatabasePool;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
-use Utopia\DI\Container;
 use Utopia\DSN\DSN;
 use Utopia\Logger\Log;
 use Utopia\Platform\Service;
 use Utopia\Pools\Group;
-use Utopia\Queue\Broker\Pool as BrokerPool;
-use Utopia\Queue\Publisher;
-use Utopia\Queue\Queue;
 use Utopia\Registry\Registry;
 use Utopia\System\System;
-use Utopia\Telemetry\Adapter\None as NoTelemetry;
 
 use function Swoole\Coroutine\run;
 
@@ -48,6 +35,7 @@ Config::setParam('runtimes', (new Runtimes('v5'))->getAll(supported: false));
 require_once __DIR__ . '/controllers/general.php';
 
 global $register;
+global $container;
 
 $platform = new Appwrite();
 $args = $_SERVER['argv'] ?? [];
@@ -59,7 +47,6 @@ if (! isset($args[0])) {
 }
 
 $taskName = $args[0];
-$container = new Container();
 $cli = new CLI(new Generic(), $_SERVER['argv'] ?? [], $container);
 
 $platform->setCli($cli);
@@ -131,10 +118,6 @@ $container->set('dbForPlatform', function ($pools, $cache, $authorization) {
 
     return $dbForPlatform;
 }, ['pools', 'cache', 'authorization']);
-
-$container->set('console', function () {
-    return new Document(Config::getParam('console'));
-}, []);
 
 $container->set(
     'isResourceBlocked',
@@ -252,48 +235,10 @@ $container->set('getLogsDB', function (Group $pools, Cache $cache, Authorization
         return $database;
     };
 }, ['pools', 'cache', 'authorization']);
-$container->set('publisher', function (Group $pools) {
-    return new BrokerPool(publisher: $pools->get('publisher'));
-}, ['pools']);
-$container->set('publisherDatabases', function (BrokerPool $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherFunctions', function (BrokerPool $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherMigrations', function (BrokerPool $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherMessaging', function (BrokerPool $publisher) {
-    return $publisher;
-}, ['publisher']);
+
 $container->set('usage', function () {
     return new UsageContext();
 }, []);
-$container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForCertificates', fn (Publisher $publisher) => new CertificatePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_CERTIFICATES_QUEUE_NAME', Event::CERTIFICATES_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForStatsResources', fn (Publisher $publisher) => new StatsResourcesPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForFunctions', fn (Publisher $publisher) => new FunctionPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', Event::FUNCTIONS_QUEUE_TTL)
-), ['publisher']);
-$container->set('publisherForDatabase', fn (Publisher $publisherDatabases) => new DatabasePublisher(
-    $publisherDatabases,
-    new Queue(System::getEnv('_APP_DATABASE_QUEUE_NAME', Event::DATABASE_QUEUE_NAME))
-), ['publisherDatabases']);
-$container->set('publisherForDeletes', fn (Publisher $publisher) => new DeletePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_DELETE_QUEUE_NAME', Event::DELETE_QUEUE_NAME))
-), ['publisher']);
 $container->set('logError', function (Registry $register) {
     return function (Throwable $error, string $namespace, string $action) use ($register) {
         Console::error('[Error] Timestamp: ' . date('c', time()));
@@ -346,13 +291,9 @@ $container->set('logError', function (Registry $register) {
     };
 }, ['register']);
 
-$container->set('executor', fn () => new Executor(), []);
-
 $container->set('bus', function (Registry $register) use ($container) {
     return $register->get('bus')->setResolver(fn (string $name) => $container->get($name));
 }, ['register']);
-
-$container->set('telemetry', fn () => new NoTelemetry(), []);
 
 $exitCode = 0;
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -53,6 +53,93 @@ global $register;
 global $container;
 $container = new Container();
 
+$container->set('console', fn () => new Document(Config::getParam('console')), []);
+
+$container->set('executor', fn () => new Executor(), []);
+
+$container->set('telemetry', fn () => new NoTelemetry(), []);
+
+$container->set('publisher', fn (Group $pools) => new BrokerPool(publisher: $pools->get('publisher')), ['pools']);
+
+$container->set('publisherDatabases', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherFunctions', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherMigrations', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherMails', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherDeletes', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherMessaging', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherWebhooks', fn (Publisher $publisher) => $publisher, ['publisher']);
+
+$container->set('publisherForAudits', fn (Publisher $publisher) => new AuditPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForCertificates', fn (Publisher $publisher) => new CertificatePublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_CERTIFICATES_QUEUE_NAME', Event::CERTIFICATES_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForScreenshots', fn (Publisher $publisher) => new ScreenshotPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_SCREENSHOTS_QUEUE_NAME', Event::SCREENSHOTS_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForExecutions', fn (Publisher $publisher) => new ExecutionPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_EXECUTIONS_QUEUE_NAME', Event::EXECUTIONS_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForFunctions', fn (Publisher $publisher) => new FunctionPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', Event::FUNCTIONS_QUEUE_TTL)
+), ['publisher']);
+
+$container->set('publisherForMigrations', fn (Publisher $publisher) => new MigrationPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_MIGRATIONS_QUEUE_NAME', Event::MIGRATIONS_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForStatsResources', fn (Publisher $publisher) => new StatsResourcesPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForBuilds', fn (Publisher $publisher) => new BuildPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_BUILDS_QUEUE_NAME', Event::BUILDS_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForDatabase', fn (Publisher $publisherDatabases) => new DatabasePublisher(
+    $publisherDatabases,
+    new Queue(System::getEnv('_APP_DATABASE_QUEUE_NAME', Event::DATABASE_QUEUE_NAME))
+), ['publisherDatabases']);
+
+$container->set('publisherForDeletes', fn (Publisher $publisher) => new DeletePublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_DELETE_QUEUE_NAME', Event::DELETE_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForMails', fn (Publisher $publisher) => new MailPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_MAILS_QUEUE_NAME', Event::MAILS_QUEUE_NAME))
+), ['publisher']);
+
+$container->set('publisherForMessaging', fn (Publisher $publisher) => new MessagingPublisher(
+    $publisher,
+    new Queue(System::getEnv('_APP_MESSAGING_QUEUE_NAME', Event::MESSAGING_QUEUE_NAME))
+), ['publisher']);
+
 $container->set('logger', function ($register) {
     return $register->get('logger');
 }, ['register']);
@@ -67,93 +154,12 @@ $container->set('localeCodes', function () {
     return array_map(fn ($locale) => $locale['code'], Config::getParam('locale-codes', []));
 });
 
-// Queues - shared infrastructure (stateless pool wrappers)
-$container->set('publisher', function (Group $pools) {
-    return new BrokerPool(publisher: $pools->get('publisher'));
-}, ['pools']);
-$container->set('publisherDatabases', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherFunctions', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherMigrations', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherMails', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherDeletes', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherMessaging', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherWebhooks', function (Publisher $publisher) {
-    return $publisher;
-}, ['publisher']);
-$container->set('publisherForAudits', fn (Publisher $publisher) => new AuditPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_AUDITS_QUEUE_NAME', Event::AUDITS_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForCertificates', fn (Publisher $publisher) => new CertificatePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_CERTIFICATES_QUEUE_NAME', Event::CERTIFICATES_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForScreenshots', fn (Publisher $publisher) => new ScreenshotPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_SCREENSHOTS_QUEUE_NAME', Event::SCREENSHOTS_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForUsage', fn (Publisher $publisher) => new UsagePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_STATS_USAGE_QUEUE_NAME', Event::STATS_USAGE_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForExecutions', fn (Publisher $publisher) => new ExecutionPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_EXECUTIONS_QUEUE_NAME', Event::EXECUTIONS_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForFunctions', fn (Publisher $publisher) => new FunctionPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', Event::FUNCTIONS_QUEUE_TTL)
-), ['publisher']);
-$container->set('publisherForMigrations', fn (Publisher $publisher) => new MigrationPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_MIGRATIONS_QUEUE_NAME', Event::MIGRATIONS_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForStatsResources', fn (Publisher $publisher) => new StatsResourcesPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_STATS_RESOURCES_QUEUE_NAME', Event::STATS_RESOURCES_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForBuilds', fn (Publisher $publisher) => new BuildPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_BUILDS_QUEUE_NAME', Event::BUILDS_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForDatabase', fn (Publisher $publisherDatabases) => new DatabasePublisher(
-    $publisherDatabases,
-    new Queue(System::getEnv('_APP_DATABASE_QUEUE_NAME', Event::DATABASE_QUEUE_NAME))
-), ['publisherDatabases']);
-$container->set('publisherForDeletes', fn (Publisher $publisher) => new DeletePublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_DELETE_QUEUE_NAME', Event::DELETE_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForMails', fn (Publisher $publisher) => new MailPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_MAILS_QUEUE_NAME', Event::MAILS_QUEUE_NAME))
-), ['publisher']);
-$container->set('publisherForMessaging', fn (Publisher $publisher) => new MessagingPublisher(
-    $publisher,
-    new Queue(System::getEnv('_APP_MESSAGING_QUEUE_NAME', Event::MESSAGING_QUEUE_NAME))
-), ['publisher']);
 
 /**
  * Platform configuration
  */
 $container->set('platform', function () {
     return Config::getParam('platform', []);
-}, []);
-
-$container->set('console', function () {
-    return new Document(Config::getParam('console'));
 }, []);
 
 $container->set('authorization', function () {
@@ -213,8 +219,6 @@ $container->set('getLogsDB', function (Group $pools, Cache $cache, Authorization
         return $database;
     };
 }, ['pools', 'cache', 'authorization']);
-
-$container->set('telemetry', fn () => new NoTelemetry());
 
 $container->set('cache', function (Group $pools, Telemetry $telemetry) {
     $list = Config::getParam('pools-cache', []);
@@ -416,5 +420,3 @@ $container->set(
     'isResourceBlocked',
     fn () => fn (Document $project, string $resourceType, ?string $resourceId) => false
 );
-
-$container->set('executor', fn () => new Executor());

--- a/app/init/worker/message.php
+++ b/app/init/worker/message.php
@@ -1,7 +1,6 @@
 <?php
 
 use Appwrite\Event\Event;
-use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Appwrite\Event\Realtime;
 use Appwrite\Event\Webhook;
 use Appwrite\Usage\Context;
@@ -21,7 +20,6 @@ use Utopia\DSN\DSN;
 use Utopia\Logger\Log;
 use Utopia\Pools\Group;
 use Utopia\Queue\Publisher;
-use Utopia\Queue\Queue;
 use Utopia\Registry\Registry;
 use Utopia\Storage\Device\Telemetry as TelemetryDevice;
 use Utopia\System\System;
@@ -334,10 +332,6 @@ return function (Container $container): void {
         return new Webhook($publisher);
     }, ['publisher']);
 
-    $container->set('publisherForFunctions', fn (Publisher $publisher) => new FunctionPublisher(
-        $publisher,
-        new Queue(System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', Event::FUNCTIONS_QUEUE_NAME), 'utopia-queue', Event::FUNCTIONS_QUEUE_TTL)
-    ), ['publisher']);
     $container->set('queueForRealtime', function () {
         return new Realtime();
     }, []);


### PR DESCRIPTION
## What
- Keep `app/init/resources.php` as the shared DI resource source instead of adding a separate shared resource file.
- Move overlapping publisher resource definitions out of `app/cli.php`, while keeping them registered in `app/init/resources.php`.
- Move simple overlapping resources into `app/init/resources.php`: `console`, `executor`, and `telemetry`.
- Reuse the container initialized by `app/init.php` in `app/cli.php`, so CLI tasks get the shared resources from `resources.php` without duplicate registrations.
- Remove the duplicate `publisherForFunctions` registration from `app/init/worker/message.php`, relying on the shared registration loaded through `app/init.php`.

## Why
`resources.php` is already the shared bootstrap resource file. This PR keeps that pattern and removes duplicated resource definitions from other entrypoints, while leaving request-, task-, and message-specific resources in their context-specific files.

## Notes
- No new shared resource file is introduced.
- `app/init/resources/` remains reserved for nested `resources.php` context files like `request.php`.
- Database resources are intentionally left untouched because their API, task, and worker variants have different timeout and lifecycle behavior.

## Tests
- `composer format app/cli.php app/init/resources.php app/init/worker/message.php`
- `php -l app/cli.php`
- `php -l app/init/resources.php`
- `php -l app/init/worker/message.php`
