### PR TITLE
fix: skip 4xx typed exceptions in VCS deployments instead of 500ing

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -578,6 +578,14 @@ trait Deployment
 
                 Span::add("{$logBase}.build.triggered", 'true');
                 //TODO: Add event?
+            } catch (Exception $e) {
+                Span::add("{$logBase}.error", $e->getMessage());
+                Span::add("{$logBase}.error.type", $e->getType());
+                if ($e->getCode() < 500) {
+                    Console::warning("Skipping repository '{$repository->getId()}' ({$e->getType()}): {$e->getMessage()}");
+                    continue;
+                }
+                $errors[] = $e->getMessage();
             } catch (\Throwable $e) {
                 Span::add("{$logBase}.error", $e->getMessage());
                 $errors[] = $e->getMessage();


### PR DESCRIPTION
## Summary

Typed Appwrite exceptions thrown inside the per-repository loop in [`createGitDeployments`](https://github.com/appwrite/appwrite/blob/22be6514fb/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php#L46-L596) were being caught by a blanket `\Throwable` handler at [line 581](https://github.com/appwrite/appwrite/blob/22be6514fb/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php#L581-L584), collected into `$errors[]`, and re-thrown after the loop at [line 588](https://github.com/appwrite/appwrite/blob/22be6514fb/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php#L587-L589) as `Exception::GENERAL_UNKNOWN` (HTTP 500). This caused GitHub webhook deliveries to return 500 — and Sentry alerts to fire — for legitimate **client-side** error conditions where a 4xx is the correct response.

Typed 4xx exceptions thrown inside this loop today:

- [`PROJECT_NOT_FOUND`](https://github.com/appwrite/appwrite/blob/22be6514fb/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php#L76) (404) — stale repository row pointing at a deleted project
- [`PROVIDER_REPOSITORY_NOT_FOUND`](https://github.com/appwrite/appwrite/blob/22be6514fb/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php#L151) (404) — repository deleted on the provider side
- Any other typed exception subclasses may throw via the [`$this->beforeCreateGitDeployment(...)`](https://github.com/appwrite/appwrite/blob/22be6514fb/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php#L79) hook overridden by downstream consumers.

Mapping in `app/config/errors.php`: `GENERAL_UNKNOWN` → 500 (Sentry-reported), `PROJECT_NOT_FOUND` → 404, `PROVIDER_REPOSITORY_NOT_FOUND` → 404.

## Fix

Add a `catch (Exception $e)` clause before the existing `\Throwable` catch. When the typed exception's HTTP code is `< 500`, log a warning, record the type on the span, and skip the repository. Unexpected `\Throwable` and 5xx-coded typed exceptions still fall through to `$errors[]` and surface as `GENERAL_UNKNOWN`.

```php
} catch (Exception $e) {
    Span::add("{$logBase}.error", $e->getMessage());
    Span::add("{$logBase}.error.type", $e->getType());
    if ($e->getCode() < 500) {
        Console::warning("Skipping repository '{$repository->getId()}' ({$e->getType()}): {$e->getMessage()}");
        continue;
    }
    $errors[] = $e->getMessage();
} catch (\Throwable $e) {
    Span::add("{$logBase}.error", $e->getMessage());
    $errors[] = $e->getMessage();
}
```

Gating by HTTP code (rather than enumerating type strings) covers all current 4xx typed exceptions — including any subclass-defined types injected via the `beforeCreateGitDeployment` hook — and any future 4xx types without further changes.

## Test plan

- [ ] Trigger a GitHub push webhook against a repository whose `projectId` no longer exists → expect `Console::warning` log entry, no Sentry alert, webhook still returns 200 for any sibling deployable repositories
- [ ] Trigger against a deleted provider repo → expect warning + skip
- [ ] Verify a genuine internal error (e.g. queue failure) still surfaces as `GENERAL_UNKNOWN` and reaches Sentry
- [x] `composer lint` / Pint
- [x] `composer analyze` / PHPStan
