### PR TITLE
Wait for benchmark health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,6 +761,15 @@ jobs:
         run: |
           docker tag ${{ env.IMAGE }}:before ${{ env.IMAGE }}
           docker compose up -d --wait --no-build
+          for attempt in $(seq 1 5); do
+            if curl -fsS http://localhost/v1/health; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            sleep 1
+          done
 
       - name: Prepare benchmark files
         run: rm -f benchmark-before-summary.json benchmark-after-summary.json benchmark-before-samples.json benchmark-after-samples.json
@@ -816,6 +825,15 @@ jobs:
         run: |
           docker tag ${{ env.IMAGE }}:after ${{ env.IMAGE }}
           docker compose up -d --wait --no-build
+          for attempt in $(seq 1 5); do
+            if curl -fsS http://localhost/v1/health; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            sleep 1
+          done
 
       - name: Benchmark after
         id: benchmark_after


### PR DESCRIPTION
## What does this PR do?

Adds a short external health wait before each benchmark run. The benchmark uses k6 from the runner host against `http://localhost/v1`, so this gives Traefik/Appwrite a few seconds to serve `/v1/health` after `docker compose up --wait` completes.

This keeps the existing benchmark job structure and failure handling unchanged.

## Test Plan

- Parsed `.github/workflows/ci.yml` with Ruby YAML.
- Ran `actionlint .github/workflows/ci.yml`.
- Ran `git diff --check`.

## Related PRs and Issues

- #12421

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
