### PR TITLE
fix: keep single SMTP recipient in To header

### DIFF
--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -624,8 +624,8 @@ class Messaging extends Action
         $content = $data['content'];
         $html = $data['html'] ?? false;
 
-        // For SMTP, move all recipients to BCC and use default recipient in TO field
-        if ($provider->getAttribute('provider') === 'smtp') {
+        // For SMTP batches with multiple recipients, keep addresses hidden from each other.
+        if ($provider->getAttribute('provider') === 'smtp' && \count($to) > 1) {
             foreach ($to as $recipient) {
                 $bcc[] = ['email' => $recipient];
             }


### PR DESCRIPTION
## What does this PR do?

Keeps the original `To` recipient when a custom SMTP email batch contains exactly one recipient.

On `1.9.x`, `buildEmailMessage()` currently moves every SMTP recipient into BCC and then passes an empty `To` array into `Email`. That matches the missing visible `To` header reported in #12365 for normal single-recipient sends.

For multi-recipient SMTP batches, this PR keeps the existing BCC behavior so recipients are not exposed to each other.

## Test Plan

- `git diff --check`

I could not run `php -l src/Appwrite/Platform/Workers/Messaging.php` locally because PHP is not installed in this Windows environment.

## Related

- Fixes #12365
- This should compose with #11300: if email batches are later forced to one recipient for privacy, those single-recipient SMTP emails will keep a real `To` header instead of being rewritten to BCC.

This was implemented with Codex assistance, with the final diff manually reviewed and kept focused.
