### PR TITLE
fix: emit documents.*.create events for relationship-cascaded child documents

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -416,6 +416,96 @@ abstract class Action extends DatabasesAction
     }
 
     /**
+     * Trigger create events for documents that were created through relationship cascading.
+     *
+     * @param array $nestedCreates
+     * @param Document $database
+     * @param Database $dbForProject
+     * @param Event $queueForEvents
+     * @param Event $queueForRealtime
+     * @param FunctionPublisher $publisherForFunctions
+     * @param Event $queueForWebhooks
+     * @param EventProcessor $eventProcessor
+     * @return void
+     */
+    protected function triggerRelationshipCreates(
+        array $nestedCreates,
+        Document $database,
+        Database $dbForProject,
+        Event $queueForEvents,
+        Event $queueForRealtime,
+        FunctionPublisher $publisherForFunctions,
+        Event $queueForWebhooks,
+        EventProcessor $eventProcessor
+    ): void {
+        if (empty($nestedCreates)) {
+            return;
+        }
+
+        $project = $queueForEvents->getProject();
+        $functionsEvents = $eventProcessor->getFunctionsEvents($project, $dbForProject);
+        $webhooksEvents = $eventProcessor->getWebhooksEvents($project);
+
+        foreach ($nestedCreates as $nested) {
+            $collection = $nested['collection'];
+            $documentId = $nested['documentId'];
+
+            $event = 'databases.[databaseId].collections.[collectionId].documents.[documentId].create';
+
+            $queueForEvents
+                ->setEvent($event)
+                ->setParam('databaseId', $database->getId())
+                ->setContext('database', $database)
+                ->setParam('collectionId', $collection->getId())
+                ->setParam('tableId', $collection->getId())
+                ->setContext($this->getCollectionsEventsContext(), $collection)
+                ->setParam('documentId', $documentId)
+                ->setParam('rowId', $documentId);
+
+            $queueForRealtime
+                ->from($queueForEvents)
+                ->trigger();
+
+            $generatedEvents = Event::generateEvents(
+                $queueForEvents->getEvent(),
+                $queueForEvents->getParams()
+            );
+
+            if (!empty($functionsEvents)) {
+                foreach ($generatedEvents as $event) {
+                    if (isset($functionsEvents[$event])) {
+                        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                            event: $queueForEvents->getEvent(),
+                            params: $queueForEvents->getParams(),
+                            project: $queueForEvents->getProject(),
+                            user: $queueForEvents->getUser(),
+                            userId: $queueForEvents->getUserId(),
+                            payload: $queueForEvents->getPayload(),
+                            platform: $queueForEvents->getPlatform(),
+                        ));
+                        break;
+                    }
+                }
+            }
+
+            if (!empty($webhooksEvents)) {
+                foreach ($generatedEvents as $event) {
+                    if (isset($webhooksEvents[$event])) {
+                        $queueForWebhooks
+                            ->from($queueForEvents)
+                            ->trigger();
+                        break;
+                    }
+                }
+            }
+        }
+
+        $queueForEvents->reset();
+        $queueForRealtime->reset();
+        $queueForWebhooks->reset();
+    }
+
+    /**
      * For triggering different queues for each document for a bulk documents
      * @param string $event
      * @param Document $database

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -282,7 +282,9 @@ class Create extends Action
 
         $operations = 0;
 
-        $checkPermissions = function (Document $collection, Document $document, string $permission) use ($isAPIKey, $isPrivilegedUser, &$checkPermissions, $dbForProject, $database, &$operations, $authorization) {
+        $nestedCreates = [];
+
+        $checkPermissions = function (Document $collection, Document $document, string $permission) use ($isAPIKey, $isPrivilegedUser, &$checkPermissions, $dbForProject, $database, &$operations, $authorization, &$nestedCreates) {
             $operations++;
 
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
@@ -340,6 +342,11 @@ class Create extends Action
 
                         if ($current->isEmpty()) {
                             $type = Database::PERMISSION_CREATE;
+
+                            $nestedCreates[] = [
+                                'collection' => $relatedCollection,
+                                'documentId' => $relation->getId(),
+                            ];
 
                             if (isset($relation['$id']) && $relation['$id'] === 'unique()') {
                                 $relation['$id'] = ID::unique();
@@ -479,6 +486,17 @@ class Create extends Action
         } catch (StructureException $e) {
             throw new Exception($this->getStructureException(), $e->getMessage());
         }
+
+        $this->triggerRelationshipCreates(
+            nestedCreates: $nestedCreates,
+            database: $database,
+            dbForProject: $dbForProject,
+            queueForEvents: $queueForEvents,
+            queueForRealtime: $queueForRealtime,
+            publisherForFunctions: $publisherForFunctions,
+            queueForWebhooks: $queueForWebhooks,
+            eventProcessor: $eventProcessor,
+        );
 
         $queueForEvents
             ->setParam('databaseId', $databaseId)


### PR DESCRIPTION
Fixes #9041 - when creating documents with relationships (one-to-one, one-to-many, many-to-one, many-to-many), the nested child documents created by the relationship cascade did not trigger individual \documents.*.create\ events. This caused realtime listeners and webhooks to miss these creates.

## Changes
- Track nested relationship creates in Create.php and Action.php