### PR TITLE
Unify client and server SDK specs

### DIFF
--- a/app/config/sdks.php
+++ b/app/config/sdks.php
@@ -19,6 +19,10 @@ return [
                 'dev' => false,
                 'hidden' => false,
                 'family' => APP_SDK_PLATFORM_CLIENT,
+                'platforms' => [
+                    APP_SDK_PLATFORM_CLIENT,
+                    APP_SDK_PLATFORM_SERVER,
+                ],
                 'prism' => 'javascript',
                 'source' => \realpath(__DIR__ . '/../sdks/client-web'),
                 'gitUrl' => 'git@github.com:appwrite/sdk-for-web.git',

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -71,6 +71,89 @@ class SDKs extends Action
         ))));
     }
 
+    /**
+     * @param array<string> $platforms
+     */
+    protected function filterSpecForPlatforms(string $spec, array $platforms): string
+    {
+        $decoded = \json_decode($spec, true, flags: JSON_THROW_ON_ERROR);
+
+        foreach ($decoded['paths'] ?? [] as $path => $methods) {
+            foreach ($methods as $method => $operation) {
+                if (!\is_array($operation)) {
+                    continue;
+                }
+
+                $operationPlatforms = $operation['x-appwrite']['platforms'] ?? [];
+                if (empty(\array_intersect($platforms, $operationPlatforms))) {
+                    unset($decoded['paths'][$path][$method]);
+                    continue;
+                }
+
+                $decoded['paths'][$path][$method] = $this->applyPlatformSecurity($operation, $platforms);
+            }
+
+            if (empty($decoded['paths'][$path])) {
+                unset($decoded['paths'][$path]);
+            }
+        }
+
+        return \json_encode($decoded, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $operation
+     * @param array<string> $platforms
+     * @return array<string, mixed>
+     */
+    protected function applyPlatformSecurity(array $operation, array $platforms): array
+    {
+        $platformSecurity = $operation['x-appwrite']['platformSecurity'] ?? [];
+        if (!empty($platformSecurity)) {
+            $operation['x-appwrite']['auth'] = $this->mergePlatformSecurity($platformSecurity, $platforms);
+        }
+
+        foreach ($operation['x-appwrite']['methods'] ?? [] as $index => $method) {
+            $methodPlatforms = $method['platforms'] ?? [];
+            if (!empty($methodPlatforms) && empty(\array_intersect($platforms, $methodPlatforms))) {
+                unset($operation['x-appwrite']['methods'][$index]);
+                continue;
+            }
+
+            $methodPlatformSecurity = $method['platformSecurity'] ?? [];
+            if (!empty($methodPlatformSecurity)) {
+                $method['auth'] = $this->mergePlatformSecurity($methodPlatformSecurity, $platforms);
+                $operation['x-appwrite']['methods'][$index] = $method;
+            }
+        }
+
+        if (isset($operation['x-appwrite']['methods'])) {
+            $operation['x-appwrite']['methods'] = \array_values($operation['x-appwrite']['methods']);
+        }
+
+        return $operation;
+    }
+
+    /**
+     * @param array<string, list<array<string, array>>> $platformSecurity
+     * @param array<string> $platforms
+     * @return array<string, array>
+     */
+    protected function mergePlatformSecurity(array $platformSecurity, array $platforms): array
+    {
+        $merged = [];
+
+        foreach ($platforms as $platform) {
+            foreach ($platformSecurity[$platform] ?? [] as $security) {
+                foreach ($security as $name => $scopes) {
+                    $merged[$name] = $scopes;
+                }
+            }
+        }
+
+        return $merged;
+    }
+
     public function __construct()
     {
         $this
@@ -308,13 +391,26 @@ class SDKs extends Action
                 } else {
                     Console::log('  Fetching API spec...');
 
-                    $specPath = __DIR__ . '/../../../../app/config/specs/swagger2-' . $version . '-' . $language['family'] . '.json';
+                    $specPlatforms = $language['platforms'] ?? $language['specPlatforms'] ?? null;
+                    if (!\is_array($specPlatforms) && \in_array($language['family'], [APP_SDK_PLATFORM_CLIENT, APP_SDK_PLATFORM_SERVER], true)) {
+                        $specPlatforms = [$language['family']];
+                    }
+
+                    $specPath = \is_array($specPlatforms)
+                        ? __DIR__ . '/../../../../app/config/specs/swagger2-' . $version . '.json'
+                        : __DIR__ . '/../../../../app/config/specs/swagger2-' . $version . '-' . $language['family'] . '.json';
 
                     if (!file_exists($specPath)) {
                         throw new \Exception('Spec file not found: ' . $specPath . '. Please run "docker compose exec appwrite specs --version=' . $version . '" first to generate the specs.');
                     }
 
                     $spec = file_get_contents($specPath);
+                    if ($spec === false) {
+                        throw new \Exception('Failed to read spec file: ' . $specPath);
+                    }
+                    if (\is_array($specPlatforms)) {
+                        $spec = $this->filterSpecForPlatforms($spec, $specPlatforms);
+                    }
                 }
 
                 $cover = 'https://github.com/appwrite/appwrite/raw/main/public/images/github.png';

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -492,6 +492,47 @@ class Specs extends Action
         return $sdkPlatforms;
     }
 
+    /**
+     * @param array<string, array<string, mixed>> $keys
+     * @return array<string, mixed>
+     */
+    protected function getMergedPublicKeys(array $keys): array
+    {
+        return \array_replace(
+            $keys[APP_SDK_PLATFORM_CLIENT] ?? [],
+            $keys[APP_SDK_PLATFORM_SERVER] ?? [],
+        );
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $keys
+     * @return array<int, array{name: string, platform: string, targetPlatforms: array<string>, fileSuffix: string, keys: array<string, mixed>, authCount: int}>
+     */
+    protected function getSpecTargets(array $keys, array $authCounts): array
+    {
+        $targets = [
+            [
+                'name' => 'public',
+                'platform' => 'public',
+                'targetPlatforms' => [APP_SDK_PLATFORM_CLIENT, APP_SDK_PLATFORM_SERVER],
+                'fileSuffix' => '',
+                'keys' => $this->getMergedPublicKeys($keys),
+                'authCount' => 0,
+            ],
+        ];
+
+        $targets[] = [
+            'name' => APP_SDK_PLATFORM_CONSOLE,
+            'platform' => APP_SDK_PLATFORM_CONSOLE,
+            'targetPlatforms' => [APP_SDK_PLATFORM_CONSOLE],
+            'fileSuffix' => '-' . APP_SDK_PLATFORM_CONSOLE,
+            'keys' => $keys[APP_SDK_PLATFORM_CONSOLE],
+            'authCount' => $authCounts[APP_SDK_PLATFORM_CONSOLE] ?? 0,
+        ];
+
+        return $targets;
+    }
+
     public function action(string $version, string $mode, ?string $git, ?string $message, ?string $branch): void
     {
         if (\is_null($git)) {
@@ -525,9 +566,9 @@ class Specs extends Action
         $specsContainer->set('localeCodes', fn () => \array_map(fn ($locale) => $locale['code'], Config::getParam('locale-codes', [])));
         $specsContainer->set('plan', fn () => []);
 
-        $platforms = static::getPlatforms();
         $authCounts = $this->getAuthCounts();
         $keys = $this->getKeys();
+        $specTargets = $this->getSpecTargets($keys, $authCounts);
 
         $generatedFiles = [];
         $endpoint = System::getEnv('_APP_HOME', 'https://appwrite.io');
@@ -538,7 +579,9 @@ class Specs extends Action
             throw new Exception('Failed to create specs directory: ' . $specsDir);
         }
 
-        foreach ($platforms as $platform) {
+        foreach ($specTargets as $specTarget) {
+            $platform = $specTarget['platform'];
+            $targetPlatforms = $specTarget['targetPlatforms'];
             $routes = [];
             $models = [];
             $services = [];
@@ -559,7 +602,10 @@ class Specs extends Action
                         /** @var Method $sdk */
                         $hide = $sdk->isHidden();
 
-                        if ($hide === true || (\is_array($hide) && \in_array($platform, $hide))) {
+                        if (
+                            $hide === true
+                            || (\is_array($hide) && empty(\array_diff($targetPlatforms, $hide)))
+                        ) {
                             continue;
                         }
 
@@ -582,7 +628,7 @@ class Specs extends Action
                             continue;
                         }
 
-                        if (!\in_array($platform, $sdkPlatforms)) {
+                        if (empty(\array_intersect($targetPlatforms, $sdkPlatforms))) {
                             continue;
                         }
 
@@ -601,8 +647,8 @@ class Specs extends Action
                     continue;
                 }
 
-                // Check if current platform is included in service's platforms
-                if (!\in_array($platform, $service['platforms'] ?? [])) {
+                // Check if any target platform is included in service's platforms
+                if (empty(\array_intersect($targetPlatforms, $service['platforms'] ?? []))) {
                     continue;
                 }
 
@@ -615,7 +661,7 @@ class Specs extends Action
             $models = $response->getModels();
 
             foreach ($models as $key => $value) {
-                if ($platform !== APP_SDK_PLATFORM_CONSOLE && !$value->isPublic()) {
+                if (!\in_array(APP_SDK_PLATFORM_CONSOLE, $targetPlatforms, true) && !$value->isPublic()) {
                     unset($models[$key]);
                 }
             }
@@ -625,9 +671,12 @@ class Specs extends Action
                 $services,
                 $routes,
                 $models,
-                $keys[$platform],
-                $authCounts[$platform] ?? 0,
-                $platform
+                $specTarget['keys'],
+                $specTarget['authCount'],
+                $platform,
+                $targetPlatforms,
+                $authCounts,
+                $keys,
             ];
 
             foreach (['swagger2', 'open-api3'] as $format) {
@@ -652,14 +701,14 @@ class Specs extends Action
                     ->setParam('docs.url', $endpoint . '/docs');
 
                 $path = $mocks
-                    ? $specsDir . '/' . $format . '-mocks-' . $platform . '.json'
-                    : $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
+                    ? $specsDir . '/' . $format . '-mocks' . $specTarget['fileSuffix'] . '.json'
+                    : $specsDir . '/' . $format . '-' . $version . $specTarget['fileSuffix'] . '.json';
 
                 try {
                     $parsedSpecs = $specs->parse();
                     $this->verifyParsedSpec($parsedSpecs);
                 } catch (\RuntimeException $e) {
-                    throw new \RuntimeException("Spec generation failed for {$platform} ({$format}): " . $e->getMessage(), 0, $e);
+                    throw new \RuntimeException("Spec generation failed for {$specTarget['name']} ({$format}): " . $e->getMessage(), 0, $e);
                 }
 
                 $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);
@@ -710,13 +759,20 @@ class Specs extends Action
 
             // Copy generated spec files into specs/{version}/ subdirectory
             $prPlatforms = static::getPlatformsForPR();
+            $knownPlatforms = static::getPlatforms();
             $prFiles = \array_filter(
                 $generatedFiles,
-                fn (string $file) => \in_array(
-                    \substr(\basename($file, '.json'), \strrpos(\basename($file, '.json'), '-') + 1),
-                    $prPlatforms,
-                    true
-                )
+                function (string $file) use ($prPlatforms, $knownPlatforms): bool {
+                    $name = \basename($file, '.json');
+                    $suffix = \substr($name, \strrpos($name, '-') + 1);
+
+                    if (\in_array($suffix, $knownPlatforms, true)) {
+                        return \in_array($suffix, $prPlatforms, true);
+                    }
+
+                    return \in_array(APP_SDK_PLATFORM_CLIENT, $prPlatforms, true)
+                        || \in_array(APP_SDK_PLATFORM_SERVER, $prPlatforms, true);
+                }
             );
 
             $specsSubDir = $mocks ? 'mocks' : $version;

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK\Specification;
 
+use Appwrite\SDK\AuthType;
 use Appwrite\Utopia\Response\Model;
 use Utopia\Config\Config;
 use Utopia\DI\Container;
@@ -25,6 +26,21 @@ abstract class Format
     protected array $keys;
     protected int $authCount;
     protected string $platform;
+
+    /**
+     * @var array<string>
+     */
+    protected array $targetPlatforms;
+
+    /**
+     * @var array<string, int>
+     */
+    protected array $authCountsByPlatform;
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $keysByPlatform;
     protected array $params = [
         'name' => '',
         'description' => '',
@@ -112,8 +128,18 @@ abstract class Format
 
     protected array $enumBlacklist = [];
 
-    public function __construct(Container $container, array $services, array $routes, array $models, array $keys, int $authCount, string $platform)
-    {
+    public function __construct(
+        Container $container,
+        array $services,
+        array $routes,
+        array $models,
+        array $keys,
+        int $authCount,
+        string $platform,
+        ?array $targetPlatforms = null,
+        array $authCountsByPlatform = [],
+        array $keysByPlatform = [],
+    ) {
         $this->container = $container;
         $this->services = $services;
         $this->routes = $routes;
@@ -121,6 +147,9 @@ abstract class Format
         $this->keys = $keys;
         $this->authCount = $authCount;
         $this->platform = $platform;
+        $this->targetPlatforms = $targetPlatforms ?? [$platform];
+        $this->authCountsByPlatform = $authCountsByPlatform;
+        $this->keysByPlatform = $keysByPlatform;
 
         $this->enumBlacklist = $this->buildEnumBlacklist();
     }
@@ -440,6 +469,68 @@ abstract class Format
             'x-propertyNames' => $allKeys,
             'x-mapping' => $compoundMapping,
         ]);
+    }
+
+    /**
+     * @param array<AuthType> $routeSecurity
+     * @param array<string> $routePlatforms
+     * @return array<string, list<array<string, array>>>
+     */
+    protected function getPlatformSecurity(array $routeSecurity, array $routePlatforms): array
+    {
+        $platformSecurity = [];
+
+        foreach ($this->targetPlatforms as $platform) {
+            if (!\in_array($platform, $routePlatforms, true)) {
+                continue;
+            }
+
+            $securities = $this->getSecurityForPlatform($routeSecurity, $platform);
+
+            if (!empty($securities)) {
+                $platformSecurity[$platform] = [$securities];
+            }
+        }
+
+        return $platformSecurity;
+    }
+
+    /**
+     * @param array<AuthType> $routeSecurity
+     * @return array<string, array>
+     */
+    protected function getSecurityForPlatform(array $routeSecurity, string $platform): array
+    {
+        $keys = $this->keysByPlatform[$platform] ?? $this->keys;
+        $authCount = $this->authCountsByPlatform[$platform] ?? $this->authCount;
+        $securities = ['Project' => []];
+
+        foreach ($routeSecurity as $security) {
+            if (\array_key_exists($security->value, $keys)) {
+                $securities[$security->value] = [];
+            }
+        }
+
+        return \array_slice($securities, 0, $authCount);
+    }
+
+    protected function includesTargetPlatform(array $platforms): bool
+    {
+        return !empty(\array_intersect($this->targetPlatforms, $platforms));
+    }
+
+    protected function isMultiPlatformSpec(): bool
+    {
+        return \count($this->targetPlatforms) > 1;
+    }
+
+    protected function getIncludedPlatforms(array $platforms): array
+    {
+        if (!$this->isMultiPlatformSpec()) {
+            return \array_values(\array_unique($platforms));
+        }
+
+        return \array_values(\array_intersect($this->targetPlatforms, $platforms));
     }
 
     protected function getRequestEnumName(string $service, string $method, string $param): ?string

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -514,25 +514,6 @@ abstract class Format
         return \array_slice($securities, 0, $authCount);
     }
 
-    protected function includesTargetPlatform(array $platforms): bool
-    {
-        return !empty(\array_intersect($this->targetPlatforms, $platforms));
-    }
-
-    protected function isMultiPlatformSpec(): bool
-    {
-        return \count($this->targetPlatforms) > 1;
-    }
-
-    protected function getIncludedPlatforms(array $platforms): array
-    {
-        if (!$this->isMultiPlatformSpec()) {
-            return \array_values(\array_unique($platforms));
-        }
-
-        return \array_values(\array_intersect($this->targetPlatforms, $platforms));
-    }
-
     protected function getRequestEnumName(string $service, string $method, string $param): ?string
     {
         /* `$service` is `$namespace` */

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -146,7 +146,7 @@ class OpenAPI3 extends Format
                     'rate-time' => $route->getLabel('abuse-time', 3600),
                     'rate-key' => $route->getLabel('abuse-key', 'url:{url},ip:{ip}'),
                     'scope' => $route->getLabel('scope', ''),
-                    'platforms' => $sdkPlatforms,
+                    'platforms' => $this->getIncludedPlatforms($sdkPlatforms),
                     'packaging' => $sdk->isPackaging(),
                     'public' => $sdk->isPublic(),
                 ],
@@ -172,22 +172,16 @@ class OpenAPI3 extends Format
                     $methodSecurities = $methodObj->getAuth();
                     $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
 
-                    if (!\in_array($this->platform, $methodSdkPlatforms)) {
+                    if (!$this->includesTargetPlatform($methodSdkPlatforms)) {
                         continue;
                     }
 
-                    $methodSecurities = ['Project' => []];
-                    foreach ($methodObj->getAuth() as $security) {
-                        if (\array_key_exists($security->value, $this->keys)) {
-                            $methodSecurities[$security->value] = [];
-                        }
-                    }
+                    $methodSecurities = $this->getSecurityForPlatform($methodObj->getAuth(), $this->platform);
 
                     $additionalMethod = [
                         'name' => $methodObj->getMethodName(),
                         'namespace' => $methodObj->getNamespace(),
                         'desc' => $methodObj->getDesc(),
-                        'auth' => \array_slice($methodSecurities, 0, $this->authCount),
                         'parameters' => [],
                         'required' => [],
                         'responses' => [],
@@ -195,6 +189,13 @@ class OpenAPI3 extends Format
                         'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodObj->getMethodName()) . '.md',
                         'public' => $methodObj->isPublic(),
                     ];
+
+                    if ($this->isMultiPlatformSpec()) {
+                        $additionalMethod['platforms'] = $this->getIncludedPlatforms($methodSdkPlatforms);
+                        $additionalMethod['platformSecurity'] = $this->getPlatformSecurity($methodObj->getAuth(), $methodSdkPlatforms);
+                    } else {
+                        $additionalMethod['auth'] = $methodSecurities;
+                    }
 
                     // add deprecation only if method has it!
                     if ($methodObj->getDeprecated()) {
@@ -371,7 +372,11 @@ class OpenAPI3 extends Format
                     }
                 }
 
-                $temp['x-appwrite']['auth'] = array_slice($securities, 0, $this->authCount);
+                if ($this->isMultiPlatformSpec()) {
+                    $temp['x-appwrite']['platformSecurity'] = $this->getPlatformSecurity($sdk->getAuth(), $sdkPlatforms);
+                } else {
+                    $temp['x-appwrite']['auth'] = array_slice($securities, 0, $this->authCount);
+                }
                 $temp['security'][] = $securities;
             }
 

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -146,7 +146,9 @@ class OpenAPI3 extends Format
                     'rate-time' => $route->getLabel('abuse-time', 3600),
                     'rate-key' => $route->getLabel('abuse-key', 'url:{url},ip:{ip}'),
                     'scope' => $route->getLabel('scope', ''),
-                    'platforms' => $this->getIncludedPlatforms($sdkPlatforms),
+                    'platforms' => \count($this->targetPlatforms) > 1
+                        ? \array_values(\array_intersect($this->targetPlatforms, $sdkPlatforms))
+                        : \array_values(\array_unique($sdkPlatforms)),
                     'packaging' => $sdk->isPackaging(),
                     'public' => $sdk->isPublic(),
                 ],
@@ -172,11 +174,9 @@ class OpenAPI3 extends Format
                     $methodSecurities = $methodObj->getAuth();
                     $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
 
-                    if (!$this->includesTargetPlatform($methodSdkPlatforms)) {
+                    if (empty(\array_intersect($this->targetPlatforms, $methodSdkPlatforms))) {
                         continue;
                     }
-
-                    $methodSecurities = $this->getSecurityForPlatform($methodObj->getAuth(), $this->platform);
 
                     $additionalMethod = [
                         'name' => $methodObj->getMethodName(),
@@ -190,11 +190,11 @@ class OpenAPI3 extends Format
                         'public' => $methodObj->isPublic(),
                     ];
 
-                    if ($this->isMultiPlatformSpec()) {
-                        $additionalMethod['platforms'] = $this->getIncludedPlatforms($methodSdkPlatforms);
+                    if (\count($this->targetPlatforms) > 1) {
+                        $additionalMethod['platforms'] = \array_values(\array_intersect($this->targetPlatforms, $methodSdkPlatforms));
                         $additionalMethod['platformSecurity'] = $this->getPlatformSecurity($methodObj->getAuth(), $methodSdkPlatforms);
                     } else {
-                        $additionalMethod['auth'] = $methodSecurities;
+                        $additionalMethod['auth'] = $this->getSecurityForPlatform($methodObj->getAuth(), $this->platform);
                     }
 
                     // add deprecation only if method has it!
@@ -372,7 +372,7 @@ class OpenAPI3 extends Format
                     }
                 }
 
-                if ($this->isMultiPlatformSpec()) {
+                if (\count($this->targetPlatforms) > 1) {
                     $temp['x-appwrite']['platformSecurity'] = $this->getPlatformSecurity($sdk->getAuth(), $sdkPlatforms);
                 } else {
                     $temp['x-appwrite']['auth'] = array_slice($securities, 0, $this->authCount);

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -3,7 +3,6 @@
 namespace Appwrite\SDK\Specification\Format;
 
 use Appwrite\Platform\Tasks\Specs;
-use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\MethodType;
@@ -106,9 +105,10 @@ class Swagger2 extends Format
             $additionalMethods = null;
             if (\is_array($sdk)) {
                 $additionalMethods = $sdk;
-                /** @var Method $sdk */
                 $sdk = $sdk[0];
             }
+
+            /** @var Method $sdk */
 
             $consumes = [];
             if (strtoupper($route->getMethod()) !== 'GET' && strtoupper($route->getMethod()) !== 'HEAD') {
@@ -149,7 +149,7 @@ class Swagger2 extends Format
                     'rate-time' => $route->getLabel('abuse-time', 3600),
                     'rate-key' => $route->getLabel('abuse-key', 'url:{url},ip:{ip}'),
                     'scope' => $route->getLabel('scope', ''),
-                    'platforms' => $sdkPlatforms,
+                    'platforms' => $this->getIncludedPlatforms($sdkPlatforms),
                     'packaging' => $sdk->isPackaging(),
                     'public' => $sdk->isPublic(),
                 ],
@@ -179,23 +179,16 @@ class Swagger2 extends Format
                     $methodSecurities = $methodObj->getAuth();
                     $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
 
-                    if (!\in_array($this->platform, $methodSdkPlatforms)) {
+                    if (!$this->includesTargetPlatform($methodSdkPlatforms)) {
                         continue;
                     }
 
-                    $methodSecurities = ['Project' => []];
-                    foreach ($methodObj->getAuth() as $security) {
-                        /** @var AuthType $security */
-                        if (\array_key_exists($security->value, $this->keys)) {
-                            $methodSecurities[$security->value] = [];
-                        }
-                    }
+                    $methodSecurities = $this->getSecurityForPlatform($methodObj->getAuth(), $this->platform);
 
                     $additionalMethod = [
                         'name' => $methodObj->getMethodName(),
                         'namespace' => $methodObj->getNamespace(),
                         'desc' => $methodObj->getDesc(),
-                        'auth' => \array_slice($methodSecurities, 0, $this->authCount),
                         'parameters' => [],
                         'required' => [],
                         'responses' => [],
@@ -203,6 +196,13 @@ class Swagger2 extends Format
                         'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodObj->getMethodName()) . '.md',
                         'public' => $methodObj->isPublic(),
                     ];
+
+                    if ($this->isMultiPlatformSpec()) {
+                        $additionalMethod['platforms'] = $this->getIncludedPlatforms($methodSdkPlatforms);
+                        $additionalMethod['platformSecurity'] = $this->getPlatformSecurity($methodObj->getAuth(), $methodSdkPlatforms);
+                    } else {
+                        $additionalMethod['auth'] = $methodSecurities;
+                    }
 
                     // add deprecation only if method has it!
                     if ($methodObj->getDeprecated()) {
@@ -368,7 +368,11 @@ class Swagger2 extends Format
                     }
                 }
 
-                $temp['x-appwrite']['auth'] = \array_slice($securities, 0, $this->authCount);
+                if ($this->isMultiPlatformSpec()) {
+                    $temp['x-appwrite']['platformSecurity'] = $this->getPlatformSecurity($sdk->getAuth(), $sdkPlatforms);
+                } else {
+                    $temp['x-appwrite']['auth'] = \array_slice($securities, 0, $this->authCount);
+                }
                 $temp['security'][] = $securities;
             }
 
@@ -385,7 +389,7 @@ class Swagger2 extends Format
 
             $parameters = \array_merge(
                 $route->getParams(),
-                $sdk->getAdditionalParameters() ?? [],
+                $sdk->getAdditionalParameters(),
             );
 
             foreach ($parameters as $name => $param) { // Set params

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -149,7 +149,9 @@ class Swagger2 extends Format
                     'rate-time' => $route->getLabel('abuse-time', 3600),
                     'rate-key' => $route->getLabel('abuse-key', 'url:{url},ip:{ip}'),
                     'scope' => $route->getLabel('scope', ''),
-                    'platforms' => $this->getIncludedPlatforms($sdkPlatforms),
+                    'platforms' => \count($this->targetPlatforms) > 1
+                        ? \array_values(\array_intersect($this->targetPlatforms, $sdkPlatforms))
+                        : \array_values(\array_unique($sdkPlatforms)),
                     'packaging' => $sdk->isPackaging(),
                     'public' => $sdk->isPublic(),
                 ],
@@ -179,11 +181,9 @@ class Swagger2 extends Format
                     $methodSecurities = $methodObj->getAuth();
                     $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
 
-                    if (!$this->includesTargetPlatform($methodSdkPlatforms)) {
+                    if (empty(\array_intersect($this->targetPlatforms, $methodSdkPlatforms))) {
                         continue;
                     }
-
-                    $methodSecurities = $this->getSecurityForPlatform($methodObj->getAuth(), $this->platform);
 
                     $additionalMethod = [
                         'name' => $methodObj->getMethodName(),
@@ -197,11 +197,11 @@ class Swagger2 extends Format
                         'public' => $methodObj->isPublic(),
                     ];
 
-                    if ($this->isMultiPlatformSpec()) {
-                        $additionalMethod['platforms'] = $this->getIncludedPlatforms($methodSdkPlatforms);
+                    if (\count($this->targetPlatforms) > 1) {
+                        $additionalMethod['platforms'] = \array_values(\array_intersect($this->targetPlatforms, $methodSdkPlatforms));
                         $additionalMethod['platformSecurity'] = $this->getPlatformSecurity($methodObj->getAuth(), $methodSdkPlatforms);
                     } else {
-                        $additionalMethod['auth'] = $methodSecurities;
+                        $additionalMethod['auth'] = $this->getSecurityForPlatform($methodObj->getAuth(), $this->platform);
                     }
 
                     // add deprecation only if method has it!
@@ -368,7 +368,7 @@ class Swagger2 extends Format
                     }
                 }
 
-                if ($this->isMultiPlatformSpec()) {
+                if (\count($this->targetPlatforms) > 1) {
                     $temp['x-appwrite']['platformSecurity'] = $this->getPlatformSecurity($sdk->getAuth(), $sdkPlatforms);
                 } else {
                     $temp['x-appwrite']['auth'] = \array_slice($securities, 0, $this->authCount);


### PR DESCRIPTION
## Summary
- generate one public client+server spec plus the console spec
- add platformSecurity metadata for platform-specific SDK auth
- update SDK generation to filter merged specs by target platform
- configure the Web SDK to consume both client and server methods

## Tests
- php -l changed files
- php app/cli.php specs --version=1.9.x --git=no
- php app/cli.php sdks --platform=client --sdk=web --version=1.9.x --git=no --mode=examples
- php app/cli.php sdks --platform=server --sdk=nodejs --version=1.9.x --git=no --mode=examples