### PR TITLE
Fix public hostname DNS resolution in Swoole

### DIFF
--- a/src/Appwrite/Network/Validator/PublicHostname.php
+++ b/src/Appwrite/Network/Validator/PublicHostname.php
@@ -117,19 +117,23 @@ class PublicHostname extends Validator
      */
     public static function resolve(string $hostname): array
     {
-        $ipv4 = @\gethostbynamel($hostname) ?: [];
-
+        $ipv4 = [];
         $ipv6 = [];
-        $records = @\dns_get_record($hostname, DNS_AAAA);
+
+        $records = @\dns_get_record($hostname, DNS_A | DNS_AAAA);
         if (\is_array($records)) {
             foreach ($records as $record) {
+                if (!empty($record['ip'])) {
+                    $ipv4[] = $record['ip'];
+                }
+
                 if (!empty($record['ipv6'])) {
                     $ipv6[] = $record['ipv6'];
                 }
             }
         }
 
-        return \array_values(\array_unique(\array_merge($ipv4, $ipv6)));
+        return \array_values(\array_unique([...$ipv4, ...$ipv6]));
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Fixes public hostname validation in Swoole workers by resolving both A and AAAA records with `dns_get_record()` instead of mixing `gethostbynamel()` for IPv4 and `dns_get_record()` for IPv6.

The favicon endpoint validates user-provided URLs with `PublicHostname` before fetching them. In the Swoole HTTP worker path, `gethostbynamel()` is hooked by Swoole and can return `false` even when the hostname has valid A records. We reproduced this with `github.com`: without Swoole hooks, `gethostbynamel('github.com')` returns `20.207.73.82`; with `SWOOLE_HOOK_ALL` inside a coroutine, `gethostbynamel('github.com')` returns `false`, while `dns_get_record('github.com', DNS_A)` still returns the same public A record.

This caused valid public hostnames with only A records to be treated as non-resolving. `github.com` exposed the issue because it had no AAAA response in the test environment, so the old resolver returned an empty address list and `/avatars/favicon?url=https://github.com/` failed with `avatar_remote_url_failed` before the fetch happened. Hosts with AAAA records, such as `appwrite.io` or `github.githubassets.com`, could still pass because the IPv6 lookup provided a fallback.

Using `dns_get_record($hostname, DNS_A + DNS_AAAA)` keeps the SSRF guard behavior intact by validating all resolved A and AAAA records, while avoiding the hooked `gethostbynamel()` path that failed in Swoole workers.

## Test Plan

- `composer lint src/Appwrite/Network/Validator/PublicHostname.php`
- `php -l src/Appwrite/Network/Validator/PublicHostname.php`
- `php vendor/bin/phpunit --configuration phpunit.xml tests/unit/Network/Validators/PublicHostnameTest.php`
- Verified Swoole-hooked resolution locally with `SWOOLE_HOOK_ALL` inside a coroutine:
  - `github.com` resolves and validates as public using `PublicHostname::resolve()`
  - `appwrite.io` resolves A and AAAA records and validates as public
  - `github.githubassets.com` resolves A and AAAA records and validates as public

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
