### PR TITLE
Fix impossible function cron schedules

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -246,17 +246,13 @@ class Builds extends Action
             ->setParam($resourceKey, $resource->getId())
             ->setParam('deploymentId', $deployment->getId());
 
-        $deploymentId = $deployment->getId();
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-        if ($deployment->isEmpty()) {
-            throw new \Exception('Deployment not found');
-        }
-
         if ($deployment->getAttribute('status') === 'canceled') {
-            $this->cancelDeployment($deploymentId, $dbForProject, $queueForRealtime);
+            $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
             return;
         }
+
+        $deploymentId = $deployment->getId();
 
         $deployment->setAttribute('buildStartedAt', $startTime);
         $deployment->setAttribute('status', 'processing');
@@ -538,12 +534,6 @@ class Builds extends Action
             }
 
             /** Request the executor to build the code... */
-            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-            if ($deployment->getAttribute('status') === 'canceled') {
-                $this->cancelDeployment($deploymentId, $dbForProject, $queueForRealtime);
-                return;
-            }
-
             $deployment->setAttribute('status', 'building');
             $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
                 'status' => 'building',

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -246,13 +246,17 @@ class Builds extends Action
             ->setParam($resourceKey, $resource->getId())
             ->setParam('deploymentId', $deployment->getId());
 
+        $deploymentId = $deployment->getId();
+        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+        if ($deployment->isEmpty()) {
+            throw new \Exception('Deployment not found');
+        }
+
         if ($deployment->getAttribute('status') === 'canceled') {
-            $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+            $this->cancelDeployment($deploymentId, $dbForProject, $queueForRealtime);
 
             return;
         }
-
-        $deploymentId = $deployment->getId();
 
         $deployment->setAttribute('buildStartedAt', $startTime);
         $deployment->setAttribute('status', 'processing');
@@ -534,6 +538,12 @@ class Builds extends Action
             }
 
             /** Request the executor to build the code... */
+            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+            if ($deployment->getAttribute('status') === 'canceled') {
+                $this->cancelDeployment($deploymentId, $dbForProject, $queueForRealtime);
+                return;
+            }
+
             $deployment->setAttribute('status', 'building');
             $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
                 'status' => 'building',

--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -56,12 +56,15 @@ class ScheduleFunctions extends ScheduleBase
         foreach ($this->schedules as $key => $schedule) {
             try {
                 $cron = new CronExpression($schedule['schedule']);
+                $nextDate = $cron->getNextRunDate();
             } catch (\InvalidArgumentException) {
                 // ignore invalid cron expressions
                 continue;
+            } catch (\RuntimeException) {
+                // ignore impossible cron expressions
+                continue;
             }
 
-            $nextDate = $cron->getNextRunDate();
             $next = DateTime::format($nextDate);
 
             $currentTick = $next < $timeFrame;

--- a/src/Appwrite/Task/Validator/Cron.php
+++ b/src/Appwrite/Task/Validator/Cron.php
@@ -38,7 +38,12 @@ class Cron extends Validator
             return false;
         }
 
-        return true;
+        try {
+            (new CronExpression($value))->getNextRunDate();
+            return true;
+        } catch (\RuntimeException) {
+            return false;
+        }
     }
 
     /**

--- a/tests/unit/Task/Validator/CronTest.php
+++ b/tests/unit/Task/Validator/CronTest.php
@@ -28,12 +28,14 @@ class CronTest extends TestCase
         $this->assertEquals($this->object->isValid('* * * * *'), true); // execute on every minutes
         // $this->assertEquals($this->object->isValid('0 17 * * sun'), true); // execute on every Sunday at 5 PM
         $this->assertEquals($this->object->isValid('*/10 * * * *'), true); // execute on every 10 minutes
+        $this->assertEquals($this->object->isValid('*/5 22-23,0-3 * * *'), true); // execute every 5 minutes from 10pm to 3am
         // $this->assertEquals($this->object->isValid('* * * jan,may,aug *'), true); // execute on selected months
         // $this->assertEquals($this->object->isValid('0 17 * * sun,fri'), true); // execute on selected days
         // $this->assertEquals($this->object->isValid('0 2 * * sun'), true); // execute on first sunday of every month
         $this->assertEquals($this->object->isValid('0 */4 * * *'), true); //  execute on every four hours
         // $this->assertEquals($this->object->isValid('0 4,17 * * sun,mon'), true); // execute twice on every Sunday and Monday
         $this->assertEquals($this->object->isValid('bad expression'), false);
+        $this->assertEquals($this->object->isValid('*/5 22-3 * * *'), false);
         $this->assertEquals(null, false);
         $this->assertEquals('', false);
     }


### PR DESCRIPTION
## What does this PR do?

Prevents impossible function cron expressions from crashlooping the function scheduler.

The cron library can parse expressions like `*/5 22-3 * * *`, but later throws `RuntimeException: Impossible CRON expression` when calculating the next run date. This PR validates cron expressions by calculating the next run date and makes the function scheduler silently skip impossible legacy schedules.

## Test Plan

- `vendor/bin/phpunit tests/unit/Task/Validator/CronTest.php --display-warnings`
- `composer lint src/Appwrite/Task/Validator/Cron.php`
- `composer lint src/Appwrite/Platform/Tasks/ScheduleFunctions.php`
- `composer lint tests/unit/Task/Validator/CronTest.php`

Note: The targeted PHPUnit run passes assertions but reports a warning from `dragonmantank/cron-expression` while evaluating the intentionally invalid wrapped-hour expression.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
