### PR TITLE
Add query project auth scheme to specs

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -139,6 +139,12 @@ class Specs extends Action
                     'description' => 'Your project ID',
                     'in' => 'header',
                 ],
+                'ProjectQuery' => [
+                    'type' => 'apiKey',
+                    'name' => 'project',
+                    'description' => 'Your project ID',
+                    'in' => 'query',
+                ],
                 'JWT' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-JWT',
@@ -194,6 +200,12 @@ class Specs extends Action
                     'name' => 'X-Appwrite-Project',
                     'description' => 'Your project ID',
                     'in' => 'header',
+                ],
+                'ProjectQuery' => [
+                    'type' => 'apiKey',
+                    'name' => 'project',
+                    'description' => 'Your project ID',
+                    'in' => 'query',
                 ],
                 'Key' => [
                     'type' => 'apiKey',
@@ -262,6 +274,12 @@ class Specs extends Action
                     'name' => 'X-Appwrite-Project',
                     'description' => 'Your project ID',
                     'in' => 'header',
+                ],
+                'ProjectQuery' => [
+                    'type' => 'apiKey',
+                    'name' => 'project',
+                    'description' => 'Your project ID',
+                    'in' => 'query',
                 ],
                 'Key' => [
                     'type' => 'apiKey',

--- a/src/Appwrite/SDK/Method.php
+++ b/src/Appwrite/SDK/Method.php
@@ -32,6 +32,7 @@ class Method
      * @param array $additionalParameters
      * @param string $desc
      * @param bool $public Whether this method should be rendered on the website/documentation
+     * @param string $projectAuth Project authentication security scheme to use in specs
      */
     public function __construct(
         protected string $namespace,
@@ -49,11 +50,16 @@ class Method
         protected array $parameters = [],
         protected array $additionalParameters = [],
         protected string $desc = '',
-        protected bool $public = true
+        protected bool $public = true,
+        protected string $projectAuth = 'Project'
     ) {
         $this->validateMethod($name, $namespace);
         $this->validateAuthTypes($auth);
         $this->validateDesc($description);
+
+        if (!\in_array($projectAuth, ['Project', 'ProjectQuery'], true)) {
+            self::$errors[] = "Error with {$this->getRouteName()} method: Invalid project auth scheme";
+        }
 
         foreach ($responses as $response) {
             $this->validateResponseModel($response->getModel());
@@ -221,6 +227,11 @@ class Method
     public function getAdditionalParameters(): array
     {
         return $this->additionalParameters;
+    }
+
+    public function getProjectAuth(): string
+    {
+        return $this->projectAuth;
     }
 
     public function setNamespace(string $namespace): self

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -85,6 +85,10 @@ class OpenAPI3 extends Format
             $output['components']['securitySchemes']['Project']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
         }
 
+        if (isset($output['components']['securitySchemes']['ProjectQuery'])) {
+            $output['components']['securitySchemes']['ProjectQuery']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
+        }
+
         if (isset($output['components']['securitySchemes']['Key'])) {
             $output['components']['securitySchemes']['Key']['x-appwrite'] = ['demo' => '<YOUR_API_KEY>'];
         }
@@ -184,7 +188,7 @@ class OpenAPI3 extends Format
                         continue;
                     }
 
-                    $methodSecurities = ['Project' => []];
+                    $methodSecurities = [$methodObj->getProjectAuth() => []];
                     foreach ($methodObj->getAuth() as $security) {
                         if (\array_key_exists($security->value, $this->keys)) {
                             $methodSecurities[$security->value] = [];
@@ -370,7 +374,7 @@ class OpenAPI3 extends Format
             }
 
             if (!empty($scope)) {
-                $securities = ['Project' => []];
+                $securities = [$sdk->getProjectAuth() => []];
 
                 foreach ($sdk->getAuth() as $security) {
                     /** @var AuthType $security */

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -74,6 +74,10 @@ class Swagger2 extends Format
             $output['securityDefinitions']['Project']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
         }
 
+        if (isset($output['securityDefinitions']['ProjectQuery'])) {
+            $output['securityDefinitions']['ProjectQuery']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
+        }
+
         if (isset($output['securityDefinitions']['Key'])) {
             $output['securityDefinitions']['Key']['x-appwrite'] = ['demo' => '<YOUR_API_KEY>'];
         }
@@ -184,7 +188,7 @@ class Swagger2 extends Format
                         continue;
                     }
 
-                    $methodSecurities = ['Project' => []];
+                    $methodSecurities = [$methodObj->getProjectAuth() => []];
                     foreach ($methodObj->getAuth() as $security) {
                         /** @var AuthType $security */
                         if (\array_key_exists($security->value, $this->keys)) {
@@ -361,7 +365,7 @@ class Swagger2 extends Format
             }
 
             if (!empty($scope)) {
-                $securities = ['Project' => []];
+                $securities = [$sdk->getProjectAuth() => []];
 
                 foreach ($sdk->getAuth() as $security) {
                     if (\array_key_exists($security->value, $this->keys)) {


### PR DESCRIPTION
## What does this PR do?

Adds a `ProjectQuery` OpenAPI security scheme for project authentication through the `project` query parameter, alongside the existing `Project` header scheme.

This also lets SDK method metadata choose which project auth scheme is emitted in generated Swagger 2 and OpenAPI 3 operation security, while preserving `Project` as the default for existing routes.

## Test Plan

- `php -l src/Appwrite/SDK/Method.php`
- `php -l src/Appwrite/Platform/Tasks/Specs.php`
- `php -l src/Appwrite/SDK/Specification/Format/Swagger2.php`
- `php -l src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- `git diff --check`
- `vendor/bin/pint --test src/Appwrite/SDK/Method.php src/Appwrite/Platform/Tasks/Specs.php src/Appwrite/SDK/Specification/Format/Swagger2.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- `php app/cli.php specs --version=1.9.x --git=no`
- Verified generated Swagger 2 and OpenAPI 3 specs include `ProjectQuery` with `name: project` and `in: query` for client, server, and console specs.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
