### PR TITLE
Fix missing platform variables in SMTP test email template

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Tests/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Tests/Create.php
@@ -69,6 +69,7 @@ class Create extends Action
             ->inject('response')
             ->inject('project')
             ->inject('publisherForMails')
+            ->inject('platform')
             ->inject('plan')
             ->callback($this->action(...));
     }
@@ -89,6 +90,7 @@ class Create extends Action
         Response $response,
         Document $project,
         MailPublisher $publisherForMails,
+        array $platform,
         array $plan
     ): void {
         // Backwards compatibility: use inline params if provided, otherwise fall back to project SMTP config.
@@ -144,14 +146,7 @@ class Create extends Action
         $template = Template::fromFile(APP_CE_CONFIG_DIR . '/locale/templates/email-smtp-test.tpl');
         $template
             ->setParam('{{from}}', "{$senderName} ({$senderEmail})")
-            ->setParam('{{replyTo}}', "{$replyToNameDisplay} ({$replyToEmailDisplay})")
-            ->setParam('{{logoUrl}}', $plan['logoUrl'] ?? APP_EMAIL_LOGO_URL)
-            ->setParam('{{accentColor}}', $plan['accentColor'] ?? APP_EMAIL_ACCENT_COLOR)
-            ->setParam('{{twitterUrl}}', $plan['twitterUrl'] ?? APP_SOCIAL_TWITTER)
-            ->setParam('{{discordUrl}}', $plan['discordUrl'] ?? APP_SOCIAL_DISCORD)
-            ->setParam('{{githubUrl}}', $plan['githubUrl'] ?? APP_SOCIAL_GITHUB_APPWRITE)
-            ->setParam('{{termsUrl}}', $plan['termsUrl'] ?? APP_EMAIL_TERMS_URL)
-            ->setParam('{{privacyUrl}}', $plan['privacyUrl'] ?? APP_EMAIL_PRIVACY_URL);
+            ->setParam('{{replyTo}}', "{$replyToNameDisplay} ({$replyToEmailDisplay})");
 
         foreach ($emails as $email) {
             $publisherForMails->enqueue(new MailMessage(
@@ -171,6 +166,17 @@ class Create extends Action
                     'senderEmail' => $senderEmail,
                     'senderName' => $senderName,
                 ],
+                variables: [
+                    'platform' => $platform['platformName'] ?? APP_NAME,
+                    'logoUrl' => $platform['logoUrl'] ?? APP_EMAIL_LOGO_URL,
+                    'accentColor' => $platform['accentColor'] ?? APP_EMAIL_ACCENT_COLOR,
+                    'twitter' => $platform['twitterUrl'] ?? APP_SOCIAL_TWITTER,
+                    'discord' => $platform['discordUrl'] ?? APP_SOCIAL_DISCORD,
+                    'github' => $platform['githubUrl'] ?? APP_SOCIAL_GITHUB_APPWRITE,
+                    'terms' => $platform['termsUrl'] ?? APP_EMAIL_TERMS_URL,
+                    'privacy' => $platform['privacyUrl'] ?? APP_EMAIL_PRIVACY_URL,
+                ],
+                platform: $platform,
             ));
         }
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Tests/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Tests/Create.php
@@ -70,7 +70,6 @@ class Create extends Action
             ->inject('project')
             ->inject('publisherForMails')
             ->inject('platform')
-            ->inject('plan')
             ->callback($this->action(...));
     }
 
@@ -91,7 +90,6 @@ class Create extends Action
         Document $project,
         MailPublisher $publisherForMails,
         array $platform,
-        array $plan
     ): void {
         // Backwards compatibility: use inline params if provided, otherwise fall back to project SMTP config.
         // When inline params are provided they are treated as self-contained — project config is ignored


### PR DESCRIPTION
The SMTP test email uses email-base-styled.tpl as its base template, which contains {{platform}}, {{logoUrl}}, {{accentColor}}, and social/ legal link placeholders. These were never passed as template variables, causing them to render as literal strings (e.g. "{{platform}} logo").

Inject the platform config and pass the variables to MailMessage, matching the pattern used by OTP and magic-url email flows.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
