### PR TITLE
fix(builds): wrap vcsCommentLocks delete with Authorization::skip()

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -41,6 +41,7 @@ use Utopia\Span\Span;
 use Utopia\Storage\Device;
 use Utopia\Storage\Device\Local;
 use Utopia\System\System;
+use Utopia\Database\Validator\Authorization;
 use Utopia\VCS\Adapter\Git\GitHub;
 
 class Builds extends Action
@@ -77,6 +78,7 @@ class Builds extends Action
             ->inject('log')
             ->inject('executor')
             ->inject('plan')
+            ->inject('authorization')
             ->callback($this->action(...));
     }
 
@@ -102,7 +104,8 @@ class Builds extends Action
         Device $deviceForFiles,
         Log $log,
         Executor $executor,
-        array $plan
+        array $plan,
+        Authorization $authorization
     ): void {
         Console::log('Build action started');
 
@@ -1452,7 +1455,7 @@ class Builds extends Action
                     $comment->addBuild($project, $resource, $resourceType, $status, $deployment->getId(), ['type' => 'logs'], $previewUrl);
                     $github->updateComment($owner, $repositoryName, $commentId, $comment->generateComment());
                 } finally {
-                    $dbForPlatform->deleteDocument('vcsCommentLocks', $commentId);
+                    $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $commentId));
                 }
             }
         } catch (\Throwable $th) {


### PR DESCRIPTION
The deleteDocument('vcsCommentLocks', ...) in Builds.php was not wrapped with Authorization::skip(), while three identical calls in Deployment.php are. Add the missing Authorization import, constructor injection, action parameter, and skip() wrapper to match the consistent pattern used elsewhere.

This is a code quality fix � in the current worker context authorization is disabled, so the delete works without skip(). However, the inconsistency creates a maintenance hazard; if worker authorization is ever enabled this would silently leak vcsCommentLocks documents.
