### PR TITLE
fix: reject root directory path traversal in builds worker

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -51,6 +51,28 @@ class Builds extends Action
     }
 
     /**
+     * Normalize a build root directory and reject path traversal.
+     *
+     * Collapses a leading "./" and surrounding slashes, then rejects any
+     * remaining ".." segment so the value cannot escape the build directory
+     * once it is interpolated into filesystem and shell paths downstream.
+     *
+     * @throws Exception when the path contains a ".." segment
+     */
+    public static function normalizeRootDirectory(string $rootDirectory): string
+    {
+        $rootDirectory = \rtrim($rootDirectory, '/');
+        $rootDirectory = \ltrim($rootDirectory, '.');
+        $rootDirectory = \ltrim($rootDirectory, '/');
+
+        if ($rootDirectory !== '' && \preg_match('#(^|/)\.\.(/|$)#', $rootDirectory)) {
+            throw new \Exception('Invalid root directory');
+        }
+
+        return $rootDirectory;
+    }
+
+    /**
      * @throws Exception
      */
     public function __construct()
@@ -296,10 +318,7 @@ class Builds extends Action
                 $templateReferenceType = $template->getAttribute('referenceType', '');
                 $templateReferenceValue = $template->getAttribute('referenceValue', '');
 
-                $templateRootDirectory = $template->getAttribute('rootDirectory', '');
-                $templateRootDirectory = \rtrim($templateRootDirectory, '/');
-                $templateRootDirectory = \ltrim($templateRootDirectory, '.');
-                $templateRootDirectory = \ltrim($templateRootDirectory, '/');
+                $templateRootDirectory = self::normalizeRootDirectory($template->getAttribute('rootDirectory', ''));
 
                 if (! empty($templateRepositoryName) && ! empty($templateOwnerName) && ! empty($templateReferenceType) && ! empty($templateReferenceValue)) {
                     $stdout = '';
@@ -361,10 +380,7 @@ class Builds extends Action
             } elseif ($isVcsEnabled) {
                 // VCS and VCS+Temaplte
                 $tmpDirectory = '/tmp/builds/' . $deploymentId . '/code';
-                $rootDirectory = $resource->getAttribute('providerRootDirectory', '');
-                $rootDirectory = \rtrim($rootDirectory, '/');
-                $rootDirectory = \ltrim($rootDirectory, '.');
-                $rootDirectory = \ltrim($rootDirectory, '/');
+                $rootDirectory = self::normalizeRootDirectory($resource->getAttribute('providerRootDirectory', ''));
 
                 $owner = $github->getOwnerName($providerInstallationId);
                 $repositoryName = $github->getRepositoryName($providerRepositoryId);
@@ -419,10 +435,7 @@ class Builds extends Action
                 $templateReferenceType = $template->getAttribute('referenceType', '');
                 $templateReferenceValue = $template->getAttribute('referenceValue', '');
 
-                $templateRootDirectory = $template->getAttribute('rootDirectory', '');
-                $templateRootDirectory = \rtrim($templateRootDirectory, '/');
-                $templateRootDirectory = \ltrim($templateRootDirectory, '.');
-                $templateRootDirectory = \ltrim($templateRootDirectory, '/');
+                $templateRootDirectory = self::normalizeRootDirectory($template->getAttribute('rootDirectory', ''));
 
                 if (! empty($templateRepositoryName) && ! empty($templateOwnerName) && ! empty($templateReferenceType) && ! empty($templateReferenceValue)) {
                     // Clone template repo

--- a/tests/unit/Platform/Modules/Functions/Workers/BuildsTest.php
+++ b/tests/unit/Platform/Modules/Functions/Workers/BuildsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Platform\Modules\Functions\Workers;
+
+use Appwrite\Platform\Modules\Functions\Workers\Builds;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class BuildsTest extends TestCase
+{
+    #[DataProvider('validRootDirectoryProvider')]
+    public function testNormalizeRootDirectoryNormalizesValidPaths(string $input, string $expected): void
+    {
+        $this->assertSame($expected, Builds::normalizeRootDirectory($input));
+    }
+
+    public static function validRootDirectoryProvider(): array
+    {
+        return [
+            'empty stays empty' => ['', ''],
+            'current directory collapses to empty' => ['./', ''],
+            'bare dot collapses to empty' => ['.', ''],
+            'bare parent collapses to empty' => ['..', ''],
+            'leading ./ is stripped' => ['./src', 'src'],
+            'surrounding slashes are stripped' => ['/src/', 'src'],
+            'trailing slash is stripped' => ['src/', 'src'],
+            'leading ./ with trailing slash' => ['./src/', 'src'],
+            'nested path is preserved' => ['src/app', 'src/app'],
+            'dotfile parent is preserved' => ['src/.env.local', 'src/.env.local'],
+            'single leading parent collapses to in-sandbox subdir' => ['../etc', 'etc'],
+        ];
+    }
+
+    #[DataProvider('traversalRootDirectoryProvider')]
+    public function testNormalizeRootDirectoryRejectsTraversal(string $input): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid root directory');
+
+        Builds::normalizeRootDirectory($input);
+    }
+
+    public static function traversalRootDirectoryProvider(): array
+    {
+        return [
+            'multi level parent escape' => ['../../etc/passwd'],
+            'embedded parent segment' => ['foo/../bar'],
+            'trailing parent segment' => ['foo/..'],
+            'dot slash parent' => ['./../etc'],
+            'multi embedded parent' => ['foo/../../bar'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Reapplies the path-traversal protection on build root directories that was reverted in `6ed54706b3` ("Restore original ./ stripping", part of #12450) — this time **without** the regression that took builds down.

### Background
- The original hardening (`8e02beff58`, #12413) replaced `rtrim('/')→ltrim('.')→ltrim('/')` with `trim('/')` + a `..` rejection.
- `trim($x, '/')` strips slashes but **not** dots, so the leading-dot normalization was lost: `./` resolved to `.` and `./src` stayed `./src`. Deployments/templates that store `providerRootDirectory: "./"` then pointed the build at the wrong directory → empty source → `npm ENOENT ... package.json`. All Sites/template builds broke and the change was reverted, which also removed the `..` rejection — so the traversal weakness is live again on `1.9.x`.

### This change
Extracts a single `Builds::normalizeRootDirectory()` used by all three build paths (template, VCS, VCS+template) that:
1. Keeps the **original** normalization — `rtrim('/')`, `ltrim('.')`, `ltrim('/')` — so `./` → `''` and `./src` → `src` (no build regression).
2. Adds the `..` rejection **after** normalization, so a single leading `./` collapses before the check while any residual/embedded `..` segment is rejected.

**Invariant:** the helper can never return a value containing a `..` segment or an absolute path, so a crafted `providerRootDirectory` can't escape the build directory when interpolated into the downstream `mkdir`/`rsync`/`tar`/clone paths.

| input | result |
|---|---|
| `./`, `.`, `..` | `''` (repo root) |
| `./src`, `/src/`, `src/` | `src` |
| `../etc` | `etc` (single `../` sandboxed in-tree) |
| `../../etc/passwd` | rejected |
| `foo/../bar`, `foo/..` | rejected |

## Test plan

- [x] New unit test `tests/unit/Platform/Modules/Functions/Workers/BuildsTest.php` (16 cases) covering the normalize/reject matrix — `OK`
- [x] `composer lint` (Pint) — passed
- [x] PHPStan level 4 on the changed file — no errors
- [ ] CI: Sites + Functions e2e green on `1.9.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)