### PR TITLE
fix(users): ensure prefs update event returns full user payload

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1844,7 +1844,8 @@ Http::patch('/v1/users/:userId/prefs')
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['prefs' => $prefs]));
 
         $queueForEvents
-            ->setParam('userId', $user->getId());
+            ->setParam('userId', $user->getId())
+            ->setPayload($response->output($user, Response::MODEL_USER));
 
         $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
     });

--- a/tests/e2e/Services/ProjectWebhooks/WebhooksCustomServerTest.php
+++ b/tests/e2e/Services/ProjectWebhooks/WebhooksCustomServerTest.php
@@ -554,8 +554,10 @@ final class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Signature'], $signatureExpected);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
-        $this->assertSame(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
-        $this->assertEquals('b', $webhook['data']['a']);
+        $this->assertEquals(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
+        $this->assertNotEmpty($webhook['data']['$id']);
+        $this->assertEquals($id, $webhook['data']['$id']);
+        $this->assertEquals(['a' => 'b'], $webhook['data']['prefs']);
     }
 
     public function testUpdateUserStatus(): void


### PR DESCRIPTION
When updating user preferences via the API, the prefs update event (users.*.update.prefs) was only sending the userId parameter without the full user payload. This caused webhook consumers to receive incomplete data.

Changes:
- Added setPayload to event queue chain in users.php
- Updated WebhooksCustomServerTest.php to verify full user object in webhook payload