### PR TITLE
chore: trace database worker with Span::add instead of Console logging

### DIFF
--- a/app/init/worker/message.php
+++ b/app/init/worker/message.php
@@ -18,6 +18,7 @@ use Utopia\Logger\Log;
 use Utopia\Pools\Group;
 use Utopia\Queue\Publisher;
 use Utopia\Registry\Registry;
+use Utopia\Span\Span;
 use Utopia\Storage\Device\Telemetry as TelemetryDevice;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -55,7 +56,11 @@ return function (Container $container): void {
             return $project;
         }
 
-        return $dbForPlatform->getDocument('projects', $project->getId());
+        $project = $dbForPlatform->getDocument('projects', $project->getId());
+
+        Span::add('project.id', $project->getId());
+
+        return $project;
     }, ['message', 'dbForPlatform']);
 
     $container->set('dbForProject', fn (DatabaseFactory $databaseFactory, Document $project, Database $dbForPlatform) => $project->isEmpty() || $project->getId() === 'console'

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -5,7 +5,6 @@ namespace Appwrite\Platform\Modules\Databases\Workers;
 use Appwrite\Event\Message\Database as DatabaseMessage;
 use Appwrite\Event\Realtime;
 use Exception;
-use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
@@ -18,6 +17,7 @@ use Utopia\Database\Query;
 use Utopia\Logger\Log;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
+use Utopia\Span\Span;
 
 class Databases extends Action
 {
@@ -73,11 +73,21 @@ class Databases extends Action
         $log->addTag('projectId', $project->getId());
         $log->addTag('type', $type);
 
+        Span::add('project.id', $project->getId());
+        Span::add('payload.type', $type);
+        Span::add('queue.pid', $message->getPid());
+        Span::add('queue.name', $message->getQueue());
+        Span::add('message.timestamp', (string) $message->getTimestamp());
+        Span::add('database.collection.id', $collection->getId());
+        Span::add('database.document.id', $document->getId());
+
         if ($database->isEmpty()) {
             throw new Exception('Missing database');
         }
 
         $log->addTag('databaseId', $database->getId());
+
+        Span::add('database.id', $database->getId());
 
         match (\strval($type)) {
             DATABASE_TYPE_DELETE_DATABASE => $this->deleteDatabase($database, $dbForProject, $dbForDatabases),
@@ -88,14 +98,6 @@ class Databases extends Action
             DATABASE_TYPE_DELETE_INDEX => $this->deleteIndex($database, $collection, $document, $project, $dbForPlatform, $dbForProject, $dbForDatabases, $queueForRealtime),
             default => throw new Exception('No database operation for type: ' . \strval($type)),
         };
-
-        Console::info("Finished processing database operation: \n" . \json_encode([
-            'type' => $type,
-            'projectId' => $project->getId(),
-            'databaseId' => $database->getId(),
-            'collectionId' => $collection->getId(),
-            'documentId' => $document->getId(),
-        ], JSON_PRETTY_PRINT));
     }
 
     /**
@@ -206,8 +208,6 @@ class Databases extends Action
 
             $dbForProject->updateDocument('attributes', $attribute->getId(), $attribute->setAttribute('status', 'available'));
         } catch (\Throwable $e) {
-            Console::error($e->getMessage());
-
             if ($e instanceof DatabaseException) {
                 $attribute->setAttribute('error', $e->getMessage());
                 if (! $relatedAttribute->isEmpty()) {
@@ -309,7 +309,7 @@ class Databases extends Action
                 }
 
             } catch (NotFound $e) {
-                Console::error($e->getMessage());
+                Span::add('database.attribute.not_found', $e->getMessage());
 
                 $dbForProject->deleteDocument('attributes', $attribute->getId());
 
@@ -318,8 +318,6 @@ class Databases extends Action
                 }
 
             } catch (\Throwable $e) {
-                Console::error($e->getMessage());
-
                 if ($e instanceof DatabaseException) {
                     $attribute->setAttribute('error', $e->getMessage());
                     if (!$relatedAttribute->isEmpty()) {
@@ -456,7 +454,6 @@ class Databases extends Action
             }
             $dbForProject->updateDocument('indexes', $index->getId(), $index->setAttribute('status', 'available'));
         } catch (\Throwable $e) {
-            Console::error($e->getMessage());
             if ($e instanceof DatabaseException) {
                 $index->setAttribute('error', $e->getMessage());
             }
@@ -512,8 +509,6 @@ class Databases extends Action
             $dbForProject->deleteDocument('indexes', $index->getId());
             $index->setAttribute('status', 'deleted');
         } catch (\Throwable $e) {
-            Console::error($e->getMessage());
-
             if ($e instanceof DatabaseException) {
                 $index->setAttribute('error', $e->getMessage());
             }
@@ -613,8 +608,6 @@ class Databases extends Action
      */
     protected function deleteByGroup(string $collectionId, array $queries, Database $database, ?callable $callback = null): void
     {
-        $start = \microtime(true);
-
         try {
             $count = $database->deleteDocuments(
                 $collectionId,
@@ -624,12 +617,11 @@ class Databases extends Action
             );
         } catch (\Throwable $th) {
             $tenant = $database->getSharedTables() ? 'Tenant:'.$database->getTenant() : '';
-            Console::error("Failed to delete documents/rows for collection/table: {$database->getNamespace()}_{$collectionId} {$tenant} :{$th->getMessage()}");
+            Span::add('delete_by_group.error', "Failed to delete documents/rows for collection/table: {$database->getNamespace()}_{$collectionId} {$tenant} :{$th->getMessage()}");
             return;
         }
 
-        $end = \microtime(true);
-        Console::info("Deleted {$count} documents/rows by group in " . ($end - $start) . " seconds");
+        Span::add('delete_by_group.count', $count);
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -620,11 +620,11 @@ class Databases extends Action
                 $callback
             );
         } catch (\Throwable $th) {
-            Span::add('delete_by_group.namespace', $database->getNamespace());
-            Span::add('delete_by_group.collection.id', $collectionId);
+            Span::add('database.namespace', $database->getNamespace());
             if ($database->getSharedTables()) {
-                Span::add('delete_by_group.tenant', $database->getTenant());
+                Span::add('database.tenant', $database->getTenant());
             }
+            Span::add('delete_by_group.collection', $collectionId);
             Span::add('delete_by_group.error', $th->getMessage());
             return;
         }

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -569,33 +569,50 @@ class Databases extends Action
 
         $dbForDatabases->deleteCollection('database_' . $databaseInternalId . '_collection_' . $collection->getSequence());
 
-        /**
-         * Related collections relating to current collection
-         */
-        $this->deleteByGroup(
-            'attributes',
-            [
+        // The table is already dropped, so attempt every metadata cleanup even
+        // if an earlier one fails -- skipping the rest would leave orphaned
+        // attribute/index rows. Re-throw the first failure afterwards so the
+        // worker marks the message failed and retries the outstanding work.
+        $cleanups = [
+            /**
+             * Related collections relating to current collection
+             */
+            fn () => $this->deleteByGroup(
+                'attributes',
+                [
+                    Query::equal('databaseInternalId', [$databaseInternalId]),
+                    Query::equal('type', [Database::VAR_RELATIONSHIP]),
+                    Query::notEqual('collectionInternalId', $collectionInternalId),
+                    Query::contains('options', ['"relatedCollection":"'. $collectionId .'"']),
+                ],
+                $dbForProject,
+                function ($attribute) use ($dbForProject, $databaseInternalId) {
+                    $dbForProject->purgeCachedDocument('database_' . $databaseInternalId, $attribute->getAttribute('collectionId'));
+                    $dbForProject->purgeCachedCollection('database_' . $databaseInternalId . '_collection_' . $attribute->getAttribute('collectionInternalId'));
+                }
+            ),
+            fn () => $this->deleteByGroup('attributes', [
                 Query::equal('databaseInternalId', [$databaseInternalId]),
-                Query::equal('type', [Database::VAR_RELATIONSHIP]),
-                Query::notEqual('collectionInternalId', $collectionInternalId),
-                Query::contains('options', ['"relatedCollection":"'. $collectionId .'"']),
-            ],
-            $dbForProject,
-            function ($attribute) use ($dbForProject, $databaseInternalId) {
-                $dbForProject->purgeCachedDocument('database_' . $databaseInternalId, $attribute->getAttribute('collectionId'));
-                $dbForProject->purgeCachedCollection('database_' . $databaseInternalId . '_collection_' . $attribute->getAttribute('collectionInternalId'));
+                Query::equal('collectionInternalId', [$collectionInternalId])
+            ], $dbForProject),
+            fn () => $this->deleteByGroup('indexes', [
+                Query::equal('databaseInternalId', [$databaseInternalId]),
+                Query::equal('collectionInternalId', [$collectionInternalId])
+            ], $dbForProject),
+        ];
+
+        $error = null;
+        foreach ($cleanups as $cleanup) {
+            try {
+                $cleanup();
+            } catch (\Throwable $e) {
+                $error ??= $e;
             }
-        );
+        }
 
-        $this->deleteByGroup('attributes', [
-            Query::equal('databaseInternalId', [$databaseInternalId]),
-            Query::equal('collectionInternalId', [$collectionInternalId])
-        ], $dbForProject);
-
-        $this->deleteByGroup('indexes', [
-            Query::equal('databaseInternalId', [$databaseInternalId]),
-            Query::equal('collectionInternalId', [$collectionInternalId])
-        ], $dbForProject);
+        if ($error !== null) {
+            throw $error;
+        }
     }
 
 

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -616,8 +616,6 @@ class Databases extends Action
     {
         Span::add('delete_by_group.collection.id', $collectionId);
 
-        // A failed batch delete is non-recoverable: let it propagate to the
-        // worker's error handler so the message is marked failed and retried.
         $count = $database->deleteDocuments(
             $collectionId,
             $queries,

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -612,6 +612,10 @@ class Databases extends Action
      */
     protected function deleteByGroup(string $collectionId, array $queries, Database $database, ?callable $callback = null): void
     {
+        Span::add('database.namespace', $database->getNamespace());
+        Span::add('database.tenant', $database->getTenant());
+        Span::add('delete_by_group.collection', $collectionId);
+
         try {
             $count = $database->deleteDocuments(
                 $collectionId,
@@ -620,11 +624,6 @@ class Databases extends Action
                 $callback
             );
         } catch (\Throwable $th) {
-            Span::add('database.namespace', $database->getNamespace());
-            if ($database->getSharedTables()) {
-                Span::add('database.tenant', $database->getTenant());
-            }
-            Span::add('delete_by_group.collection', $collectionId);
             Span::add('delete_by_group.error', $th->getMessage());
             return;
         }

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -610,23 +610,20 @@ class Databases extends Action
      * @param Database $database
      * @param callable|null $callback
      * @return void
-     * @throws Exception
+     * @throws \Throwable
      */
     protected function deleteByGroup(string $collectionId, array $queries, Database $database, ?callable $callback = null): void
     {
         Span::add('delete_by_group.collection.id', $collectionId);
 
-        try {
-            $count = $database->deleteDocuments(
-                $collectionId,
-                $queries,
-                Database::DELETE_BATCH_SIZE,
-                $callback
-            );
-        } catch (\Throwable $th) {
-            Span::add('delete_by_group.error', $th->getMessage());
-            return;
-        }
+        // A failed batch delete is non-recoverable: let it propagate to the
+        // worker's error handler so the message is marked failed and retried.
+        $count = $database->deleteDocuments(
+            $collectionId,
+            $queries,
+            Database::DELETE_BATCH_SIZE,
+            $callback
+        );
 
         Span::add('delete_by_group.count', $count);
     }

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -614,7 +614,7 @@ class Databases extends Action
     {
         Span::add('database.namespace', $database->getNamespace());
         Span::add('database.tenant', $database->getTenant());
-        Span::add('delete_by_group.collection', $collectionId);
+        Span::add('delete_by_group.collection.id', $collectionId);
 
         try {
             $count = $database->deleteDocuments(

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -569,9 +569,6 @@ class Databases extends Action
 
         $dbForDatabases->deleteCollection('database_' . $databaseInternalId . '_collection_' . $collection->getSequence());
 
-        // The table is already dropped, so run every metadata cleanup even if
-        // one fails -- skipping the rest would orphan attribute/index rows.
-        // attemptAll re-throws the first failure so the message is retried.
         $this->attemptAll(
             // Related collections relating to current collection
             fn () => $this->deleteByGroup(

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -61,11 +61,25 @@ class Databases extends Action
             throw new Exception('Missing payload');
         }
 
+        Span::add('project.id', $project->getId());
+        Span::add('queue.pid', $message->getPid());
+        Span::add('queue.name', $message->getQueue());
+        Span::add('message.timestamp', (string) $message->getTimestamp());
+
         $databaseMessage = DatabaseMessage::fromArray($payload);
+
         $type = $databaseMessage->type;
+        Span::add('payload.type', $type);
+
         $document = $databaseMessage->row ?? $databaseMessage->document ?? new Document();
+        Span::add('database.document.id', $document->getId());
+
         $collection = $databaseMessage->table ?? $databaseMessage->collection ?? new Document();
+        Span::add('database.collection.id', $collection->getId());
+
         $database = $databaseMessage->database ?? new Document();
+        Span::add('database.id', $database->getId());
+
         /**
          * @var Database $dbForDatabases
          */
@@ -73,21 +87,11 @@ class Databases extends Action
         $log->addTag('projectId', $project->getId());
         $log->addTag('type', $type);
 
-        Span::add('project.id', $project->getId());
-        Span::add('payload.type', $type);
-        Span::add('queue.pid', $message->getPid());
-        Span::add('queue.name', $message->getQueue());
-        Span::add('message.timestamp', (string) $message->getTimestamp());
-        Span::add('database.collection.id', $collection->getId());
-        Span::add('database.document.id', $document->getId());
-
         if ($database->isEmpty()) {
             throw new Exception('Missing database');
         }
 
         $log->addTag('databaseId', $database->getId());
-
-        Span::add('database.id', $database->getId());
 
         match (\strval($type)) {
             DATABASE_TYPE_DELETE_DATABASE => $this->deleteDatabase($database, $dbForProject, $dbForDatabases),
@@ -616,8 +620,12 @@ class Databases extends Action
                 $callback
             );
         } catch (\Throwable $th) {
-            $tenant = $database->getSharedTables() ? 'Tenant:'.$database->getTenant() : '';
-            Span::add('delete_by_group.error', "Failed to delete documents/rows for collection/table: {$database->getNamespace()}_{$collectionId} {$tenant} :{$th->getMessage()}");
+            Span::add('delete_by_group.namespace', $database->getNamespace());
+            Span::add('delete_by_group.collection.id', $collectionId);
+            if ($database->getSharedTables()) {
+                Span::add('delete_by_group.tenant', $database->getTenant());
+            }
+            Span::add('delete_by_group.error', $th->getMessage());
             return;
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -569,56 +569,33 @@ class Databases extends Action
 
         $dbForDatabases->deleteCollection('database_' . $databaseInternalId . '_collection_' . $collection->getSequence());
 
-        $this->attemptAll(
-            // Related collections relating to current collection
-            fn () => $this->deleteByGroup(
-                'attributes',
-                [
-                    Query::equal('databaseInternalId', [$databaseInternalId]),
-                    Query::equal('type', [Database::VAR_RELATIONSHIP]),
-                    Query::notEqual('collectionInternalId', $collectionInternalId),
-                    Query::contains('options', ['"relatedCollection":"'. $collectionId .'"']),
-                ],
-                $dbForProject,
-                function ($attribute) use ($dbForProject, $databaseInternalId) {
-                    $dbForProject->purgeCachedDocument('database_' . $databaseInternalId, $attribute->getAttribute('collectionId'));
-                    $dbForProject->purgeCachedCollection('database_' . $databaseInternalId . '_collection_' . $attribute->getAttribute('collectionInternalId'));
-                }
-            ),
-            fn () => $this->deleteByGroup('attributes', [
+        /**
+         * Related collections relating to current collection
+         */
+        $this->deleteByGroup(
+            'attributes',
+            [
                 Query::equal('databaseInternalId', [$databaseInternalId]),
-                Query::equal('collectionInternalId', [$collectionInternalId])
-            ], $dbForProject),
-            fn () => $this->deleteByGroup('indexes', [
-                Query::equal('databaseInternalId', [$databaseInternalId]),
-                Query::equal('collectionInternalId', [$collectionInternalId])
-            ], $dbForProject),
-        );
-    }
-
-    /**
-     * Run every cleanup even if some fail, then re-throw the first failure so
-     * the worker marks the message failed and retries the outstanding work.
-     *
-     * @param callable ...$cleanups
-     * @return void
-     * @throws \Throwable
-     */
-    private function attemptAll(callable ...$cleanups): void
-    {
-        $error = null;
-
-        foreach ($cleanups as $cleanup) {
-            try {
-                $cleanup();
-            } catch (\Throwable $e) {
-                $error ??= $e;
+                Query::equal('type', [Database::VAR_RELATIONSHIP]),
+                Query::notEqual('collectionInternalId', $collectionInternalId),
+                Query::contains('options', ['"relatedCollection":"'. $collectionId .'"']),
+            ],
+            $dbForProject,
+            function ($attribute) use ($dbForProject, $databaseInternalId) {
+                $dbForProject->purgeCachedDocument('database_' . $databaseInternalId, $attribute->getAttribute('collectionId'));
+                $dbForProject->purgeCachedCollection('database_' . $databaseInternalId . '_collection_' . $attribute->getAttribute('collectionInternalId'));
             }
-        }
+        );
 
-        if ($error !== null) {
-            throw $error;
-        }
+        $this->deleteByGroup('attributes', [
+            Query::equal('databaseInternalId', [$databaseInternalId]),
+            Query::equal('collectionInternalId', [$collectionInternalId])
+        ], $dbForProject);
+
+        $this->deleteByGroup('indexes', [
+            Query::equal('databaseInternalId', [$databaseInternalId]),
+            Query::equal('collectionInternalId', [$collectionInternalId])
+        ], $dbForProject);
     }
 
 
@@ -628,18 +605,23 @@ class Databases extends Action
      * @param Database $database
      * @param callable|null $callback
      * @return void
-     * @throws \Throwable
+     * @throws Exception
      */
     protected function deleteByGroup(string $collectionId, array $queries, Database $database, ?callable $callback = null): void
     {
         Span::add('delete_by_group.collection.id', $collectionId);
 
-        $count = $database->deleteDocuments(
-            $collectionId,
-            $queries,
-            Database::DELETE_BATCH_SIZE,
-            $callback
-        );
+        try {
+            $count = $database->deleteDocuments(
+                $collectionId,
+                $queries,
+                Database::DELETE_BATCH_SIZE,
+                $callback
+            );
+        } catch (\Throwable $th) {
+            Span::add('delete_by_group.error', $th->getMessage());
+            return;
+        }
 
         Span::add('delete_by_group.count', $count);
     }

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -569,14 +569,11 @@ class Databases extends Action
 
         $dbForDatabases->deleteCollection('database_' . $databaseInternalId . '_collection_' . $collection->getSequence());
 
-        // The table is already dropped, so attempt every metadata cleanup even
-        // if an earlier one fails -- skipping the rest would leave orphaned
-        // attribute/index rows. Re-throw the first failure afterwards so the
-        // worker marks the message failed and retries the outstanding work.
-        $cleanups = [
-            /**
-             * Related collections relating to current collection
-             */
+        // The table is already dropped, so run every metadata cleanup even if
+        // one fails -- skipping the rest would orphan attribute/index rows.
+        // attemptAll re-throws the first failure so the message is retried.
+        $this->attemptAll(
+            // Related collections relating to current collection
             fn () => $this->deleteByGroup(
                 'attributes',
                 [
@@ -599,9 +596,21 @@ class Databases extends Action
                 Query::equal('databaseInternalId', [$databaseInternalId]),
                 Query::equal('collectionInternalId', [$collectionInternalId])
             ], $dbForProject),
-        ];
+        );
+    }
 
+    /**
+     * Run every cleanup even if some fail, then re-throw the first failure so
+     * the worker marks the message failed and retries the outstanding work.
+     *
+     * @param callable ...$cleanups
+     * @return void
+     * @throws \Throwable
+     */
+    private function attemptAll(callable ...$cleanups): void
+    {
         $error = null;
+
         foreach ($cleanups as $cleanup) {
             try {
                 $cleanup();

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -61,11 +61,6 @@ class Databases extends Action
             throw new Exception('Missing payload');
         }
 
-        Span::add('project.id', $project->getId());
-        Span::add('queue.pid', $message->getPid());
-        Span::add('queue.name', $message->getQueue());
-        Span::add('message.timestamp', (string) $message->getTimestamp());
-
         $databaseMessage = DatabaseMessage::fromArray($payload);
 
         $type = $databaseMessage->type;

--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -79,6 +79,8 @@ class Databases extends Action
 
         $database = $databaseMessage->database ?? new Document();
         Span::add('database.id', $database->getId());
+        Span::add('database.namespace', $dbForProject->getNamespace());
+        Span::add('database.tenant', $dbForProject->getTenant());
 
         /**
          * @var Database $dbForDatabases
@@ -612,8 +614,6 @@ class Databases extends Action
      */
     protected function deleteByGroup(string $collectionId, array $queries, Database $database, ?callable $callback = null): void
     {
-        Span::add('database.namespace', $database->getNamespace());
-        Span::add('database.tenant', $database->getTenant());
         Span::add('delete_by_group.collection.id', $collectionId);
 
         try {


### PR DESCRIPTION
## What

Replaces unstructured `Console::info`/`Console::error` logging in the database worker (`src/Appwrite/Platform/Modules/Databases/Workers/Databases.php`) with structured `Span::add` tracing.

## Changes

- **Operation context up front** — the trailing `Console::info("Finished processing…")` JSON dump is replaced with spans added at the start of `action()`: `project.id`, `payload.type`, `queue.pid`, `queue.name`, `message.timestamp`, `database.id`, `database.collection.id`, `database.document.id` (following the existing Functions worker convention).
- **Rethrowing catch blocks** (`createAttribute`, `deleteAttribute`, `createIndex`, `deleteIndex`) — removed `Console::error($e->getMessage())`. The entry-point harness owns span error lifecycle, and the rethrown exception already carries the message, so these were redundant.
- **Swallowed cases surfaced as spans** so they stay visible:
  - `deleteAttribute` `NotFound` catch → `database.attribute.not_found`
  - `deleteByGroup` swallowed error → `delete_by_group.error`; success count → `delete_by_group.count` (dropped manual `microtime` timing since the harness already times the worker span)
- Removed the now-unused `Utopia\Console` import; added `Utopia\Span\Span`.

The structured `$log->addTag(...)` logger tags are kept (they feed error reporting, not unstructured console output).

## Notes

`composer format` / `composer analyze` should be run in the Docker container before merge — vendor binaries aren't present in the local checkout. `php -l` passes with no syntax errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)