### PR TITLE
Fix flaky benchmark readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,7 +819,6 @@ jobs:
 
       - name: Benchmark after
         id: benchmark_after
-        continue-on-error: true
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         env:
           APPWRITE_ENDPOINT: 'http://localhost/v1'
@@ -861,7 +860,3 @@ jobs:
             benchmark-before-samples.json
             benchmark-after-samples.json
           retention-days: 7
-
-      - name: Fail benchmark
-        if: always() && steps.benchmark_after.outcome != 'success'
-        run: exit 1


### PR DESCRIPTION
## What does this PR do?

Makes benchmark CI failures surface on the actual `Benchmark after` step instead of a later `Fail benchmark` sentinel step with no useful logs.

The benchmark job still runs cleanup, PR commenting, and artifact upload after a k6 failure because those steps already use `if: always()` or `if: !cancelled()`. This keeps the existing startup behavior consistent with the other CI jobs while making the real k6 error visible on the failed step.

## Test Plan

- Parsed `.github/workflows/ci.yml` with Ruby YAML.
- Ran `actionlint .github/workflows/ci.yml`.

## Related PRs and Issues

- #12421

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
