### PR TITLE
Expose providerBranches and providerPaths in Function and Site response

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/Func.php
+++ b/src/Appwrite/Utopia/Response/Model/Func.php
@@ -182,6 +182,20 @@ class Func extends Model
                 'default' => false,
                 'example' => false,
             ])
+            ->addRule('providerBranches', [
+                'type' => self::TYPE_STRING,
+                'description' => 'List of branch name patterns that trigger automatic deployments. Supports glob wildcards. Empty list deploys on all branches.',
+                'default' => [],
+                'example' => ['main', 'feat/*'],
+                'array' => true,
+            ])
+            ->addRule('providerPaths', [
+                'type' => self::TYPE_STRING,
+                'description' => 'List of file path patterns that trigger automatic deployments. Supports glob wildcards. Empty list deploys on all file changes.',
+                'default' => [],
+                'example' => ['src/**', '!docs/**'],
+                'array' => true,
+            ])
             ->addRule('buildSpecification', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Machine specification for deployment builds.',

--- a/src/Appwrite/Utopia/Response/Model/Site.php
+++ b/src/Appwrite/Utopia/Response/Model/Site.php
@@ -173,6 +173,20 @@ class Site extends Model
                 'default' => false,
                 'example' => false,
             ])
+            ->addRule('providerBranches', [
+                'type' => self::TYPE_STRING,
+                'description' => 'List of branch name patterns that trigger automatic deployments. Supports glob wildcards. Empty list deploys on all branches.',
+                'default' => [],
+                'example' => ['main', 'feat/*'],
+                'array' => true,
+            ])
+            ->addRule('providerPaths', [
+                'type' => self::TYPE_STRING,
+                'description' => 'List of file path patterns that trigger automatic deployments. Supports glob wildcards. Empty list deploys on all file changes.',
+                'default' => [],
+                'example' => ['src/**', '!docs/**'],
+                'array' => true,
+            ])
             ->addRule('buildSpecification', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Machine specification for deployment builds.',


### PR DESCRIPTION
…se models

These fields were already persisted on update but omitted from the response model, causing them to disappear after a page refresh in the console.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
