### PR TITLE
refactor: decompose the shared API shutdown hook + drop deprecated Route::getParamsValues()

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -38,7 +38,6 @@ use Utopia\Database\Validator\Authorization\Input;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Http;
 use Utopia\Http\Route;
-use Utopia\Http\Router;
 use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -787,6 +786,7 @@ Http::shutdown()
 Http::shutdown()
     ->groups(['api'])
     ->inject('route')
+    ->inject('params')
     ->inject('request')
     ->inject('response')
     ->inject('project')
@@ -806,7 +806,7 @@ Http::shutdown()
     ->inject('bus')
     ->inject('apiKey')
     ->inject('mode')
-    ->action(function (Route $route, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode) use ($parseLabel) {
+    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode) use ($parseLabel) {
 
         $responsePayload = $response->getPayload();
 
@@ -863,13 +863,14 @@ Http::shutdown()
             }
         }
 
-        $preparedPath = Router::preparePath($route->getMatchedPath());
-        $pathValues = $route->getPathValues($request, $preparedPath[0]);
+        // $params holds the URL path values (injected from the route match);
+        // merge in query/body params and declared defaults to reproduce the
+        // full resolved param set, with path values taking precedence.
         $reqParams = $request->getParams();
 
         $requestParams = [];
         foreach ($route->getParams() as $key => $param) {
-            $requestParams[$key] = $pathValues[$key] ?? $reqParams[$key] ?? $param['default'];
+            $requestParams[$key] = $params[$key] ?? $reqParams[$key] ?? $param['default'];
         }
 
         /**

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -863,13 +863,6 @@ Http::shutdown()
             }
         }
 
-        // Reproduce the resolved param set: injected path values take precedence
-        // over query/body params, falling back to each param's declared default.
-        $requestParams = [];
-        foreach ($route->getParams() as $key => $param) {
-            $requestParams[$key] = $params[$key] ?? $request->getParam($key, $param['default']);
-        }
-
         /**
          * Abuse labels
          */
@@ -910,7 +903,7 @@ Http::shutdown()
          */
         $pattern = $route->getLabel('audits.resource', null);
         if (! empty($pattern)) {
-            $resource = $parseLabel($pattern, $responsePayload, $requestParams, $user, $project);
+            $resource = $parseLabel($pattern, $responsePayload, $params, $user, $project);
             if (! empty($resource) && $resource !== $pattern) {
                 $auditContext->resource = $resource;
             }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -38,6 +38,7 @@ use Utopia\Database\Validator\Authorization\Input;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Http;
 use Utopia\Http\Route;
+use Utopia\Http\Router;
 use Utopia\Span\Span;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -862,7 +863,14 @@ Http::shutdown()
             }
         }
 
-        $requestParams = $route->getParamsValues();
+        $preparedPath = Router::preparePath($route->getMatchedPath());
+        $pathValues = $route->getPathValues($request, $preparedPath[0]);
+        $reqParams = $request->getParams();
+
+        $requestParams = [];
+        foreach ($route->getParams() as $key => $param) {
+            $requestParams[$key] = $pathValues[$key] ?? $reqParams[$key] ?? $param['default'];
+        }
 
         /**
          * Abuse labels

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -794,19 +794,14 @@ Http::shutdown()
     ->inject('queueForEvents')
     ->inject('auditContext')
     ->inject('publisherForAudits')
-    ->inject('usage')
-    ->inject('publisherForUsage')
     ->inject('publisherForFunctions')
     ->inject('queueForWebhooks')
     ->inject('queueForRealtime')
     ->inject('dbForProject')
-    ->inject('authorization')
     ->inject('timelimit')
     ->inject('eventProcessor')
-    ->inject('bus')
-    ->inject('apiKey')
     ->inject('mode')
-    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, Context $usage, UsagePublisher $publisherForUsage, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, Authorization $authorization, callable $timelimit, EventProcessor $eventProcessor, Bus $bus, ?Key $apiKey, string $mode) use ($parseLabel) {
+    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, callable $timelimit, EventProcessor $eventProcessor, string $mode) use ($parseLabel) {
 
         $responsePayload = $response->getPayload();
 
@@ -950,43 +945,6 @@ Http::shutdown()
 
             $publisherForAudits->enqueue(AuditMessage::fromContext($auditContext));
         }
-
-        if ($project->getId() !== 'console') {
-            if (! $user->isPrivileged($authorization->getRoles())) {
-                $bus->dispatch(new RequestCompleted(
-                    project: $project->getArrayCopy(),
-                    request: $request,
-                    response: $response,
-                ));
-            }
-
-            // Publish usage metrics if context has data
-            if (! $usage->isEmpty()) {
-                $metrics = $usage->getMetrics();
-
-                // Filter out API key disabled metrics using suffix pattern matching
-                $disabledMetrics = $apiKey?->getDisabledMetrics() ?? [];
-                if (! empty($disabledMetrics)) {
-                    $metrics = array_values(array_filter($metrics, function ($metric) use ($disabledMetrics) {
-                        foreach ($disabledMetrics as $pattern) {
-                            if (str_ends_with($metric['key'], $pattern)) {
-                                return false;
-                            }
-                        }
-
-                        return true;
-                    }));
-                }
-
-                $message = new UsageMessage(
-                    project: $project,
-                    metrics: $metrics,
-                    reduce: $usage->getReduce()
-                );
-
-                $publisherForUsage->enqueue($message);
-            }
-        }
     });
 
 Http::shutdown()
@@ -1010,58 +968,106 @@ Http::shutdown()
             return;
         }
 
-        // Reproduce the resolved param set: injected path values take precedence
-        // over query/body params, falling back to each param's declared default.
-        $requestParams = [];
-        foreach ($route->getParams() as $key => $param) {
-            $requestParams[$key] = $params[$key] ?? $request->getParam($key, $param['default']);
-        }
-
-        $resource = $resourceType = null;
-        $pattern = $route->getLabel('cache.resource', null);
-        if (! empty($pattern)) {
-            $resource = $parseLabel($pattern, $data, $requestParams, $user, $project);
-        }
-
-        $pattern = $route->getLabel('cache.resourceType', null);
-        if (! empty($pattern)) {
-            $resourceType = $parseLabel($pattern, $data, $requestParams, $user, $project);
-        }
-
         $cache = new Cache(
             new Filesystem(APP_STORAGE_CACHE . DIRECTORY_SEPARATOR . 'app-' . $project->getId())
         );
-
         $key = $request->cacheIdentifier();
         $signature = md5($data['payload']);
-        $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
-        $accessedAt = $cacheLog->getAttribute('accessedAt', 0);
         $now = DateTime::now();
+        $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
+
+        // First request for this resource: record it and persist the payload.
         if ($cacheLog->isEmpty()) {
+            // Resolve resource labels lazily — only needed when creating the entry.
+            $requestParams = [];
+            foreach ($route->getParams() as $paramKey => $param) {
+                $requestParams[$paramKey] = $params[$paramKey] ?? $request->getParam($paramKey, $param['default']);
+            }
+
+            $resourcePattern = $route->getLabel('cache.resource', null);
+            $resourceTypePattern = $route->getLabel('cache.resourceType', null);
+
             try {
                 $authorization->skip(fn () => $dbForProject->createDocument('cache', new Document([
                     '$id' => $key,
-                    'resource' => $resource,
-                    'resourceType' => $resourceType,
+                    'resource' => empty($resourcePattern) ? null : $parseLabel($resourcePattern, $data, $requestParams, $user, $project),
+                    'resourceType' => empty($resourceTypePattern) ? null : $parseLabel($resourceTypePattern, $data, $requestParams, $user, $project),
                     'mimeType' => $response->getContentType(),
                     'accessedAt' => $now,
                     'signature' => $signature,
                 ])));
+                $cache->save($key, $data['payload']);
+
+                return;
             } catch (DuplicateException) {
-                // Race condition: another concurrent request already created the cache document
+                // Race condition: another concurrent request already created the entry.
                 $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
             }
-        } elseif (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_CACHE_UPDATE)) > $accessedAt) {
-            $cacheLog->setAttribute('accessedAt', $now);
-            $authorization->skip(fn () => $dbForProject->updateDocument('cache', $cacheLog->getId(), new Document([
-                'accessedAt' => $cacheLog->getAttribute('accessedAt')
-            ])));
-            // Overwrite the file every APP_CACHE_UPDATE seconds to update the file modified time that is used in the TTL checks in cache->load()
-            $cache->save($key, $data['payload']);
         }
 
-        if ($signature !== $cacheLog->getAttribute('signature')) {
+        // Existing entry: refresh the access time once per APP_CACHE_UPDATE window
+        // (keeps the file mtime current for TTL checks) and re-persist on content change.
+        $stale = DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_CACHE_UPDATE)) > $cacheLog->getAttribute('accessedAt', 0);
+        if ($stale) {
+            $authorization->skip(fn () => $dbForProject->updateDocument('cache', $cacheLog->getId(), new Document([
+                'accessedAt' => $now,
+            ])));
+        }
+
+        if ($stale || $signature !== $cacheLog->getAttribute('signature')) {
             $cache->save($key, $data['payload']);
+        }
+    });
+
+Http::shutdown()
+    ->groups(['api'])
+    ->inject('request')
+    ->inject('response')
+    ->inject('project')
+    ->inject('user')
+    ->inject('usage')
+    ->inject('publisherForUsage')
+    ->inject('authorization')
+    ->inject('bus')
+    ->inject('apiKey')
+    ->action(function (Request $request, Response $response, Document $project, User $user, Context $usage, UsagePublisher $publisherForUsage, Authorization $authorization, Bus $bus, ?Key $apiKey) {
+        if ($project->getId() === 'console') {
+            return;
+        }
+
+        if (! $user->isPrivileged($authorization->getRoles())) {
+            $bus->dispatch(new RequestCompleted(
+                project: $project->getArrayCopy(),
+                request: $request,
+                response: $response,
+            ));
+        }
+
+        // Publish usage metrics if context has data
+        if (! $usage->isEmpty()) {
+            $metrics = $usage->getMetrics();
+
+            // Filter out API key disabled metrics using suffix pattern matching
+            $disabledMetrics = $apiKey?->getDisabledMetrics() ?? [];
+            if (! empty($disabledMetrics)) {
+                $metrics = array_values(array_filter($metrics, function ($metric) use ($disabledMetrics) {
+                    foreach ($disabledMetrics as $pattern) {
+                        if (str_ends_with($metric['key'], $pattern)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }));
+            }
+
+            $message = new UsageMessage(
+                project: $project,
+                metrics: $metrics,
+                reduce: $usage->getReduce()
+            );
+
+            $publisherForUsage->enqueue($message);
         }
     });
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -786,116 +786,129 @@ Http::shutdown()
 Http::shutdown()
     ->groups(['api'])
     ->inject('route')
+    ->inject('response')
+    ->inject('project')
+    ->inject('queueForEvents')
+    ->inject('publisherForFunctions')
+    ->inject('queueForWebhooks')
+    ->inject('queueForRealtime')
+    ->inject('dbForProject')
+    ->inject('eventProcessor')
+    ->action(function (Route $route, Response $response, Document $project, Event $queueForEvents, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, EventProcessor $eventProcessor) {
+        if (empty($queueForEvents->getEvent())) {
+            return;
+        }
+
+        if (empty($queueForEvents->getPayload())) {
+            $queueForEvents->setPayload($response->getPayload());
+        }
+
+        // Get project and function/webhook events (cached)
+        $functionsEvents = $eventProcessor->getFunctionsEvents($project, $dbForProject);
+        $webhooksEvents = $eventProcessor->getWebhooksEvents($project);
+
+        // Generate events for this operation
+        $generatedEvents = Event::generateEvents(
+            $queueForEvents->getEvent(),
+            $queueForEvents->getParams()
+        );
+
+        $allowedOnConsole = !empty(\array_intersect($route->getGroups(), Realtime::CONSOLE_ALLOWLIST));
+        if ($project->getId() !== 'console' || $allowedOnConsole) {
+            $queueForRealtime
+                ->from($queueForEvents)
+                ->trigger();
+        }
+
+        // Only trigger functions if there are matching function events
+        if (! empty($functionsEvents)) {
+            foreach ($generatedEvents as $event) {
+                if (isset($functionsEvents[$event])) {
+                    $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                        event: $queueForEvents->getEvent(),
+                        params: $queueForEvents->getParams(),
+                        project: $queueForEvents->getProject(),
+                        user: $queueForEvents->getUser(),
+                        userId: $queueForEvents->getUserId(),
+                        payload: $queueForEvents->getPayload(),
+                        platform: $queueForEvents->getPlatform(),
+                    ));
+                    break;
+                }
+            }
+        }
+
+        // Only trigger webhooks if there are matching webhook events
+        if (! empty($webhooksEvents)) {
+            foreach ($generatedEvents as $event) {
+                if (isset($webhooksEvents[$event])) {
+                    $queueForWebhooks
+                        ->from($queueForEvents)
+                        ->trigger();
+                    break;
+                }
+            }
+        }
+    });
+
+Http::shutdown()
+    ->groups(['api'])
+    ->inject('route')
+    ->inject('request')
+    ->inject('response')
+    ->inject('project')
+    ->inject('user')
+    ->inject('timelimit')
+    ->action(function (Route $route, Request $request, Response $response, Document $project, User $user, callable $timelimit) {
+        $abuseEnabled = System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') !== 'disabled';
+        $abuseResetCode = $route->getLabel('abuse-reset', []);
+        $abuseResetCode = \is_array($abuseResetCode) ? $abuseResetCode : [$abuseResetCode];
+
+        if (! $abuseEnabled || \count($abuseResetCode) === 0 || ! \in_array($response->getStatusCode(), $abuseResetCode)) {
+            return;
+        }
+
+        $abuseKeyLabel = $route->getLabel('abuse-key', 'url:{url},ip:{ip}');
+        $abuseKeyLabel = (! is_array($abuseKeyLabel)) ? [$abuseKeyLabel] : $abuseKeyLabel;
+
+        foreach ($abuseKeyLabel as $abuseKey) {
+            $start = $request->getContentRangeStart();
+            $end = $request->getContentRangeEnd();
+            $timeLimit = $timelimit($abuseKey, $route->getLabel('abuse-limit', 0), $route->getLabel('abuse-time', 3600));
+            $timeLimit
+                ->setParam('{projectId}', $project->getId())
+                ->setParam('{userId}', $user->getId())
+                ->setParam('{userAgent}', $request->getUserAgent(''))
+                ->setParam('{ip}', $request->getIP())
+                ->setParam('{url}', $request->getHostname() . $route->getPath())
+                ->setParam('{method}', $request->getMethod())
+                ->setParam('{chunkId}', (int) ($start / ($end + 1 - $start)));
+
+            foreach ($request->getParams() as $key => $value) { // Set request params as potential abuse keys
+                if (! empty($value)) {
+                    $timeLimit->setParam('{param-' . $key . '}', (\is_array($value)) ? \json_encode($value) : $value);
+                }
+            }
+
+            $abuse = new Abuse($timeLimit);
+            $abuse->reset();
+        }
+    });
+
+Http::shutdown()
+    ->groups(['api'])
+    ->inject('route')
     ->inject('params')
     ->inject('request')
     ->inject('response')
     ->inject('project')
     ->inject('user')
-    ->inject('queueForEvents')
     ->inject('auditContext')
     ->inject('publisherForAudits')
-    ->inject('publisherForFunctions')
-    ->inject('queueForWebhooks')
-    ->inject('queueForRealtime')
-    ->inject('dbForProject')
-    ->inject('timelimit')
-    ->inject('eventProcessor')
     ->inject('mode')
-    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, Event $queueForEvents, AuditContext $auditContext, Audit $publisherForAudits, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, Realtime $queueForRealtime, Database $dbForProject, callable $timelimit, EventProcessor $eventProcessor, string $mode) use ($parseLabel) {
-
+    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, AuditContext $auditContext, Audit $publisherForAudits, string $mode) use ($parseLabel) {
         $responsePayload = $response->getPayload();
 
-        if (! empty($queueForEvents->getEvent())) {
-            if (empty($queueForEvents->getPayload())) {
-                $queueForEvents->setPayload($responsePayload);
-            }
-
-            // Get project and function/webhook events (cached)
-            $functionsEvents = $eventProcessor->getFunctionsEvents($project, $dbForProject);
-            $webhooksEvents = $eventProcessor->getWebhooksEvents($project);
-
-            // Generate events for this operation
-            $generatedEvents = Event::generateEvents(
-                $queueForEvents->getEvent(),
-                $queueForEvents->getParams()
-            );
-
-            $allowedOnConsole = !empty(\array_intersect($route->getGroups(), Realtime::CONSOLE_ALLOWLIST));
-            if ($project->getId() !== 'console' || $allowedOnConsole) {
-                $queueForRealtime
-                    ->from($queueForEvents)
-                    ->trigger();
-            }
-
-            // Only trigger functions if there are matching function events
-            if (! empty($functionsEvents)) {
-                foreach ($generatedEvents as $event) {
-                    if (isset($functionsEvents[$event])) {
-                        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
-                            event: $queueForEvents->getEvent(),
-                            params: $queueForEvents->getParams(),
-                            project: $queueForEvents->getProject(),
-                            user: $queueForEvents->getUser(),
-                            userId: $queueForEvents->getUserId(),
-                            payload: $queueForEvents->getPayload(),
-                            platform: $queueForEvents->getPlatform(),
-                        ));
-                        break;
-                    }
-                }
-            }
-
-            // Only trigger webhooks if there are matching webhook events
-            if (! empty($webhooksEvents)) {
-                foreach ($generatedEvents as $event) {
-                    if (isset($webhooksEvents[$event])) {
-                        $queueForWebhooks
-                            ->from($queueForEvents)
-                            ->trigger();
-                        break;
-                    }
-                }
-            }
-        }
-
-        /**
-         * Abuse labels
-         */
-        $abuseEnabled = System::getEnv('_APP_OPTIONS_ABUSE', 'enabled') !== 'disabled';
-        $abuseResetCode = $route->getLabel('abuse-reset', []);
-        $abuseResetCode = \is_array($abuseResetCode) ? $abuseResetCode : [$abuseResetCode];
-
-        if ($abuseEnabled && \count($abuseResetCode) > 0 && \in_array($response->getStatusCode(), $abuseResetCode)) {
-            $abuseKeyLabel = $route->getLabel('abuse-key', 'url:{url},ip:{ip}');
-            $abuseKeyLabel = (! is_array($abuseKeyLabel)) ? [$abuseKeyLabel] : $abuseKeyLabel;
-
-            foreach ($abuseKeyLabel as $abuseKey) {
-                $start = $request->getContentRangeStart();
-                $end = $request->getContentRangeEnd();
-                $timeLimit = $timelimit($abuseKey, $route->getLabel('abuse-limit', 0), $route->getLabel('abuse-time', 3600));
-                $timeLimit
-                    ->setParam('{projectId}', $project->getId())
-                    ->setParam('{userId}', $user->getId())
-                    ->setParam('{userAgent}', $request->getUserAgent(''))
-                    ->setParam('{ip}', $request->getIP())
-                    ->setParam('{url}', $request->getHostname() . $route->getPath())
-                    ->setParam('{method}', $request->getMethod())
-                    ->setParam('{chunkId}', (int) ($start / ($end + 1 - $start)));
-
-                foreach ($request->getParams() as $key => $value) { // Set request params as potential abuse keys
-                    if (! empty($value)) {
-                        $timeLimit->setParam('{param-' . $key . '}', (\is_array($value)) ? \json_encode($value) : $value);
-                    }
-                }
-
-                $abuse = new Abuse($timeLimit);
-                $abuse->reset();
-            }
-        }
-
-        /**
-         * Audit labels
-         */
         $pattern = $route->getLabel('audits.resource', null);
         if (! empty($pattern)) {
             $resource = $parseLabel($pattern, $responsePayload, $params, $user, $project);

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -958,61 +958,6 @@ Http::shutdown()
             $publisherForAudits->enqueue(AuditMessage::fromContext($auditContext));
         }
 
-        // Cache label
-        $useCache = $route->getLabel('cache', false);
-        if ($useCache) {
-            $resource = $resourceType = null;
-            $data = $response->getPayload();
-            $statusCode = $response->getStatusCode();
-            if (! empty($data['payload']) && $statusCode >= 200 && $statusCode < 300) {
-                $pattern = $route->getLabel('cache.resource', null);
-                if (! empty($pattern)) {
-                    $resource = $parseLabel($pattern, $responsePayload, $requestParams, $user, $project);
-                }
-
-                $pattern = $route->getLabel('cache.resourceType', null);
-                if (! empty($pattern)) {
-                    $resourceType = $parseLabel($pattern, $responsePayload, $requestParams, $user, $project);
-                }
-
-                $cache = new Cache(
-                    new Filesystem(APP_STORAGE_CACHE . DIRECTORY_SEPARATOR . 'app-' . $project->getId())
-                );
-
-                $key = $request->cacheIdentifier();
-                $signature = md5($data['payload']);
-                $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
-                $accessedAt = $cacheLog->getAttribute('accessedAt', 0);
-                $now = DateTime::now();
-                if ($cacheLog->isEmpty()) {
-                    try {
-                        $authorization->skip(fn () => $dbForProject->createDocument('cache', new Document([
-                            '$id' => $key,
-                            'resource' => $resource,
-                            'resourceType' => $resourceType,
-                            'mimeType' => $response->getContentType(),
-                            'accessedAt' => $now,
-                            'signature' => $signature,
-                        ])));
-                    } catch (DuplicateException) {
-                        // Race condition: another concurrent request already created the cache document
-                        $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
-                    }
-                } elseif (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_CACHE_UPDATE)) > $accessedAt) {
-                    $cacheLog->setAttribute('accessedAt', $now);
-                    $authorization->skip(fn () => $dbForProject->updateDocument('cache', $cacheLog->getId(), new Document([
-                        'accessedAt' => $cacheLog->getAttribute('accessedAt')
-                    ])));
-                    // Overwrite the file every APP_CACHE_UPDATE seconds to update the file modified time that is used in the TTL checks in cache->load()
-                    $cache->save($key, $data['payload']);
-                }
-
-                if ($signature !== $cacheLog->getAttribute('signature')) {
-                    $cache->save($key, $data['payload']);
-                }
-            }
-        }
-
         if ($project->getId() !== 'console') {
             if (! $user->isPrivileged($authorization->getRoles())) {
                 $bus->dispatch(new RequestCompleted(
@@ -1048,6 +993,82 @@ Http::shutdown()
 
                 $publisherForUsage->enqueue($message);
             }
+        }
+    });
+
+Http::shutdown()
+    ->groups(['api'])
+    ->inject('route')
+    ->inject('params')
+    ->inject('request')
+    ->inject('response')
+    ->inject('project')
+    ->inject('user')
+    ->inject('dbForProject')
+    ->inject('authorization')
+    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization) use ($parseLabel) {
+        if (! $route->getLabel('cache', false)) {
+            return;
+        }
+
+        $data = $response->getPayload();
+        $statusCode = $response->getStatusCode();
+        if (empty($data['payload']) || $statusCode < 200 || $statusCode >= 300) {
+            return;
+        }
+
+        // Reproduce the resolved param set: injected path values take precedence
+        // over query/body params, falling back to each param's declared default.
+        $requestParams = [];
+        foreach ($route->getParams() as $key => $param) {
+            $requestParams[$key] = $params[$key] ?? $request->getParam($key, $param['default']);
+        }
+
+        $resource = $resourceType = null;
+        $pattern = $route->getLabel('cache.resource', null);
+        if (! empty($pattern)) {
+            $resource = $parseLabel($pattern, $data, $requestParams, $user, $project);
+        }
+
+        $pattern = $route->getLabel('cache.resourceType', null);
+        if (! empty($pattern)) {
+            $resourceType = $parseLabel($pattern, $data, $requestParams, $user, $project);
+        }
+
+        $cache = new Cache(
+            new Filesystem(APP_STORAGE_CACHE . DIRECTORY_SEPARATOR . 'app-' . $project->getId())
+        );
+
+        $key = $request->cacheIdentifier();
+        $signature = md5($data['payload']);
+        $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
+        $accessedAt = $cacheLog->getAttribute('accessedAt', 0);
+        $now = DateTime::now();
+        if ($cacheLog->isEmpty()) {
+            try {
+                $authorization->skip(fn () => $dbForProject->createDocument('cache', new Document([
+                    '$id' => $key,
+                    'resource' => $resource,
+                    'resourceType' => $resourceType,
+                    'mimeType' => $response->getContentType(),
+                    'accessedAt' => $now,
+                    'signature' => $signature,
+                ])));
+            } catch (DuplicateException) {
+                // Race condition: another concurrent request already created the cache document
+                $cacheLog = $authorization->skip(fn () => $dbForProject->getDocument('cache', $key));
+            }
+        } elseif (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_CACHE_UPDATE)) > $accessedAt) {
+            $cacheLog->setAttribute('accessedAt', $now);
+            $authorization->skip(fn () => $dbForProject->updateDocument('cache', $cacheLog->getId(), new Document([
+                'accessedAt' => $cacheLog->getAttribute('accessedAt')
+            ])));
+            // Overwrite the file every APP_CACHE_UPDATE seconds to update the file modified time that is used in the TTL checks in cache->load()
+            $cache->save($key, $data['payload']);
+        }
+
+        if ($signature !== $cacheLog->getAttribute('signature')) {
+            $cache->save($key, $data['payload']);
         }
     });
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -863,14 +863,11 @@ Http::shutdown()
             }
         }
 
-        // $params holds the URL path values (injected from the route match);
-        // merge in query/body params and declared defaults to reproduce the
-        // full resolved param set, with path values taking precedence.
-        $reqParams = $request->getParams();
-
+        // Reproduce the resolved param set: injected path values take precedence
+        // over query/body params, falling back to each param's declared default.
         $requestParams = [];
         foreach ($route->getParams() as $key => $param) {
-            $requestParams[$key] = $params[$key] ?? $reqParams[$key] ?? $param['default'];
+            $requestParams[$key] = $params[$key] ?? $request->getParam($key, $param['default']);
         }
 
         /**


### PR DESCRIPTION
## What

Two related changes to `app/controllers/shared/api.php`:

1. **Remove the deprecated `Route::getParamsValues()` call.**
2. **Decompose the monolithic `['api']` shutdown hook** into focused, single-responsibility hooks.

## Why

`getParamsValues()` reads request-scoped values stored on the **shared, long-lived `Route` object** (via `setParamValue()`) — request state on an object shared across Swoole coroutines, which is being deprecated in `utopia-php/http`. The current http version exposes per-request data as injectable **locals** (`route`, `params`) resolved from the dispatch frame instead.

While migrating that one call, the surrounding shutdown hook was a ~200-line "god hook" with 16 injections handling events, abuse, audit, cache, and usage in one closure. Splitting it makes each concern injection-minimal and independently readable.

## How

**Param values:** the audit code only needs URL path params (every `audits.resource` token is a path segment — verified across the codebase), so it uses the injected `params` local directly. Only the cache hook needs the full resolved set (the Avatars screenshot `cache.resource` key references query params like `{request.width}`), so it reconstructs `path → query/body → default` there — matching the framework's own `getArguments()` precedence.

**Hook decomposition** — one `['api']` shutdown hook became five, each injecting only what it uses:

| Hook | Responsibility | Injections |
|------|----------------|-----------|
| Events | realtime / function / webhook dispatch | route, response, project, queueForEvents, publisherForFunctions, queueForWebhooks, queueForRealtime, dbForProject, eventProcessor |
| Abuse | abuse-reset handling | route, request, response, project, user, timelimit |
| Audit | audit logging | route, params, request, response, project, user, auditContext, publisherForAudits, mode |
| Cache | response caching | route, params, request, response, project, user, dbForProject, authorization |
| Usage | RequestCompleted + usage metrics | request, response, project, user, usage, publisherForUsage, authorization, bus, apiKey |

The hooks are registered in the original execution order (**events → abuse → audit → cache → usage**); group shutdown hooks run in registration order, so behaviour is unchanged. The pre-existing `['session']`-group shutdown hook is untouched.

**Tightening along the way:** early-return guards flatten the events, abuse, and cache hooks; the cache hook resolves its resource labels lazily inside the create branch (so the param reconstruction + label parsing run only on a cache miss, not on every cached hit) and makes the create path `save`-and-`return` explicitly rather than relying on the empty-document signature mismatch.

## Verification

- `getParamsValues` no longer appears in `app/` or `src/`.
- `php -l`, Pint (PSR-12), and PHPStan level 3 (`[OK] No errors`) all pass.
- Verified every injection in each hook is actually used, and that the hook ordering matches the original in-closure flow.

> Not run locally (CI will cover): the E2E suite. Worth exercising audit-log resource names, the avatar/file cache keys + invalidation, and usage-metric publishing, since those are the behaviours moved between hooks.

## Notes for review

- This turns one hook invocation into five per request; the framework just iterates registered hooks, so overhead is negligible, but the ordering guarantees are the thing to sanity-check.
- The cache hook's lazy label resolution means `cache.resource` / `cache.resourceType` are evaluated only when the entry is first created (which is the only time they're written) — confirm nothing expects re-evaluation on refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)