### PR TITLE
Fix Swagger enum keys metadata

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -611,19 +611,15 @@ class Swagger2 extends Format
                                     }
 
                                     $enumKeys = [];
-                                    if (!empty($enum->map)) {
-                                        foreach ($enumValues as $enumValue) {
-                                            $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
-                                        }
+                                    foreach ($enumValues as $enumValue) {
+                                        $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
                                     }
 
                                     $node['items']['enum'] = $enumValues;
                                     if (!empty($enum->name)) {
                                         $node['items']['x-enum-name'] = $enum->name;
                                     }
-                                    if (!empty($enumKeys)) {
-                                        $node['items']['x-enum-keys'] = $enumKeys;
-                                    }
+                                    $node['items']['x-enum-keys'] = $enumKeys;
                                 }
                             }
                             if ($validator->getType() === 'integer') {
@@ -652,19 +648,15 @@ class Swagger2 extends Format
                                     }
 
                                     $enumKeys = [];
-                                    if (!empty($enum->map)) {
-                                        foreach ($enumValues as $enumValue) {
-                                            $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
-                                        }
+                                    foreach ($enumValues as $enumValue) {
+                                        $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
                                     }
 
                                     $node['enum'] = $enumValues;
                                     if (!empty($enum->name)) {
                                         $node['x-enum-name'] = $enum->name;
                                     }
-                                    if (!empty($enumKeys)) {
-                                        $node['x-enum-keys'] = $enumKeys;
-                                    }
+                                    $node['x-enum-keys'] = $enumKeys;
                                 }
                             }
                             if ($validator->getType() === 'integer') {


### PR DESCRIPTION
## What does this PR do?

Ensures Swagger 2 enum parameters always include `x-enum-keys`, even when no explicit enum key map is configured. This prevents sdk-generator from warning on scalar enum parameters or payload properties that have enum values but no `x-enum-keys` field.

## Test Plan

- `composer lint src/Appwrite/SDK/Specification/Format/Swagger2.php`

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
