### PR TITLE
Refactor Presence to typed metadata property; drop additionalPropertiesKey hack + Swagger2 PHPStan unblock

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -857,13 +857,6 @@ class OpenAPI3 extends Format
 
             if ($model->isAny()) {
                 $output['components']['schemas'][$model->getType()]['additionalProperties'] = true;
-
-                $additionalKey = \method_exists($model, 'getAdditionalPropertiesKey')
-                    ? $model->getAdditionalPropertiesKey()
-                    : null;
-                if ($additionalKey !== null) {
-                    $output['components']['schemas'][$model->getType()]['x-additional-properties-key'] = $additionalKey;
-                }
             }
 
             if (!empty($required)) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -761,7 +761,9 @@ class Swagger2 extends Format
                         /// If the enum flag is Set, add the enum values to the body
                         $body['schema']['properties'][$name]['enum'] = $node['enum'];
                         $body['schema']['properties'][$name]['x-enum-name'] = $node['x-enum-name'] ?? null;
-                        $body['schema']['properties'][$name]['x-enum-keys'] = $node['x-enum-keys'];
+                        if (isset($node['x-enum-keys'])) {
+                            $body['schema']['properties'][$name]['x-enum-keys'] = $node['x-enum-keys'];
+                        }
                     }
 
                     if ($parameter['nullable']) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -822,13 +822,6 @@ class Swagger2 extends Format
 
             if ($model->isAny()) {
                 $output['definitions'][$model->getType()]['additionalProperties'] = true;
-
-                $additionalKey = \method_exists($model, 'getAdditionalPropertiesKey')
-                    ? $model->getAdditionalPropertiesKey()
-                    : null;
-                if ($additionalKey !== null) {
-                    $output['definitions'][$model->getType()]['x-additional-properties-key'] = $additionalKey;
-                }
             }
 
             if (!empty($required)) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -761,9 +761,7 @@ class Swagger2 extends Format
                         /// If the enum flag is Set, add the enum values to the body
                         $body['schema']['properties'][$name]['enum'] = $node['enum'];
                         $body['schema']['properties'][$name]['x-enum-name'] = $node['x-enum-name'] ?? null;
-                        if (isset($node['x-enum-keys'])) {
-                            $body['schema']['properties'][$name]['x-enum-keys'] = $node['x-enum-keys'];
-                        }
+                        $body['schema']['properties'][$name]['x-enum-keys'] = $node['x-enum-keys'];
                     }
 
                     if ($parameter['nullable']) {

--- a/src/Appwrite/Utopia/Response/Model/Any.php
+++ b/src/Appwrite/Utopia/Response/Model/Any.php
@@ -13,26 +13,6 @@ class Any extends Model
     protected bool $any = true;
 
     /**
-     * JSON wire-format key under which extra/dynamic attributes are exposed in
-     * generated SDK models (e.g. Document<T>'s `data` slot). Default null means
-     * SDK templates fall back to their hardcoded "data" key. Set this on
-     * subclasses (via setAdditionalPropertiesKey) to use a custom key like
-     * "metadata" while still benefiting from the generic `Model<T>` mapping.
-     */
-    protected ?string $additionalPropertiesKey = null;
-
-    public function setAdditionalPropertiesKey(string $key): self
-    {
-        $this->additionalPropertiesKey = $key;
-        return $this;
-    }
-
-    public function getAdditionalPropertiesKey(): ?string
-    {
-        return $this->additionalPropertiesKey;
-    }
-
-    /**
      * Get Name
      *
      * @return string

--- a/src/Appwrite/Utopia/Response/Model/Presence.php
+++ b/src/Appwrite/Utopia/Response/Model/Presence.php
@@ -3,9 +3,10 @@
 namespace Appwrite\Utopia\Response\Model;
 
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Response\Model;
 use Utopia\Database\Document as DatabaseDocument;
 
-class Presence extends Any
+class Presence extends Model
 {
     public function getName(): string
     {
@@ -19,9 +20,6 @@ class Presence extends Any
 
     public function __construct()
     {
-        // Expose user-defined extras under "metadata" instead of the SDK default "data"
-        $this->setAdditionalPropertiesKey('metadata');
-
         $this
             ->addRule('$id', [
                 'type' => self::TYPE_STRING,
@@ -73,9 +71,14 @@ class Presence extends Any
                 'required' => false,
                 'default' => null,
                 'example' => self::TYPE_DATETIME_EXAMPLE,
+            ])
+            ->addRule('metadata', [
+                'type' => self::TYPE_JSON,
+                'description' => 'Presence metadata.',
+                'required' => false,
+                'default' => null,
+                'example' => ['key' => 'value'],
             ]);
-        // User-defined extras flow through Any's generic mapping, surfaced under
-        // the "metadata" key declared via setAdditionalPropertiesKey() above.
     }
 
     public function filter(DatabaseDocument $document): DatabaseDocument


### PR DESCRIPTION
## What changed

Migrates the `Presence` response model to standard OpenAPI 3 form and removes the now-unused `additionalPropertiesKey` mechanism from `Any` + the OpenAPI/Swagger spec emitters. Also folds in a pre-existing PHPStan failure fix that was otherwise blocking the `Analyze` signal for any 1.9.x PR.

### Presence migration (sister PR: appwrite/sdk-generator#1560)

`Presence` previously extended `Any` and called `$this->setAdditionalPropertiesKey('metadata')` in its constructor. This was a non-standard OpenAPI hack: it marked the outer schema as `additionalProperties: true` *and* signalled (via the `x-additional-properties-key` vendor extension) that the dynamic extras should be exposed under a `metadata` sub-key in generated client models.

This conflicted with the standard OpenAPI 3 meaning of outer-level `additionalProperties: true` — which says extras are siblings of typed properties, inline — which is what `Row` and `Document` actually need (and continue to need; they keep extending `Any`).

The Presence wire format is in fact `{$id, userId, status, source, expiresAt, metadata: {...}}` — `metadata` is a genuine nested object, not inline extras. The OpenAPI-correct representation is to declare `metadata` as a regular property of type `object` with `additionalProperties: true` on that property.

Changes:

- `src/Appwrite/Utopia/Response/Model/Presence.php` — extends base `Model` (not `Any`); declares `metadata` as a normal `TYPE_JSON` property; drops `setAdditionalPropertiesKey('metadata')` and the stale extras comment block.
- `src/Appwrite/Utopia/Response/Model/Any.php` — drops the `$additionalPropertiesKey` field, `setAdditionalPropertiesKey()`, and `getAdditionalPropertiesKey()`. `Any` now only carries `$any = true` plus the base `getName/Type/SampleData` methods.
- `src/Appwrite/SDK/Specification/Format/OpenAPI3.php` — drops the `x-additional-properties-key` emission inside the `isAny()` block.
- `src/Appwrite/SDK/Specification/Format/Swagger2.php` — same emission removal.

The sister `sdk-generator` PR (#1560) drops the `additionalPropertiesKey` extension reading on the generator side, so generated SDKs naturally produce `metadata: Map<String, dynamic>...` as a normal typed property for Presence.

### Swagger2 PHPStan unblock

`composer analyze` was failing on `src/Appwrite/SDK/Specification/Format/Swagger2.php:764` with:

```
Offset 'x-enum-keys' on array{...} in isset() always exists and is not nullable.
```

PHPStan correctly inferred that within the outer `if (isset($node['enum']))` (line 760), `$node['x-enum-keys']` is also always set: the only branch that ever sets `$node['enum']` (the `string` / `Enum` validator handling around line 656) unconditionally sets `$node['x-enum-keys']` immediately after on line 659. The inner `if (isset($node['x-enum-keys']))` at line 764 was therefore dead code.

This was pre-existing on `1.9.x` (PR #12402 also merged with the same Analyze failure), leaving the analyze signal effectively unusable. Removed the inner `if` and assigned unconditionally. One file, -3 / +1.

## Verification

- `composer lint` on edited files: pint passes.
- `composer analyze`: **[OK] No errors** (1608 files).
- E2E `Tests / E2E / MongoDB (dedicated) / Presences` — passes (was passing on the previous push too).
- OpenAPI specs under `app/config/specs/` not regenerated locally — needs running app/DB. Maintainers should run `bin/specs` as part of CI/release after merge.
