### PR TITLE
docs: improve CLI endpoint formatting

### DIFF
--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -9,7 +9,7 @@ $ appwrite login
 ? Enter your password ********
 ✓ Success 
 ```
-This will also prompt you to enter your Appwrite endpoint ( default: http://localhost/v1 ) 
+This will also prompt you to enter your Appwrite endpoint (default: `http://localhost/v1`)
 
 * ### Initialising your project
 Once logged in, the CLI needs to be initialised before you can use it with your Appwrite project. You can do this with the `appwrite init project` command. 


### PR DESCRIPTION
## Summary

Improves formatting consistency for the Appwrite CLI endpoint example in the getting started guide.

## Changes

* Removed unnecessary spacing around the default endpoint example
* Formatted the default endpoint URL as inline code for better readability

## Testing

* Documentation-only changes