### PR TITLE
Revert template root directory path-stripping changes

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -297,10 +297,9 @@ class Builds extends Action
                 $templateReferenceValue = $template->getAttribute('referenceValue', '');
 
                 $templateRootDirectory = $template->getAttribute('rootDirectory', '');
-                $templateRootDirectory = \trim($templateRootDirectory, '/');
-                if ($templateRootDirectory !== '' && \preg_match('#(^|/)\.\.(/|$)#', $templateRootDirectory)) {
-                    throw new \Exception('Invalid template root directory');
-                }
+                $templateRootDirectory = \rtrim($templateRootDirectory, '/');
+                $templateRootDirectory = \ltrim($templateRootDirectory, '.');
+                $templateRootDirectory = \ltrim($templateRootDirectory, '/');
 
                 if (! empty($templateRepositoryName) && ! empty($templateOwnerName) && ! empty($templateReferenceType) && ! empty($templateReferenceValue)) {
                     $stdout = '';
@@ -363,10 +362,9 @@ class Builds extends Action
                 // VCS and VCS+Temaplte
                 $tmpDirectory = '/tmp/builds/' . $deploymentId . '/code';
                 $rootDirectory = $resource->getAttribute('providerRootDirectory', '');
-                $rootDirectory = \trim($rootDirectory, '/');
-                if ($rootDirectory !== '' && \preg_match('#(^|/)\.\.(/|$)#', $rootDirectory)) {
-                    throw new \Exception('Invalid root directory');
-                }
+                $rootDirectory = \rtrim($rootDirectory, '/');
+                $rootDirectory = \ltrim($rootDirectory, '.');
+                $rootDirectory = \ltrim($rootDirectory, '/');
 
                 $owner = $github->getOwnerName($providerInstallationId);
                 $repositoryName = $github->getRepositoryName($providerRepositoryId);
@@ -422,10 +420,9 @@ class Builds extends Action
                 $templateReferenceValue = $template->getAttribute('referenceValue', '');
 
                 $templateRootDirectory = $template->getAttribute('rootDirectory', '');
-                $templateRootDirectory = \trim($templateRootDirectory, '/');
-                if ($templateRootDirectory !== '' && \preg_match('#(^|/)\.\.(/|$)#', $templateRootDirectory)) {
-                    throw new \Exception('Invalid template root directory');
-                }
+                $templateRootDirectory = \rtrim($templateRootDirectory, '/');
+                $templateRootDirectory = \ltrim($templateRootDirectory, '.');
+                $templateRootDirectory = \ltrim($templateRootDirectory, '/');
 
                 if (! empty($templateRepositoryName) && ! empty($templateOwnerName) && ! empty($templateReferenceType) && ! empty($templateReferenceValue)) {
                     // Clone template repo

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -298,9 +298,6 @@ class Builds extends Action
 
                 $templateRootDirectory = $template->getAttribute('rootDirectory', '');
                 $templateRootDirectory = \trim($templateRootDirectory, '/');
-                while (\str_starts_with($templateRootDirectory, './')) {
-                    $templateRootDirectory = \substr($templateRootDirectory, 2);
-                }
                 if ($templateRootDirectory !== '' && \preg_match('#(^|/)\.\.(/|$)#', $templateRootDirectory)) {
                     throw new \Exception('Invalid template root directory');
                 }
@@ -426,9 +423,6 @@ class Builds extends Action
 
                 $templateRootDirectory = $template->getAttribute('rootDirectory', '');
                 $templateRootDirectory = \trim($templateRootDirectory, '/');
-                while (\str_starts_with($templateRootDirectory, './')) {
-                    $templateRootDirectory = \substr($templateRootDirectory, 2);
-                }
                 if ($templateRootDirectory !== '' && \preg_match('#(^|/)\.\.(/|$)#', $templateRootDirectory)) {
                     throw new \Exception('Invalid template root directory');
                 }

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2274,7 +2274,7 @@ class SitesCustomServerTest extends Scope
         $deployment = $this->createTemplateDeployment($siteId, [
             'repository' => $template['providerRepositoryId'],
             'owner' => $template['providerOwner'],
-            'rootDirectory' => $template['frameworks'][0]['providerRootDirectory'],
+            'rootDirectory' => \ltrim($template['frameworks'][0]['providerRootDirectory'], './'),
             'type' => 'tag',
             'reference' => $template['providerVersion'],
             'activate' => true
@@ -2345,7 +2345,7 @@ class SitesCustomServerTest extends Scope
         $deployment = $this->createTemplateDeployment($siteId, [
             'repository' => $template['providerRepositoryId'],
             'owner' => $template['providerOwner'],
-            'rootDirectory' => $template['frameworks'][0]['providerRootDirectory'],
+            'rootDirectory' => \ltrim($template['frameworks'][0]['providerRootDirectory'], './'),
             'type' => 'branch',
             'reference' => 'main',
             'activate' => true
@@ -2423,7 +2423,7 @@ class SitesCustomServerTest extends Scope
         $deployment = $this->createTemplateDeployment($siteId, [
             'repository' => $template['providerRepositoryId'],
             'owner' => $template['providerOwner'],
-            'rootDirectory' => $template['frameworks'][0]['providerRootDirectory'],
+            'rootDirectory' => \ltrim($template['frameworks'][0]['providerRootDirectory'], './'),
             'type' => 'commit',
             'reference' => $latestCommit,
             'activate' => true

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2274,7 +2274,7 @@ class SitesCustomServerTest extends Scope
         $deployment = $this->createTemplateDeployment($siteId, [
             'repository' => $template['providerRepositoryId'],
             'owner' => $template['providerOwner'],
-            'rootDirectory' => \ltrim($template['frameworks'][0]['providerRootDirectory'], './'),
+            'rootDirectory' => $template['frameworks'][0]['providerRootDirectory'],
             'type' => 'tag',
             'reference' => $template['providerVersion'],
             'activate' => true
@@ -2345,7 +2345,7 @@ class SitesCustomServerTest extends Scope
         $deployment = $this->createTemplateDeployment($siteId, [
             'repository' => $template['providerRepositoryId'],
             'owner' => $template['providerOwner'],
-            'rootDirectory' => \ltrim($template['frameworks'][0]['providerRootDirectory'], './'),
+            'rootDirectory' => $template['frameworks'][0]['providerRootDirectory'],
             'type' => 'branch',
             'reference' => 'main',
             'activate' => true
@@ -2423,7 +2423,7 @@ class SitesCustomServerTest extends Scope
         $deployment = $this->createTemplateDeployment($siteId, [
             'repository' => $template['providerRepositoryId'],
             'owner' => $template['providerOwner'],
-            'rootDirectory' => \ltrim($template['frameworks'][0]['providerRootDirectory'], './'),
+            'rootDirectory' => $template['frameworks'][0]['providerRootDirectory'],
             'type' => 'commit',
             'reference' => $latestCommit,
             'activate' => true


### PR DESCRIPTION
## Summary

Reverts the path-normalization changes from PR #12413 ("refactor: tighten internal validation paths") and the follow-up PR (8c8f7b7c48 "Normalize template root directories in builds") that together broke production builds.

History:
- Pre-#12413: `rtrim('/')` → `ltrim('.')` → `ltrim('/')` normalized template/VCS root directories, handling `./foo` correctly.
- #12413 swapped that for `trim('/')` + an explicit `..` regex rejection — intended to reject path traversal instead of silently stripping it, but inadvertently dropped `./` handling.
- 8c8f7b7c48 tried to patch `./` handling back in via a `while (str_starts_with(..., './'))` loop. This broke all builds in production.

This PR restores the original pre-#12413 stripping at all three sites in `Builds.php` (two template paths, one VCS path) and reverts the test relaxations in `SitesCustomServerTest.php` that were tied to the broken behavior.

Trade-off: this re-introduces the silent stripping of leading dots, so `../foo` is normalized to `foo` rather than rejected. We'll harden this properly in a follow-up — handling `./` while still rejecting `..` traversal.

## Test plan
- [ ] Verify builds succeed in production after merge
- [ ] Template-based function/site deployments work end-to-end (tag, branch, commit references)
- [ ] Follow-up: re-add `..` traversal rejection without breaking `./` handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)