### PR TITLE
fix: reset queued event on non-final chunk in createFile

### DIFF
--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -497,6 +497,8 @@ class Create extends Action
                     ->setParam('bucketId', $bucket->getId())
                     ->setParam('fileId', $file->getId())
                     ->setContext('bucket', $bucket);
+            } else {
+                $queueForEvents->reset();
             }
 
             $metadata = null; // was causing leaks as it was passed by reference


### PR DESCRIPTION
## Bug

On chunked file uploads (`POST /v1/storage/buckets/{bucketId}/files`), the route registers the templated event label `buckets.[bucketId].files.[fileId].create` on `queueForEvents` during init.

Inside the `finalizeUpload` closure in `Create.php`, the event params (`bucketId`, `fileId`) are only set when the final chunk completes (`$chunksUploaded === $chunks`). On an **intermediate (non-final) chunk** the request still returns `201`, but `setParam('bucketId')` is skipped. The `App::shutdown()` handler then calls `Event::generateEvents()` against the still-templated `[bucketId]` placeholder and throws:

```
[bucketId] is missing from the params
```

## Root cause

The `if ($chunksUploaded === $chunks)` block had no `else` branch, so an intermediate chunk left a queued event with an unpopulated template that the shutdown hook could not resolve.

## Fix

Reset the queued event when the upload is not yet complete, so no templated event is generated until the final chunk lands. This mirrors the `$queueForEvents->reset()` already used by the other early-exit paths in the same closure.

```php
            if ($chunksUploaded === $chunks) {
                $queueForEvents
                    ->setParam('bucketId', $bucket->getId())
                    ->setParam('fileId', $file->getId())
                    ->setContext('bucket', $bucket);
            } else {
                $queueForEvents->reset();
            }
```

## Scope / impact

- Only **chunked uploads on intermediate chunks** were affected. Single-shot uploads and the final chunk already populate the params correctly.
- Failed requests are unaffected, because Utopia skips shutdown hooks when the request throws — the error only surfaced on the otherwise-successful (201) intermediate-chunk path.

## Verification

- `pint --test` on the changed file: passed
- `phpstan analyse` (level 4) on the changed file: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
