### PR TITLE
fix: add trailing slash to Authentik authorize URL

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Authentik.php
+++ b/src/Appwrite/Auth/OAuth2/Authentik.php
@@ -42,7 +42,7 @@ class Authentik extends OAuth2
      */
     public function getLoginURL(): string
     {
-        return 'https://' . $this->getAuthentikDomain() . '/application/o/authorize?' . \http_build_query([
+        return 'https://' . $this->getAuthentikDomain() . '/application/o/authorize/?' . \http_build_query([
             'client_id' => $this->appID,
             'redirect_uri' => $this->callback,
             'state' => \json_encode($this->state),


### PR DESCRIPTION
## What does this PR do?

Fixes the OAuth2 authorization URL for Authentik provider. The `getLoginURL()` was producing `/application/o/authorize?` (missing trailing slash before query string), causing Authentik to reject the request. All other endpoints in the same class (`/token/`, `/userinfo/`) already include the trailing slash.

## Changes

- `src/Appwrite/Auth/OAuth2/Authentik.php`: Added trailing slash to authorize URL (`/application/o/authorize/`)

## Test Plan

1. Configure Authentik as an OAuth2 provider in Appwrite
2. Initiate login flow
3. Verify browser redirects to `/application/o/authorize/?...` instead of `/application/o/authorize?...`
4. Verify Authentik accepts the authorization request

## Related Issues

- Fixes #9567
