### PR TITLE
Add npm registry override for compute builds

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -1072,7 +1072,7 @@ return [
             ],
             [
                 'name' => '_APP_COMPUTE_NPM_REGISTRY',
-                'description' => 'The npm registry URL used by function and site build containers. Leave empty to use the runtime default npm registry.',
+                'description' => 'The npm registry URL used by function and site build containers. Leave empty to use the runtime default npm registry. This can point to a caching proxy for registry.npmjs.org.',
                 'introduction' => '1.9.0',
                 'default' => '',
                 'required' => false,

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -1071,6 +1071,15 @@ return [
                 'filter' => ''
             ],
             [
+                'name' => '_APP_COMPUTE_NPM_REGISTRY',
+                'description' => 'The npm registry URL used by function and site build containers. Leave empty to use the runtime default npm registry.',
+                'introduction' => '1.9.0',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
                 'name' => '_APP_DOCKER_HUB_USERNAME',
                 'description' => 'The username for hub.docker.com. This variable is used to pull images from hub.docker.com.',
                 'introduction' => '1.2.0',

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -665,8 +665,7 @@ class Builds extends Action
             }
 
             $npmRegistry = System::getEnv('_APP_COMPUTE_NPM_REGISTRY', '');
-            $npmToken = $vars['NPM_TOKEN'] ?? '';
-            if (! empty($npmRegistry) && empty($npmToken)) {
+            if (! empty($npmRegistry)) {
                 if (! isset($vars['NPM_CONFIG_REGISTRY']) && ! isset($vars['NPM_CONFIG_REPLACE_REGISTRY_HOST'])) {
                     $vars['NPM_CONFIG_REGISTRY'] = $npmRegistry;
                     $vars['NPM_CONFIG_REPLACE_REGISTRY_HOST'] = 'npmjs';

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -664,6 +664,15 @@ class Builds extends Action
                     break;
             }
 
+            $npmRegistry = System::getEnv('_APP_COMPUTE_NPM_REGISTRY', '');
+            $npmToken = $vars['NPM_TOKEN'] ?? '';
+            if (! empty($npmRegistry) && empty($npmToken)) {
+                if (! isset($vars['NPM_CONFIG_REGISTRY']) && ! isset($vars['NPM_CONFIG_REPLACE_REGISTRY_HOST'])) {
+                    $vars['NPM_CONFIG_REGISTRY'] = $npmRegistry;
+                    $vars['NPM_CONFIG_REPLACE_REGISTRY_HOST'] = 'npmjs';
+                }
+            }
+
             $command = $this->getCommand(
                 resource: $resource,
                 deployment: $deployment


### PR DESCRIPTION
## What
- Add `_APP_COMPUTE_NPM_REGISTRY` to configure an npm registry for function and site build containers
- Inject npm registry config only when `NPM_TOKEN` is not set
- Preserve user-provided npm config by skipping injection if `NPM_CONFIG_REGISTRY` or `NPM_CONFIG_REPLACE_REGISTRY_HOST` is already set

## Testing
- `php -l app/config/variables.php`
- `php -l src/Appwrite/Platform/Modules/Functions/Workers/Builds.php`