### PR TITLE
feat(sdks): add isomorphic spec platform

### DIFF
--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -103,6 +103,7 @@ const APP_SDK_PLATFORM_SERVER = 'server';
 const APP_SDK_PLATFORM_CLIENT = 'client';
 const APP_SDK_PLATFORM_CONSOLE = 'console';
 const APP_SDK_PLATFORM_STATIC = 'static';
+const APP_SDK_PLATFORM_ISOMORPHIC = 'isomorphic';
 const APP_VCS_GITHUB_USERNAME = 'Appwrite';
 const APP_VCS_GITHUB_EMAIL = 'team@appwrite.io';
 const APP_VCS_GITHUB_URL = 'https://github.com/TeamAppwrite';

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -308,7 +308,8 @@ class SDKs extends Action
                 } else {
                     Console::log('  Fetching API spec...');
 
-                    $specPath = __DIR__ . '/../../../../app/config/specs/swagger2-' . $version . '-' . $language['family'] . '.json';
+                    $specPlatform = $language['specPlatform'] ?? $language['family'];
+                    $specPath = __DIR__ . '/../../../../app/config/specs/swagger2-' . $version . '-' . $specPlatform . '.json';
 
                     if (!file_exists($specPath)) {
                         throw new \Exception('Spec file not found: ' . $specPath . '. Please run "docker compose exec appwrite specs --version=' . $version . '" first to generate the specs.');

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -79,7 +79,26 @@ class Specs extends Action
             APP_SDK_PLATFORM_CLIENT,
             APP_SDK_PLATFORM_SERVER,
             APP_SDK_PLATFORM_CONSOLE,
+            APP_SDK_PLATFORM_ISOMORPHIC,
         ];
+    }
+
+    /**
+     * Real platforms whose filters apply to a given (possibly virtual) platform.
+     *
+     * The isomorphic platform is a virtual union of `client` and `server` — its spec includes
+     * any route or service that would normally be emitted in either platform's spec. All other
+     * platforms map to themselves.
+     *
+     * @return array<string>
+     */
+    private static function effectivePlatformsFor(string $platform): array
+    {
+        if ($platform === APP_SDK_PLATFORM_ISOMORPHIC) {
+            return [APP_SDK_PLATFORM_CLIENT, APP_SDK_PLATFORM_SERVER];
+        }
+
+        return [$platform];
     }
 
     /**
@@ -121,6 +140,7 @@ class Specs extends Action
             'client' => 1,
             'server' => 2,
             'console' => 1,
+            APP_SDK_PLATFORM_ISOMORPHIC => 1,
         ];
     }
 
@@ -131,7 +151,7 @@ class Specs extends Action
      */
     protected function getKeys(): array
     {
-        return [
+        $keys = [
             APP_SDK_PLATFORM_CLIENT => [
                 'Project' => [
                     'type' => 'apiKey',
@@ -325,6 +345,12 @@ class Specs extends Action
                 ],
             ],
         ];
+
+        // Isomorphic platform shares the auth surface of both client and server runtimes; the
+        // generated SDK picks one auth path at construction time via its factories.
+        $keys[APP_SDK_PLATFORM_ISOMORPHIC] = $keys[APP_SDK_PLATFORM_CLIENT] + $keys[APP_SDK_PLATFORM_SERVER];
+
+        return $keys;
     }
 
     protected function verifyParsedSpec(array $spec): void
@@ -542,6 +568,7 @@ class Specs extends Action
             $routes = [];
             $models = [];
             $services = [];
+            $effectivePlatforms = static::effectivePlatformsFor($platform);
 
             foreach ($appRoutes as $key => $method) {
                 foreach ($method as $route) {
@@ -559,7 +586,10 @@ class Specs extends Action
                         /** @var Method $sdk */
                         $hide = $sdk->isHidden();
 
-                        if ($hide === true || (\is_array($hide) && \in_array($platform, $hide))) {
+                        // A method is hidden from a (possibly virtual) platform when it is hidden
+                        // from every real platform that platform expands to. For real platforms
+                        // this matches the legacy single-element check.
+                        if ($hide === true || (\is_array($hide) && empty(\array_diff($effectivePlatforms, $hide)))) {
                             continue;
                         }
 
@@ -582,7 +612,7 @@ class Specs extends Action
                             continue;
                         }
 
-                        if (!\in_array($platform, $sdkPlatforms)) {
+                        if (empty(\array_intersect($effectivePlatforms, $sdkPlatforms))) {
                             continue;
                         }
 
@@ -601,8 +631,8 @@ class Specs extends Action
                     continue;
                 }
 
-                // Check if current platform is included in service's platforms
-                if (!\in_array($platform, $service['platforms'] ?? [])) {
+                // Check if any effective platform is included in service's platforms
+                if (empty(\array_intersect($effectivePlatforms, $service['platforms'] ?? []))) {
                     continue;
                 }
 

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -125,6 +125,22 @@ abstract class Format
         $this->enumBlacklist = $this->buildEnumBlacklist();
     }
 
+    /**
+     * Real platforms whose filters apply to this (possibly virtual) format platform.
+     *
+     * The isomorphic platform expands to client + server; all others map to themselves.
+     *
+     * @return array<string>
+     */
+    protected function effectivePlatforms(): array
+    {
+        if ($this->platform === APP_SDK_PLATFORM_ISOMORPHIC) {
+            return [APP_SDK_PLATFORM_CLIENT, APP_SDK_PLATFORM_SERVER];
+        }
+
+        return [$this->platform];
+    }
+
     protected function buildEnumBlacklist(): array
     {
         $blacklist = [];

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -172,7 +172,7 @@ class OpenAPI3 extends Format
                     $methodSecurities = $methodObj->getAuth();
                     $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
 
-                    if (!\in_array($this->platform, $methodSdkPlatforms)) {
+                    if (empty(\array_intersect($this->effectivePlatforms(), $methodSdkPlatforms))) {
                         continue;
                     }
 

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -179,7 +179,7 @@ class Swagger2 extends Format
                     $methodSecurities = $methodObj->getAuth();
                     $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
 
-                    if (!\in_array($this->platform, $methodSdkPlatforms)) {
+                    if (empty(\array_intersect($this->effectivePlatforms(), $methodSdkPlatforms))) {
                         continue;
                     }
 


### PR DESCRIPTION
## Summary

Adds a virtual `isomorphic` SDK platform whose spec is the union of the existing `client` and `server` specs. This lets a single SDK release (concretely: the web SDK) surface methods from both runtimes — including ones that are hidden from the `server` spec or auth-excluded from it.

Motivation: the upcoming isomorphic Web SDK (sdk-generator [#1512](https://github.com/appwrite/sdk-generator/pull/1512)) targets `--platform=server` but needs to keep all the methods previously shipped on the client side (e.g. `account.createOAuth2Session`, `account.createPushTarget` / `update` / `delete`) so existing browser callers don't regress. Without this PR, generating the web SDK against `--platform=server` drops those methods because they're hidden from / auth-excluded from the server spec.

## Changes

- `APP_SDK_PLATFORM_ISOMORPHIC = 'isomorphic'` constant
- `Specs.php`
  - Adds isomorphic to `getPlatforms()`, `getKeys()` (union of client + server keys), `getAuthCounts()`
  - Generalizes the route + service filters with an `effectivePlatformsFor()` helper that expands `isomorphic` to `[client, server]`; legacy single-platform behavior is preserved
- `SDKs.php`
  - New optional `specPlatform` config field per SDK; falls back to `family`. Lets a `server`-family SDK consume the `isomorphic` spec without changing its rendering family
- `Format.php` (base) — `effectivePlatforms()` helper
- `Format/Swagger2.php`, `Format/OpenAPI3.php` — use `effectivePlatforms()` in the additional-methods filter so rename pairs like `createMfaAuthenticator` ↔ `createMFAAuthenticator` continue to surface in the isomorphic spec

## Verification

Regenerated specs and the web SDK locally with `specPlatform: isomorphic` on a server-family `web` SDK config:

- `swagger2-1.9.x-isomorphic.json` contains 606 operations (= server's 602 + the four client-only `account.createOAuth2Session` / `createPushTarget` / `updatePushTarget` / `deletePushTarget`)
- Diffing generated `server-web/` against the live `appwrite/sdk-for-web` `main` branch shows zero method removals
- Rename pairs (`createMfaAuthenticator` + `createMFAAuthenticator`, etc.) both appear in the generated output

## Test plan

- [ ] CI passes
- [ ] Manual: `php app/cli.php specs --version=1.9.x --git=no` produces a non-empty `swagger2-1.9.x-isomorphic.json` whose operation count ≥ server spec's
- [ ] Manual: an SDK with `specPlatform => APP_SDK_PLATFORM_ISOMORPHIC` consumes that spec correctly