### PR TITLE
fix(project): cast smtpPort to int in response model

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -94,7 +94,7 @@ class Project extends Model
             ->addRule('smtpPort', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'SMTP server port',
-                'default' => '',
+                'default' => 0,
                 'example' => 25,
             ])
             ->addRule('smtpUsername', [
@@ -225,7 +225,7 @@ class Project extends Model
         $document->setAttribute('smtpReplyToEmail', $smtp['replyToEmail'] ?? $smtp['replyTo'] ?? ''); // Includes backwards compatibility
         $document->setAttribute('smtpReplyToName', $smtp['replyToName'] ?? '');
         $document->setAttribute('smtpHost', $smtp['host'] ?? '');
-        $document->setAttribute('smtpPort', $smtp['port'] ?? '');
+        $document->setAttribute('smtpPort', (int) ($smtp['port'] ?? 0));
         $document->setAttribute('smtpUsername', $smtp['username'] ?? '');
         $document->setAttribute('smtpPassword', ''); // Write-only: never expose the stored value
         $document->setAttribute('smtpSecure', $smtp['secure'] ?? '');

--- a/tests/e2e/Services/Project/ProjectConsoleClientTest.php
+++ b/tests/e2e/Services/Project/ProjectConsoleClientTest.php
@@ -103,7 +103,7 @@ class ProjectConsoleClientTest extends Scope
         $this->assertSame('', $response['body']['smtpReplyToEmail']);
         $this->assertSame('', $response['body']['smtpReplyToName']);
         $this->assertSame('', $response['body']['smtpHost']);
-        $this->assertSame('', $response['body']['smtpPort']);
+        $this->assertSame(0, $response['body']['smtpPort']);
         $this->assertSame('', $response['body']['smtpUsername']);
         $this->assertSame('', $response['body']['smtpPassword']);
         $this->assertSame('', $response['body']['smtpSecure']);


### PR DESCRIPTION
## Problem

`GET /v1/project` (and the SDK's `Project::get()`) crashes typed-SDK consumers when the project has no custom SMTP configured. The response model declares `smtpPort` as `INTEGER`, but the filter emits an empty string when the underlying attribute isn't set:

```php
$document->setAttribute('smtpPort', $smtp['port'] ?? '');
```

A typed PHP SDK (e.g. `Appwrite\Models\Project`) declares `public int $smtpPort` on its constructor. Receiving `''` for an `int` parameter throws:

```
Project::__construct: $smtpPort must be of type int, string given
```

This surfaces in the migrations worker every time the source project is read via SDK — including all `Source=Appwrite -> Destination=Appwrite` migrations after [#12370](https://github.com/appwrite/appwrite/pull/12370) lets external sources through.

The same contract violation also affects Go/Java/Kotlin/Swift/.NET SDKs (deserialization rejects the type mismatch); Node.js and Python accept the wrong-typed value silently which causes weird downstream bugs.

## Fix

Two trivial changes in `src/Appwrite/Utopia/Response/Model/Project.php`:

1. Schema default for `smtpPort` is now `0` (was `''`) — matches the declared `INTEGER` type. `0` is the "absence" sentinel (consistent with the empty-string default the other smtp* fields use to signal unset).
2. `expandSmtpFields` casts the value to int before setting the attribute: `(int) ($smtp['port'] ?? 0)`.

Empty/null/missing port → `0` → SDK gets an int → no crash.

## Test plan
- [ ] CI green
- [ ] `GET /v1/project` on a project without custom SMTP returns `smtpPort: 0` (not `""`)
- [ ] Typed-SDK call (`$project->get()`) on the same project hydrates without throwing