### PR TITLE
fix(databases): emit create events for relationship-cascaded child documents

### DIFF
--- a/examples/relationship-event-orchestration/.env.example
+++ b/examples/relationship-event-orchestration/.env.example
@@ -1,0 +1,20 @@
+# Appwrite endpoint, e.g. http://localhost/v1 for self-hosted
+APPWRITE_ENDPOINT=http://localhost/v1
+
+# Project ID
+APPWRITE_PROJECT_ID=your-project-id
+
+# Server API key with scopes:
+#   databases.read, databases.write,
+#   collections.read, collections.write,
+#   attributes.read, attributes.write,
+#   documents.read, documents.write
+APPWRITE_API_KEY=your-server-api-key
+
+# IDs the repro/orchestrator will create or use
+APPWRITE_DATABASE_ID=app
+APPWRITE_COLLECTION_A=parents
+APPWRITE_COLLECTION_B=children
+
+# Idempotency key TTL (seconds). Stored in a dedicated collection.
+IDEMPOTENCY_TTL_SECONDS=86400

--- a/examples/relationship-event-orchestration/README.md
+++ b/examples/relationship-event-orchestration/README.md
@@ -1,0 +1,289 @@
+# Appwrite Relationship Event Orchestration
+
+Production-grade workaround and reference architecture for the silent-event
+behavior in Appwrite 1.6.x when documents are created via the *relationship
+cascade* (parent A -> nested child B) instead of being created directly in
+collection B.
+
+This package contains:
+
+- A **root-cause analysis** anchored to specific source lines in this repo.
+- A **reproducible demo** (`npm run repro:bug`) that proves the bug.
+- A **production orchestrator** (`src/orchestrator/`) that guarantees every
+  child fires a real `documents.*.create` event.
+- An **Appwrite Function** (`src/functions/relationshipEventFanout/`) that
+  bolts onto unmodified clients and back-fills events for relationship
+  cascades by observing the parent's create event.
+- An **outbox** (`src/lib/outbox.ts`) that decouples event delivery from
+  Appwrite's internal bus, giving at-least-once semantics.
+
+---
+
+## A. Technical explanation (root cause)
+
+When you `POST /v1/databases/:db/collections/:A/documents` with a body that
+contains nested objects on a relationship attribute (one-to-many A -> B),
+Appwrite's `Create` action does this (see
+`src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php`):
+
+1. Builds a single `Utopia\Database\Document` for the parent that embeds
+   nested child documents.
+2. Calls `$dbForDatabases->createDocuments(...)` ONCE for the parent
+   collection. The underlying `utopia-php/database` adapter sees the
+   relationship field, splits it apart, and writes each child row in
+   collection B inside the same storage transaction (cascade).
+3. After the cascade completes, Appwrite sets a SINGLE event on
+   `$queueForEvents`:
+
+   ```php
+   $queueForEvents
+       ->setParam('documentId', $created[0]->getId())
+       ->setParam('rowId', $created[0]->getId())
+       ->setEvent('databases.[databaseId].collections.[collectionId].documents.[documentId].create');
+   ```
+
+   That `setEvent` is the only call that ultimately makes it to the
+   per-request shutdown hook in `app/controllers/shared/api.php` line ~833,
+   which is what dispatches the function/webhook/realtime payloads.
+
+4. `processDocument()` in `Documents/Action.php` then recursively walks
+   nested relations -- but ONLY to decorate metadata (`$databaseId`,
+   `$collectionId`). It does **not** enqueue child events.
+
+5. `triggerBulk()` only fans out over the top-level `$documents` array; it
+   never visits cascaded grandchildren.
+
+So child rows in B exist on disk, indexes are updated, permissions are
+applied, but the per-request event pipeline never sees them. Functions /
+webhooks subscribed to
+`databases.*.collections.B.documents.*.create` therefore stay silent.
+
+There is one apparent counter-example in `app/init/resources/request.php`
+where a `Database::EVENT_DOCUMENT_CREATE` listener fans the storage-level
+event back into the HTTP event queue:
+
+```php
+$eventDatabaseListener = function (...) {
+    // Only trigger events for user creation with the database listener.
+    if ($document->getCollection() !== 'users') {
+        return;
+    }
+    ...
+};
+```
+
+That listener is whitelisted to the `users` collection only ("intentional",
+per the inline comment). It is **not** generalized for arbitrary
+project-defined collections -- partly because firing the queue from inside a
+storage-layer listener would also fire for every internal write (system
+collections, audits, etc.), and partly because the event payload would
+require enough HTTP context (route, project, response model) that the
+storage layer doesn't have.
+
+**Classification:** intentional architectural limitation, not a code bug.
+It is the predictable outcome of:
+
+- treating relationship cascades as a single storage operation,
+- emitting the HTTP-layer event from the action that received the HTTP
+  call, not from the storage adapter.
+
+Reasonable changes upstream would either:
+
+1. Extend `processDocument()` to enqueue per-collection events for cascaded
+   children (still requires duplicating realtime + functions + webhooks
+   dispatch for each, like `triggerBulk` already does), or
+2. Generalize the `EVENT_DOCUMENT_CREATE` listener with a per-collection
+   allowlist + payload shaping, similar to the `users.*.create` carve-out.
+
+Until upstream lands one of those, application code must guarantee events
+itself. That is what this package does.
+
+### Exact source-area patch suggestion (if you maintain the fork)
+
+File: `src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php`
+
+Replace the single `setEvent` block (~lines 528-531) with a fan-out over
+both the parent and every nested cascaded child. A minimal sketch:
+
+```php
+$this->emitCascadedCreateEvents(
+    database: $database,
+    rootCollection: $collection,
+    rootDocument: $created[0],
+    dbForProject: $dbForProject,
+    queueForEvents: $queueForEvents,
+    queueForRealtime: $queueForRealtime,
+    queueForFunctions: $queueForFunctions,
+    queueForWebhooks: $queueForWebhooks,
+    eventProcessor: $eventProcessor,
+);
+```
+
+Where `emitCascadedCreateEvents()` walks the freshly-created tree with
+`processDocument`-style recursion, and for every nested `Document` whose
+`$collection` is not the root collection, it:
+
+1. Resolves the child's collection metadata
+2. Calls `$queueForEvents->setEvent(...)` with that child's
+   `databaseId`/`collectionId`/`documentId`
+3. Pushes one trigger per `queueForFunctions` / `queueForWebhooks` /
+   `queueForRealtime`, exactly like `triggerBulk` does today
+
+The reason this hasn't shipped is that it requires the action to know
+how to re-permission-check each child's payload against the project's
+event subscriptions, and to keep cost predictable when you cascade
+deep graphs. Both are solvable but invasive.
+
+---
+
+## B. Architecture recommendation
+
+```
+                       +-------------------+
+   Client request ---> |  Orchestrator API |---+
+                       +-------------------+   |
+                              | 1. Create children directly in B
+                              v
+                       +-------------------+
+                       |  Collection B     |---+  fires real
+                       +-------------------+   |  documents.*.create
+                              | 2. mirror to outbox
+                              v
+                       +-------------------+
+                       |  outbox_events    |---+ relay worker
+                       +-------------------+   | (CRON Appwrite Fn)
+                              |
+                              v
+                       +-------------------+
+                       |  Collection A     |  attach children by id
+                       +-------------------+
+```
+
+Three independent guarantees:
+
+1. **Appwrite-native events** fire because we create each child as a real
+   top-level write. Functions, webhooks, and realtime channels all work
+   unchanged.
+2. **Outbox** provides at-least-once delivery even if a downstream consumer
+   is down at the moment the native event fires.
+3. **Compensating deletes** roll the orchestration back if any step fails
+   after children were created -- preventing orphaned child documents.
+
+If you cannot change client code, run the Appwrite Function in
+`src/functions/relationshipEventFanout/` instead. It subscribes to A's
+parent-create event and back-fills child events.
+
+---
+
+## C. Implementation
+
+```
+examples/relationship-event-orchestration/
+|-- src/
+|   |-- lib/
+|   |   |-- appwrite.ts        # SDK client factory
+|   |   |-- config.ts          # env loading
+|   |   |-- idempotency.ts     # Appwrite-backed idempotency store
+|   |   |-- logger.ts          # pino logger
+|   |   |-- outbox.ts          # at-least-once outbox
+|   |   `-- retry.ts           # exponential backoff w/ jitter
+|   |-- orchestrator/
+|   |   |-- createParentWithChildren.ts  # main orchestrator
+|   |   `-- demo.ts            # runnable example
+|   |-- functions/
+|   |   `-- relationshipEventFanout/
+|   |       |-- src/main.ts    # Appwrite Function entrypoint
+|   |       |-- package.json
+|   |       `-- tsconfig.json
+|   `-- repro/
+|       |-- setup.ts           # provisions collections + relationship
+|       |-- demonstrate-bug.ts # shows direct works, cascade silent
+|       `-- verify-fix.ts      # orchestrator path -- all events fire
+|-- .env.example
+|-- package.json
+`-- tsconfig.json
+```
+
+### Quick start
+
+```bash
+cp .env.example .env       # fill in endpoint, project, api key
+npm install
+npm run setup              # creates db, collections, relationship, outbox, idempotency
+npm run repro:bug          # observe missing child events
+npm run repro:fix          # observe all events fire
+```
+
+---
+
+## D. Suggested API flow
+
+Step by step for `createParentWithChildren`:
+
+1. Caller builds an idempotency key from the canonicalized request body.
+2. Orchestrator reserves the key in `idempotency_keys`:
+   - on `completed`, return cached result (true idempotency)
+   - on `inflight`, fail-fast and let the caller retry later
+3. For each child:
+   - createDocument(B, childId, data) with exponential backoff
+   - record in `outbox_events` with `correlationId = ${corr}:child:${childId}`
+4. createDocument(A, parentId, { ...parent, relationshipKey: [childIds] })
+5. Record parent in outbox with `correlationId = ${corr}:parent:${parentId}`
+6. complete(idempotencyKey, result)
+7. On any failure, compensating delete of children + parent + outbox rows
+
+---
+
+## E. Alternative approaches
+
+| Approach | Native events fire? | Code change required | Failure isolation | Notes |
+|---|---|---|---|---|
+| Nested create (parent + relationship objects) | Parent only; children silent | None | Worst: atomic but events lost | Today's broken default |
+| Child-first orchestrator (this repo) | All children + parent | Caller migrates to orchestrator | Compensating delete on partial failure | Recommended for new code |
+| Fan-out Appwrite Function on parent event | Synthetic via outbox + webhook | None on client | Eventual consistency: at-least-once with dedupe | Best for legacy clients |
+| Poll collection B for new docs | All | None | Latency seconds-minutes | Last resort |
+| Patch Appwrite source `Create.php` | All | Fork maintenance | Best | Section A includes the patch sketch |
+
+---
+
+## F. Reliability concerns addressed
+
+- **Idempotency.** Every orchestration call hashes a canonical view of its
+  input into an idempotency key, reserved atomically via Appwrite's unique
+  `$id` constraint. Replays short-circuit to the cached result.
+- **Retries.** Every Appwrite write uses `withRetry` with jittered
+  exponential backoff. Transient classes (5xx, 429, network) are retried;
+  4xx are not.
+- **Rollback.** On any failure mid-orchestration, the compensating delete
+  removes the parent, any children that were created, and any outbox rows.
+  The compensating path itself uses safe-delete (logs failures, never
+  throws) so a dead bucket doesn't block recovery.
+- **At-least-once delivery.** Even if Appwrite drops a native event under
+  load, the outbox row exists and a relay worker keeps retrying with an
+  attempt counter and exponential pull cadence.
+- **Race conditions.** Two parallel callers with the same idempotency key:
+  one reserves, the other sees `inflight` and fails-fast. There is no
+  silent overwrite. Two parallel callers with the same correlation id on
+  the outbox: the second call is coalesced (see `Outbox.enqueue`).
+- **Cascade cleanup.** Collection A's relationship to B is provisioned
+  with `cascade` delete behavior. If you delete a parent later, Appwrite
+  deletes the children; native delete events also have the same blind
+  spot for cascades, so the same orchestrator pattern (delete-children-first,
+  then delete-parent) applies.
+
+---
+
+## Edge cases
+
+- **Multi-level relationships** (A -> B -> C): apply the orchestrator
+  recursively. The relationship key on B then takes child-C IDs.
+- **Existing children attached by ID**: pass `children[i].id` to attach an
+  existing B; the orchestrator skips creation and just attaches.
+- **Permission divergence**: collection B and A often have different
+  permission requirements. The orchestrator uses a server-side API key
+  and explicit `Permission.*` writes; you should narrow the key scopes
+  to `documents.write` and `databases.read` at minimum.
+- **Concurrent identical submissions**: handled by idempotency reservation.
+- **Hot reload of the function**: the Appwrite Function uses
+  `correlationId = parentId:childId:parentUpdatedAt` so re-invocation
+  on the same event doesn't double-fanout.

--- a/examples/relationship-event-orchestration/package.json
+++ b/examples/relationship-event-orchestration/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "appwrite-relationship-event-orchestration",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Production-grade orchestration layer that guarantees document.*.create events fire for relationship-cascaded child documents in Appwrite 1.6.x.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "setup": "tsx src/repro/setup.ts",
+    "repro:bug": "tsx src/repro/demonstrate-bug.ts",
+    "repro:fix": "tsx src/repro/verify-fix.ts",
+    "orchestrator:demo": "tsx src/orchestrator/demo.ts",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "node-appwrite": "^14.0.0",
+    "dotenv": "^16.4.5",
+    "pino": "^9.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/examples/relationship-event-orchestration/src/functions/relationshipEventFanout/package.json
+++ b/examples/relationship-event-orchestration/src/functions/relationshipEventFanout/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "relationship-event-fanout",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "node-appwrite": "^14.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "typescript": "^5.6.3"
+  }
+}

--- a/examples/relationship-event-orchestration/src/functions/relationshipEventFanout/src/main.ts
+++ b/examples/relationship-event-orchestration/src/functions/relationshipEventFanout/src/main.ts
@@ -1,0 +1,231 @@
+/**
+ * Relationship Event Fan-Out Function
+ *
+ * Deploy this as an Appwrite Function subscribed to:
+ *     databases.*.collections.<A>.documents.*.create
+ *     databases.*.collections.<A>.documents.*.update
+ *
+ * The function inspects the parent document's relationship field, finds child
+ * documents that the cascade created silently, and either:
+ *   (a) re-issues a synthetic event via the outbox collection, or
+ *   (b) directly executes a downstream Appwrite Function by ID, or
+ *   (c) calls an external webhook.
+ *
+ * It is idempotent: each child is keyed in the outbox by
+ * `${parent.$id}:${child.$id}:${parent.$updatedAt}` so retries do not duplicate
+ * fan-out.
+ *
+ * Build:
+ *   npm install
+ *   npm run build
+ *
+ * Variables (configure on the Function):
+ *   APPWRITE_FUNCTION_API_ENDPOINT   (set automatically)
+ *   APPWRITE_FUNCTION_PROJECT_ID     (set automatically)
+ *   APPWRITE_API_KEY                 - dynamic key recommended, scopes:
+ *                                      databases.read, documents.write
+ *   PARENT_COLLECTION_ID             - id of collection A
+ *   CHILD_COLLECTION_ID              - id of collection B
+ *   RELATIONSHIP_KEY                 - name of the relationship attribute
+ *   FANOUT_FUNCTION_ID               - optional, function to execute per child
+ *   FANOUT_WEBHOOK_URL               - optional, HTTP webhook per child
+ */
+
+import { Client, Databases, Functions, ID, Query } from 'node-appwrite';
+
+type EventContext = {
+  req: {
+    headers: Record<string, string>;
+    bodyJson?: unknown;
+    bodyRaw?: string;
+  };
+  res: {
+    json: (data: unknown, status?: number) => unknown;
+    empty: () => unknown;
+  };
+  log: (msg: unknown) => void;
+  error: (msg: unknown) => void;
+};
+
+type AppwriteDocument = {
+  $id: string;
+  $collectionId: string;
+  $databaseId: string;
+  $createdAt: string;
+  $updatedAt: string;
+  [key: string]: unknown;
+};
+
+export default async function (context: EventContext): Promise<unknown> {
+  const { req, res, log, error } = context;
+
+  const eventHeader =
+    req.headers['x-appwrite-event'] ?? req.headers['X-Appwrite-Event'];
+  if (!eventHeader) {
+    return res.json(
+      { ok: false, reason: 'missing x-appwrite-event header' },
+      400,
+    );
+  }
+
+  const payload =
+    typeof req.bodyJson === 'object' && req.bodyJson !== null
+      ? (req.bodyJson as AppwriteDocument)
+      : (JSON.parse(req.bodyRaw ?? '{}') as AppwriteDocument);
+
+  if (!payload.$id || !payload.$collectionId) {
+    return res.json({ ok: false, reason: 'invalid event payload' }, 400);
+  }
+
+  const parentCollectionId = required('PARENT_COLLECTION_ID');
+  const childCollectionId = required('CHILD_COLLECTION_ID');
+  const relationshipKey = required('RELATIONSHIP_KEY');
+
+  if (payload.$collectionId !== parentCollectionId) {
+    return res.json({
+      ok: true,
+      skipped: true,
+      reason: `collection ${payload.$collectionId} is not the configured parent`,
+    });
+  }
+
+  const client = new Client()
+    .setEndpoint(required('APPWRITE_FUNCTION_API_ENDPOINT'))
+    .setProject(required('APPWRITE_FUNCTION_PROJECT_ID'))
+    .setKey(required('APPWRITE_API_KEY'));
+
+  const db = new Databases(client);
+  const functions = new Functions(client);
+
+  // Re-fetch the parent so we have the latest relationship state. The event
+  // payload sometimes lacks the resolved relationship snapshot.
+  const parent = (await db.getDocument(
+    payload.$databaseId,
+    parentCollectionId,
+    payload.$id,
+  )) as AppwriteDocument;
+
+  const related = parent[relationshipKey];
+  if (related == null) {
+    log('parent has no related children; nothing to fan out');
+    return res.empty();
+  }
+
+  const childIds = normalizeRelated(related);
+  log(`parent ${parent.$id}: ${childIds.length} children`);
+
+  const seen = new Set<string>();
+  for (const childId of childIds) {
+    if (seen.has(childId)) continue;
+    seen.add(childId);
+
+    const dedupeKey = `${parent.$id}:${childId}:${parent.$updatedAt}`;
+
+    const exists = await db
+      .listDocuments(payload.$databaseId, 'outbox_events', [
+        Query.equal('correlationId', dedupeKey),
+        Query.limit(1),
+      ])
+      .catch(() => ({ total: 0, documents: [] }));
+
+    if (exists.total > 0) {
+      log(`child ${childId} already fanned out; skipping`);
+      continue;
+    }
+
+    let child: AppwriteDocument;
+    try {
+      child = (await db.getDocument(
+        payload.$databaseId,
+        childCollectionId,
+        childId,
+      )) as AppwriteDocument;
+    } catch (err) {
+      error(`failed to read child ${childId}: ${stringifyError(err)}`);
+      continue;
+    }
+
+    await db.createDocument(payload.$databaseId, 'outbox_events', ID.unique(), {
+      kind: `databases.${payload.$databaseId}.collections.${childCollectionId}.documents.create`,
+      databaseId: payload.$databaseId,
+      collectionId: childCollectionId,
+      documentId: child.$id,
+      payload: JSON.stringify(child),
+      correlationId: dedupeKey,
+      status: 'pending',
+      attempts: 0,
+      lastError: null,
+      enqueuedAt: new Date().toISOString(),
+      deliveredAt: null,
+    });
+
+    const fanoutFunctionId = process.env.FANOUT_FUNCTION_ID;
+    if (fanoutFunctionId) {
+      try {
+        await functions.createExecution(
+          fanoutFunctionId,
+          JSON.stringify({
+            event: `databases.${payload.$databaseId}.collections.${childCollectionId}.documents.${child.$id}.create`,
+            source: 'relationshipEventFanout',
+            child,
+            parentId: parent.$id,
+          }),
+          true, // async
+        );
+      } catch (err) {
+        error(`fanout function execution failed: ${stringifyError(err)}`);
+      }
+    }
+
+    const webhookUrl = process.env.FANOUT_WEBHOOK_URL;
+    if (webhookUrl) {
+      try {
+        const response = await fetch(webhookUrl, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-correlation-id': dedupeKey,
+            'x-source': 'relationshipEventFanout',
+          },
+          body: JSON.stringify({ parentId: parent.$id, child }),
+        });
+        if (!response.ok) {
+          error(
+            `webhook ${webhookUrl} responded with status ${response.status}`,
+          );
+        }
+      } catch (err) {
+        error(`webhook delivery failed: ${stringifyError(err)}`);
+      }
+    }
+  }
+
+  return res.json({ ok: true, fanned: childIds.length });
+}
+
+function normalizeRelated(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => (typeof v === 'string' ? v : (v as { $id?: string })?.$id))
+      .filter((v): v is string => !!v);
+  }
+  if (typeof value === 'string') return [value];
+  if (typeof value === 'object' && value !== null) {
+    const id = (value as { $id?: string }).$id;
+    return id ? [id] : [];
+  }
+  return [];
+}
+
+function required(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`missing required env var ${key}`);
+  }
+  return value;
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return JSON.stringify(err);
+}

--- a/examples/relationship-event-orchestration/src/functions/relationshipEventFanout/tsconfig.json
+++ b/examples/relationship-event-orchestration/src/functions/relationshipEventFanout/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/relationship-event-orchestration/src/lib/appwrite.ts
+++ b/examples/relationship-event-orchestration/src/lib/appwrite.ts
@@ -1,0 +1,23 @@
+import { Client, Databases, ID } from 'node-appwrite';
+import { config } from './config.js';
+
+/**
+ * Build a fresh server-side Appwrite client.
+ *
+ * We deliberately do not memoize the client globally: the node-appwrite SDK
+ * keeps internal state on each client (headers, cookies). Creating per-task
+ * clients keeps concurrent operations isolated and lets us layer a JWT or a
+ * scoped key per-request when needed.
+ */
+export function buildClient(): Client {
+  return new Client()
+    .setEndpoint(config.endpoint)
+    .setProject(config.projectId)
+    .setKey(config.apiKey);
+}
+
+export function buildDatabases(): Databases {
+  return new Databases(buildClient());
+}
+
+export { ID };

--- a/examples/relationship-event-orchestration/src/lib/config.ts
+++ b/examples/relationship-event-orchestration/src/lib/config.ts
@@ -1,0 +1,22 @@
+import 'dotenv/config';
+
+function required(key: string): string {
+  const value = process.env[key];
+  if (!value || value.trim() === '') {
+    throw new Error(`Missing required env var ${key}`);
+  }
+  return value;
+}
+
+export const config = {
+  endpoint: required('APPWRITE_ENDPOINT'),
+  projectId: required('APPWRITE_PROJECT_ID'),
+  apiKey: required('APPWRITE_API_KEY'),
+  databaseId: process.env.APPWRITE_DATABASE_ID ?? 'app',
+  collectionA: process.env.APPWRITE_COLLECTION_A ?? 'parents',
+  collectionB: process.env.APPWRITE_COLLECTION_B ?? 'children',
+  idempotencyTtlSeconds: Number.parseInt(
+    process.env.IDEMPOTENCY_TTL_SECONDS ?? '86400',
+    10,
+  ),
+} as const;

--- a/examples/relationship-event-orchestration/src/lib/idempotency.ts
+++ b/examples/relationship-event-orchestration/src/lib/idempotency.ts
@@ -1,0 +1,240 @@
+import { Databases, ID, Permission, Query, Role } from 'node-appwrite';
+import { config } from './config.js';
+import { logger } from './logger.js';
+
+/**
+ * Idempotency store backed by an Appwrite collection.
+ *
+ * The contract is:
+ *   begin(key, ttlSec)   -> RESERVED | INFLIGHT | COMPLETED
+ *   complete(key, result)-> attaches the result so future replays can
+ *                           short-circuit
+ *
+ * The reservation uses an Appwrite document with the idempotency key as `$id`.
+ * Duplicate `$id` triggers a duplicate-document error (409) atomically, so we
+ * never need a distributed lock service.
+ */
+export const IDEMPOTENCY_COLLECTION = 'idempotency_keys';
+
+export type IdempotencyOutcome<TResult> =
+  | { state: 'reserved' }
+  | { state: 'inflight'; startedAt: string }
+  | { state: 'completed'; result: TResult; finishedAt: string };
+
+export class IdempotencyStore {
+  constructor(private readonly db: Databases) {}
+
+  /**
+   * Try to claim an idempotency key.
+   *
+   * RETURNS:
+   *  - `reserved` : this caller owns the operation; proceed
+   *  - `inflight` : another caller is still working; the caller may poll or fail-fast
+   *  - `completed`: the operation is finished; the caller should return the cached result
+   */
+  async begin<TResult>(
+    key: string,
+    ttlSeconds: number = config.idempotencyTtlSeconds,
+  ): Promise<IdempotencyOutcome<TResult>> {
+    try {
+      await this.db.createDocument(
+        config.databaseId,
+        IDEMPOTENCY_COLLECTION,
+        key,
+        {
+          status: 'inflight',
+          startedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + ttlSeconds * 1000).toISOString(),
+          result: null,
+        },
+        [
+          Permission.read(Role.any()),
+          Permission.update(Role.any()),
+          Permission.delete(Role.any()),
+        ],
+      );
+      return { state: 'reserved' };
+    } catch (error) {
+      const code = (error as { code?: number }).code;
+      if (code !== 409) {
+        throw error;
+      }
+
+      const existing = await this.db.getDocument(
+        config.databaseId,
+        IDEMPOTENCY_COLLECTION,
+        key,
+      );
+
+      if (existing.status === 'completed') {
+        return {
+          state: 'completed',
+          result: existing.result as TResult,
+          finishedAt: existing.finishedAt as string,
+        };
+      }
+      return {
+        state: 'inflight',
+        startedAt: existing.startedAt as string,
+      };
+    }
+  }
+
+  /**
+   * Mark an idempotency key as completed and attach the result.
+   * The result must be JSON-serializable.
+   */
+  async complete<TResult>(key: string, result: TResult): Promise<void> {
+    await this.db.updateDocument(
+      config.databaseId,
+      IDEMPOTENCY_COLLECTION,
+      key,
+      {
+        status: 'completed',
+        finishedAt: new Date().toISOString(),
+        result: JSON.stringify(result),
+      },
+    );
+  }
+
+  /**
+   * Best-effort cleanup of expired idempotency rows. Safe to run from a cron.
+   */
+  async gc(batch = 100): Promise<number> {
+    const now = new Date().toISOString();
+    let removed = 0;
+
+    const expired = await this.db.listDocuments(
+      config.databaseId,
+      IDEMPOTENCY_COLLECTION,
+      [Query.lessThan('expiresAt', now), Query.limit(batch)],
+    );
+
+    for (const doc of expired.documents) {
+      try {
+        await this.db.deleteDocument(
+          config.databaseId,
+          IDEMPOTENCY_COLLECTION,
+          doc.$id,
+        );
+        removed++;
+      } catch (error) {
+        logger.warn({ id: doc.$id, error }, 'idempotency gc: failed to delete');
+      }
+    }
+
+    return removed;
+  }
+}
+
+/**
+ * Helper: deterministic idempotency key for a (parent, children) submission.
+ * Callers should hash a stable shape that includes the user, parent id, and
+ * children payload to make replays safe.
+ */
+export function buildIdempotencyKey(parts: Record<string, unknown>): string {
+  const canonical = JSON.stringify(parts, Object.keys(parts).sort());
+  return `idem_${djb2(canonical)}`;
+}
+
+function djb2(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
+ * Provision the idempotency collection. Called by `repro/setup.ts`.
+ */
+export async function ensureIdempotencyCollection(db: Databases): Promise<void> {
+  try {
+    await db.getCollection(config.databaseId, IDEMPOTENCY_COLLECTION);
+    return;
+  } catch (error) {
+    if ((error as { code?: number }).code !== 404) throw error;
+  }
+
+  await db.createCollection(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'Idempotency Keys',
+    [
+      Permission.read(Role.any()),
+      Permission.create(Role.any()),
+      Permission.update(Role.any()),
+      Permission.delete(Role.any()),
+    ],
+    true, // documentSecurity
+  );
+
+  await db.createStringAttribute(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'status',
+    32,
+    true,
+  );
+  await db.createDatetimeAttribute(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'startedAt',
+    true,
+  );
+  await db.createDatetimeAttribute(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'finishedAt',
+    false,
+  );
+  await db.createDatetimeAttribute(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'expiresAt',
+    true,
+  );
+  await db.createStringAttribute(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'result',
+    1_000_000,
+    false,
+  );
+
+  await db.createIndex(
+    config.databaseId,
+    IDEMPOTENCY_COLLECTION,
+    'expiresAt_idx',
+    'key',
+    ['expiresAt'],
+    ['ASC'],
+  );
+
+  await waitForAttributes(db, IDEMPOTENCY_COLLECTION, [
+    'status',
+    'startedAt',
+    'finishedAt',
+    'expiresAt',
+    'result',
+  ]);
+}
+
+async function waitForAttributes(
+  db: Databases,
+  collectionId: string,
+  keys: string[],
+): Promise<void> {
+  // Attribute creation is asynchronous in Appwrite. We poll until all keys
+  // become 'available' or 30 s pass, whichever first.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const list = await db.listAttributes(config.databaseId, collectionId);
+    const byKey = new Map(list.attributes.map((a: any) => [a.key, a.status]));
+    if (keys.every((k) => byKey.get(k) === 'available')) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(
+    `attributes ${keys.join(', ')} did not become available within 30s`,
+  );
+}

--- a/examples/relationship-event-orchestration/src/lib/logger.ts
+++ b/examples/relationship-event-orchestration/src/lib/logger.ts
@@ -1,0 +1,10 @@
+import pino from 'pino';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+  base: { service: 'relationship-event-orchestration' },
+  redact: ['req.headers.authorization', 'apiKey', 'env.APPWRITE_API_KEY'],
+  timestamp: pino.stdTimeFunctions.isoTime,
+});
+
+export type Logger = typeof logger;

--- a/examples/relationship-event-orchestration/src/lib/outbox.ts
+++ b/examples/relationship-event-orchestration/src/lib/outbox.ts
@@ -1,0 +1,216 @@
+import { Databases, ID, Permission, Query, Role } from 'node-appwrite';
+import { config } from './config.js';
+import { logger } from './logger.js';
+import { withRetry } from './retry.js';
+
+/**
+ * Outbox pattern.
+ *
+ * Why we need it:
+ *   Appwrite 1.6.x does NOT emit `documents.*.create` events for child
+ *   documents that are cascaded into existence via a parent's relationship
+ *   field (see RCA in README). That means functions subscribed to
+ *   `databases.*.collections.B.documents.*.create` will silently miss those
+ *   creations.
+ *
+ * Strategy:
+ *   1. Application code writes an *outbox row* in the same logical operation
+ *      that produces the side effect (here: a child-document create).
+ *   2. A relay worker (Appwrite Function on a CRON, or any consumer of the
+ *      `databases.*.documents.*.create` event on the outbox collection)
+ *      delivers it to the real downstream automation: HTTP webhook, queue,
+ *      function execution.
+ *   3. Rows are marked `delivered` after success, or get an attempt-counter
+ *      bump on failure so the relay can back off.
+ *
+ * Because Appwrite reliably fires events for *direct* document creation,
+ * writing to the outbox is the bridge that makes our system event-driven
+ * even though native relationship cascades are silent.
+ */
+export const OUTBOX_COLLECTION = 'outbox_events';
+
+export type OutboxEvent = {
+  kind: string;                    // e.g. 'documents.children.create'
+  databaseId: string;
+  collectionId: string;
+  documentId: string;
+  payload: Record<string, unknown>;
+  correlationId: string;
+};
+
+export type OutboxRow = OutboxEvent & {
+  $id: string;
+  status: 'pending' | 'delivered' | 'failed';
+  attempts: number;
+  lastError: string | null;
+  enqueuedAt: string;
+  deliveredAt: string | null;
+};
+
+export class Outbox {
+  constructor(private readonly db: Databases) {}
+
+  /**
+   * Enqueue an event. Must be safe to call repeatedly with the same
+   * `correlationId` -- duplicates are coalesced via a query check.
+   */
+  async enqueue(event: OutboxEvent): Promise<OutboxRow> {
+    const existing = await this.db.listDocuments(
+      config.databaseId,
+      OUTBOX_COLLECTION,
+      [Query.equal('correlationId', event.correlationId), Query.limit(1)],
+    );
+    if (existing.total > 0) {
+      logger.debug(
+        { correlationId: event.correlationId },
+        'outbox: duplicate enqueue ignored',
+      );
+      return existing.documents[0] as unknown as OutboxRow;
+    }
+
+    return (await this.db.createDocument(
+      config.databaseId,
+      OUTBOX_COLLECTION,
+      ID.unique(),
+      {
+        kind: event.kind,
+        databaseId: event.databaseId,
+        collectionId: event.collectionId,
+        documentId: event.documentId,
+        payload: JSON.stringify(event.payload),
+        correlationId: event.correlationId,
+        status: 'pending',
+        attempts: 0,
+        lastError: null,
+        enqueuedAt: new Date().toISOString(),
+        deliveredAt: null,
+      },
+      [
+        Permission.read(Role.any()),
+        Permission.update(Role.any()),
+        Permission.delete(Role.any()),
+      ],
+    )) as unknown as OutboxRow;
+  }
+
+  async markDelivered(id: string): Promise<void> {
+    await this.db.updateDocument(config.databaseId, OUTBOX_COLLECTION, id, {
+      status: 'delivered',
+      deliveredAt: new Date().toISOString(),
+      lastError: null,
+    });
+  }
+
+  async markFailed(id: string, error: unknown): Promise<void> {
+    const row = (await this.db.getDocument(
+      config.databaseId,
+      OUTBOX_COLLECTION,
+      id,
+    )) as unknown as OutboxRow;
+    await this.db.updateDocument(config.databaseId, OUTBOX_COLLECTION, id, {
+      status: row.attempts >= 9 ? 'failed' : 'pending',
+      attempts: row.attempts + 1,
+      lastError: stringifyError(error),
+    });
+  }
+
+  /**
+   * Drain pending events. Should be called from the relay worker.
+   * Returns the number of rows successfully delivered.
+   */
+  async drain(
+    handler: (row: OutboxRow) => Promise<void>,
+    batch = 25,
+  ): Promise<number> {
+    const pending = await this.db.listDocuments(
+      config.databaseId,
+      OUTBOX_COLLECTION,
+      [
+        Query.equal('status', 'pending'),
+        Query.orderAsc('enqueuedAt'),
+        Query.limit(batch),
+      ],
+    );
+
+    let delivered = 0;
+    for (const doc of pending.documents) {
+      const row = doc as unknown as OutboxRow;
+      try {
+        await withRetry(() => handler(row), {
+          attempts: 3,
+          baseDelayMs: 200,
+          maxDelayMs: 2_000,
+          operation: `outbox.deliver.${row.kind}`,
+        });
+        await this.markDelivered(row.$id);
+        delivered++;
+      } catch (error) {
+        await this.markFailed(row.$id, error);
+      }
+    }
+    return delivered;
+  }
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return JSON.stringify(error);
+}
+
+/**
+ * Provision the outbox collection. Called by `repro/setup.ts`.
+ */
+export async function ensureOutboxCollection(db: Databases): Promise<void> {
+  try {
+    await db.getCollection(config.databaseId, OUTBOX_COLLECTION);
+    return;
+  } catch (error) {
+    if ((error as { code?: number }).code !== 404) throw error;
+  }
+
+  await db.createCollection(
+    config.databaseId,
+    OUTBOX_COLLECTION,
+    'Outbox Events',
+    [
+      Permission.read(Role.any()),
+      Permission.create(Role.any()),
+      Permission.update(Role.any()),
+      Permission.delete(Role.any()),
+    ],
+    true,
+  );
+
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'kind', 128, true);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'databaseId', 64, true);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'collectionId', 64, true);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'documentId', 64, true);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'payload', 1_000_000, false);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'correlationId', 128, true);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'status', 16, true, 'pending');
+  await db.createIntegerAttribute(config.databaseId, OUTBOX_COLLECTION, 'attempts', true, 0);
+  await db.createStringAttribute(config.databaseId, OUTBOX_COLLECTION, 'lastError', 4096, false);
+  await db.createDatetimeAttribute(config.databaseId, OUTBOX_COLLECTION, 'enqueuedAt', true);
+  await db.createDatetimeAttribute(config.databaseId, OUTBOX_COLLECTION, 'deliveredAt', false);
+
+  await new Promise((r) => setTimeout(r, 1500));
+
+  await db.createIndex(
+    config.databaseId,
+    OUTBOX_COLLECTION,
+    'status_enqueuedAt_idx',
+    'key',
+    ['status', 'enqueuedAt'],
+    ['ASC', 'ASC'],
+  );
+  await db.createIndex(
+    config.databaseId,
+    OUTBOX_COLLECTION,
+    'correlationId_idx',
+    'key',
+    ['correlationId'],
+    ['ASC'],
+  );
+}

--- a/examples/relationship-event-orchestration/src/lib/retry.ts
+++ b/examples/relationship-event-orchestration/src/lib/retry.ts
@@ -1,0 +1,110 @@
+import { logger } from './logger.js';
+
+export type RetryPolicy = {
+  /** Max number of attempts (including the first call). */
+  attempts: number;
+  /** Base delay in milliseconds for exponential backoff. */
+  baseDelayMs: number;
+  /** Maximum delay cap. */
+  maxDelayMs: number;
+  /** Optional predicate to decide whether an error is retryable. */
+  isRetryable?: (error: unknown) => boolean;
+  /** Optional tag used for structured logging. */
+  operation?: string;
+};
+
+/**
+ * Default retry policy: 5 attempts, full jitter exponential backoff,
+ * retries on transient errors only (network, 5xx, 429).
+ */
+export const DEFAULT_RETRY: RetryPolicy = {
+  attempts: 5,
+  baseDelayMs: 100,
+  maxDelayMs: 5_000,
+  isRetryable: defaultIsRetryable,
+};
+
+function defaultIsRetryable(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const err = error as { code?: number; type?: string; name?: string };
+
+  if (err.code === 429) return true;
+  if (typeof err.code === 'number' && err.code >= 500 && err.code < 600) {
+    return true;
+  }
+  if (err.name === 'FetchError' || err.name === 'AbortError') return true;
+  if (err.type === 'general_server_error') return true;
+
+  return false;
+}
+
+/**
+ * Execute `fn` with exponential backoff + full jitter.
+ *
+ * Idempotency MUST be guaranteed by the caller; this helper assumes the
+ * operation is safe to repeat (use {@link withIdempotency} for that).
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  policy: RetryPolicy = DEFAULT_RETRY,
+): Promise<T> {
+  const isRetryable = policy.isRetryable ?? defaultIsRetryable;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= policy.attempts; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      lastError = error;
+
+      const retryable = isRetryable(error);
+      const exhausted = attempt >= policy.attempts;
+
+      logger.warn(
+        {
+          attempt,
+          attempts: policy.attempts,
+          operation: policy.operation,
+          retryable,
+          err: serializeError(error),
+        },
+        retryable && !exhausted
+          ? 'transient failure, retrying'
+          : 'failure, giving up',
+      );
+
+      if (!retryable || exhausted) {
+        throw error;
+      }
+
+      const expDelay = Math.min(
+        policy.maxDelayMs,
+        policy.baseDelayMs * 2 ** (attempt - 1),
+      );
+      const jitter = Math.random() * expDelay;
+      await sleep(jitter);
+    }
+  }
+
+  throw lastError;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (!error || typeof error !== 'object') {
+    return { error };
+  }
+  const err = error as Record<string, unknown>;
+  return {
+    name: err.name,
+    message: err.message,
+    code: err.code,
+    type: err.type,
+  };
+}

--- a/examples/relationship-event-orchestration/src/orchestrator/createParentWithChildren.ts
+++ b/examples/relationship-event-orchestration/src/orchestrator/createParentWithChildren.ts
@@ -1,0 +1,256 @@
+import { Databases, ID } from 'node-appwrite';
+import { config } from '../lib/config.js';
+import { logger } from '../lib/logger.js';
+import { withRetry } from '../lib/retry.js';
+import {
+  IdempotencyStore,
+  buildIdempotencyKey,
+} from '../lib/idempotency.js';
+import { Outbox } from '../lib/outbox.js';
+
+/**
+ * Public input contract.
+ *
+ * `parent`   -> attributes of the parent document (excluding the relationship
+ *               field).
+ * `children` -> attributes for each child document. We will create them in
+ *               collection B FIRST so their `documents.*.create` events fire
+ *               natively, then attach them to the parent by ID.
+ * `relationshipKey` -> name of the relationship attribute on A pointing to B.
+ *                       Example: `tasks`.
+ */
+export type CreateParentWithChildrenInput = {
+  parentId?: string;            // optional; defaults to ID.unique()
+  parent: Record<string, unknown>;
+  children: Array<{
+    id?: string;
+    data: Record<string, unknown>;
+  }>;
+  relationshipKey: string;
+  /** Optional opaque correlation id for tracing across logs/outbox. */
+  correlationId?: string;
+};
+
+export type CreateParentWithChildrenResult = {
+  parentId: string;
+  childrenIds: string[];
+  correlationId: string;
+};
+
+/**
+ * Production-grade orchestrator that GUARANTEES child-document
+ * `documents.*.create` events fire when creating a parent + children
+ * graph, by inverting the natural Appwrite "parent-first cascade" order.
+ *
+ * Strategy: children-first, attach-by-id.
+ *
+ *   1. Reserve idempotency key.
+ *   2. Create each child in collection B directly. Each create dispatches
+ *      a real `databases.[db].collections.[B].documents.[id].create` event
+ *      that subscribed functions/webhooks/realtime channels will receive.
+ *   3. Mirror each child in the outbox so a relay worker can re-deliver
+ *      to bespoke automations even if Appwrite's event bus drops a message.
+ *   4. Create the parent in collection A with the relationship field set to
+ *      an array of child IDs (not nested objects).
+ *   5. On any failure after step 2, run a compensating delete on the
+ *      successfully created children + outbox rows.
+ *   6. Persist the final result against the idempotency key.
+ *
+ * This pattern works because creating a child by ID-only on the parent does
+ * NOT trigger a child-document cascade in Appwrite -- it's a normal "attach
+ * an existing document via relationship" path and produces no implicit child
+ * creates that would bypass events.
+ */
+export class ParentWithChildrenOrchestrator {
+  constructor(
+    private readonly db: Databases,
+    private readonly idempotency: IdempotencyStore,
+    private readonly outbox: Outbox,
+  ) {}
+
+  async run(
+    input: CreateParentWithChildrenInput,
+  ): Promise<CreateParentWithChildrenResult> {
+    const correlationId =
+      input.correlationId ?? `corr_${ID.unique()}`;
+
+    const idempotencyKey = buildIdempotencyKey({
+      op: 'createParentWithChildren',
+      parentId: input.parentId ?? null,
+      children: input.children.map((c) => ({
+        id: c.id ?? null,
+        data: c.data,
+      })),
+      relationshipKey: input.relationshipKey,
+    });
+
+    const claim = await this.idempotency.begin<CreateParentWithChildrenResult>(
+      idempotencyKey,
+    );
+
+    if (claim.state === 'completed') {
+      logger.info(
+        { idempotencyKey, correlationId },
+        'idempotent replay; returning cached result',
+      );
+      return claim.result;
+    }
+    if (claim.state === 'inflight') {
+      throw new Error(
+        `another worker is already processing key=${idempotencyKey} (started ${claim.startedAt})`,
+      );
+    }
+
+    const log = logger.child({ correlationId, idempotencyKey });
+    log.info({ children: input.children.length }, 'orchestrator: starting');
+
+    const createdChildIds: string[] = [];
+    const enqueuedOutboxIds: string[] = [];
+    let parentDocumentId: string | null = null;
+
+    try {
+      // 1. Create children FIRST so each fires its own create event.
+      for (const child of input.children) {
+        const childId = child.id ?? ID.unique();
+
+        const created = await withRetry(
+          () =>
+            this.db.createDocument(
+              config.databaseId,
+              config.collectionB,
+              childId,
+              child.data,
+            ),
+          { ...defaultPolicy, operation: 'createChild' },
+        );
+        createdChildIds.push(created.$id);
+
+        // Mirror to outbox to make the downstream delivery durable.
+        const row = await this.outbox.enqueue({
+          kind: `databases.${config.databaseId}.collections.${config.collectionB}.documents.create`,
+          databaseId: config.databaseId,
+          collectionId: config.collectionB,
+          documentId: created.$id,
+          payload: created as unknown as Record<string, unknown>,
+          correlationId: `${correlationId}:child:${created.$id}`,
+        });
+        enqueuedOutboxIds.push(row.$id);
+      }
+
+      // 2. Create parent and ATTACH by id rather than nest.
+      parentDocumentId = input.parentId ?? ID.unique();
+      const parent = await withRetry(
+        () =>
+          this.db.createDocument(
+            config.databaseId,
+            config.collectionA,
+            parentDocumentId!,
+            {
+              ...input.parent,
+              [input.relationshipKey]: createdChildIds,
+            },
+          ),
+        { ...defaultPolicy, operation: 'createParent' },
+      );
+
+      // 3. Mirror the parent event too so a fan-out worker can react.
+      await this.outbox.enqueue({
+        kind: `databases.${config.databaseId}.collections.${config.collectionA}.documents.create`,
+        databaseId: config.databaseId,
+        collectionId: config.collectionA,
+        documentId: parent.$id,
+        payload: parent as unknown as Record<string, unknown>,
+        correlationId: `${correlationId}:parent:${parent.$id}`,
+      });
+
+      const result: CreateParentWithChildrenResult = {
+        parentId: parent.$id,
+        childrenIds: createdChildIds,
+        correlationId,
+      };
+
+      await this.idempotency.complete(idempotencyKey, result);
+
+      log.info(
+        { parentId: parent.$id, children: createdChildIds.length },
+        'orchestrator: success',
+      );
+      return result;
+    } catch (error) {
+      log.error({ err: error }, 'orchestrator: failure, compensating');
+      await this.compensate({
+        log,
+        createdChildIds,
+        enqueuedOutboxIds,
+        parentDocumentId,
+      });
+      throw error;
+    }
+  }
+
+  private async compensate(args: {
+    log: ReturnType<typeof logger.child>;
+    createdChildIds: string[];
+    enqueuedOutboxIds: string[];
+    parentDocumentId: string | null;
+  }): Promise<void> {
+    const { log, createdChildIds, enqueuedOutboxIds, parentDocumentId } = args;
+
+    if (parentDocumentId) {
+      await this.safeDelete(
+        () =>
+          this.db.deleteDocument(
+            config.databaseId,
+            config.collectionA,
+            parentDocumentId,
+          ),
+        log,
+        { parentId: parentDocumentId },
+      );
+    }
+
+    for (const id of createdChildIds) {
+      await this.safeDelete(
+        () =>
+          this.db.deleteDocument(
+            config.databaseId,
+            config.collectionB,
+            id,
+          ),
+        log,
+        { childId: id },
+      );
+    }
+
+    for (const id of enqueuedOutboxIds) {
+      await this.safeDelete(
+        () =>
+          this.db.deleteDocument(
+            config.databaseId,
+            'outbox_events',
+            id,
+          ),
+        log,
+        { outboxId: id },
+      );
+    }
+  }
+
+  private async safeDelete(
+    fn: () => Promise<unknown>,
+    log: ReturnType<typeof logger.child>,
+    context: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await fn();
+    } catch (error) {
+      log.warn({ err: error, ...context }, 'compensation delete failed');
+    }
+  }
+}
+
+const defaultPolicy = {
+  attempts: 5,
+  baseDelayMs: 150,
+  maxDelayMs: 3_000,
+};

--- a/examples/relationship-event-orchestration/src/orchestrator/demo.ts
+++ b/examples/relationship-event-orchestration/src/orchestrator/demo.ts
@@ -1,0 +1,31 @@
+import { buildDatabases } from '../lib/appwrite.js';
+import { logger } from '../lib/logger.js';
+import { IdempotencyStore } from '../lib/idempotency.js';
+import { Outbox } from '../lib/outbox.js';
+import { ParentWithChildrenOrchestrator } from './createParentWithChildren.js';
+
+async function main(): Promise<void> {
+  const db = buildDatabases();
+  const orchestrator = new ParentWithChildrenOrchestrator(
+    db,
+    new IdempotencyStore(db),
+    new Outbox(db),
+  );
+
+  const result = await orchestrator.run({
+    parent: { name: 'Sprint 42', status: 'open' },
+    children: [
+      { data: { title: 'Write the RFC', priority: 'high' } },
+      { data: { title: 'Land the patch', priority: 'medium' } },
+      { data: { title: 'Update docs', priority: 'low' } },
+    ],
+    relationshipKey: 'tasks',
+  });
+
+  logger.info(result, 'orchestrator demo: complete');
+}
+
+main().catch((error) => {
+  logger.error({ err: error }, 'orchestrator demo: failed');
+  process.exit(1);
+});

--- a/examples/relationship-event-orchestration/src/repro/demonstrate-bug.ts
+++ b/examples/relationship-event-orchestration/src/repro/demonstrate-bug.ts
@@ -1,0 +1,80 @@
+import { ID, Query } from 'node-appwrite';
+import { buildDatabases } from '../lib/appwrite.js';
+import { config } from '../lib/config.js';
+import { logger } from '../lib/logger.js';
+
+/**
+ * Reproduce the silent-event behavior.
+ *
+ * We assume there is a function or webhook subscribed to:
+ *     databases.{config.databaseId}.collections.{config.collectionB}.documents.*.create
+ *
+ * Manual verification:
+ *   1. Run `npm run repro:bug`
+ *   2. Inspect your function executions / webhook logs.
+ *      - The "direct B create" entry will appear.
+ *      - The "relationship cascade" children will NOT appear.
+ *
+ * We also poll the Appwrite "executions" list for any function whose events
+ * include the child create pattern, but execution visibility depends on your
+ * project setup; the test is primarily observational.
+ */
+async function main(): Promise<void> {
+  const db = buildDatabases();
+
+  // (1) DIRECT child create -> event WILL fire
+  const directChild = await db.createDocument(
+    config.databaseId,
+    config.collectionB,
+    ID.unique(),
+    { title: 'Direct create -- event should fire', priority: 'high' },
+  );
+  logger.info(
+    { id: directChild.$id },
+    'created child DIRECTLY in B (expect event in subscribers)',
+  );
+
+  // (2) RELATIONSHIP cascade -> event WILL NOT fire for children
+  const parent = await db.createDocument(
+    config.databaseId,
+    config.collectionA,
+    ID.unique(),
+    {
+      name: 'Parent that nests two children',
+      status: 'open',
+      tasks: [
+        { title: 'Nested child #1 -- NO event', priority: 'medium' },
+        { title: 'Nested child #2 -- NO event', priority: 'low' },
+      ],
+    },
+  );
+  logger.info(
+    { parentId: parent.$id },
+    'created parent in A with nested children (parent event fires; child events do NOT)',
+  );
+
+  // Sanity: verify the cascaded children actually exist server-side
+  const cascadedChildren = await db.listDocuments(
+    config.databaseId,
+    config.collectionB,
+    [Query.limit(10), Query.orderDesc('$createdAt')],
+  );
+  logger.info(
+    {
+      latestB: cascadedChildren.documents.map((d) => ({
+        id: d.$id,
+        title: d.title,
+      })),
+    },
+    'children present in B but emitted no documents.create events',
+  );
+
+  logger.info(
+    'manual check: open your subscribed function/webhook logs. Direct creates trigger events, relationship creates do not.',
+  );
+}
+
+main().catch((error) => {
+  logger.error({ err: error }, 'demonstrate-bug failed');
+  process.exit(1);
+});

--- a/examples/relationship-event-orchestration/src/repro/setup.ts
+++ b/examples/relationship-event-orchestration/src/repro/setup.ts
@@ -1,0 +1,162 @@
+import { Databases, Permission, RelationshipType, Role } from 'node-appwrite';
+import { buildDatabases } from '../lib/appwrite.js';
+import { config } from '../lib/config.js';
+import { logger } from '../lib/logger.js';
+import { ensureIdempotencyCollection } from '../lib/idempotency.js';
+import { ensureOutboxCollection } from '../lib/outbox.js';
+
+async function ensureDatabase(db: Databases): Promise<void> {
+  try {
+    await db.get(config.databaseId);
+    logger.info({ db: config.databaseId }, 'database exists');
+  } catch (error) {
+    if ((error as { code?: number }).code !== 404) throw error;
+    await db.create(config.databaseId, 'App', true);
+    logger.info({ db: config.databaseId }, 'database created');
+  }
+}
+
+async function ensureCollection(
+  db: Databases,
+  id: string,
+  name: string,
+): Promise<void> {
+  try {
+    await db.getCollection(config.databaseId, id);
+    logger.info({ id }, 'collection exists');
+    return;
+  } catch (error) {
+    if ((error as { code?: number }).code !== 404) throw error;
+  }
+  await db.createCollection(
+    config.databaseId,
+    id,
+    name,
+    [
+      Permission.read(Role.any()),
+      Permission.create(Role.any()),
+      Permission.update(Role.any()),
+      Permission.delete(Role.any()),
+    ],
+    true,
+  );
+  logger.info({ id }, 'collection created');
+}
+
+async function ensureAttribute(
+  fn: () => Promise<unknown>,
+  label: string,
+): Promise<void> {
+  try {
+    await fn();
+    logger.info({ label }, 'attribute created');
+  } catch (error) {
+    const code = (error as { code?: number }).code;
+    if (code === 409) {
+      logger.info({ label }, 'attribute already exists');
+      return;
+    }
+    throw error;
+  }
+}
+
+async function waitForAttributesAvailable(
+  db: Databases,
+  collectionId: string,
+  keys: string[],
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const list = await db.listAttributes(config.databaseId, collectionId);
+    const byKey = new Map(list.attributes.map((a: any) => [a.key, a.status]));
+    const allReady = keys.every((k) => byKey.get(k) === 'available');
+    if (allReady) return;
+    await new Promise((r) => setTimeout(r, 750));
+  }
+  throw new Error(
+    `attributes ${keys.join(', ')} did not become available in 30s`,
+  );
+}
+
+async function main(): Promise<void> {
+  const db = buildDatabases();
+  await ensureDatabase(db);
+
+  // Child collection (B)
+  await ensureCollection(db, config.collectionB, 'Children (B)');
+  await ensureAttribute(
+    () =>
+      db.createStringAttribute(
+        config.databaseId,
+        config.collectionB,
+        'title',
+        256,
+        true,
+      ),
+    'B.title',
+  );
+  await ensureAttribute(
+    () =>
+      db.createStringAttribute(
+        config.databaseId,
+        config.collectionB,
+        'priority',
+        32,
+        false,
+      ),
+    'B.priority',
+  );
+  await waitForAttributesAvailable(db, config.collectionB, ['title', 'priority']);
+
+  // Parent collection (A)
+  await ensureCollection(db, config.collectionA, 'Parents (A)');
+  await ensureAttribute(
+    () =>
+      db.createStringAttribute(
+        config.databaseId,
+        config.collectionA,
+        'name',
+        256,
+        true,
+      ),
+    'A.name',
+  );
+  await ensureAttribute(
+    () =>
+      db.createStringAttribute(
+        config.databaseId,
+        config.collectionA,
+        'status',
+        32,
+        false,
+      ),
+    'A.status',
+  );
+  await waitForAttributesAvailable(db, config.collectionA, ['name', 'status']);
+
+  // Relationship A -> B (one-to-many)
+  await ensureAttribute(
+    () =>
+      db.createRelationshipAttribute(
+        config.databaseId,
+        config.collectionA,
+        config.collectionB,
+        RelationshipType.OneToMany,
+        true,
+        'tasks',
+        'parent',
+        'cascade',
+      ),
+    'A.tasks (relationship)',
+  );
+
+  await ensureIdempotencyCollection(db);
+  await ensureOutboxCollection(db);
+
+  logger.info('setup complete');
+}
+
+main().catch((error) => {
+  logger.error({ err: error }, 'setup failed');
+  process.exit(1);
+});

--- a/examples/relationship-event-orchestration/src/repro/verify-fix.ts
+++ b/examples/relationship-event-orchestration/src/repro/verify-fix.ts
@@ -1,0 +1,60 @@
+import { buildDatabases } from '../lib/appwrite.js';
+import { logger } from '../lib/logger.js';
+import { IdempotencyStore } from '../lib/idempotency.js';
+import { Outbox } from '../lib/outbox.js';
+import { ParentWithChildrenOrchestrator } from '../orchestrator/createParentWithChildren.js';
+
+/**
+ * Confirms that using the orchestrator (children-first, attach-by-id) makes
+ * every child document fire its own `documents.*.create` event natively, while
+ * also pushing a parallel outbox row for at-least-once guaranteed delivery.
+ *
+ * After running this you should see, in the subscribed function/webhook logs:
+ *   - one event per child  (databases.*.collections.B.documents.*.create)
+ *   - one event for parent (databases.*.collections.A.documents.*.create)
+ */
+async function main(): Promise<void> {
+  const db = buildDatabases();
+  const orchestrator = new ParentWithChildrenOrchestrator(
+    db,
+    new IdempotencyStore(db),
+    new Outbox(db),
+  );
+
+  const result = await orchestrator.run({
+    parent: { name: 'Verified-Fix Parent', status: 'open' },
+    children: [
+      { data: { title: 'orchestrator child #1', priority: 'high' } },
+      { data: { title: 'orchestrator child #2', priority: 'medium' } },
+      { data: { title: 'orchestrator child #3', priority: 'low' } },
+    ],
+    relationshipKey: 'tasks',
+  });
+
+  logger.info(result, 'verify-fix complete');
+
+  // Idempotency assertion: re-run the same logical input
+  const replay = await orchestrator.run({
+    parent: { name: 'Verified-Fix Parent', status: 'open' },
+    children: [
+      { data: { title: 'orchestrator child #1', priority: 'high' } },
+      { data: { title: 'orchestrator child #2', priority: 'medium' } },
+      { data: { title: 'orchestrator child #3', priority: 'low' } },
+    ],
+    relationshipKey: 'tasks',
+  });
+  logger.info(
+    {
+      sameParent: replay.parentId === result.parentId,
+      sameChildren:
+        JSON.stringify(replay.childrenIds) ===
+        JSON.stringify(result.childrenIds),
+    },
+    'replay returned identical result (idempotency confirmed)',
+  );
+}
+
+main().catch((error) => {
+  logger.error({ err: error }, 'verify-fix failed');
+  process.exit(1);
+});

--- a/examples/relationship-event-orchestration/tsconfig.json
+++ b/examples/relationship-event-orchestration/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -504,4 +504,133 @@ abstract class Action extends DatabasesAction
         $queueForRealtime->reset();
         $queueForWebhooks->reset();
     }
+
+    /**
+     * Emit `documents.[id].create` events for child rows that were created
+     * implicitly by utopia-php/database through a relationship attribute.
+     *
+     * Why this exists:
+     *
+     * When a parent document carries nested relationship payloads (one-to-many,
+     * many-to-one, ...), utopia-php/database resolves and creates each child
+     * inside its own `silent()` block (see Database::createDocument). That
+     * silent block suppresses the low-level `EVENT_DOCUMENT_CREATE` trigger
+     * for every child row, and the HTTP create action only enqueues a single
+     * event for the root document. The end-result is that any Appwrite
+     * Function, Webhook, or Realtime subscriber listening to
+     * `databases.*.collections.{B}.documents.*.create` is never invoked for
+     * those nested children, even though the rows clearly exist in B.
+     *
+     * This helper replays the missing event for each newly-created child,
+     * mirroring exactly what `triggerBulk` does for bulk creates so behaviour
+     * is consistent regardless of how the row was inserted.
+     *
+     * Caller contract:
+     *  - `$nestedCreates` is a list of `['collection' => Document, 'documentId' => string]`.
+     *  - `$dbForDatabases` MUST be the same connection that ran the parent
+     *    `createDocuments()` (matters for documents-db/vectors-db adapters).
+     *  - On return the main `$queueForEvents` is reset (params/event/payload
+     *    cleared, context preserved). The caller is expected to re-populate
+     *    it with the root document's event right after.
+     *
+     * @param array<int, array{collection: Document, documentId: string}> $nestedCreates
+     */
+    protected function triggerRelationshipCreates(
+        array $nestedCreates,
+        Document $database,
+        Database $dbForDatabases,
+        Database $dbForProject,
+        Event $queueForEvents,
+        Event $queueForRealtime,
+        Event $queueForFunctions,
+        Event $queueForWebhooks,
+        EventProcessor $eventProcessor,
+        Authorization $authorization,
+    ): void {
+        if (empty($nestedCreates)) {
+            return;
+        }
+
+        $project = $queueForEvents->getProject();
+        $functionsEvents = $eventProcessor->getFunctionsEvents($project, $dbForProject);
+        $webhooksEvents = $eventProcessor->getWebhooksEvents($project);
+        $collectionsCache = [];
+        $isConsole = $project->getId() === 'console';
+
+        foreach ($nestedCreates as $entry) {
+            /** @var Document $relatedCollection */
+            $relatedCollection = $entry['collection'];
+            $documentId = $entry['documentId'];
+
+            $childDoc = $authorization->skip(
+                fn () => $dbForDatabases->getDocument(
+                    'database_' . $database->getSequence() . '_collection_' . $relatedCollection->getSequence(),
+                    $documentId
+                )
+            );
+
+            // Child may have been deduplicated or skipped by the adapter (e.g.
+            // when the relationship value referenced an existing row). Safe to skip.
+            if ($childDoc->isEmpty()) {
+                continue;
+            }
+
+            // Attach $databaseId / $collectionId / $tableId metadata to the
+            // payload so subscribers see the same shape as a direct create.
+            $this->processDocument(
+                database: $database,
+                collection: $relatedCollection,
+                document: $childDoc,
+                dbForProject: $dbForProject,
+                collectionsCache: $collectionsCache,
+                authorization: $authorization,
+            );
+
+            $queueForEvents
+                ->setEvent('databases.[databaseId].collections.[collectionId].documents.[documentId].create')
+                ->setParam('databaseId', $database->getId())
+                ->setContext('database', $database)
+                ->setParam('collectionId', $relatedCollection->getId())
+                ->setParam('tableId', $relatedCollection->getId())
+                ->setContext($this->getCollectionsEventsContext(), $relatedCollection)
+                ->setParam('documentId', $childDoc->getId())
+                ->setParam('rowId', $childDoc->getId())
+                ->setPayload($childDoc->getArrayCopy());
+
+            // Realtime is suppressed for the console project to match api.php shutdown logic.
+            if (!$isConsole) {
+                $queueForRealtime->from($queueForEvents)->trigger();
+            }
+
+            $generatedEvents = Event::generateEvents(
+                $queueForEvents->getEvent(),
+                $queueForEvents->getParams()
+            );
+
+            if (!empty($functionsEvents)) {
+                foreach ($generatedEvents as $eventName) {
+                    if (isset($functionsEvents[$eventName])) {
+                        $queueForFunctions->from($queueForEvents)->trigger();
+                        break;
+                    }
+                }
+            }
+
+            if (!empty($webhooksEvents)) {
+                foreach ($generatedEvents as $eventName) {
+                    if (isset($webhooksEvents[$eventName])) {
+                        $queueForWebhooks->from($queueForEvents)->trigger();
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Clear params/event/payload so the caller can set the root event
+        // cleanly. Context (project, user, database, etc.) is preserved by reset().
+        $queueForEvents->reset();
+        $queueForRealtime->reset();
+        $queueForFunctions->reset();
+        $queueForWebhooks->reset();
+    }
 }

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -542,7 +542,7 @@ abstract class Action extends DatabasesAction
         Database $dbForProject,
         Event $queueForEvents,
         Event $queueForRealtime,
-        Event $queueForFunctions,
+        FunctionPublisher $publisherForFunctions,
         Event $queueForWebhooks,
         EventProcessor $eventProcessor,
         Authorization $authorization,
@@ -610,7 +610,15 @@ abstract class Action extends DatabasesAction
             if (!empty($functionsEvents)) {
                 foreach ($generatedEvents as $eventName) {
                     if (isset($functionsEvents[$eventName])) {
-                        $queueForFunctions->from($queueForEvents)->trigger();
+                        $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                            event: $queueForEvents->getEvent(),
+                            params: $queueForEvents->getParams(),
+                            project: $queueForEvents->getProject(),
+                            user: $queueForEvents->getUser(),
+                            userId: $queueForEvents->getUserId(),
+                            payload: $queueForEvents->getPayload(),
+                            platform: $queueForEvents->getPlatform(),
+                        ));
                         break;
                     }
                 }
@@ -630,7 +638,6 @@ abstract class Action extends DatabasesAction
         // cleanly. Context (project, user, database, etc.) is preserved by reset().
         $queueForEvents->reset();
         $queueForRealtime->reset();
-        $queueForFunctions->reset();
         $queueForWebhooks->reset();
     }
 }

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -282,7 +282,16 @@ class Create extends Action
 
         $operations = 0;
 
-        $checkPermissions = function (Document $collection, Document $document, string $permission) use ($isAPIKey, $isPrivilegedUser, &$checkPermissions, $dbForProject, $database, &$operations, $authorization) {
+        // Tracks every nested relationship child that will be created implicitly
+        // by utopia-php/database during the root createDocuments() call.
+        // utopia wraps that work in silent(), which suppresses EVENT_DOCUMENT_CREATE
+        // for the children. After the root insert finishes we replay the
+        // documents.*.create event for each entry here so Functions, Webhooks,
+        // and Realtime fire exactly as they would for a direct child create.
+        // Shape: [ ['collection' => Document, 'documentId' => string], ... ]
+        $nestedCreates = [];
+
+        $checkPermissions = function (Document $collection, Document $document, string $permission) use ($isAPIKey, $isPrivilegedUser, &$checkPermissions, $dbForProject, $database, &$operations, $authorization, &$nestedCreates) {
             $operations++;
 
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
@@ -344,6 +353,15 @@ class Create extends Action
                             if (isset($relation['$id']) && $relation['$id'] === 'unique()') {
                                 $relation['$id'] = ID::unique();
                             }
+
+                            // Record this child for post-create event replay.
+                            // We capture both the related Collection document
+                            // (needed for sequence + attribute schema) and the
+                            // child's $id (assigned moments earlier).
+                            $nestedCreates[] = [
+                                'collection' => $relatedCollection,
+                                'documentId' => $relation->getId(),
+                            ];
                         } else {
                             $relation->setAttribute('$collection', $relatedCollection->getId());
                             $type = Database::PERMISSION_UPDATE;
@@ -479,6 +497,23 @@ class Create extends Action
         } catch (StructureException $e) {
             throw new Exception($this->getStructureException(), $e->getMessage());
         }
+
+        // Replay create events for any rows that were inserted implicitly
+        // through a relationship attribute. Must run BEFORE we configure the
+        // root event below: triggerRelationshipCreates() calls reset() on the
+        // events queue once it's done, and the root event is set up next.
+        $this->triggerRelationshipCreates(
+            $nestedCreates,
+            $database,
+            $dbForDatabases,
+            $dbForProject,
+            $queueForEvents,
+            $queueForRealtime,
+            $queueForFunctions,
+            $queueForWebhooks,
+            $eventProcessor,
+            $authorization,
+        );
 
         $queueForEvents
             ->setParam('databaseId', $databaseId)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -509,7 +509,7 @@ class Create extends Action
             $dbForProject,
             $queueForEvents,
             $queueForRealtime,
-            $queueForFunctions,
+            $publisherForFunctions,
             $queueForWebhooks,
             $eventProcessor,
             $authorization,


### PR DESCRIPTION
## Changes

- Add cascade event dispatching to Action.php for belongsTo relationships
- Emit documents.*.create events for relationship-cascaded child documents
- Add relationship-event-orchestration example project

Closes #12401