### PR TITLE
fix: restrict advisor auth types

### DIFF
--- a/src/Appwrite/Platform/Modules/Advisor/Http/Insights/Get.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Insights/Get.php
@@ -36,7 +36,7 @@ class Get extends Action
                 group: 'insights',
                 name: 'getInsight',
                 description: '/docs/references/advisor/get-insight.md',
-                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Insights/XList.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Insights/XList.php
@@ -42,7 +42,7 @@ class XList extends Action
                 group: 'insights',
                 name: 'listInsights',
                 description: '/docs/references/advisor/list-insights.md',
-                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Get.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Get.php
@@ -37,7 +37,7 @@ class Get extends Action
                 group: 'reports',
                 name: 'getReport',
                 description: '/docs/references/advisor/get-report.md',
-                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Reports/XList.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Reports/XList.php
@@ -41,7 +41,7 @@ class XList extends Action
                 group: 'reports',
                 name: 'listReports',
                 description: '/docs/references/advisor/list-reports.md',
-                auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::KEY, AuthType::JWT],
+                auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/tests/unit/Advisor/AuthTest.php
+++ b/tests/unit/Advisor/AuthTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Advisor;
+
+use Appwrite\Platform\Modules\Advisor\Http\Insights\Get as GetInsight;
+use Appwrite\Platform\Modules\Advisor\Http\Insights\XList as ListInsights;
+use Appwrite\Platform\Modules\Advisor\Http\Reports\Delete as DeleteReport;
+use Appwrite\Platform\Modules\Advisor\Http\Reports\Get as GetReport;
+use Appwrite\Platform\Modules\Advisor\Http\Reports\XList as ListReports;
+use Appwrite\SDK\AuthType;
+use Appwrite\SDK\Method;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Utopia\Platform\Action;
+
+class AuthTest extends TestCase
+{
+    #[DataProvider('advisorActionsProvider')]
+    public function testAdvisorApisOnlySupportAdminAndKeyAuth(Action $action): void
+    {
+        /** @var Method $method */
+        $method = $action->getLabels()['sdk'];
+
+        $this->assertSame([AuthType::ADMIN, AuthType::KEY], $method->getAuth());
+    }
+
+    public static function advisorActionsProvider(): array
+    {
+        return [
+            'get report' => [new GetReport()],
+            'list reports' => [new ListReports()],
+            'delete report' => [new DeleteReport()],
+            'get insight' => [new GetInsight()],
+            'list insights' => [new ListInsights()],
+        ];
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Restricts Advisor SDK auth metadata to admin and API key auth only. Report and insight read endpoints no longer advertise session or JWT client auth; delete was already admin/API key only.

Adds a unit regression that checks every Advisor HTTP action exposes only `ADMIN` and `KEY` auth types.

## Test Plan

- `composer format -- src/Appwrite/Platform/Modules/Advisor/Http/Reports/Get.php src/Appwrite/Platform/Modules/Advisor/Http/Reports/XList.php src/Appwrite/Platform/Modules/Advisor/Http/Insights/Get.php src/Appwrite/Platform/Modules/Advisor/Http/Insights/XList.php tests/unit/Advisor/AuthTest.php`
- `composer lint -- src/Appwrite/Platform/Modules/Advisor/Http/Reports/Get.php src/Appwrite/Platform/Modules/Advisor/Http/Reports/XList.php src/Appwrite/Platform/Modules/Advisor/Http/Insights/Get.php src/Appwrite/Platform/Modules/Advisor/Http/Insights/XList.php tests/unit/Advisor/AuthTest.php`
- `vendor/bin/phpunit tests/unit/Advisor/AuthTest.php`
- `php -l` on each changed PHP file
- `git diff --check`

## Related PRs and Issues

- None

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
