### PR TITLE
Fix: Update build status badge to point to main branch instead of master

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -15,7 +15,7 @@
 [![We're Hiring](https://img.shields.io/static/v1?label=We're&message=Hiring&color=blue&style=flat-square)](https://appwrite.io/company/careers)
 [![Hacktoberfest](https://img.shields.io/static/v1?label=hacktoberfest&message=friendly&color=191120&style=flat-square)](https://hacktoberfest.appwrite.io)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord?r=Github)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/appwrite/appwrite/tests.yml?branch=master&label=tests&style=flat-square)](https://github.com/appwrite/appwrite/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/appwrite/appwrite/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/appwrite/appwrite/actions)
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 
 <!-- [![Docker Pulls](https://img.shields.io/docker/pulls/appwrite/appwrite?color=f02e65&style=flat-square)](https://hub.docker.com/r/appwrite/appwrite) -->


### PR DESCRIPTION
## 🎯 What does this PR do?

Fix the build status badge in README files to point to the `main` branch instead of the deprecated `master` branch.

## 📝 Changes

- Updated build status badge URLs from `branch=master` to `branch=main`
- The badge now correctly displays CI/CD status for the main branch

## 🔗 Fixes

Closes #9594

## ✅ Checklist

- [x] I have read the Contributing Guidelines
- [x] Changes are tested locally
- [x] Related issue #9594 is referenced

