### PR TITLE
Publish cloud tags to appwrite/ce image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       with:
-        images: appwrite/cloud
+        images: appwrite/ce
         tags: |
           type=ref,event=tag
 


### PR DESCRIPTION
## What

Point the `cl-*` tag publish workflow at the `appwrite/ce` image instead of `appwrite/cloud`.

## Why

When cutting a special cloud tag, the build should publish to the `appwrite/ce` image rather than `appwrite/cloud`.

## Changes

- `.github/workflows/publish.yml`: `images: appwrite/cloud` → `images: appwrite/ce`

The trigger (`cl-*` tags) and cloud build-args (`VITE_CONSOLE_MODE=cloud`, growth endpoint, GA project) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)