### PR TITLE
chore: bump appwrite/php-runtimes to 0.20.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -161,16 +161,16 @@
         },
         {
             "name": "appwrite/php-runtimes",
-            "version": "0.20.0",
+            "version": "0.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/runtimes.git",
-                "reference": "7d9b7f4eef5c0a142a60907b06de2219d025c5c3"
+                "reference": "e9213dfe9fff1b67de77aa61dbcae5f4ca10b6d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/runtimes/zipball/7d9b7f4eef5c0a142a60907b06de2219d025c5c3",
-                "reference": "7d9b7f4eef5c0a142a60907b06de2219d025c5c3",
+                "url": "https://api.github.com/repos/appwrite/runtimes/zipball/e9213dfe9fff1b67de77aa61dbcae5f4ca10b6d6",
+                "reference": "e9213dfe9fff1b67de77aa61dbcae5f4ca10b6d6",
                 "shasum": ""
             },
             "require": {
@@ -210,9 +210,9 @@
             ],
             "support": {
                 "issues": "https://github.com/appwrite/runtimes/issues",
-                "source": "https://github.com/appwrite/runtimes/tree/0.20.0"
+                "source": "https://github.com/appwrite/runtimes/tree/0.20.1"
             },
-            "time": "2026-05-01T07:47:07+00:00"
+            "time": "2026-05-24T03:00:39+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
Bumps `appwrite/php-runtimes` from 0.20.0 → 0.20.1.

The 0.20.1 release adds two new runtimes:

- **Dart 3.12.0**
- **Flutter 3.44.0** (pinned to `ghcr.io/adrianjagielak/flutter:3.44.0`, the community continuation of the now-deprecated `cirruslabs/docker-images-flutter`)

Release notes: https://github.com/appwrite/runtimes/releases/tag/0.20.1
Companion runtime images: open-runtimes/open-runtimes#495 (Dart) and #496 (Flutter), both merged.

Only `composer.lock` is touched — the `composer.json` constraint was already `0.20.*`.