### PR TITLE
fix(uploads): reset queueForEvents on idempotent chunked-upload retry

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -227,6 +227,7 @@ class Create extends Action
         }
 
         if ($completed) {
+            $queueForEvents->reset();
             return;
         }
 
@@ -249,6 +250,8 @@ class Create extends Action
                     $metadata = \array_merge($deployment->getAttribute('sourceMetadata', []), $metadata);
 
                     if ($uploaded === $chunks) {
+                        $queueForEvents->reset();
+
                         $response
                             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -227,6 +227,7 @@ class Create extends Action
         }
 
         if ($completed) {
+            $queueForEvents->reset();
             return;
         }
 
@@ -257,6 +258,8 @@ class Create extends Action
                     $metadata = \array_merge($deployment->getAttribute('sourceMetadata', []), $metadata);
 
                     if ($uploaded === $chunks) {
+                        $queueForEvents->reset();
+
                         $response
                             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -320,6 +320,7 @@ class Create extends Action
         }
 
         if ($completed) {
+            $queueForEvents->reset();
             return;
         }
 
@@ -336,6 +337,8 @@ class Create extends Action
                     if (empty($contentRange)) {
                         throw new Exception(Exception::STORAGE_FILE_ALREADY_EXISTS);
                     }
+
+                    $queueForEvents->reset();
 
                     $response
                         ->setStatusCode(Response::STATUS_CODE_OK)


### PR DESCRIPTION
## Summary

Idempotent retry of a fully-uploaded chunked upload returns HTTP 500 instead of replaying the previous response. Affects `POST /v1/storage/buckets/:bucketId/files`, `POST /v1/functions/:functionId/deployments`, and `POST /v1/sites/:siteId/deployments`.

Sentry signature: `InvalidArgumentException: [bucketId] is missing from the params.` (and `[deploymentId]` for the deployment endpoints).

## Root cause

#12138 (`feat: support out-of-order chunked uploads`) added an early `return` for the case where the SDK retries an already-complete chunked upload — server responds 200 with the existing resource, idempotently. Correct in spirit, but the `return` exits the action *before* the `$queueForEvents->setParam('bucketId', …)` calls at the bottom of the action.

Sequence when the bug fires:

1. Action returns cleanly (no throw) → Utopia HTTP runs the shutdown hook.
2. Shutdown hook in `app/controllers/shared/api.php` calls `Event::generateEvents($queueForEvents->getEvent(), $queueForEvents->getParams())`. Event is still set from the init hook (`'buckets.[bucketId].files.[fileId].create'`), params are empty.
3. `Event::generateEvents` validates that each `[token]` in the pattern has a matching key in params and throws `\InvalidArgumentException("[bucketId] is missing from the params.")`.
4. `\InvalidArgumentException` (PHP built-in) has code 0. The error handler in `app/controllers/general.php` only normalizes a fixed set of exception classes; `\InvalidArgumentException` falls through. The status-code switch only allow-lists specific 4xx/5xx codes; 0 is not in the list, so it lands in the default branch: `$code = 500; $message = 'Server Error'`.

End result: a successful idempotent retry surfaces to the client as a 500.

Trigger conditions in production: network blip mid-upload + client retry, or any out-of-order retransmit that arrives after the original final chunk has already been persisted.

## Fix

Call `$queueForEvents->reset()` on every early-return path. The resource was created on a *previous* request — that request already fired (or attempted to fire) `file.create` / `deployment.create`. Firing the event again now would double-trigger webhooks and Functions for a single logical creation.

`reset()` clears `event` to `''`, so the `if (! empty($queueForEvents->getEvent()))` guard in the shutdown hook short-circuits and `generateEvents` (and the realtime/webhooks/functions dispatches that follow) are skipped. This matches the existing convention used by Databases bulk/no-op paths (`Bulk/Delete.php`, `Bulk/Upsert.php`, `Documents/Update.php`, `Documents/Delete.php`, etc.).

Each of the three Create endpoints has two early-return paths — one post-lock, one inside the finalize closure. Reset is added at both sites in all three files. 6 reset() calls, 9 lines total.

## Test plan

- [ ] Manual: chunked file upload, force-retry the final chunk after success; verify 200 (not 500) and that webhook/function listening on `buckets.*.files.*.create` does not double-fire.
- [ ] Manual: same for Functions deployment chunked upload.
- [ ] Manual: same for Sites deployment chunked upload.
- [ ] E2E: out-of-order chunked upload tests added in #12138 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
