### PR TITLE
Remove dead isset on x-enum-keys in Swagger2 parameter parser

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -761,9 +761,7 @@ class Swagger2 extends Format
                         /// If the enum flag is Set, add the enum values to the body
                         $body['schema']['properties'][$name]['enum'] = $node['enum'];
                         $body['schema']['properties'][$name]['x-enum-name'] = $node['x-enum-name'] ?? null;
-                        if (isset($node['x-enum-keys'])) {
-                            $body['schema']['properties'][$name]['x-enum-keys'] = $node['x-enum-keys'];
-                        }
+                        $body['schema']['properties'][$name]['x-enum-keys'] = $node['x-enum-keys'];
                     }
 
                     if ($parameter['nullable']) {


### PR DESCRIPTION
## Bug

`composer analyze` (PHPStan level 3) fails on `src/Appwrite/SDK/Specification/Format/Swagger2.php:764`:

```
Offset 'x-enum-keys' on array{...} in isset() always exists and is not nullable.
```

PHPStan correctly infers that within the `if (isset($node['enum']))` branch (line 760), `$node['x-enum-keys']` is also always set — because the sole upstream branch that ever sets `$node['enum']` (the `string` / `Enum` validator block ending around line 656) unconditionally sets `$node['x-enum-keys']` immediately after on line 659. The inner `if (isset($node['x-enum-keys']))` at line 764 is therefore dead code.

## Fix

Remove the redundant inner `if` and assign unconditionally. One file, -3 / +1.

## Verification

- `composer analyze` — **[OK] No errors** (1608 files scanned).
- `composer lint src/Appwrite/SDK/Specification/Format/Swagger2.php` — pint passed.

Pre-existing failure on `1.9.x`; previous attempt at addressing this area (#12402) also merged with the same Analyze failure, leaving the analyze signal effectively unusable for any 1.9.x PR. This unblocks it.
