### PR TITLE
feat(storage): expose sizeActual in File response model

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/File.php
+++ b/src/Appwrite/Utopia/Response/Model/File.php
@@ -67,6 +67,12 @@ class File extends Model
                 'default' => 0,
                 'example' => 17890,
             ])
+            ->addRule('sizeActual', [
+                'type' => self::TYPE_INTEGER,
+                'description' => 'File actual stored size in bytes after compression and/or encryption.',
+                'default' => 0,
+                'example' => 12345,
+            ])
             ->addRule('chunksTotal', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Total number of chunks available',


### PR DESCRIPTION
## What

Adds `sizeActual` to the File response model so the compressed/encrypted on-disk size is returned alongside `sizeOriginal`.

```diff
  sizeOriginal: 17890
+ sizeActual: 12345
  chunksTotal: ...
```

## Why

The `sizeActual` attribute is already persisted on file documents (set during upload in `Storage/Http/Buckets/Files/Create.php` and stored via the `sizeActual` column in `app/config/collections/common.php`). It just wasn't exposed in the API response. Surfacing it lets clients see how much storage a file actually consumes after compression and/or encryption.

## Changes

- `src/Appwrite/Utopia/Response/Model/File.php` — add `sizeActual` rule (integer, bytes)

## Test plan

- [ ] `GET /v1/storage/buckets/{bucketId}/files/{fileId}` returns `sizeActual` for both compressed and uncompressed buckets
- [ ] `POST /v1/storage/buckets/{bucketId}/files` (createFile) response includes `sizeActual`
- [ ] `listFiles` items include `sizeActual`
- [ ] OpenAPI / SDK specs regenerate cleanly with the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)