### PR TITLE
Enable RunsOn OTEL for E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
 
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service }}
-    runs-on: ${{ matrix.runner || format('runs-on={0}/runner=4cpu-linux-x64/volume=120g/spot=false', github.run_id) }}
+    runs-on: ${{ matrix.runner || format('runs-on={0}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel', github.run_id) }}
     needs: [build, matrix]
     permissions:
       contents: read
@@ -447,11 +447,11 @@ jobs:
         ]
         include:
           - service: Databases
-            runner: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/volume=120g/spot=false
+            runner: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/volume=120g/spot=false/extras=otel
             paratest_processes: 3
             timeout_minutes: 30
           - service: TablesDB
-            runner: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/volume=120g/spot=false
+            runner: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/volume=120g/spot=false/extras=otel
             paratest_processes: 3
             timeout_minutes: 30
           - service: Migrations


### PR DESCRIPTION
## What does this PR do?

Enables RunsOn runner-side OpenTelemetry export for the existing E2E service matrix by adding `extras=otel` to the RunsOn runner labels.

This keeps the current runner sizes and scope unchanged: only the E2E service matrix RunsOn jobs are opted into OTEL, including the default 4 CPU runner and the Databases/TablesDB 8 CPU overrides.

## Test Plan

- Ran `actionlint .github/workflows/ci.yml`.
- Verified all RunsOn labels in `.github/workflows/ci.yml` include `extras=otel`.

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
