### PR TITLE
fix(migrations): validate source URL host before DB fast path

### DIFF
--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -198,15 +198,15 @@ class Migrations extends Action
         /** @var Database|null $projectDB */
         $projectDB = null;
         $useAppwriteApiSource = false;
-        if ($source === SourceAppwrite::getName() && empty($credentials['projectId'])) {
+        $isAppwriteSource = $source === SourceAppwrite::getName();
+        $isAppwriteToAppwrite = $isAppwriteSource
+            && $destination === DestinationAppwrite::getName();
+
+        if ($isAppwriteSource && empty($credentials['projectId'])) {
             throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_ID_REQUIRED);
         }
 
-        if (! empty($credentials['projectId'])) {
-            $isAppwriteSource = $source === SourceAppwrite::getName();
-            $isAppwriteToAppwrite = $isAppwriteSource
-                && $destination === DestinationAppwrite::getName();
-
+        if ($isAppwriteSource) {
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
             // Same projectId may collide with an external Appwrite — trust the DB fast
@@ -242,7 +242,7 @@ class Migrations extends Action
             $destinationRegion = $this->project->getAttribute('region', 'default');
 
             $isLocalSource = !$this->sourceProject->isEmpty()
-                && (!$isAppwriteSource || $isLocalEndpoint)
+                && $isLocalEndpoint
                 && (!$isAppwriteToAppwrite || $sourceRegion === $destinationRegion);
 
             if ($isLocalSource) {

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -209,22 +209,18 @@ class Migrations extends Action
         if ($isAppwriteSource) {
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
 
-            // Same projectId may collide with an external Appwrite — trust the DB fast
-            // path only when the source URL targets this cluster's public or internal host.
+            // Trust DB fast path only when the source URL targets this cluster's host
+            // (env-configured or this project's verified custom API domain).
             $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
-            $rawDomain = System::getEnv('_APP_DOMAIN', '');
-            $rawMigrationHost = System::getEnv('_APP_MIGRATION_HOST', '');
-            $localDomain = $rawDomain !== '' ? (parse_url('http://' . $rawDomain, PHP_URL_HOST) ?: '') : '';
-            $migrationHost = $rawMigrationHost !== '' ? (parse_url('http://' . $rawMigrationHost, PHP_URL_HOST) ?: '') : '';
+            $publicDomain = parse_url('http://' . System::getEnv('_APP_DOMAIN', ''), PHP_URL_HOST) ?: '';
+            $internalHost = parse_url('http://' . System::getEnv('_APP_MIGRATION_HOST', ''), PHP_URL_HOST) ?: '';
 
             $allowedHosts = array_filter([
-                $localDomain,
-                $localDomain !== '' ? '*.' . $localDomain : null,
-                $migrationHost,
+                $publicDomain,
+                $publicDomain !== '' ? '*.' . $publicDomain : null,
+                $internalHost,
             ]);
 
-            // Include the source project's custom API domain so customers using
-            // a configured custom domain still get the DB fast path.
             if (is_string($sourceHost) && !$this->sourceProject->isEmpty()) {
                 $rule = $this->dbForPlatform->findOne('rules', [
                     Query::equal('domain', [$sourceHost]),
@@ -236,7 +232,9 @@ class Migrations extends Action
                 }
             }
 
-            $isLocalEndpoint = is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost);
+            $isLocalEndpoint = is_string($sourceHost)
+                && !empty($allowedHosts)
+                && (new Hostname($allowedHosts))->isValid($sourceHost);
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -236,10 +236,7 @@ class Migrations extends Action
                 }
             }
 
-            // Empty-string endpoint slips through processMigration's `??` defaulting (which only
-            // catches null/absent); treat it as targeting the internal migration host.
-            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
-                || (empty($credentials['endpoint']) && $migrationHost !== '');
+            $isLocalEndpoint = is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost);
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -236,7 +236,10 @@ class Migrations extends Action
                 }
             }
 
-            $isLocalEndpoint = is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost);
+            // Empty-string endpoint slips through processMigration's `??` defaulting (which only
+            // catches null/absent); treat it as targeting the internal migration host.
+            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
+                || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -236,9 +236,7 @@ class Migrations extends Action
                 }
             }
 
-            // Empty endpoint: processMigration defaults it to the internal host before reaching here.
-            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
-                || (empty($credentials['endpoint']) && $migrationHost !== '');
+            $isLocalEndpoint = is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost);
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -225,6 +225,7 @@ class Migrations extends Action
                 $rule = $this->dbForPlatform->findOne('rules', [
                     Query::equal('domain', [$sourceHost]),
                     Query::equal('type', ['api']),
+                    Query::equal('status', [RULE_STATUS_VERIFIED]),
                     Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
                 ]);
                 if (!$rule->isEmpty()) {

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -242,7 +242,8 @@ class Migrations extends Action
             $destinationRegion = $this->project->getAttribute('region', 'default');
 
             $isLocalSource = !$this->sourceProject->isEmpty()
-                && (!$isAppwriteSource || ($isLocalEndpoint && $sourceRegion === $destinationRegion));
+                && (!$isAppwriteSource || $isLocalEndpoint)
+                && (!$isAppwriteToAppwrite || $sourceRegion === $destinationRegion);
 
             if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -49,6 +49,7 @@ use Utopia\Platform\Action;
 use Utopia\Queue\Message;
 use Utopia\Storage\Device;
 use Utopia\System\System;
+use Utopia\Validator\Hostname;
 
 class Migrations extends Action
 {
@@ -202,18 +203,55 @@ class Migrations extends Action
         }
 
         if (! empty($credentials['projectId'])) {
+            $isAppwriteSource = $source === SourceAppwrite::getName();
+            $isAppwriteToAppwrite = $isAppwriteSource
+                && $destination === DestinationAppwrite::getName();
+
             $this->sourceProject = $this->dbForPlatform->getDocument('projects', $credentials['projectId']);
-            if ($this->sourceProject->isEmpty()) {
-                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
+
+            // Same projectId may collide with an external Appwrite — trust the DB fast
+            // path only when the source URL targets this cluster's public or internal host.
+            $sourceHost = parse_url($credentials['endpoint'] ?? '', PHP_URL_HOST);
+            $rawDomain = System::getEnv('_APP_DOMAIN', '');
+            $rawMigrationHost = System::getEnv('_APP_MIGRATION_HOST', '');
+            $localDomain = $rawDomain !== '' ? (parse_url('http://' . $rawDomain, PHP_URL_HOST) ?: '') : '';
+            $migrationHost = $rawMigrationHost !== '' ? (parse_url('http://' . $rawMigrationHost, PHP_URL_HOST) ?: '') : '';
+
+            $allowedHosts = array_filter([
+                $localDomain,
+                $localDomain !== '' ? '*.' . $localDomain : null,
+                $migrationHost,
+            ]);
+
+            // Include the source project's custom API domain so customers using
+            // a configured custom domain still get the DB fast path.
+            if (is_string($sourceHost) && !$this->sourceProject->isEmpty()) {
+                $rule = $this->dbForPlatform->findOne('rules', [
+                    Query::equal('domain', [$sourceHost]),
+                    Query::equal('type', ['api']),
+                    Query::equal('projectInternalId', [$this->sourceProject->getSequence()]),
+                ]);
+                if (!$rule->isEmpty()) {
+                    $allowedHosts[] = $sourceHost;
+                }
             }
+
+            // Empty endpoint: processMigration defaults it to the internal host before reaching here.
+            $isLocalEndpoint = (is_string($sourceHost) && !empty($allowedHosts) && (new Hostname($allowedHosts))->isValid($sourceHost))
+                || (empty($credentials['endpoint']) && $migrationHost !== '');
 
             $sourceRegion = $this->sourceProject->getAttribute('region', 'default');
             $destinationRegion = $this->project->getAttribute('region', 'default');
-            $useAppwriteApiSource = $source === SourceAppwrite::getName()
-                && $destination === DestinationAppwrite::getName()
-                && $sourceRegion !== $destinationRegion;
-            if (! $useAppwriteApiSource) {
+
+            $isLocalSource = !$this->sourceProject->isEmpty()
+                && (!$isAppwriteSource || ($isLocalEndpoint && $sourceRegion === $destinationRegion));
+
+            if ($isLocalSource) {
                 $projectDB = call_user_func($this->getProjectDB, $this->sourceProject);
+            } elseif ($isAppwriteToAppwrite) {
+                $useAppwriteApiSource = true;
+            } else {
+                throw new Exception(Exception::MIGRATION_SOURCE_PROJECT_NOT_FOUND);
             }
         }
         $getDatabasesDB = fn (Document $database): Database =>


### PR DESCRIPTION
## Problem

The migrations worker decides how to read the source project using only a `projectId` lookup against the local platform DB. Two failure modes follow:

1. **Pre-flight throw on external sources.** Cloud → self-hosted (or self-hosted → self-hosted) migrations fail with `MIGRATION_SOURCE_PROJECT_NOT_FOUND` because the local lookup returns empty.

2. **Silent zero-row migrations on `projectId` collision.** Customers often recreate the destination with the **same id** to preserve cross-references (`createdBy`, `userId`, etc.). The lookup hits the local collision, the worker takes the DB fast path, and reports `status="completed"` with `0 rows transferred`.

## Fix

Treat the local `projectId` lookup as a *candidate*. Take the DB fast path only when the source URL's host belongs to this installation. Otherwise fall through to the SDK/HTTP path so the external source is read correctly.

The source URL's host must match one of:
- `_APP_DOMAIN` (exact + `*.` wildcard for subdomains)
- `_APP_MIGRATION_HOST` (internal host workers default to when `endpoint` is omitted)
- A custom API domain from the source project's `rules` collection (exact, scoped to the source project)

Match uses [`Utopia\Validator\Hostname`](https://github.com/utopia-php/validators) — the same validator `Appwrite\Network\Cors` uses for CORS allow-listing. Env values are normalized through `parse_url('http://' . $env, PHP_URL_HOST)` so a port suffix doesn't break equality.

```php
$isLocalSource = !$this->sourceProject->isEmpty()
    && (!$isAppwriteSource || ($isLocalEndpoint && $sourceRegion === $destinationRegion));
```

## Test plan
- [ ] CI green
- [ ] Cloud → self-hosted with **same projectId** on both sides transfers rows from the cloud project (not from the empty local project)
- [ ] Cloud → self-hosted with different projectIds completes end-to-end
- [ ] Intra-cluster same-host migration → still DB fast path
- [ ] Source URL on configured custom domain → still DB fast path
