### PR TITLE
Fix: subspan ending main request span

### DIFF
--- a/src/Utopia/Bus/Bus.php
+++ b/src/Utopia/Bus/Bus.php
@@ -37,14 +37,19 @@ class Bus
 
         foreach ($listeners as $listener) {
             $deps = array_map($resolver, $listener->getInjections());
-            Span::init('listener.' . $listener::getName());
-            Span::add('bus.event', $event::class);
+
+            Span::current()?->add('listener.' . $listener::getName() . '.event', $event::class);
+            
             try {
                 ($listener->getCallback())($event, ...$deps);
+                Span::current()?->add('listener.' . $listener::getName() . '.success', true);
             } catch (\Throwable $e) {
-                Span::error($e);
-            } finally {
-                Span::current()?->finish();
+                Span::current()?->add('listener.' . $listener::getName() . '.success', false);
+                Span::current()?->add('listener.' . $listener::getName() . '.error.code', $e->getCode());
+                Span::current()?->add('listener.' . $listener::getName() . '.error.message', $e->getMessage());
+                Span::current()?->add('listener.' . $listener::getName() . '.error.line', $e->getLine());
+                Span::current()?->add('listener.' . $listener::getName() . '.error.file', $e->getFile());
+                Span::current()?->add('listener.' . $listener::getName() . '.error.trace', $e->getTraceAsString());
             }
         }
     }

--- a/src/Utopia/Bus/Bus.php
+++ b/src/Utopia/Bus/Bus.php
@@ -39,7 +39,7 @@ class Bus
             $deps = array_map($resolver, $listener->getInjections());
 
             Span::current()?->add('listener.' . $listener::getName() . '.event', $event::class);
-            
+
             try {
                 ($listener->getCallback())($event, ...$deps);
                 Span::current()?->add('listener.' . $listener::getName() . '.success', true);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

On Cloud I noticed span exporter was missing project ID. Further investigation showed this is due to busses initializing separate spans, causing loss of previous data.

This PR solves that. Ideal solution would be nested coroutine, but thats rabbit hole. Maybe later.

## Test Plan

Manual QA with Cloud situation that used to fail

## Related PRs and Issues

x

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
