### PR TITLE
feat(sites): allow bun and deno as build runtimes for JS frameworks

### DIFF
--- a/app/config/frameworks.php
+++ b/app/config/frameworks.php
@@ -14,7 +14,11 @@ return [
         'name' => 'Analog',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/analog/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/analog/env.sh',
         'adapters' => [
@@ -40,7 +44,11 @@ return [
         'name' => 'Angular',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/angular/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/angular/env.sh',
         'adapters' => [
@@ -66,7 +74,11 @@ return [
         'name' => 'Next.js',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/next-js/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/next-js/env.sh',
         'adapters' => [
@@ -91,7 +103,11 @@ return [
         'name' => 'React',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'adapters' => [
             'static' => [
                 'key' => 'static',
@@ -108,7 +124,11 @@ return [
         'name' => 'Nuxt',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/nuxt/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/nuxt/env.sh',
         'adapters' => [
@@ -133,7 +153,11 @@ return [
         'name' => 'Vue.js',
         'screenshotSleep' => 5000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'adapters' => [
             'static' => [
                 'key' => 'static',
@@ -150,7 +174,11 @@ return [
         'name' => 'SvelteKit',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/sveltekit/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/sveltekit/env.sh',
         'adapters' => [
@@ -175,7 +203,11 @@ return [
         'name' => 'Astro',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/astro/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/astro/env.sh',
         'adapters' => [
@@ -200,7 +232,11 @@ return [
         'name' => 'TanStack Start',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/tanstack-start/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/tanstack-start/env.sh',
         'adapters' => [
@@ -225,7 +261,11 @@ return [
         'name' => 'Remix',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'bundleCommand' => 'bash /usr/local/server/helpers/remix/bundle.sh',
         'envCommand' => 'source /usr/local/server/helpers/remix/env.sh',
         'adapters' => [
@@ -250,7 +290,11 @@ return [
         'name' => 'Lynx',
         'screenshotSleep' => 5000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'adapters' => [
             'static' => [
                 'key' => 'static',
@@ -284,7 +328,11 @@ return [
         'name' => 'React Native',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'adapters' => [
             'static' => [
                 'key' => 'static',
@@ -301,7 +349,11 @@ return [
         'name' => 'Vite',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'adapters' => [
             'static' => [
                 'key' => 'static',
@@ -317,7 +369,11 @@ return [
         'name' => 'Other',
         'screenshotSleep' => 3000,
         'buildRuntime' => 'node-22',
-        'runtimes' => $templateRuntimes['NODE'],
+        'runtimes' => array_merge(
+            $templateRuntimes['NODE'],
+            $templateRuntimes['BUN'],
+            $templateRuntimes['DENO']
+        ),
         'adapters' => [
             'static' => [
                 'key' => 'static',


### PR DESCRIPTION
## What does this PR do?

Adds `bun` and `deno` versions to the `runtimes` allowlist for every NODE-based Sites framework. Until now `framework.runtimes` was hardcoded to NODE-only, so the Console **Build runtime** dropdown only showed node versions for Sites even though open-runtimes ships bun and deno images.

The change is one line per framework:

```diff
- 'runtimes' => $templateRuntimes['NODE'],
+ 'runtimes' => array_merge(
+     $templateRuntimes['NODE'],
+     $templateRuntimes['BUN'],
+     $templateRuntimes['DENO']
+ ),
```

Applied to 14 frameworks: analog, angular, nextjs, react, nuxt, vue, sveltekit, astro, tanstack-start, remix, lynx, react-native, vite, other. Flutter stays `FLUTTER`-only.

## Why this is safe

- `framework.runtimes` is only consumed by the Console UI to populate the build-runtime dropdown. The server-side `WhiteList` validator on `POST /v1/sites` already accepts any key in `Config::getParam('runtimes')`, so CLI/REST callers could already pick `bun-1.3`, `deno-2.6`, etc.
- The build image itself is resolved at build time by the openruntimes executor from the `buildRuntime` string. No new images are introduced here.

## Test Plan

- `GET /v1/sites/frameworks` now returns the merged list for every NODE framework (e.g. `react.runtimes` contains node, bun and deno versions).
- Console **Build runtime** dropdown on a React site renders bun and deno alongside node.
- Deployed a Vite/React static site with `buildRuntime: bun-1.3` via the CLI end to end: build log shows `bun install`, vite build succeeded, deployment status `ready`, site served HTTP 200.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — N/A