### PR TITLE
chore: composer update utopia-php/database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,7 @@ jobs:
             echo "_APP_DB_HOST=mongodb" >> $GITHUB_ENV
             echo "_APP_DB_PORT=27017" >> $GITHUB_ENV
           elif [ "${{ matrix.database }}" = "PostgreSQL" ]; then
+            echo "COMPOSE_FILE=docker-compose.yml:docker-compose.ci-postgres.yml" >> $GITHUB_ENV
             echo "COMPOSE_PROFILES=postgresql" >> $GITHUB_ENV
             echo "_APP_DB_ADAPTER=postgresql" >> $GITHUB_ENV
             echo "_APP_DB_HOST=postgresql" >> $GITHUB_ENV

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "5.*",
+        "utopia-php/database": "dev-main as 5.9.0",
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3140,16 +3140,16 @@
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -3196,7 +3196,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3216,7 +3216,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "551924e300a646e6f433ea0a0f3d6c9f",
+    "content-hash": "22527fed7377783fba0d3a83be3a9f4d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3923,16 +3923,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "5.9.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "477bae83e27631f78c159f45b0441c0c7dc69050"
+                "reference": "567901977c0128a3bd1cb9917553ebb4c1055582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/477bae83e27631f78c159f45b0441c0c7dc69050",
-                "reference": "477bae83e27631f78c159f45b0441c0c7dc69050",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/567901977c0128a3bd1cb9917553ebb4c1055582",
+                "reference": "567901977c0128a3bd1cb9917553ebb4c1055582",
                 "shasum": ""
             },
             "require": {
@@ -3957,6 +3957,7 @@
                 "swoole/ide-helper": "5.1.3",
                 "utopia-php/cli": "0.22.*"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -3977,9 +3978,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/5.9.0"
+                "source": "https://github.com/utopia-php/database/tree/main"
             },
-            "time": "2026-05-17T15:57:21+00:00"
+            "time": "2026-05-19T02:54:27+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -8549,9 +8550,17 @@
             "time": "2026-05-27T13:05:51+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/database",
+            "version": "dev-main",
+            "alias": "5.9.0",
+            "alias_normalized": "5.9.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "utopia-php/database": 20,
         "utopia-php/http": 5
     },
     "prefer-stable": true,

--- a/docker-compose.ci-postgres.yml
+++ b/docker-compose.ci-postgres.yml
@@ -1,0 +1,7 @@
+services:
+  postgresql:
+    command: >
+      postgres
+      -c fsync=off
+      -c synchronous_commit=off
+      -c full_page_writes=off


### PR DESCRIPTION
## What

Runs `composer update utopia-php/database` on the latest `1.9.x` branch.

`utopia-php/database` is pinned to `dev-main` for this CI matrix run. The lockfile also includes the resulting transitive dependency refresh.

This also applies PostgreSQL-only CI settings for the E2E matrix:

- `fsync=off`, which disables flushing data to disk after writes. This makes writes much faster, but if the runner crashes, loses power, or the container is killed unexpectedly, database corruption or data loss can occur.
- `synchronous_commit=off`, which lets PostgreSQL report transaction commit success without waiting for the commit to be physically written to disk. This improves transaction throughput, but recent committed transactions can be lost during a crash.
- `full_page_writes=off`, which disables writing full data pages to WAL after a checkpoint. This reduces WAL volume and improves performance, but increases the risk of corruption after crashes.

## Why

Refresh locked dependencies and run the full CI matrix against the updated lockfile and database dependency source.

The PostgreSQL settings are limited to automated CI databases where durability does not matter. These settings are commonly used for automated tests, CI/CD pipelines, temporary development databases, and benchmarks where crash recovery is not required.