### PR TITLE
fix: set team object as event payload for teams.*.update.prefs

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
@@ -76,7 +76,9 @@ class Update extends Action
             'prefs' => $prefs->getArrayCopy()
         ]));
 
-        $queueForEvents->setParam('teamId', $team->getId());
+        $queueForEvents
+            ->setParam('teamId', $team->getId())
+            ->setPayload($response->output($team, Response::MODEL_TEAM));
 
         $response->dynamic($prefs, Response::MODEL_PREFERENCES);
     }


### PR DESCRIPTION
Previously the \	eams.*.update.prefs\ event only sent the team ID as a parameter but did not include a payload. Function/webhook subscribers received an empty event payload.

This fix sets the full team object as the event payload so that subscribers can access team properties without an additional API call.

---
Rebased onto official/1.9.x (b9052d52d0). Force-pushed Tue Jun 2 2026.