### PR TITLE
Tag migrations-worker Sentry events with source projectId and endpoint

### DIFF
--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -577,11 +577,21 @@ class Migrations extends Action
             }
 
             if ($publish) {
-                call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), [
+                $extras = [
                     'migrationId' => $migration->getId(),
                     'source' => $migration->getAttribute('source') ?? '',
                     'destination' => $migration->getAttribute('destination') ?? '',
-                ]);
+                ];
+
+                // Include source identifiers for Appwrite sources to make Sentry events
+                // self-debuggable. Never include the apiKey or any other secret.
+                if ($migration->getAttribute('source') === SourceAppwrite::getName()) {
+                    $credentials = $migration->getAttribute('credentials', []) ?? [];
+                    $extras['sourceProjectId'] = $credentials['projectId'] ?? '';
+                    $extras['sourceEndpoint'] = $credentials['endpoint'] ?? '';
+                }
+
+                call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), $extras);
             }
         } finally {
             try {


### PR DESCRIPTION
## Summary

When a migrations-worker exception is publishable (the spike's gate arm 1 with `publish=true`, or arm 3 for unknown types), include the source project's identifying info in the Sentry event's extras. Lets on-call jump from a Sentry event straight to the failing migration without first having to query the migration document.

## What changed

`src/Appwrite/Platform/Workers/Migrations.php` — the publish block in the outer catch now builds extras conditionally:

```php
$extras = [
    'migrationId' => $migration->getId(),
    'source'      => $migration->getAttribute('source') ?? '',
    'destination' => $migration->getAttribute('destination') ?? '',
];

// Include source identifiers for Appwrite sources to make Sentry events
// self-debuggable. Never include the apiKey or any other secret.
if ($migration->getAttribute('source') === SourceAppwrite::getName()) {
    $credentials = $migration->getAttribute('credentials', []) ?? [];
    $extras['sourceProjectId'] = $credentials['projectId'] ?? '';
    $extras['sourceEndpoint']  = $credentials['endpoint']  ?? '';
}

call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), $extras);
```

## Notes

- **Only Appwrite sources.** `credentials` has different keys per source type (Firebase `serviceAccount`, Supabase `subdomain`/`adminSecret`/etc.); a blanket dump would risk leaking sensitive fields from other source types. Future per-source enrichment can be additive.
- **No `apiKey`.** Same reason — the credentials map contains the source-side API key/secret. We explicitly only pluck `projectId` and `endpoint`.
- **No behaviour change** when `$publish === false` — the gate already drops those events before this block runs (the spike).

## Sentry event impact

Before: events have `migrationId` / `source` / `destination` only. Tracking back to the source project requires querying the migration doc.

After: events also carry `extra.sourceProjectId` and `extra.sourceEndpoint` for Appwrite-sourced migrations. Visible in the event's Extras panel without needing a follow-up DB lookup.
