### PR TITLE
Fix chunked upload resume without file read permission

### DIFF
--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -260,8 +260,8 @@ class Create extends Action
         };
 
         try {
-            $locks($lockKey, 600, function () use ($bucket, &$chunks, $contentRange, $dbForProject, $deviceForFiles, $fileId, $fileName, $fileSize, &$metadata, $path, $permissions, $response, &$completed): void {
-                $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+            $locks($lockKey, 600, function () use ($authorization, $bucket, &$chunks, $contentRange, $dbForProject, $deviceForFiles, $fileId, $fileName, $fileSize, &$metadata, $path, $permissions, $response, &$completed): void {
+                $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
                 if (!$file->isEmpty()) {
                     $chunks = $file->getAttribute('chunksTotal', 1);
                     $uploaded = $file->getAttribute('chunksUploaded', 0);
@@ -325,7 +325,7 @@ class Create extends Action
         }
 
         $finalizeUpload = function (int $chunksUploaded) use ($authorization, $bucket, &$chunks, $contentRange, $dbForProject, $deviceForFiles, $fileId, $fileName, $fileSize, &$metadata, $mergeUploadMetadata, $path, $permissions, $queueForEvents, $response): void {
-            $file = $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId);
+            $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
             $uploaded = 0;
 
             if (!$file->isEmpty()) {

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1289,6 +1289,91 @@ trait StorageBase
         $this->assertEquals(204, $deleteBucketResponse['headers']['status-code']);
     }
 
+    public function testCreateBucketFileChunkedUploadWithoutReadPermission(): void
+    {
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'bucketId' => ID::unique(),
+            'name' => 'Test Bucket Chunked Upload No Read Permission',
+            'fileSecurity' => true,
+            'permissions' => [
+                Permission::create(Role::any()),
+            ],
+        ]);
+
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+
+        $bucketId = $bucket['body']['$id'];
+        $source = __DIR__ . "/../../../resources/disk-a/large-file.mp4";
+        $totalSize = \filesize($source);
+        $chunkSize = 5 * 1024 * 1024;
+        $mimeType = mime_content_type($source);
+        $fileId = ID::unique();
+        $uploadedFileId = null;
+
+        $this->assertGreaterThan($chunkSize, $totalSize, 'Test file must span at least 2 chunks');
+
+        try {
+            $handle = fopen($source, 'rb');
+            $this->assertNotFalse($handle, "Could not open test resource: $source");
+
+            $firstChunk = fread($handle, $chunkSize);
+            $secondChunk = fread($handle, min($chunkSize, $totalSize - $chunkSize));
+            fclose($handle);
+
+            $permissions = [
+                Permission::delete(Role::user($this->getUser()['$id'])),
+            ];
+
+            $firstUpload = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'content-range' => 'bytes 0-' . ($chunkSize - 1) . '/' . $totalSize,
+            ], $this->getHeaders()), [
+                'fileId' => $fileId,
+                'file' => new CURLFile('data://' . $mimeType . ';base64,' . base64_encode($firstChunk), $mimeType, 'large-file.mp4'),
+                'permissions' => $permissions,
+            ]);
+
+            $this->assertEquals(201, $firstUpload['headers']['status-code']);
+            $this->assertNotContains(Permission::read(Role::user($this->getUser()['$id'])), $firstUpload['body']['$permissions']);
+
+            $uploadedFileId = $firstUpload['body']['$id'];
+            $secondChunkEnd = $chunkSize + strlen($secondChunk) - 1;
+
+            $secondUpload = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
+                'content-type' => 'multipart/form-data',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'content-range' => 'bytes ' . $chunkSize . '-' . $secondChunkEnd . '/' . $totalSize,
+                'x-appwrite-id' => $uploadedFileId,
+            ], $this->getHeaders()), [
+                'fileId' => $fileId,
+                'file' => new CURLFile('data://' . $mimeType . ';base64,' . base64_encode($secondChunk), $mimeType, 'large-file.mp4'),
+                'permissions' => $permissions,
+            ]);
+
+            $this->assertEquals(201, $secondUpload['headers']['status-code'], $secondUpload['body']['message'] ?? '');
+            $this->assertEquals(2, $secondUpload['body']['chunksUploaded']);
+        } finally {
+            if (!empty($uploadedFileId)) {
+                $this->client->call(Client::METHOD_DELETE, '/storage/buckets/' . $bucketId . '/files/' . $uploadedFileId, [
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                    'x-appwrite-key' => $this->getProject()['apiKey'],
+                ]);
+            }
+
+            $this->client->call(Client::METHOD_DELETE, '/storage/buckets/' . $bucketId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+        }
+    }
+
     public function testCreateBucketFileOutOfOrder(): void
     {
         // Create a bucket for this test

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1313,6 +1313,7 @@ trait StorageBase
         $mimeType = mime_content_type($source);
         $fileId = ID::unique();
         $uploadedFileId = null;
+        $chunksTotal = (int) ceil($totalSize / $chunkSize);
 
         $this->assertGreaterThan($chunkSize, $totalSize, 'Test file must span at least 2 chunks');
 
@@ -1320,44 +1321,47 @@ trait StorageBase
             $handle = fopen($source, 'rb');
             $this->assertNotFalse($handle, "Could not open test resource: $source");
 
-            $firstChunk = fread($handle, $chunkSize);
-            $secondChunk = fread($handle, min($chunkSize, $totalSize - $chunkSize));
-            fclose($handle);
-
             $permissions = [
                 Permission::delete(Role::user($this->getUser()['$id'])),
             ];
 
-            $firstUpload = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
-                'content-type' => 'multipart/form-data',
-                'x-appwrite-project' => $this->getProject()['$id'],
-                'content-range' => 'bytes 0-' . ($chunkSize - 1) . '/' . $totalSize,
-            ], $this->getHeaders()), [
-                'fileId' => $fileId,
-                'file' => new CURLFile('data://' . $mimeType . ';base64,' . base64_encode($firstChunk), $mimeType, 'large-file.mp4'),
-                'permissions' => $permissions,
-            ]);
+            for ($chunk = 0; $chunk < $chunksTotal; $chunk++) {
+                $start = $chunk * $chunkSize;
+                $chunkData = fread($handle, min($chunkSize, $totalSize - $start));
+                $end = $start + strlen($chunkData) - 1;
 
-            $this->assertEquals(201, $firstUpload['headers']['status-code']);
-            $this->assertNotContains(Permission::read(Role::user($this->getUser()['$id'])), $firstUpload['body']['$permissions']);
+                $headers = [
+                    'content-type' => 'multipart/form-data',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                    'content-range' => 'bytes ' . $start . '-' . $end . '/' . $totalSize,
+                ];
 
-            $uploadedFileId = $firstUpload['body']['$id'];
-            $secondChunkEnd = $chunkSize + strlen($secondChunk) - 1;
+                if (!empty($uploadedFileId)) {
+                    $headers['x-appwrite-id'] = $uploadedFileId;
+                }
 
-            $secondUpload = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge([
-                'content-type' => 'multipart/form-data',
-                'x-appwrite-project' => $this->getProject()['$id'],
-                'content-range' => 'bytes ' . $chunkSize . '-' . $secondChunkEnd . '/' . $totalSize,
-                'x-appwrite-id' => $uploadedFileId,
-            ], $this->getHeaders()), [
-                'fileId' => $fileId,
-                'file' => new CURLFile('data://' . $mimeType . ';base64,' . base64_encode($secondChunk), $mimeType, 'large-file.mp4'),
-                'permissions' => $permissions,
-            ]);
+                $upload = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucketId . '/files', array_merge($headers, $this->getHeaders()), [
+                    'fileId' => $fileId,
+                    'file' => new CURLFile('data://' . $mimeType . ';base64,' . base64_encode($chunkData), $mimeType, 'large-file.mp4'),
+                    'permissions' => $permissions,
+                ]);
 
-            $this->assertEquals(201, $secondUpload['headers']['status-code'], $secondUpload['body']['message'] ?? '');
-            $this->assertEquals(2, $secondUpload['body']['chunksUploaded']);
+                $this->assertEquals(201, $upload['headers']['status-code'], $upload['body']['message'] ?? '');
+                $this->assertEquals($chunk + 1, $upload['body']['chunksUploaded']);
+
+                $uploadedFileId ??= $upload['body']['$id'];
+            }
+
+            fclose($handle);
+
+            $this->assertNotContains(Permission::read(Role::user($this->getUser()['$id'])), $upload['body']['$permissions']);
+            $this->assertEquals($chunksTotal, $upload['body']['chunksTotal']);
+            $this->assertEquals($chunksTotal, $upload['body']['chunksUploaded']);
         } finally {
+            if (isset($handle) && \is_resource($handle)) {
+                fclose($handle);
+            }
+
             if (!empty($uploadedFileId)) {
                 $this->client->call(Client::METHOD_DELETE, '/storage/buckets/' . $bucketId . '/files/' . $uploadedFileId, [
                     'content-type' => 'application/json',

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1324,6 +1324,7 @@ trait StorageBase
             $permissions = [
                 Permission::delete(Role::user($this->getUser()['$id'])),
             ];
+            $upload = null;
 
             for ($chunk = 0; $chunk < $chunksTotal; $chunk++) {
                 $start = $chunk * $chunkSize;
@@ -1353,6 +1354,10 @@ trait StorageBase
             }
 
             fclose($handle);
+
+            if ($upload === null) {
+                $this->fail('Expected at least one chunk upload response.');
+            }
 
             $this->assertNotContains(Permission::read(Role::user($this->getUser()['$id'])), $upload['body']['$permissions']);
             $this->assertEquals($chunksTotal, $upload['body']['chunksTotal']);


### PR DESCRIPTION
## What changed
- Use skipped authorization for internal chunked-upload file lookups so pending uploads can resume even when the file does not grant read permission.
- Add an e2e regression test covering a second chunk upload when file-level read permission is absent.

## Testing
- Reproduced failure by temporarily reverting the skipped reads, rebuilding containers, and running the targeted test: failed with 409 storage_file_already_exists.
- Restored fix, rebuilt containers, and reran: OK (3 tests, 63 assertions).
- composer format src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php tests/e2e/Services/Storage/StorageBase.php
- composer lint src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php tests/e2e/Services/Storage/StorageBase.php