### PR TITLE
fix(health): use injected cache resource for healthcheck

### DIFF
--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Cache/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Cache/Get.php
@@ -8,12 +8,10 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
-use Utopia\Cache\Adapter\Pool as CachePool;
-use Utopia\Config\Config;
+use Utopia\Cache\Cache;
 use Utopia\Database\Document;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Pools\Group;
 
 class Get extends Action
 {
@@ -47,44 +45,31 @@ class Get extends Action
                 contentType: ContentType::JSON
             ))
             ->inject('response')
-            ->inject('pools')
+            ->inject('cache')
             ->callback($this->action(...));
     }
 
-    public function action(Response $response, Group $pools): void
+    public function action(Response $response, Cache $cache): void
     {
         $output = [];
-        $failures = [];
 
-        $configs = [
-            'Cache' => Config::getParam('pools-cache'),
-        ];
+        $checkStart = \microtime(true);
 
-        foreach ($configs as $key => $config) {
-            foreach ($config as $cache) {
-                try {
-                    $adapter = new CachePool($pools->get($cache));
-
-                    $checkStart = \microtime(true);
-
-                    if ($adapter->ping()) {
-                        $output[] = new Document([
-                            'name' => $key . " ($cache)",
-                            'status' => 'pass',
-                            'ping' => \round((\microtime(true) - $checkStart) * 1000),
-                        ]);
-                    } else {
-                        $failures[] = $cache;
-                    }
-                } catch (\Throwable) {
-                    $failures[] = $cache;
-                }
-            }
+        try {
+            $ok = $cache->ping();
+        } catch (\Throwable) {
+            $ok = false;
         }
 
-        if (!empty($failures)) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Cache failure on: ' . \implode(', ', $failures));
+        if (!$ok) {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Cache failure on: cache');
         }
+
+        $output[] = new Document([
+            'name' => 'Cache',
+            'status' => 'pass',
+            'ping' => \round((\microtime(true) - $checkStart) * 1000),
+        ]);
 
         $response->dynamic(new Document([
             'statuses' => $output,


### PR DESCRIPTION
## Summary
- Inject the live `cache` resource into `/v1/health/cache` and ping it directly instead of rebuilding `CachePool` adapters from `pools-cache`.
- The container in `app/init/resources.php` already builds the correct adapter (pool, multiplexing, none), so the healthcheck now exercises the actual configured cache.
- Drops the per-pool iteration and the `new CachePool(...)` rebuild path that would fail for connections not registered in the pool group (e.g. multiplexing).

## Test plan
- [ ] `GET /v1/health/cache` returns 200 with `{ name: "Cache", status: "pass" }` on a healthy instance
- [ ] Returns 500 with `Cache failure on: cache` when the cache backend is down
- [ ] Verify against multiplexing cache configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)