### PR TITLE
feat: add Sign Language (sgn) to ISO 639-1 language list

### DIFF
--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -719,6 +719,11 @@ return [
         "nativeName" => "Sängö"
     ],
     [
+        "code" => "sgn",
+        "name" => "Sign Language",
+        "nativeName" => "Sign Language"
+    ],
+    [
         "code" => "sh",
         "name" => "Serbo-Croatian",
         "nativeName" => "Srpskohrvatski / Српскохрватски"


### PR DESCRIPTION
## Description

Adds 'sgn' (Sign Language) to the ISO 639-1 language list in the locale configuration. This is the general ISO 639 code for sign languages as a group, improving accessibility and inclusivity for the Deaf and hard-of-hearing community.

Closes #8201

## What was changed

- Added `sgn` (Sign Language) entry to `app/config/locale/languages.php`