### PR TITLE
fix(oidc): allow clearing maxAge via explicit null in OIDC update

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Oidc.php
+++ b/src/Appwrite/Auth/OAuth2/Oidc.php
@@ -43,13 +43,25 @@ class Oidc extends OAuth2
      */
     public function getLoginURL(): string
     {
-        return $this->getAuthorizationEndpoint() . '?' . \http_build_query([
+        $params = [
             'client_id' => $this->appID,
             'redirect_uri' => $this->callback,
             'state' => \json_encode($this->state),
             'scope' => \implode(' ', $this->getScopes()),
             'response_type' => 'code',
-        ]);
+        ];
+
+        $prompt = $this->getPrompt();
+        if (!empty($prompt)) {
+            $params['prompt'] = $prompt;
+        }
+
+        $maxAge = $this->getMaxAge();
+        if ($maxAge !== null) {
+            $params['max_age'] = $maxAge;
+        }
+
+        return $this->getAuthorizationEndpoint() . '?' . \http_build_query($params);
     }
 
     /**
@@ -194,6 +206,40 @@ class Oidc extends OAuth2
         $secret = $this->getAppSecret();
 
         return $secret['clientSecret'] ?? '';
+    }
+
+    /**
+     * Extracts the prompt values from the JSON stored in appSecret.
+     *
+     * @return string
+     */
+    protected function getPrompt(): string
+    {
+        $secret = $this->getAppSecret();
+        $prompt = $secret['prompt'] ?? [];
+
+        if (!\is_array($prompt)) {
+            $prompt = [$prompt];
+        }
+
+        return \implode(' ', $prompt);
+    }
+
+    /**
+     * Extracts the max_age value from the JSON stored in appSecret.
+     *
+     * @return int|null
+     */
+    protected function getMaxAge(): ?int
+    {
+        $secret = $this->getAppSecret();
+        $maxAge = $secret['maxAge'] ?? null;
+
+        if ($maxAge === null || $maxAge === '') {
+            return null;
+        }
+
+        return (int) $maxAge;
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
@@ -10,6 +10,7 @@ use Appwrite\Platform\Modules\Project\Http\Project\OAuth2\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -152,6 +153,7 @@ class Update extends Base
             ->inject('dbForPlatform')
             ->inject('project')
             ->inject('authorization')
+            ->inject('request')
             ->inject('queueForEvents')
             ->callback($this->handle(...));
     }
@@ -203,6 +205,7 @@ class Update extends Base
         Database $dbForPlatform,
         Document $project,
         Authorization $authorization,
+        Request $request,
         QueueEvent $queueForEvents
     ): void {
         $providerId = static::getProviderId();
@@ -230,7 +233,7 @@ class Update extends Base
             'tokenEndpoint' => $tokenURL ?? ($existing['tokenEndpoint'] ?? ''),
             'userInfoEndpoint' => $userInfoURL ?? ($existing['userInfoEndpoint'] ?? ''),
             'prompt' => $prompt ?? ($existing['prompt'] ?? []),
-            'maxAge' => $maxAge ?? ($existing['maxAge'] ?? null),
+            'maxAge' => \array_key_exists('maxAge', $request->getParams()) ? $maxAge : ($existing['maxAge'] ?? null),
         ];
 
         // When enabling, require either wellKnownEndpoint alone, or all three

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
@@ -232,7 +232,7 @@ class Update extends Base
             'authorizationEndpoint' => $authorizationURL ?? ($existing['authorizationEndpoint'] ?? ''),
             'tokenEndpoint' => $tokenURL ?? ($existing['tokenEndpoint'] ?? ''),
             'userInfoEndpoint' => $userInfoURL ?? ($existing['userInfoEndpoint'] ?? ''),
-            'prompt' => $prompt ?? ($existing['prompt'] ?? []),
+            'prompt' => \array_key_exists('prompt', $request->getParams()) ? ($prompt ?? []) : ($existing['prompt'] ?? []),
             'maxAge' => \array_key_exists('maxAge', $request->getParams()) ? $maxAge : ($existing['maxAge'] ?? null),
         ];
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
@@ -14,10 +14,14 @@ use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
+use Utopia\Platform\Enum;
+use Utopia\Validator\ArrayList;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Nullable;
+use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\URL;
+use Utopia\Validator\WhiteList;
 
 class Update extends Base
 {
@@ -93,6 +97,18 @@ class Update extends Base
                 'example' => 'https://myoauth.com/oauth2/userinfo',
                 'hint' => '',
             ],
+            [
+                '$id' => 'prompt',
+                'name' => 'Prompt',
+                'example' => '["consent"]',
+                'hint' => '',
+            ],
+            [
+                '$id' => 'maxAge',
+                'name' => 'Max Age',
+                'example' => '3600',
+                'hint' => '',
+            ],
         ]);
     }
 
@@ -129,6 +145,8 @@ class Update extends Base
             ->param('authorizationURL', null, new Nullable(new URL(allowEmpty: true)), 'OpenID Connect authorization endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/authorize', optional: true)
             ->param('tokenURL', null, new Nullable(new URL(allowEmpty: true)), 'OpenID Connect token endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/token', optional: true, aliases: ['tokenUrl'])
             ->param('userInfoURL', null, new Nullable(new URL(allowEmpty: true)), 'OpenID Connect user info endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/userinfo', optional: true, aliases: ['userInfoUrl'])
+            ->param('prompt', null, new Nullable(new ArrayList(new WhiteList(['none', 'login', 'consent', 'select_account'], true), 4)), 'Array of OpenID Connect prompt values controlling the authentication and consent screens. If "none" is included, it must be the only element. "none" means: don\'t display any authentication or consent screens. "login" means: prompt the user to re-authenticate. "consent" means: prompt the user for consent. "select_account" means: prompt the user to select an account.', optional: true, enum: new Enum(name: 'ProjectOAuth2OidcPrompt'))
+            ->param('maxAge', null, new Nullable(new Range(0, PHP_INT_MAX, Range::TYPE_INTEGER)), 'Maximum authentication age in seconds. When set, the user must have authenticated within this many seconds, otherwise they are prompted to re-authenticate. Set to null or omit to leave unspecified.', optional: true)
             ->param('enabled', null, new Nullable(new Boolean()), 'OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid.', true)
             ->inject('response')
             ->inject('dbForPlatform')
@@ -153,6 +171,8 @@ class Update extends Base
             'authorizationURL' => $decoded['authorizationEndpoint'] ?? '',
             'tokenURL' => $decoded['tokenEndpoint'] ?? '',
             'userInfoURL' => $decoded['userInfoEndpoint'] ?? '',
+            'prompt' => $decoded['prompt'] ?? [],
+            'maxAge' => $decoded['maxAge'] ?? null,
         ]);
     }
 
@@ -176,6 +196,8 @@ class Update extends Base
         ?string $authorizationURL,
         ?string $tokenURL,
         ?string $userInfoURL,
+        ?array $prompt,
+        ?int $maxAge,
         ?bool $enabled,
         Response $response,
         Database $dbForPlatform,
@@ -186,8 +208,12 @@ class Update extends Base
         $providerId = static::getProviderId();
         $queueForEvents->setParam('providerId', $providerId);
 
+        if ($prompt !== null && \in_array('none', $prompt) && \count($prompt) > 1) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'When "none" is used as a prompt value, it must be the only element in the array.');
+        }
+
         // The secret is stored as JSON
-        // `{"clientSecret": "...", "wellKnownEndpoint": "...", "authorizationEndpoint": "...", "tokenEndpoint": "...", "userInfoEndpoint": "..."}`
+        // `{"clientSecret": "...", "wellKnownEndpoint": "...", "authorizationEndpoint": "...", "tokenEndpoint": "...", "userInfoEndpoint": "...", "prompt": [...], "maxAge": ...}`
         // so that the OIDC OAuth2 adapter can extract each endpoint individually.
         // Merge new values with what's already stored so that submitting only a
         // subset of fields leaves the others untouched.
@@ -203,6 +229,8 @@ class Update extends Base
             'authorizationEndpoint' => $authorizationURL ?? ($existing['authorizationEndpoint'] ?? ''),
             'tokenEndpoint' => $tokenURL ?? ($existing['tokenEndpoint'] ?? ''),
             'userInfoEndpoint' => $userInfoURL ?? ($existing['userInfoEndpoint'] ?? ''),
+            'prompt' => $prompt ?? ($existing['prompt'] ?? []),
+            'maxAge' => $maxAge ?? ($existing['maxAge'] ?? null),
         ];
 
         // When enabling, require either wellKnownEndpoint alone, or all three

--- a/src/Appwrite/Utopia/Response/Model/OAuth2Oidc.php
+++ b/src/Appwrite/Utopia/Response/Model/OAuth2Oidc.php
@@ -53,6 +53,21 @@ class OAuth2Oidc extends OAuth2Base
                 'description' => 'OpenID Connect user info endpoint URL.',
                 'default' => '',
                 'example' => 'https://myoauth.com/oauth2/userinfo',
+            ])
+            ->addRule('prompt', [
+                'type' => self::TYPE_ENUM,
+                'description' => 'OpenID Connect prompt values controlling the authentication and consent screens.',
+                'default' => [],
+                'example' => ['consent'],
+                'array' => true,
+                'enum' => ['none', 'login', 'consent', 'select_account'],
+            ])
+            ->addRule('maxAge', [
+                'type' => self::TYPE_INTEGER,
+                'description' => 'Maximum authentication age in seconds. When set, the user must have authenticated within this many seconds.',
+                'default' => null,
+                'example' => 3600,
+                'required' => false,
             ]);
     }
 

--- a/tests/e2e/Services/Project/OAuth2Base.php
+++ b/tests/e2e/Services/Project/OAuth2Base.php
@@ -281,7 +281,457 @@ trait OAuth2Base
 
     public function testUpdateOAuth2OktaRoundTrip(): void
     {
-        $update = $this->updateOAuth2('okta', [
+        // Only authorization+token, missing userInfo — must fail to enable.
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-partial',
+            'clientSecret' => 'oidc-partial-secret',
+            'authorizationURL' => 'https://idp.example.com/oauth2/authorize',
+            'tokenURL' => 'https://idp.example.com/oauth2/token',
+            'enabled' => true,
+        ]);
+
+        $this->assertSame(400, $response['headers']['status-code']);
+        $this->assertSame('general_argument_invalid', $response['body']['type']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcEnableSucceedsWithWellKnown(): void
+    {
+        $update = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-enable-client',
+            'clientSecret' => 'oidc-enable-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'enabled' => true,
+        ]);
+
+        $this->assertSame(200, $update['headers']['status-code']);
+        $this->assertTrue($update['body']['enabled']);
+
+        // GET must hide clientSecret while keeping clientId and the URL.
+        $get = $this->getOAuth2Provider('oidc');
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertTrue($get['body']['enabled']);
+        $this->assertSame('oidc-enable-client', $get['body']['clientId']);
+        $this->assertSame('https://idp.example.com/.well-known/openid-configuration', $get['body']['wellKnownURL']);
+        $this->assertSame('', $get['body']['clientSecret']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcEnableInSeparateRequestWithWellKnown(): void
+    {
+        // Configure URLs first with `enabled: false`. Then enable in a SECOND
+        // request that omits all URL fields. The merge-on-enable logic in
+        // Oidc::handle() must see the previously-stored wellKnownEndpoint and
+        // allow the toggle. This is the headline feature of the merge logic.
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-split-wk-client',
+            'clientSecret' => 'oidc-split-wk-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'enabled' => false,
+        ]);
+
+        $enable = $this->updateOAuth2('oidc', [
+            'enabled' => true,
+        ]);
+        $this->assertSame(200, $enable['headers']['status-code']);
+        $this->assertTrue($enable['body']['enabled']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcEnableAcrossRequestsWithDiscoveryURLs(): void
+    {
+        // Reset to clean state — earlier tests in this section may have left
+        // partial URL state when running in any order.
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+
+        // Request 1: configure two of the three discovery URLs.
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-split-discovery',
+            'clientSecret' => 'oidc-split-discovery-secret',
+            'authorizationURL' => 'https://idp.example.com/oauth2/authorize',
+            'tokenURL' => 'https://idp.example.com/oauth2/token',
+            'enabled' => false,
+        ]);
+
+        // Request 2: send only the third URL plus enable=true. The merged
+        // state must include the two stored URLs + the new one to satisfy
+        // the all-three-discovery-URLs branch of the enable check.
+        $enable = $this->updateOAuth2('oidc', [
+            'userInfoURL' => 'https://idp.example.com/oauth2/userinfo',
+            'enabled' => true,
+        ]);
+        $this->assertSame(200, $enable['headers']['status-code']);
+        $this->assertTrue($enable['body']['enabled']);
+
+        // Confirm all three URLs ended up persisted (merge wrote the new
+        // userInfoURL while preserving the previously stored two).
+        $get = $this->getOAuth2Provider('oidc');
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertSame('https://idp.example.com/oauth2/authorize', $get['body']['authorizationURL']);
+        $this->assertSame('https://idp.example.com/oauth2/token', $get['body']['tokenURL']);
+        $this->assertSame('https://idp.example.com/oauth2/userinfo', $get['body']['userInfoURL']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcEnableFailsAfterClearingWellKnown(): void
+    {
+        // Seed wellKnownURL only (no discovery URLs).
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-clear-then-enable',
+            'clientSecret' => 'oidc-clear-then-enable-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+
+        // Clear wellKnownURL and try to enable in the same request. Merge
+        // sees `wellKnown=''` (the cleared empty wins over the stored value
+        // because the new value is non-null) and no discovery URLs → 400.
+        // This is the inverse of testUpdateOAuth2OidcEnableInSeparateRequestWithWellKnown:
+        // confirms the merge correctly *replaces* with empty rather than
+        // falling back to the stored non-empty value.
+        $response = $this->updateOAuth2('oidc', [
+            'wellKnownURL' => '',
+            'enabled' => true,
+        ]);
+        $this->assertSame(400, $response['headers']['status-code']);
+        $this->assertSame('general_argument_invalid', $response['body']['type']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcSwitchModesWellKnownToDiscovery(): void
+    {
+        // Configure with wellKnownURL, then switch to the three-discovery-URL
+        // mode in a single request: clear wellKnown, set the three URLs,
+        // enable. Merge sees wellKnown='' AND all three discovery URLs set →
+        // hasAllDiscovery branch passes.
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-switch-client',
+            'clientSecret' => 'oidc-switch-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'enabled' => false,
+        ]);
+
+        $switch = $this->updateOAuth2('oidc', [
+            'wellKnownURL' => '',
+            'authorizationURL' => 'https://idp.example.com/oauth2/authorize',
+            'tokenURL' => 'https://idp.example.com/oauth2/token',
+            'userInfoURL' => 'https://idp.example.com/oauth2/userinfo',
+            'enabled' => true,
+        ]);
+        $this->assertSame(200, $switch['headers']['status-code']);
+        $this->assertTrue($switch['body']['enabled']);
+        $this->assertSame('', $switch['body']['wellKnownURL']);
+        $this->assertSame('https://idp.example.com/oauth2/authorize', $switch['body']['authorizationURL']);
+        $this->assertSame('https://idp.example.com/oauth2/token', $switch['body']['tokenURL']);
+        $this->assertSame('https://idp.example.com/oauth2/userinfo', $switch['body']['userInfoURL']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcURLsAcceptEmpty(): void
+    {
+        // All four URL fields use `Nullable(URL(allowEmpty: true))`. Passing `''`
+        // for each must clear them rather than 400 on URL validation.
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-clear-client',
+            'clientSecret' => 'oidc-clear-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'authorizationURL' => 'https://idp.example.com/oauth2/authorize',
+            'tokenURL' => 'https://idp.example.com/oauth2/token',
+            'userInfoURL' => 'https://idp.example.com/oauth2/userinfo',
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['wellKnownURL']);
+        $this->assertSame('', $response['body']['authorizationURL']);
+        $this->assertSame('', $response['body']['tokenURL']);
+        $this->assertSame('', $response['body']['userInfoURL']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcBackwardCompatibleResponseFormat(): void
+    {
+        // Reset to clean state
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+
+        $headers = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-response-format' => '1.9.3',
+        ];
+        $headers = \array_merge($headers, $this->getHeaders());
+
+        // Update using OLD param names (aliases must still work)
+        $response = $this->client->call(
+            Client::METHOD_PATCH,
+            '/project/oauth2/oidc',
+            $headers,
+            [
+                'clientId' => 'oidc-compat-client',
+                'clientSecret' => 'oidc-compat-secret',
+                'tokenUrl' => 'https://idp.example.com/oauth2/token',
+                'userInfoUrl' => 'https://idp.example.com/oauth2/userinfo',
+                'enabled' => false,
+            ],
+        );
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertArrayHasKey('tokenUrl', $response['body']);
+        $this->assertArrayHasKey('userInfoUrl', $response['body']);
+        $this->assertArrayNotHasKey('tokenURL', $response['body']);
+        $this->assertArrayNotHasKey('userInfoURL', $response['body']);
+        $this->assertSame('https://idp.example.com/oauth2/token', $response['body']['tokenUrl']);
+        $this->assertSame('https://idp.example.com/oauth2/userinfo', $response['body']['userInfoUrl']);
+
+        // GET with 1.9.3 format must also return old param names
+        $get = $this->client->call(
+            Client::METHOD_GET,
+            '/project/oauth2/oidc',
+            $headers,
+        );
+
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertArrayHasKey('tokenUrl', $get['body']);
+        $this->assertArrayHasKey('userInfoUrl', $get['body']);
+        $this->assertArrayNotHasKey('tokenURL', $get['body']);
+        $this->assertArrayNotHasKey('userInfoURL', $get['body']);
+        $this->assertSame('https://idp.example.com/oauth2/token', $get['body']['tokenUrl']);
+        $this->assertSame('https://idp.example.com/oauth2/userinfo', $get['body']['userInfoUrl']);
+
+        // LIST with 1.9.3 format must also return old param names for OIDC
+        $list = $this->client->call(
+            Client::METHOD_GET,
+            '/project/oauth2',
+            $headers,
+        );
+
+        $this->assertSame(200, $list['headers']['status-code']);
+        $oidcEntry = null;
+        foreach ($list['body']['providers'] as $provider) {
+            if ($provider['$id'] === 'oidc') {
+                $oidcEntry = $provider;
+                break;
+            }
+        }
+        $this->assertNotNull($oidcEntry, 'OIDC provider missing from listOAuth2Providers response');
+        $this->assertArrayHasKey('tokenUrl', $oidcEntry);
+        $this->assertArrayHasKey('userInfoUrl', $oidcEntry);
+        $this->assertArrayNotHasKey('tokenURL', $oidcEntry);
+        $this->assertArrayNotHasKey('userInfoURL', $oidcEntry);
+        $this->assertSame('https://idp.example.com/oauth2/token', $oidcEntry['tokenUrl']);
+        $this->assertSame('https://idp.example.com/oauth2/userinfo', $oidcEntry['userInfoUrl']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPromptAndMaxAge(): void
+    {
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-prompt-client',
+            'clientSecret' => 'oidc-prompt-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'prompt' => ['login', 'consent'],
+            'maxAge' => 3600,
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(['login', 'consent'], $response['body']['prompt']);
+        $this->assertSame(3600, $response['body']['maxAge']);
+
+        // GET reads back prompt + maxAge while hiding the clientSecret.
+        $get = $this->getOAuth2Provider('oidc');
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertSame(['login', 'consent'], $get['body']['prompt']);
+        $this->assertSame(3600, $get['body']['maxAge']);
+        $this->assertSame('', $get['body']['clientSecret']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'authorizationURL' => '',
+            'tokenURL' => '',
+            'userInfoURL' => '',
+            'prompt' => [],
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPartialPreservesPromptAndMaxAge(): void
+    {
+        // Seed prompt + maxAge.
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-seed-client',
+            'clientSecret' => 'oidc-seed-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'prompt' => ['select_account'],
+            'maxAge' => 120,
+            'enabled' => false,
+        ]);
+
+        // Update only clientId — prompt and maxAge must be preserved.
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-rotated-client',
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('oidc-rotated-client', $response['body']['clientId']);
+        $this->assertSame(['select_account'], $response['body']['prompt']);
+        $this->assertSame(120, $response['body']['maxAge']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPromptNoneAloneRejected(): void
+    {
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-prompt-none',
+            'clientSecret' => 'oidc-prompt-none-secret',
+            'prompt' => ['none', 'consent'],
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(400, $response['headers']['status-code']);
+        $this->assertSame('general_argument_invalid', $response['body']['type']);
+    }
+
+    public function testUpdateOAuth2OidcMaxAgeNegativeRejected(): void
+    {
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-maxage-negative',
+            'clientSecret' => 'oidc-maxage-negative-secret',
+            'maxAge' => -1,
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    // =========================================================================
+    // Update Okta (clientId + clientSecret + optional domain/authServer)
+    // =========================================================================
+
+    public function testUpdateOAuth2Okta(): void
+    {
+        $response = $this->updateOAuth2('okta', [
             'clientId' => '0oa00000000000000698',
             'clientSecret' => 'okta-secret',
             'domain' => 'trial-6400025.okta.com',

--- a/tests/e2e/Services/Project/OAuth2Base.php
+++ b/tests/e2e/Services/Project/OAuth2Base.php
@@ -664,6 +664,7 @@ trait OAuth2Base
             'tokenURL' => '',
             'userInfoURL' => '',
             'prompt' => [],
+            'maxAge' => null,
             'enabled' => false,
         ]);
     }
@@ -696,6 +697,7 @@ trait OAuth2Base
             'clientSecret' => '',
             'wellKnownURL' => '',
             'prompt' => [],
+            'maxAge' => null,
             'enabled' => false,
         ]);
     }
@@ -723,6 +725,61 @@ trait OAuth2Base
         ]);
 
         $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testUpdateOAuth2OidcMaxAgeClearViaNull(): void
+    {
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-maxage-clear',
+            'clientSecret' => 'oidc-maxage-clear-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'maxAge' => 3600,
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'maxAge' => null,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertNull($response['body']['maxAge']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'maxAge' => null,
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPromptClearViaNull(): void
+    {
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-prompt-clear',
+            'clientSecret' => 'oidc-prompt-clear-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'prompt' => ['login', 'consent'],
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'prompt' => null,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame([], $response['body']['prompt']);
+
+        // Cleanup
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'enabled' => false,
+        ]);
     }
 
     // =========================================================================


### PR DESCRIPTION
Fixes: Unable to clear maxAge after it has been set. Related to #12462

## Changes
- Injected Request object to check if maxAge was explicitly provided via array_key_exists
- When maxAge is explicitly sent (even as null), use the provided value
- When omitted, keep the existing stored value

## Root Cause
The null-coalescing merge ( ?? ) made it impossible to clear maxAge once set, because both "not provided" and "explicitly null" resolved to PHP null. Added Request injection to distinguish the two cases via array_key_exists.
