### PR TITLE
fix(messaging): preserve To header for SMTP emails

### DIFF
--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -264,9 +264,15 @@ class Messaging extends Action
                     default => throw new \Exception('Provider with the requested ID is of the incorrect type')
                 };
 
+                $maxMessagesPerRequest = $adapter->getMaxMessagesPerRequest();
+
+                if ($providerType === MESSAGE_TYPE_EMAIL && $provider->getAttribute('provider') === 'smtp') {
+                    $maxMessagesPerRequest = 1;
+                }
+
                 $batches = \array_chunk(
                     \array_keys($identifiersForProvider),
-                    $adapter->getMaxMessagesPerRequest()
+                    $maxMessagesPerRequest
                 );
 
                 return batch(\array_map(function ($batch) use ($message, $provider, $providerType, $adapter, $dbForProject, $deviceForFiles, $project, $publisherForUsage) {
@@ -623,14 +629,6 @@ class Messaging extends Action
         $subject = $data['subject'];
         $content = $data['content'];
         $html = $data['html'] ?? false;
-
-        // For SMTP, move all recipients to BCC and use default recipient in TO field
-        if ($provider->getAttribute('provider') === 'smtp') {
-            foreach ($to as $recipient) {
-                $bcc[] = ['email' => $recipient];
-            }
-            $to = [];
-        }
 
         return new Email(
             $to,

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -2163,6 +2163,86 @@ trait MessagingBase
         ];
     }
 
+    public function testSendEmailWithSMTPIncludesToHeader(): void
+    {
+        $recipient = 'smtp-message-' . \uniqid() . '@appwrite.io';
+        $subject = 'SMTP recipient header ' . \uniqid();
+
+        $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/smtp', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'providerId' => ID::unique(),
+            'name' => 'SMTP message provider',
+            'host' => 'maildev',
+            'port' => 1025,
+            'username' => 'user',
+            'password' => 'password',
+            'fromName' => 'SMTP Message Sender',
+            'fromEmail' => 'smtp-message@appwrite.io',
+            'enabled' => true,
+        ]);
+
+        $this->assertEquals(201, $provider['headers']['status-code']);
+
+        $user = $this->client->call(Client::METHOD_POST, '/users', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'userId' => ID::unique(),
+            'email' => 'smtp-message-owner-' . \uniqid() . '@appwrite.io',
+            'password' => 'password',
+            'name' => 'SMTP Message User',
+        ]);
+
+        $this->assertEquals(201, $user['headers']['status-code']);
+
+        $target = $this->client->call(Client::METHOD_POST, '/users/' . $user['body']['$id'] . '/targets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'targetId' => ID::unique(),
+            'providerType' => 'email',
+            'providerId' => $provider['body']['$id'],
+            'identifier' => $recipient,
+        ]);
+
+        $this->assertEquals(201, $target['headers']['status-code']);
+
+        $email = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'targets' => [$target['body']['$id']],
+            'subject' => $subject,
+            'content' => 'SMTP messages should include the direct recipient in the To header.',
+        ]);
+
+        $this->assertEquals(201, $email['headers']['status-code']);
+
+        $emailMessageId = $email['body']['$id'];
+        $this->assertEventually(function () use ($emailMessageId) {
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+            $this->assertEquals(MessageStatus::SENT, $response['body']['status']);
+        }, 30000, 500);
+
+        $email = $this->getLastEmailByAddress($recipient, function ($email) use ($subject) {
+            $this->assertSame($subject, $email['subject']);
+        });
+
+        $this->assertSame($recipient, $email['to'][0]['address']);
+        $this->assertSame('smtp-message@appwrite.io', $email['from'][0]['address']);
+    }
+
     public function testUpdateEmail(): void
     {
         $params = $this->setupSentEmailData();


### PR DESCRIPTION
## What does this PR do?

Fixes SMTP messaging emails missing a visible `To` header.

Previously, the Messaging worker moved all SMTP direct recipients into BCC and sent the email with an empty `To` list. Some email clients, including Gmail, displayed delivered emails without recipient information.

This PR keeps the actual SMTP recipient in the `To` header and sends SMTP email batches one recipient at a time, preserving recipient privacy while ensuring a valid visible `To` header.

---

## Test Plan

Ran the targeted Messaging E2E test:

```bash
docker compose exec appwrite test tests/e2e/Services/Messaging --filter=testSendEmailWithSMTPIncludesToHeader
```

Result:

```text
OK (3 tests, 78 assertions)
```

Also ran formatting checks:

```bash
composer lint src/Appwrite/Platform/Workers/Messaging.php
composer lint tests/e2e/Services/Messaging/MessagingBase.php
```

---

## Related PRs and Issues

* Closes #12365

---

## Checklist

* [x] Have you read the Contributing Guidelines on issues
  (https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

* [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

This PR does not change API metadata, so no specs or documentation updates were required.
