### PR TITLE
fix(migrations): correctly route SourceAppwrite reads to local DB or SDK

### DIFF
--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -210,8 +210,6 @@ class Migrations extends Action
 
             // Same projectId may collide with an external Appwrite — trust the DB fast
             // path only when the source URL targets this cluster's public or internal host.
-            // Env values are run through parse_url too so a port suffix (appwrite:8080)
-            // can't break equality with the port-stripped source host.
             $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
             $rawDomain = System::getEnv('_APP_DOMAIN', '');
             $rawMigrationHost = System::getEnv('_APP_MIGRATION_HOST', '');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -488,7 +488,10 @@ class Migrations extends Action
         try {
             $credentials = $migration->getAttribute('credentials', []);
 
-            if ($migration->getAttribute('source') === SourceAppwrite::getName()) {
+            // Appwrite -> Appwrite requires explicit user-supplied source credentials;
+            // defaulting would silently self-call with the destination's own key.
+            if ($migration->getAttribute('source') === SourceAppwrite::getName()
+                && $migration->getAttribute('destination') !== DestinationAppwrite::getName()) {
                 $credentials['projectId'] = $credentials['projectId'] ?? $project->getId();
                 $credentials['apiKey'] = $credentials['apiKey'] ?? $tempAPIKey;
                 $credentials['endpoint'] = $credentials['endpoint'] ?? $endpoint;

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -205,10 +205,6 @@ class Migrations extends Action
             $isAppwriteToAppwrite = $source === SourceAppwrite::getName()
                 && $destination === DestinationAppwrite::getName();
 
-            if ($isAppwriteToAppwrite && (empty($credentials['endpoint']) || empty($credentials['apiKey']))) {
-                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
-            }
-
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
             $isLocalSource = false;
@@ -218,11 +214,18 @@ class Migrations extends Action
                 } else {
                     // For Appwrite -> Appwrite, require apiKey to actually belong to
                     // the local project — a destination reusing the source's id
-                    // would otherwise collide.
-                    $keyMatches = !$this->dbForPlatform->findOne('keys', [
-                        Query::equal('secret', [$credentials['apiKey']]),
+                    // would otherwise collide. `secret` is encrypted at rest so it
+                    // can't be queried directly; read the project's keys and compare
+                    // in memory (typical project has <10 keys).
+                    $keyMatches = false;
+                    foreach ($this->dbForPlatform->find('keys', [
                         Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                    ])->isEmpty();
+                    ]) as $key) {
+                        if ($key->getAttribute('secret') === $credentials['apiKey']) {
+                            $keyMatches = true;
+                            break;
+                        }
+                    }
                     $sameRegion = $this->sourceProject->getAttribute('region', 'default')
                         === $this->project->getAttribute('region', 'default');
                     $isLocalSource = $keyMatches && $sameRegion;
@@ -487,19 +490,14 @@ class Migrations extends Action
 
         try {
             $credentials = $migration->getAttribute('credentials', []);
-            $isAppwriteSource = $migration->getAttribute('source') === SourceAppwrite::getName();
-            $isAppwriteDestination = $migration->getAttribute('destination') === DestinationAppwrite::getName();
-            $isAppwriteToAppwrite = $isAppwriteSource && $isAppwriteDestination;
 
-            // Appwrite -> Appwrite requires explicit user-supplied source credentials;
-            // defaulting would silently self-call with the destination's own key.
-            if ($isAppwriteSource && !$isAppwriteToAppwrite) {
+            if ($migration->getAttribute('source') === SourceAppwrite::getName()) {
                 $credentials['projectId'] = $credentials['projectId'] ?? $project->getId();
                 $credentials['apiKey'] = $credentials['apiKey'] ?? $tempAPIKey;
                 $credentials['endpoint'] = $credentials['endpoint'] ?? $endpoint;
             }
 
-            if ($isAppwriteDestination) {
+            if ($migration->getAttribute('destination') === DestinationAppwrite::getName()) {
                 $credentials['destinationApiKey'] = $tempAPIKey;
                 $credentials['destinationEndpoint'] = $endpoint;
             }

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -207,11 +207,8 @@ class Migrations extends Action
 
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            // Same projectId on source and destination only means "local" when the source
-            // endpoint's host is one of this installation's hostnames — _APP_DOMAIN is the
-            // public host users paste from console; _APP_MIGRATION_HOST is the internal one
-            // workers default to when the caller omits `endpoint`. Anything else is an
-            // external Appwrite that happens to share an id, and we must go over SDK/HTTP.
+            // Same projectId may collide with an external Appwrite — trust the DB fast
+            // path only when the source URL targets this cluster's public or internal host.
             $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
             $localDomain = System::getEnv('_APP_DOMAIN', '');
             $migrationHost = System::getEnv('_APP_MIGRATION_HOST', '');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -228,9 +228,10 @@ class Migrations extends Action
             // a configured custom domain still get the DB fast path.
             $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
                 || (empty($credentials['endpoint']) && $migrationHost !== '')
-                || (is_string($sourceHost) && !$this->dbForPlatform->findOne('rules', [
+                || (is_string($sourceHost) && !$this->sourceProject->isEmpty() && !$this->dbForPlatform->findOne('rules', [
                     Query::equal('domain', [$sourceHost]),
                     Query::equal('type', ['api']),
+                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
                 ])->isEmpty());
 
             $isLocalSource = !$this->sourceProject->isEmpty()

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -202,20 +202,20 @@ class Migrations extends Action
         }
 
         if (! empty($credentials['projectId'])) {
+            $isAppwriteToAppwrite = $source === SourceAppwrite::getName()
+                && $destination === DestinationAppwrite::getName();
+
+            if ($isAppwriteToAppwrite && (empty($credentials['endpoint']) || empty($credentials['apiKey']))) {
+                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
+            }
+
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            // For Appwrite -> Appwrite, "project exists locally with this id" is not
-            // enough to take the DB fast path: a destination project deliberately
-            // created with the source's projectId (to preserve cross-references like
-            // createdBy/userId) would collide. Verify the user-supplied apiKey actually
-            // belongs to the local project — only then is it safe to read direct.
+            // Verify the apiKey belongs to the local project — a destination project
+            // deliberately reusing the source's projectId would otherwise be mistaken
+            // for the source and migrate zero rows.
             $isLocalSource = false;
-            if (
-                $source === SourceAppwrite::getName()
-                && $destination === DestinationAppwrite::getName()
-                && !$this->sourceProject->isEmpty()
-                && !empty($credentials['apiKey'])
-            ) {
+            if ($isAppwriteToAppwrite && !$this->sourceProject->isEmpty()) {
                 $keyDoc = $this->dbForPlatform->findOne('keys', [
                     Query::equal('secret', [$credentials['apiKey']]),
                     Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
@@ -225,8 +225,7 @@ class Migrations extends Action
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');
-            $useAppwriteApiSource = $source === SourceAppwrite::getName()
-                && $destination === DestinationAppwrite::getName()
+            $useAppwriteApiSource = $isAppwriteToAppwrite
                 && (!$isLocalSource || $sourceRegion !== $destinationRegion);
 
             if (! $useAppwriteApiSource) {
@@ -234,13 +233,6 @@ class Migrations extends Action
                     throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
                 }
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
-            } elseif (!$isLocalSource) {
-                // External source — processMigration defaults missing endpoint/apiKey to this
-                // instance, which would silently self-call with the destination's key. Require
-                // explicit credentials so the failure mode is clear.
-                if (empty($credentials['endpoint']) || empty($credentials['apiKey'])) {
-                    throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
-                }
             }
         }
         $getDatabasesDB = fn (Document $database): Database =>

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -211,7 +211,12 @@ class Migrations extends Action
             // path only when the source URL targets this cluster's public or internal host.
             $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
             $localDomain = System::getEnv('_APP_DOMAIN', '');
-            $migrationHost = System::getEnv('_APP_MIGRATION_HOST', '');
+            // _APP_MIGRATION_HOST may include a port (appwrite:8080); strip it the same
+            // way parse_url does for the source URL so the equality check stays correct.
+            $migrationHostEnv = System::getEnv('_APP_MIGRATION_HOST', '');
+            $migrationHost = $migrationHostEnv !== ''
+                ? (parse_url('http://' . $migrationHostEnv, PHP_URL_HOST) ?: $migrationHostEnv)
+                : '';
 
             $matchesDomain = $localDomain !== ''
                 && ($sourceHost === $localDomain || str_ends_with((string) $sourceHost, '.' . $localDomain));

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -223,16 +223,22 @@ class Migrations extends Action
                 $migrationHost,
             ]);
 
-            // Empty endpoint: processMigration defaults it to the internal host before reaching here.
-            // Custom API domains are looked up directly in `rules` so customers using
+            // Include the source project's custom API domain so customers using
             // a configured custom domain still get the DB fast path.
-            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
-                || (empty($credentials['endpoint']) && $migrationHost !== '')
-                || (is_string($sourceHost) && !$this->sourceProject->isEmpty() && !$this->dbForPlatform->findOne('rules', [
+            if (is_string($sourceHost) && !$this->sourceProject->isEmpty()) {
+                $rule = $this->dbForPlatform->findOne('rules', [
                     Query::equal('domain', [$sourceHost]),
                     Query::equal('type', ['api']),
                     Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                ])->isEmpty());
+                ]);
+                if (!$rule->isEmpty()) {
+                    $allowedHosts[] = $sourceHost;
+                }
+            }
+
+            // Empty endpoint: processMigration defaults it to the internal host before reaching here.
+            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
+                || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $isLocalSource = !$this->sourceProject->isEmpty()
                 && (!$isAppwriteSource || $isLocalEndpoint);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -211,28 +211,32 @@ class Migrations extends Action
 
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            // Verify the apiKey belongs to the local project — a destination project
-            // deliberately reusing the source's projectId would otherwise be mistaken
-            // for the source and migrate zero rows.
-            $isLocalSource = false;
-            if ($isAppwriteToAppwrite && !$this->sourceProject->isEmpty()) {
-                $keyDoc = $this->dbForPlatform->findOne('keys', [
-                    Query::equal('secret', [$credentials['apiKey']]),
-                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                ]);
-                $isLocalSource = $keyDoc !== false && !$keyDoc->isEmpty();
-            }
-
-            $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
-            $destinationRegion = $this->project->getAttribute('region', 'default');
-            $useAppwriteApiSource = $isAppwriteToAppwrite
-                && (!$isLocalSource || $sourceRegion !== $destinationRegion);
-
-            if (! $useAppwriteApiSource) {
-                if ($this->sourceProject->isEmpty()) {
+            if ($this->sourceProject->isEmpty()) {
+                if (!$isAppwriteToAppwrite) {
                     throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
                 }
-                $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
+                $useAppwriteApiSource = true;
+            } else {
+                // Verify the apiKey belongs to the local project — a destination project
+                // deliberately reusing the source's projectId would otherwise be mistaken
+                // for the source and migrate zero rows.
+                $isLocalSource = false;
+                if ($isAppwriteToAppwrite) {
+                    $keyDoc = $this->dbForPlatform->findOne('keys', [
+                        Query::equal('secret', [$credentials['apiKey']]),
+                        Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
+                    ]);
+                    $isLocalSource = $keyDoc !== false && !$keyDoc->isEmpty();
+                }
+
+                $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
+                $destinationRegion = $this->project->getAttribute('region', 'default');
+                $useAppwriteApiSource = $isAppwriteToAppwrite
+                    && (!$isLocalSource || $sourceRegion !== $destinationRegion);
+
+                if (! $useAppwriteApiSource) {
+                    $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
+                }
             }
         }
         $getDatabasesDB = fn (Document $database): Database =>

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -223,22 +223,15 @@ class Migrations extends Action
                 $migrationHost,
             ]);
 
-            // Include the source project's custom API domains so customers using
-            // a configured custom domain still get the DB fast path.
-            if (!$this->sourceProject->isEmpty()) {
-                $rules = $this->dbForPlatform->find('rules', [
-                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                    Query::equal('type', ['api']),
-                    Query::limit(100),
-                ]);
-                foreach ($rules as $rule) {
-                    $allowedHosts[] = $rule->getAttribute('domain');
-                }
-            }
-
             // Empty endpoint: processMigration defaults it to the internal host before reaching here.
+            // Custom API domains are looked up directly in `rules` so customers using
+            // a configured custom domain still get the DB fast path.
             $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
-                || (empty($credentials['endpoint']) && $migrationHost !== '');
+                || (empty($credentials['endpoint']) && $migrationHost !== '')
+                || (is_string($sourceHost) && !$this->dbForPlatform->findOne('rules', [
+                    Query::equal('domain', [$sourceHost]),
+                    Query::equal('type', ['api']),
+                ])->isEmpty());
 
             $isLocalSource = !$this->sourceProject->isEmpty()
                 && (!$isAppwriteSource || $isLocalEndpoint);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -211,7 +211,17 @@ class Migrations extends Action
 
             $candidate = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            if ($this->canReadSourceFromLocalDb($candidate, $credentials, $isAppwriteToAppwrite)) {
+            // For Appwrite -> Appwrite, require apiKey to actually belong to the local
+            // project — a destination reusing the source's id would otherwise collide.
+            $isLocalSource = !$candidate->isEmpty() && (!$isAppwriteToAppwrite || (
+                !$this->dbForPlatform->findOne('keys', [
+                    Query::equal('secret', [$credentials['apiKey']]),
+                    Query::equal('projectInternalId', [$candidate->getSequence()]),
+                ])->isEmpty()
+                && $candidate->getAttribute('region', 'default') === $this->project->getAttribute('region', 'default')
+            ));
+
+            if ($isLocalSource) {
                 $this->sourceProject = $candidate;
                 $projectDB = call_user_func($this->getProjectDB, $candidate);
             } elseif ($isAppwriteToAppwrite) {
@@ -278,38 +288,6 @@ class Migrations extends Action
         $this->sourceReport = $migrationSource->report($resources);
 
         return $migrationSource;
-    }
-
-    /**
-     * The local platform DB only holds the truth for the *destination* project. For
-     * SourceAppwrite -> DestinationAppwrite we may find a same-id project locally
-     * that isn't actually the source (a destination project deliberately created
-     * with the source's id to preserve cross-references). Verify the supplied apiKey
-     * belongs to that local project before trusting it; same-region match is the
-     * final gate before the direct-DB fast path.
-     */
-    private function canReadSourceFromLocalDb(Document $candidate, array $credentials, bool $isAppwriteToAppwrite): bool
-    {
-        if ($candidate->isEmpty()) {
-            return false;
-        }
-
-        // Source -> CSV/JSON/Backup always reads the local DB; no cross-cluster
-        // semantics, so a successful lookup is enough.
-        if (!$isAppwriteToAppwrite) {
-            return true;
-        }
-
-        $keyDoc = $this->dbForPlatform->findOne('keys', [
-            Query::equal('secret', [$credentials['apiKey']]),
-            Query::equal('projectInternalId', [$candidate->getSequence()]),
-        ]);
-        if ($keyDoc->isEmpty()) {
-            return false;
-        }
-
-        return $candidate->getAttribute('region', 'default')
-            === $this->project->getAttribute('region', 'default');
     }
 
     /**

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -247,8 +247,10 @@ class Migrations extends Action
         }
 
         $sourceEndpoint = $credentials['endpoint'] ?? '';
-        if ($source === SourceAppwrite::getName()) {
-            // Loopback isn't reachable from the worker container; rewrite to internal host.
+        if ($source === SourceAppwrite::getName() && !$useAppwriteApiSource) {
+            // Rewrite loopback only on the DB fast path. On the SDK path, the user-supplied
+            // endpoint is authoritative — silently redirecting it to the internal host would
+            // turn a misrouted external migration into a self-call against this cluster.
             $sourceEndpoint = $this->resolveLocalEndpoint($sourceEndpoint);
         }
 

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -237,13 +237,8 @@ class Migrations extends Action
                 }
             }
 
-            // Loopback addresses are always "this cluster" from a worker's perspective.
-            $isLoopback = is_string($sourceHost)
-                && in_array(strtolower($sourceHost), ['localhost', '127.0.0.1', '0.0.0.0', '::1'], true);
-
             // Empty endpoint: processMigration defaults it to the internal host before reaching here.
-            $isLocalEndpoint = $isLoopback
-                || (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
+            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
                 || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $isLocalSource = !$this->sourceProject->isEmpty()

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -207,25 +207,12 @@ class Migrations extends Action
 
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            $isLocalSource = false;
-            if (!$this->sourceProject->isEmpty()) {
-                if (!$isAppwriteToAppwrite) {
-                    $isLocalSource = true;
-                } else {
-                    // `secret` is encrypted at rest — load project keys and compare in memory.
-                    $projectKeys = $this->dbForPlatform->find('keys', [
-                        Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                    ]);
-                    $keyMatches = in_array(
-                        $credentials['apiKey'],
-                        array_map(fn (Document $k) => $k->getAttribute('secret'), $projectKeys),
-                        true
-                    );
-                    $sameRegion = $this->sourceProject->getAttribute('region', 'default')
-                        === $this->project->getAttribute('region', 'default');
-                    $isLocalSource = $keyMatches && $sameRegion;
-                }
-            }
+            // Same projectId on source and destination only means "local" when the source
+            // endpoint points at this installation — otherwise it's an external Appwrite
+            // that happens to share an id, and we must go over SDK/HTTP.
+            $isLocalSource = !$this->sourceProject->isEmpty()
+                && (!$isAppwriteToAppwrite
+                    || str_contains($credentials['endpoint'] ?? '', System::getEnv('_APP_DOMAIN', '_')));
 
             if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -224,8 +224,26 @@ class Migrations extends Action
                 $migrationHost,
             ]);
 
+            // Include the source project's custom API domains so customers using
+            // a configured custom domain still get the DB fast path.
+            if (!$this->sourceProject->isEmpty()) {
+                $rules = $this->dbForPlatform->find('rules', [
+                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
+                    Query::equal('type', ['api']),
+                    Query::limit(100),
+                ]);
+                foreach ($rules as $rule) {
+                    $allowedHosts[] = $rule->getAttribute('domain');
+                }
+            }
+
+            // Loopback addresses are always "this cluster" from a worker's perspective.
+            $isLoopback = is_string($sourceHost)
+                && in_array(strtolower($sourceHost), ['localhost', '127.0.0.1', '0.0.0.0', '::1'], true);
+
             // Empty endpoint: processMigration defaults it to the internal host before reaching here.
-            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
+            $isLocalEndpoint = $isLoopback
+                || (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
                 || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $isLocalSource = !$this->sourceProject->isEmpty()

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -203,16 +203,16 @@ class Migrations extends Action
 
         if (! empty($credentials['projectId'])) {
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
-            if ($this->sourceProject->isEmpty()) {
-                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
-            }
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');
             $useAppwriteApiSource = $source === SourceAppwrite::getName()
                 && $destination === DestinationAppwrite::getName()
-                && $sourceRegion !== $destinationRegion;
+                && ($this->sourceProject->isEmpty() || $sourceRegion !== $destinationRegion);
             if (! $useAppwriteApiSource) {
+                if ($this->sourceProject->isEmpty()) {
+                    throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
+                }
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
             }
         }

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -226,7 +226,7 @@ class Migrations extends Action
                         Query::equal('secret', [$credentials['apiKey']]),
                         Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
                     ]);
-                    $isLocalSource = $keyDoc !== false && !$keyDoc->isEmpty();
+                    $isLocalSource = !$keyDoc->isEmpty();
                 }
 
                 $sourceRegion = $this->sourceProject->getAttribute('region', 'default');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -216,7 +216,10 @@ class Migrations extends Action
             $matchesDomain = $localDomain !== ''
                 && ($sourceHost === $localDomain || str_ends_with((string) $sourceHost, '.' . $localDomain));
             $matchesInternal = $migrationHost !== '' && $sourceHost === $migrationHost;
-            $isLocalEndpoint = is_string($sourceHost) && ($matchesDomain || $matchesInternal);
+            // Empty endpoint is defaulted to the internal host by processMigration, so
+            // treat it as local up-front for callers that bypass that defaulting (tests).
+            $isLocalEndpoint = (is_string($sourceHost) && ($matchesDomain || $matchesInternal))
+                || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $isLocalSource = !$this->sourceProject->isEmpty()
                 && (!$isAppwriteToAppwrite || $isLocalEndpoint);
@@ -234,6 +237,14 @@ class Migrations extends Action
         $queries = [];
         if ($source === SourceAppwrite::getName() && in_array($destination, [DestinationCSV::getName(), DestinationJSON::getName()])) {
             $queries = Query::parseQueries($migrationOptions['queries'] ?? []);
+        }
+
+        $sourceEndpoint = $credentials['endpoint'] ?? '';
+        if ($source === SourceAppwrite::getName()) {
+            // Loopback URLs are unreachable from inside the worker container — rewrite
+            // them to the internal host on both DB and SDK paths so the SDK fallback /
+            // primary call resolves. SDK auth (apiKey) still gates access on the SDK path.
+            $sourceEndpoint = $this->resolveLocalEndpoint($sourceEndpoint);
         }
 
         $migrationSource = match ($source) {
@@ -260,7 +271,7 @@ class Migrations extends Action
             ),
             SourceAppwrite::getName() => new SourceAppwrite(
                 $credentials['projectId'],
-                $credentials['endpoint'],
+                $sourceEndpoint,
                 $credentials['apiKey'],
                 $getDatabasesDB,
                 $useAppwriteApiSource ? SourceAppwrite::SOURCE_API : SourceAppwrite::SOURCE_DATABASE,
@@ -470,12 +481,7 @@ class Migrations extends Action
         $aggregatedResources = [];
         $caughtError = null;
 
-        $host = System::getEnv('_APP_MIGRATION_HOST');
-        if (empty($host)) {
-            throw new \Exception('_APP_MIGRATION_HOST is not set');
-        }
-
-        $endpoint = 'http://' . $host . '/v1';
+        $endpoint = $this->getMigrationEndpoint();
 
         try {
             $credentials = $migration->getAttribute('credentials', []);
@@ -680,6 +686,34 @@ class Migrations extends Action
         }
 
         return ($this->getDatabasesDB)($database);
+    }
+
+    private function resolveLocalEndpoint(string $endpoint): string
+    {
+        if ($endpoint === '') {
+            return $this->getMigrationEndpoint();
+        }
+
+        $host = parse_url($endpoint, PHP_URL_HOST);
+        if (!is_string($host)) {
+            return $endpoint;
+        }
+
+        if (!in_array(strtolower($host), ['localhost', '127.0.0.1', '0.0.0.0', '::1'], true)) {
+            return $endpoint;
+        }
+
+        return $this->getMigrationEndpoint();
+    }
+
+    private function getMigrationEndpoint(): string
+    {
+        $host = System::getEnv('_APP_MIGRATION_HOST');
+        if (empty($host)) {
+            throw new \Exception('_APP_MIGRATION_HOST is not set');
+        }
+
+        return 'http://' . $host . '/v1';
     }
 
     /**

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -209,34 +209,15 @@ class Migrations extends Action
                 throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
             }
 
-            $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
+            $candidate = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            if ($this->sourceProject->isEmpty()) {
-                if (!$isAppwriteToAppwrite) {
-                    throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
-                }
+            if ($this->canReadSourceFromLocalDb($candidate, $credentials, $isAppwriteToAppwrite)) {
+                $this->sourceProject = $candidate;
+                $projectDB = call_user_func($this->getProjectDB, $candidate);
+            } elseif ($isAppwriteToAppwrite) {
                 $useAppwriteApiSource = true;
             } else {
-                // Verify the apiKey belongs to the local project — a destination project
-                // deliberately reusing the source's projectId would otherwise be mistaken
-                // for the source and migrate zero rows.
-                $isLocalSource = false;
-                if ($isAppwriteToAppwrite) {
-                    $keyDoc = $this->dbForPlatform->findOne('keys', [
-                        Query::equal('secret', [$credentials['apiKey']]),
-                        Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                    ]);
-                    $isLocalSource = !$keyDoc->isEmpty();
-                }
-
-                $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
-                $destinationRegion = $this->project->getAttribute('region', 'default');
-                $useAppwriteApiSource = $isAppwriteToAppwrite
-                    && (!$isLocalSource || $sourceRegion !== $destinationRegion);
-
-                if (! $useAppwriteApiSource) {
-                    $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
-                }
+                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
             }
         }
         $getDatabasesDB = fn (Document $database): Database =>
@@ -297,6 +278,38 @@ class Migrations extends Action
         $this->sourceReport = $migrationSource->report($resources);
 
         return $migrationSource;
+    }
+
+    /**
+     * The local platform DB only holds the truth for the *destination* project. For
+     * SourceAppwrite -> DestinationAppwrite we may find a same-id project locally
+     * that isn't actually the source (a destination project deliberately created
+     * with the source's id to preserve cross-references). Verify the supplied apiKey
+     * belongs to that local project before trusting it; same-region match is the
+     * final gate before the direct-DB fast path.
+     */
+    private function canReadSourceFromLocalDb(Document $candidate, array $credentials, bool $isAppwriteToAppwrite): bool
+    {
+        if ($candidate->isEmpty()) {
+            return false;
+        }
+
+        // Source -> CSV/JSON/Backup always reads the local DB; no cross-cluster
+        // semantics, so a successful lookup is enough.
+        if (!$isAppwriteToAppwrite) {
+            return true;
+        }
+
+        $keyDoc = $this->dbForPlatform->findOne('keys', [
+            Query::equal('secret', [$credentials['apiKey']]),
+            Query::equal('projectInternalId', [$candidate->getSequence()]),
+        ]);
+        if ($keyDoc->isEmpty()) {
+            return false;
+        }
+
+        return $candidate->getAttribute('region', 'default')
+            === $this->project->getAttribute('region', 'default');
     }
 
     /**

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -216,8 +216,7 @@ class Migrations extends Action
             $matchesDomain = $localDomain !== ''
                 && ($sourceHost === $localDomain || str_ends_with((string) $sourceHost, '.' . $localDomain));
             $matchesInternal = $migrationHost !== '' && $sourceHost === $migrationHost;
-            // Empty endpoint is defaulted to the internal host by processMigration, so
-            // treat it as local up-front for callers that bypass that defaulting (tests).
+            // Empty endpoint: processMigration defaults it to the internal host before reaching here.
             $isLocalEndpoint = (is_string($sourceHost) && ($matchesDomain || $matchesInternal))
                 || (empty($credentials['endpoint']) && $migrationHost !== '');
 
@@ -241,9 +240,7 @@ class Migrations extends Action
 
         $sourceEndpoint = $credentials['endpoint'] ?? '';
         if ($source === SourceAppwrite::getName()) {
-            // Loopback URLs are unreachable from inside the worker container — rewrite
-            // them to the internal host on both DB and SDK paths so the SDK fallback /
-            // primary call resolves. SDK auth (apiKey) still gates access on the SDK path.
+            // Loopback isn't reachable from the worker container; rewrite to internal host.
             $sourceEndpoint = $this->resolveLocalEndpoint($sourceEndpoint);
         }
 

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -211,15 +211,23 @@ class Migrations extends Action
 
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            // For Appwrite -> Appwrite, require apiKey to actually belong to the local
-            // project — a destination reusing the source's id would otherwise collide.
-            $isLocalSource = !$this->sourceProject->isEmpty() && (!$isAppwriteToAppwrite || (
-                !$this->dbForPlatform->findOne('keys', [
-                    Query::equal('secret', [$credentials['apiKey']]),
-                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                ])->isEmpty()
-                && $this->sourceProject->getAttribute('region', 'default') === $this->project->getAttribute('region', 'default')
-            ));
+            $isLocalSource = false;
+            if (!$this->sourceProject->isEmpty()) {
+                if (!$isAppwriteToAppwrite) {
+                    $isLocalSource = true;
+                } else {
+                    // For Appwrite -> Appwrite, require apiKey to actually belong to
+                    // the local project — a destination reusing the source's id
+                    // would otherwise collide.
+                    $keyMatches = !$this->dbForPlatform->findOne('keys', [
+                        Query::equal('secret', [$credentials['apiKey']]),
+                        Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
+                    ])->isEmpty();
+                    $sameRegion = $this->sourceProject->getAttribute('region', 'default')
+                        === $this->project->getAttribute('region', 'default');
+                    $isLocalSource = $keyMatches && $sameRegion;
+                }
+            }
 
             if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -204,17 +204,37 @@ class Migrations extends Action
         if (! empty($credentials['projectId'])) {
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
+            // For Appwrite -> Appwrite, "project exists locally with this id" is not
+            // enough to take the DB fast path: a destination project deliberately
+            // created with the source's projectId (to preserve cross-references like
+            // createdBy/userId) would collide. Verify the user-supplied apiKey actually
+            // belongs to the local project — only then is it safe to read direct.
+            $isLocalSource = false;
+            if (
+                $source === SourceAppwrite::getName()
+                && $destination === DestinationAppwrite::getName()
+                && !$this->sourceProject->isEmpty()
+                && !empty($credentials['apiKey'])
+            ) {
+                $keyDoc = $this->dbForPlatform->findOne('keys', [
+                    Query::equal('secret', [$credentials['apiKey']]),
+                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
+                ]);
+                $isLocalSource = $keyDoc !== false && !$keyDoc->isEmpty();
+            }
+
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');
             $useAppwriteApiSource = $source === SourceAppwrite::getName()
                 && $destination === DestinationAppwrite::getName()
-                && ($this->sourceProject->isEmpty() || $sourceRegion !== $destinationRegion);
+                && (!$isLocalSource || $sourceRegion !== $destinationRegion);
+
             if (! $useAppwriteApiSource) {
                 if ($this->sourceProject->isEmpty()) {
                     throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
                 }
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
-            } elseif ($this->sourceProject->isEmpty()) {
+            } elseif (!$isLocalSource) {
                 // External source — processMigration defaults missing endpoint/apiKey to this
                 // instance, which would silently self-call with the destination's key. Require
                 // explicit credentials so the failure mode is clear.

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -257,14 +257,6 @@ class Migrations extends Action
             $queries = Query::parseQueries($migrationOptions['queries'] ?? []);
         }
 
-        $sourceEndpoint = $credentials['endpoint'] ?? '';
-        if ($source === SourceAppwrite::getName() && !$useAppwriteApiSource) {
-            // Rewrite loopback only on the DB fast path. On the SDK path, the user-supplied
-            // endpoint is authoritative — silently redirecting it to the internal host would
-            // turn a misrouted external migration into a self-call against this cluster.
-            $sourceEndpoint = $this->resolveLocalEndpoint($sourceEndpoint);
-        }
-
         $migrationSource = match ($source) {
             Firebase::getName() => new Firebase(
                 json_decode($credentials['serviceAccount'], true),
@@ -289,7 +281,7 @@ class Migrations extends Action
             ),
             SourceAppwrite::getName() => new SourceAppwrite(
                 $credentials['projectId'],
-                $sourceEndpoint,
+                $credentials['endpoint'],
                 $credentials['apiKey'],
                 $getDatabasesDB,
                 $useAppwriteApiSource ? SourceAppwrite::SOURCE_API : SourceAppwrite::SOURCE_DATABASE,
@@ -499,7 +491,12 @@ class Migrations extends Action
         $aggregatedResources = [];
         $caughtError = null;
 
-        $endpoint = $this->getMigrationEndpoint();
+        $host = System::getEnv('_APP_MIGRATION_HOST');
+        if (empty($host)) {
+            throw new \Exception('_APP_MIGRATION_HOST is not set');
+        }
+
+        $endpoint = 'http://' . $host . '/v1';
 
         try {
             $credentials = $migration->getAttribute('credentials', []);
@@ -704,34 +701,6 @@ class Migrations extends Action
         }
 
         return ($this->getDatabasesDB)($database);
-    }
-
-    private function resolveLocalEndpoint(string $endpoint): string
-    {
-        if ($endpoint === '') {
-            return $this->getMigrationEndpoint();
-        }
-
-        $host = parse_url($endpoint, PHP_URL_HOST);
-        if (!is_string($host)) {
-            return $endpoint;
-        }
-
-        if (!in_array(strtolower($host), ['localhost', '127.0.0.1', '0.0.0.0', '::1'], true)) {
-            return $endpoint;
-        }
-
-        return $this->getMigrationEndpoint();
-    }
-
-    private function getMigrationEndpoint(): string
-    {
-        $host = System::getEnv('_APP_MIGRATION_HOST');
-        if (empty($host)) {
-            throw new \Exception('_APP_MIGRATION_HOST is not set');
-        }
-
-        return 'http://' . $host . '/v1';
     }
 
     /**

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -487,17 +487,19 @@ class Migrations extends Action
 
         try {
             $credentials = $migration->getAttribute('credentials', []);
+            $isAppwriteSource = $migration->getAttribute('source') === SourceAppwrite::getName();
+            $isAppwriteDestination = $migration->getAttribute('destination') === DestinationAppwrite::getName();
+            $isAppwriteToAppwrite = $isAppwriteSource && $isAppwriteDestination;
 
             // Appwrite -> Appwrite requires explicit user-supplied source credentials;
             // defaulting would silently self-call with the destination's own key.
-            if ($migration->getAttribute('source') === SourceAppwrite::getName()
-                && $migration->getAttribute('destination') !== DestinationAppwrite::getName()) {
+            if ($isAppwriteSource && !$isAppwriteToAppwrite) {
                 $credentials['projectId'] = $credentials['projectId'] ?? $project->getId();
                 $credentials['apiKey'] = $credentials['apiKey'] ?? $tempAPIKey;
                 $credentials['endpoint'] = $credentials['endpoint'] ?? $endpoint;
             }
 
-            if ($migration->getAttribute('destination') === DestinationAppwrite::getName()) {
+            if ($isAppwriteDestination) {
                 $credentials['destinationApiKey'] = $tempAPIKey;
                 $credentials['destinationEndpoint'] = $endpoint;
             }

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -209,21 +209,20 @@ class Migrations extends Action
                 throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
             }
 
-            $candidate = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
+            $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
             // For Appwrite -> Appwrite, require apiKey to actually belong to the local
             // project — a destination reusing the source's id would otherwise collide.
-            $isLocalSource = !$candidate->isEmpty() && (!$isAppwriteToAppwrite || (
+            $isLocalSource = !$this->sourceProject->isEmpty() && (!$isAppwriteToAppwrite || (
                 !$this->dbForPlatform->findOne('keys', [
                     Query::equal('secret', [$credentials['apiKey']]),
-                    Query::equal('projectInternalId', [$candidate->getSequence()]),
+                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
                 ])->isEmpty()
-                && $candidate->getAttribute('region', 'default') === $this->project->getAttribute('region', 'default')
+                && $this->sourceProject->getAttribute('region', 'default') === $this->project->getAttribute('region', 'default')
             ));
 
             if ($isLocalSource) {
-                $this->sourceProject = $candidate;
-                $projectDB = call_user_func($this->getProjectDB, $candidate);
+                $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
             } elseif ($isAppwriteToAppwrite) {
                 $useAppwriteApiSource = true;
             } else {

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -214,6 +214,13 @@ class Migrations extends Action
                     throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
                 }
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
+            } elseif ($this->sourceProject->isEmpty()) {
+                // External source — processMigration defaults missing endpoint/apiKey to this
+                // instance, which would silently self-call with the destination's key. Require
+                // explicit credentials so the failure mode is clear.
+                if (empty($credentials['endpoint']) || empty($credentials['apiKey'])) {
+                    throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
+                }
             }
         }
         $getDatabasesDB = fn (Document $database): Database =>

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -208,11 +208,15 @@ class Migrations extends Action
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
             // Same projectId on source and destination only means "local" when the source
-            // endpoint points at this installation — otherwise it's an external Appwrite
+            // endpoint's host is this installation — otherwise it's an external Appwrite
             // that happens to share an id, and we must go over SDK/HTTP.
+            $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
+            $localDomain = System::getEnv('_APP_DOMAIN', '');
+            $isLocalEndpoint = is_string($sourceHost) && $localDomain !== ''
+                && ($sourceHost === $localDomain || str_ends_with($sourceHost, '.' . $localDomain));
+
             $isLocalSource = !$this->sourceProject->isEmpty()
-                && (!$isAppwriteToAppwrite
-                    || str_contains($credentials['endpoint'] ?? '', System::getEnv('_APP_DOMAIN', '_')));
+                && (!$isAppwriteToAppwrite || $isLocalEndpoint);
 
             if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -212,20 +212,15 @@ class Migrations extends Action
                 if (!$isAppwriteToAppwrite) {
                     $isLocalSource = true;
                 } else {
-                    // For Appwrite -> Appwrite, require apiKey to actually belong to
-                    // the local project — a destination reusing the source's id
-                    // would otherwise collide. `secret` is encrypted at rest so it
-                    // can't be queried directly; read the project's keys and compare
-                    // in memory (typical project has <10 keys).
-                    $keyMatches = false;
-                    foreach ($this->dbForPlatform->find('keys', [
+                    // `secret` is encrypted at rest — load project keys and compare in memory.
+                    $projectKeys = $this->dbForPlatform->find('keys', [
                         Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
-                    ]) as $key) {
-                        if ($key->getAttribute('secret') === $credentials['apiKey']) {
-                            $keyMatches = true;
-                            break;
-                        }
-                    }
+                    ]);
+                    $keyMatches = in_array(
+                        $credentials['apiKey'],
+                        array_map(fn (Document $k) => $k->getAttribute('secret'), $projectKeys),
+                        true
+                    );
                     $sameRegion = $this->sourceProject->getAttribute('region', 'default')
                         === $this->project->getAttribute('region', 'default');
                     $isLocalSource = $keyMatches && $sameRegion;

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -208,12 +208,18 @@ class Migrations extends Action
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
             // Same projectId on source and destination only means "local" when the source
-            // endpoint's host is this installation — otherwise it's an external Appwrite
-            // that happens to share an id, and we must go over SDK/HTTP.
+            // endpoint's host is one of this installation's hostnames — _APP_DOMAIN is the
+            // public host users paste from console; _APP_MIGRATION_HOST is the internal one
+            // workers default to when the caller omits `endpoint`. Anything else is an
+            // external Appwrite that happens to share an id, and we must go over SDK/HTTP.
             $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
             $localDomain = System::getEnv('_APP_DOMAIN', '');
-            $isLocalEndpoint = is_string($sourceHost) && $localDomain !== ''
-                && ($sourceHost === $localDomain || str_ends_with($sourceHost, '.' . $localDomain));
+            $migrationHost = System::getEnv('_APP_MIGRATION_HOST', '');
+
+            $matchesDomain = $localDomain !== ''
+                && ($sourceHost === $localDomain || str_ends_with((string) $sourceHost, '.' . $localDomain));
+            $matchesInternal = $migrationHost !== '' && $sourceHost === $migrationHost;
+            $isLocalEndpoint = is_string($sourceHost) && ($matchesDomain || $matchesInternal);
 
             $isLocalSource = !$this->sourceProject->isEmpty()
                 && (!$isAppwriteToAppwrite || $isLocalEndpoint);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -203,7 +203,8 @@ class Migrations extends Action
         }
 
         if (! empty($credentials['projectId'])) {
-            $isAppwriteToAppwrite = $source === SourceAppwrite::getName()
+            $isAppwriteSource = $source === SourceAppwrite::getName();
+            $isAppwriteToAppwrite = $isAppwriteSource
                 && $destination === DestinationAppwrite::getName();
 
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
@@ -240,7 +241,7 @@ class Migrations extends Action
                 || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $isLocalSource = !$this->sourceProject->isEmpty()
-                && (!$isAppwriteToAppwrite || $isLocalEndpoint);
+                && (!$isAppwriteSource || $isLocalEndpoint);
 
             if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -240,8 +240,11 @@ class Migrations extends Action
             $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
                 || (empty($credentials['endpoint']) && $migrationHost !== '');
 
+            $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
+            $destinationRegion = $this->project->getAttribute('region', 'default');
+
             $isLocalSource = !$this->sourceProject->isEmpty()
-                && (!$isAppwriteSource || $isLocalEndpoint);
+                && (!$isAppwriteSource || ($isLocalEndpoint && $sourceRegion === $destinationRegion));
 
             if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -49,6 +49,7 @@ use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Storage\Device;
 use Utopia\System\System;
+use Utopia\Validator\Hostname;
 
 class Migrations extends Action
 {
@@ -209,20 +210,22 @@ class Migrations extends Action
 
             // Same projectId may collide with an external Appwrite — trust the DB fast
             // path only when the source URL targets this cluster's public or internal host.
+            // Env values are run through parse_url too so a port suffix (appwrite:8080)
+            // can't break equality with the port-stripped source host.
             $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
-            $localDomain = System::getEnv('_APP_DOMAIN', '');
-            // _APP_MIGRATION_HOST may include a port (appwrite:8080); strip it the same
-            // way parse_url does for the source URL so the equality check stays correct.
-            $migrationHostEnv = System::getEnv('_APP_MIGRATION_HOST', '');
-            $migrationHost = $migrationHostEnv !== ''
-                ? (parse_url('http://' . $migrationHostEnv, PHP_URL_HOST) ?: $migrationHostEnv)
-                : '';
+            $rawDomain = System::getEnv('_APP_DOMAIN', '');
+            $rawMigrationHost = System::getEnv('_APP_MIGRATION_HOST', '');
+            $localDomain = $rawDomain !== '' ? (parse_url('http://' . $rawDomain, PHP_URL_HOST) ?: '') : '';
+            $migrationHost = $rawMigrationHost !== '' ? (parse_url('http://' . $rawMigrationHost, PHP_URL_HOST) ?: '') : '';
 
-            $matchesDomain = $localDomain !== ''
-                && ($sourceHost === $localDomain || str_ends_with((string) $sourceHost, '.' . $localDomain));
-            $matchesInternal = $migrationHost !== '' && $sourceHost === $migrationHost;
+            $allowedHosts = array_filter([
+                $localDomain,
+                $localDomain !== '' ? '*.' . $localDomain : null,
+                $migrationHost,
+            ]);
+
             // Empty endpoint: processMigration defaults it to the internal host before reaching here.
-            $isLocalEndpoint = (is_string($sourceHost) && ($matchesDomain || $matchesInternal))
+            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
                 || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $isLocalSource = !$this->sourceProject->isEmpty()


### PR DESCRIPTION
## Problem

The migrations worker decided how to read the source project using only a `projectId` lookup against the local platform DB. Two failure modes followed:

1. **Pre-flight throw on external sources.** Prod → OSS onboarding (or OSS-A → OSS-B) failed with `MIGRATION_SOURCE_PROJECT_NOT_FOUND` because the local lookup returned empty.

2. **Silent zero-row migrations when the destination project shares the source's `projectId`.** Customers commonly recreate the destination with the **same id** to preserve cross-references (`createdBy`, `userId`, etc.). The lookup hit the local destination project, the worker took the DB fast path, and reported `status="completed"` with `0 rows transferred`.

## Fix

Treat the local `projectId` lookup as a *candidate*. Take the DB fast path only when the source URL's host belongs to this installation. Otherwise fall through to the SDK/HTTP path so the external source is read correctly.

The source URL's host must match one of:
- `_APP_DOMAIN` (exact + `*.` wildcard for subdomains)
- `_APP_MIGRATION_HOST` (internal host workers default to when `endpoint` is omitted)
- A custom API domain from the source project's `rules` collection

Match uses [`Utopia\Validator\Hostname`](https://github.com/utopia-php/validators) (same validator `Appwrite\Network\Cors` uses). Env values are normalized through `parse_url('http://' . $env, PHP_URL_HOST)` so a port suffix doesn't break equality.

```php
$isLocalSource = !$this->sourceProject->isEmpty()
    && (!$isAppwriteToAppwrite || $isLocalEndpoint);
```

The existing `resolveLocalEndpoint` rewrite is gated to the DB path only — on the SDK path the user-supplied endpoint is authoritative.

This is the OSS twin of [appwrite-labs/cloud#4103](https://github.com/appwrite-labs/cloud/pull/4103). Cloud layers the host match on top of a region check (cloud-native signal); OSS uses the host match alone.

## Test plan
- [ ] CI green
- [ ] Manual: Prod → self-hosted OSS migration completes end-to-end
- [ ] Manual: Prod → self-hosted OSS with **same projectId on both sides** transfers rows from cloud (not from the empty local project)
- [ ] Intra-cluster same-host migration → still DB fast path
