### PR TITLE
fix(migrations): finalize exports without a user

### DIFF
--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -338,7 +338,7 @@ class Migrations extends Action
                 $this->deviceForFiles,
                 $migration->getAttribute('resourceId'),
                 $options['bucketId'],
-                $options['filename'],
+                $migration->getId(),
                 $options['columns'],
                 $options['delimiter'],
                 $options['enclosure'],
@@ -349,7 +349,7 @@ class Migrations extends Action
                 $this->deviceForFiles,
                 $migration->getAttribute('resourceId'),
                 $options['bucketId'] ?? 'default',
-                $options['filename'],
+                $migration->getId(),
                 $options['columns'] ?? [],
             ),
             default => throw new Exception(Exception::MIGRATION_DESTINATION_TYPE_INVALID),
@@ -748,7 +748,7 @@ class Migrations extends Action
         }
 
         $extension = $migration->getAttribute('destination') === DestinationJSON::getName() ? '.json' : '.csv';
-        $path = $this->deviceForFiles->getPath($bucketId . '/' . $this->sanitizeFilename($filename) . $extension);
+        $path = $this->deviceForFiles->getPath($bucketId . '/' . $migration->getId() . $extension);
         $size = $this->deviceForFiles->getFileSize($path);
         $mime = $this->deviceForFiles->getFileMimeType($path);
         $hash = $this->deviceForFiles->getFileHash($path);
@@ -1045,21 +1045,6 @@ class Migrations extends Action
         ));
 
         Console::info("CSV export {$emailType} notification email sent to " . $user->getAttribute('email'));
-    }
-
-    /**
-     * Sanitize a filename to make it filesystem-safe
-     *
-     * @param string $filename
-     * @return string
-     */
-    protected function sanitizeFilename(string $filename): string
-    {
-        // Replace problematic characters with underscores
-        $sanitized = \preg_replace('/[:\/<>"|*?]/', '_', $filename);
-        $sanitized = \preg_replace('/[^\x20-\x7E]/', '_', $sanitized);
-        $sanitized = \trim($sanitized);
-        return empty($sanitized) ? 'export' : $sanitized;
     }
 
     /**

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -864,7 +864,8 @@ class Migrations extends Action
             return new Document([]);
         }
 
-        if (!\is_int($userInternalId) || $userInternalId < 1) {
+        $valid = \is_string($userInternalId) || (\is_int($userInternalId) && $userInternalId > 0);
+        if (!$valid) {
             $error = new \UnexpectedValueException('Invalid initiating user sequence for export migration.');
             Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
             $this->reportError($error, $migration);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -695,7 +695,15 @@ class Migrations extends Action
                 }
                 $destination_type = $migration->getAttribute('destination');
                 if ($destination_type === DestinationCSV::getName() || $destination_type === DestinationJSON::getName()) {
-                    $this->handleDataExportComplete($project, $migration, $publisherForMails, $queueForRealtime, $platform, $authorization);
+                    try {
+                        $this->handleDataExportComplete($project, $migration, $publisherForMails, $queueForRealtime, $platform, $authorization);
+                    } catch (\Throwable $th) {
+                        // The export itself has already completed; sending the completion
+                        // notification is best-effort. A failure here must not escape the
+                        // finally block, where it would mask the migration result and, in a
+                        // shared worker, disrupt other in-flight migrations.
+                        Console::error('Failed to handle data export completion for migration ' . $migration->getId() . ': ' . $th->getMessage());
+                    }
                 }
             } finally {
                 $source?->cleanup();
@@ -740,6 +748,15 @@ class Migrations extends Action
         $bucketId = 'default'; // Always use platform default bucket
         $filename = $options['filename'] ?? 'export_' . \time();
         $userInternalId = $options['userInternalId'] ?? '';
+        if (empty($userInternalId)) {
+            // Exports initiated without a user session (e.g. via an API key) have no
+            // recipient for the completion notification. Skip it: there is nobody to
+            // notify, and querying the integer-only '$sequence' attribute with an empty
+            // value would otherwise throw a query validation error.
+            Console::warning('Skipping export completion notification for migration ' . $migration->getId() . ': no initiating user.');
+            return;
+        }
+
         $user = $this->dbForPlatform->findOne('users', [
             Query::equal('$sequence', [$userInternalId])
         ]);

--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -590,6 +590,11 @@ class Migrations extends Action
                 return;
             }
 
+            $destinationType = $migration->getAttribute('destination');
+            if ($destinationType === DestinationCSV::getName() || $destinationType === DestinationJSON::getName()) {
+                $this->handleDataExportComplete($project, $migration, $publisherForMails, $queueForRealtime, $platform, $authorization);
+            }
+
             $migration->setAttribute('status', 'completed');
             $migration->setAttribute('stage', 'finished');
         } catch (\Throwable $th) {
@@ -629,7 +634,7 @@ class Migrations extends Action
                     $extras['sourceEndpoint'] = $credentials['endpoint'] ?? '';
                 }
 
-                call_user_func($this->logError, $th, 'appwrite-worker', 'appwrite-queue-' . self::getName(), $extras);
+                $this->reportError($th, $migration, $extras);
             }
         } finally {
             try {
@@ -693,18 +698,6 @@ class Migrations extends Action
                     $destination?->success();
                     $source?->success();
                 }
-                $destination_type = $migration->getAttribute('destination');
-                if ($destination_type === DestinationCSV::getName() || $destination_type === DestinationJSON::getName()) {
-                    try {
-                        $this->handleDataExportComplete($project, $migration, $publisherForMails, $queueForRealtime, $platform, $authorization);
-                    } catch (\Throwable $th) {
-                        // The export itself has already completed; sending the completion
-                        // notification is best-effort. A failure here must not escape the
-                        // finally block, where it would mask the migration result and, in a
-                        // shared worker, disrupt other in-flight migrations.
-                        Console::error('Failed to handle data export completion for migration ' . $migration->getId() . ': ' . $th->getMessage());
-                    }
-                }
             } finally {
                 $source?->cleanup();
                 $destination?->cleanup();
@@ -747,23 +740,7 @@ class Migrations extends Action
         $options = $migration->getAttribute('options', []);
         $bucketId = 'default'; // Always use platform default bucket
         $filename = $options['filename'] ?? 'export_' . \time();
-        $userInternalId = $options['userInternalId'] ?? '';
-        if (empty($userInternalId)) {
-            // Exports initiated without a user session (e.g. via an API key) have no
-            // recipient for the completion notification. Skip it: there is nobody to
-            // notify, and querying the integer-only '$sequence' attribute with an empty
-            // value would otherwise throw a query validation error.
-            Console::warning('Skipping export completion notification for migration ' . $migration->getId() . ': no initiating user.');
-            return;
-        }
-
-        $user = $this->dbForPlatform->findOne('users', [
-            Query::equal('$sequence', [$userInternalId])
-        ]);
-
-        if ($user->isEmpty()) {
-            throw new \Exception('User ' . $userInternalId . ' not found');
-        }
+        $user = $this->resolveExportUser($migration);
 
         $bucket = $this->dbForPlatform->getDocument('buckets', $bucketId);
         if ($bucket->isEmpty()) {
@@ -795,7 +772,8 @@ class Migrations extends Action
                 $migration->setAttribute('errors', $errors);
                 $migration = $this->updateMigrationDocument($migration, $project, $queueForRealtime);
 
-                $this->sendExportEmail(
+                $this->notifyExport(
+                    migration: $migration,
                     success: false,
                     project: $project,
                     user: $user,
@@ -810,11 +788,14 @@ class Migrations extends Action
             }
         }
 
+        $permissions = [];
+        if (!$user->isEmpty()) {
+            $permissions[] = Permission::read(Role::user($user->getId()));
+        }
+
         $this->dbForPlatform->createDocument('bucket_' . $bucket->getSequence(), new Document([
             '$id' => $fileId,
-            '$permissions' => [
-                Permission::read(Role::user($user->getId())),
-            ],
+            '$permissions' => $permissions,
             'bucketId' => $bucket->getId(),
             'bucketInternalId' => $bucket->getSequence(),
             'name' => $filename,
@@ -858,7 +839,8 @@ class Migrations extends Action
         $migration->setAttribute('options', $options);
         $this->updateMigrationDocument($migration, $project, $queueForRealtime);
 
-        $this->sendExportEmail(
+        $this->notifyExport(
+            migration: $migration,
             success: true,
             project: $project,
             user: $user,
@@ -868,6 +850,94 @@ class Migrations extends Action
             exportType: $migration->getAttribute('destination') === DestinationJSON::getName() ? 'JSON' : 'CSV',
             downloadUrl: $downloadUrl
         );
+    }
+
+    protected function resolveExportUser(Document $migration): Document
+    {
+        $userInternalId = $migration->getAttribute('options', [])['userInternalId'] ?? null;
+        if (\is_string($userInternalId) && \ctype_digit($userInternalId)) {
+            $userInternalId = (int) $userInternalId;
+        }
+
+        if ($userInternalId === null || $userInternalId === '') {
+            Console::warning('Finalizing export without a user permission for migration ' . $migration->getId() . ': no initiating user.');
+            return new Document([]);
+        }
+
+        if (!\is_int($userInternalId) || $userInternalId < 1) {
+            $error = new \UnexpectedValueException('Invalid initiating user sequence for export migration.');
+            Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
+            $this->reportError($error, $migration);
+            return new Document([]);
+        }
+
+        $user = $this->dbForPlatform->findOne('users', [
+            Query::equal('$sequence', [$userInternalId])
+        ]);
+
+        if ($user->isEmpty()) {
+            $error = new \RuntimeException('Initiating user not found for export migration.');
+            Console::error($error->getMessage() . ' Migration: ' . $migration->getId());
+            $this->reportError($error, $migration);
+        }
+
+        return $user;
+    }
+
+    protected function notifyExport(
+        Document $migration,
+        bool $success,
+        Document $project,
+        Document $user,
+        array $options,
+        MailPublisher $publisherForMails,
+        array $platform,
+        string $exportType = 'CSV',
+        string $downloadUrl = '',
+        float $sizeMB = 0.0,
+    ): void {
+        try {
+            $this->sendExportEmail(
+                success: $success,
+                project: $project,
+                user: $user,
+                options: $options,
+                publisherForMails: $publisherForMails,
+                platform: $platform,
+                exportType: $exportType,
+                downloadUrl: $downloadUrl,
+                sizeMB: $sizeMB,
+            );
+        } catch (\Throwable $error) {
+            Console::error('Failed to send the export notification for migration ' . $migration->getId() . ': ' . $error->getMessage());
+            $this->reportError($error, $migration);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $extras
+     */
+    protected function reportError(\Throwable $error, Document $migration, array $extras = []): void
+    {
+        if (!\is_callable($this->logError)) {
+            return;
+        }
+
+        try {
+            ($this->logError)(
+                $error,
+                'appwrite-worker',
+                'appwrite-queue-' . self::getName(),
+                [
+                    'migrationId' => $migration->getId(),
+                    'source' => $migration->getAttribute('source', ''),
+                    'destination' => $migration->getAttribute('destination', ''),
+                    ...$extras,
+                ]
+            );
+        } catch (\Throwable $loggingError) {
+            Console::error('Failed to report the migration error: ' . $loggingError->getMessage());
+        }
     }
 
     /**

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -3564,6 +3564,19 @@ trait MigrationsBase
         $this->assertEquals($response['body']['max'], 65);
         $this->assertEquals($response['body']['required'], true);
 
+        $this->assertEventually(function () use ($databaseId, $tableId) {
+            foreach (['name', 'age'] as $column) {
+                $response = $this->client->call(Client::METHOD_GET, '/tablesdb/' . $databaseId . '/tables/' . $tableId . '/columns/' . $column, [
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                    'x-appwrite-key' => $this->getProject()['apiKey'],
+                ]);
+
+                $this->assertEquals(200, $response['headers']['status-code']);
+                $this->assertEquals('available', $response['body']['status']);
+            }
+        }, 5_000, 500);
+
         // make a bucket, upload a file to it!
         $bucketOne = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
             'content-type' => 'application/json',
@@ -6704,6 +6717,19 @@ trait MigrationsBase
         $this->assertEquals($response['body']['min'], 18);
         $this->assertEquals($response['body']['max'], 65);
         $this->assertEquals($response['body']['required'], true);
+
+        $this->assertEventually(function () use ($databaseId, $tableId) {
+            foreach (['name', 'age'] as $column) {
+                $response = $this->client->call(Client::METHOD_GET, '/tablesdb/' . $databaseId . '/tables/' . $tableId . '/columns/' . $column, [
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                    'x-appwrite-key' => $this->getProject()['apiKey'],
+                ]);
+
+                $this->assertEquals(200, $response['headers']['status-code']);
+                $this->assertEquals('available', $response['body']['status']);
+            }
+        }, 5_000, 500);
 
         // make a bucket, upload a file to it!
         $bucketOne = $this->client->call(Client::METHOD_POST, '/storage/buckets', [

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -1,47 +1,75 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Migration;
 
 use Appwrite\Event\Publisher\Mail as MailPublisher;
+use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Event\Realtime;
 use Appwrite\Platform\Workers\Migrations;
+use Appwrite\Usage\Context;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
+use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
+use Utopia\Migration\Destination;
+use Utopia\Migration\Destinations\JSON as DestinationJSON;
+use Utopia\Migration\Source;
+use Utopia\Storage\Device;
 
-class MigrationsWorkerExportTest extends TestCase
+final class MigrationsWorkerExportTest extends TestCase
 {
-    /**
-     * An export initiated without a user session (e.g. via an API key) carries an
-     * empty `userInternalId`. handleDataExportComplete() must skip the completion
-     * notification in that case rather than look the user up by the integer-only
-     * `$sequence` attribute with an empty value, which throws a query validation
-     * error. Escaping processMigration()'s finally block, that exception masks the
-     * migration result and, in the shared worker, disrupts other in-flight
-     * migrations.
-     *
-     * Asserting the platform database is never queried proves the guard
-     * short-circuits before the user lookup: without the guard the worker calls
-     * findOne() (building Query::equal('$sequence', [''])), so this fails without
-     * the fix and passes with it.
-     */
-    public function testExportCompletionSkipsWhenNoInitiatingUser(): void
+    public function testExportCompletionFinalizesWithoutInitiatingUser(): void
     {
+        $file = null;
         $dbForPlatform = $this->createMock(Database::class);
         $dbForPlatform->expects($this->never())->method('findOne');
+        $dbForPlatform
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('buckets', 'default')
+            ->willReturn(new Document([
+                '$id' => 'default',
+                '$sequence' => 1,
+            ]));
+        $dbForPlatform
+            ->expects($this->once())
+            ->method('createDocument')
+            ->with(
+                'bucket_1',
+                $this->callback(function (Document $document) use (&$file): bool {
+                    $file = $document;
+                    return true;
+                })
+            )
+            ->willReturnArgument(1);
+
+        $deviceForFiles = $this->createMock(Device::class);
+        $deviceForFiles
+            ->expects($this->once())
+            ->method('getPath')
+            ->with('default/export.json')
+            ->willReturn('/tmp/export.json');
+        $deviceForFiles->expects($this->once())->method('getFileSize')->with('/tmp/export.json')->willReturn(256);
+        $deviceForFiles->expects($this->once())->method('getFileMimeType')->with('/tmp/export.json')->willReturn('application/json');
+        $deviceForFiles->expects($this->once())->method('getFileHash')->with('/tmp/export.json')->willReturn('signature');
 
         $worker = new class () extends Migrations {
-            public function callHandleDataExportComplete(
+            public function complete(
                 Database $dbForPlatform,
+                Device $deviceForFiles,
                 Document $migration,
                 MailPublisher $publisherForMails,
                 Realtime $queueForRealtime,
                 Authorization $authorization,
             ): void {
                 $this->dbForPlatform = $dbForPlatform;
+                $this->deviceForFiles = $deviceForFiles;
+                $this->plan = [];
                 $this->handleDataExportComplete(
-                    new Document([]),
+                    new Document(['$id' => 'project-id']),
                     $migration,
                     $publisherForMails,
                     $queueForRealtime,
@@ -49,19 +77,279 @@ class MigrationsWorkerExportTest extends TestCase
                     $authorization,
                 );
             }
+
+            protected function updateMigrationDocument(Document $migration, Document $project, Realtime $queueForRealtime): Document
+            {
+                return $migration;
+            }
         };
 
         $migration = new Document([
             '$id' => 'migration-without-user',
-            'options' => ['userInternalId' => ''],
+            'destination' => DestinationJSON::getName(),
+            'options' => [
+                'filename' => 'export',
+                'notify' => false,
+                'userInternalId' => '',
+            ],
         ]);
 
-        $worker->callHandleDataExportComplete(
-            $dbForPlatform,
-            $migration,
-            $this->createStub(MailPublisher::class),
-            $this->createStub(Realtime::class),
-            $this->createStub(Authorization::class),
+        $previousKey = \getenv('_APP_OPENSSL_KEY_V1');
+        $previousDomain = \getenv('_APP_DOMAIN');
+        \putenv('_APP_OPENSSL_KEY_V1=test-key');
+        \putenv('_APP_DOMAIN=example.test');
+
+        try {
+            $worker->complete(
+                $dbForPlatform,
+                $deviceForFiles,
+                $migration,
+                $this->createStub(MailPublisher::class),
+                $this->createStub(Realtime::class),
+                $this->createStub(Authorization::class),
+            );
+        } finally {
+            $this->restoreEnvironment('_APP_OPENSSL_KEY_V1', $previousKey);
+            $this->restoreEnvironment('_APP_DOMAIN', $previousDomain);
+        }
+
+        $this->assertInstanceOf(Document::class, $file);
+        $this->assertSame([], $file->getPermissions());
+        $this->assertStringContainsString(
+            '/v1/storage/buckets/default/files/',
+            (string) $migration->getAttribute('options')['downloadUrl']
         );
+    }
+
+    public function testExportCompletionNormalizesStringUserInternalId(): void
+    {
+        $user = new Document([
+            '$id' => 'user-id',
+            '$sequence' => 42,
+        ]);
+        $dbForPlatform = $this->createMock(Database::class);
+        $dbForPlatform
+            ->expects($this->once())
+            ->method('findOne')
+            ->with(
+                'users',
+                $this->callback(function (array $queries): bool {
+                    $this->assertCount(1, $queries);
+                    $this->assertInstanceOf(Query::class, $queries[0]);
+                    $this->assertSame([42], $queries[0]->getValues());
+
+                    return true;
+                })
+            )
+            ->willReturn($user);
+
+        $worker = new class () extends Migrations {
+            public function resolve(Database $dbForPlatform, Document $migration): Document
+            {
+                $this->dbForPlatform = $dbForPlatform;
+                return $this->resolveExportUser($migration);
+            }
+        };
+
+        $resolved = $worker->resolve($dbForPlatform, new Document([
+            '$id' => 'migration-with-string-user',
+            'options' => ['userInternalId' => '42'],
+        ]));
+
+        $this->assertSame('user-id', $resolved->getId());
+    }
+
+    public function testExportUserLookupFailurePropagates(): void
+    {
+        $dbForPlatform = $this->createStub(Database::class);
+        $dbForPlatform
+            ->method('findOne')
+            ->willThrowException(new \RuntimeException('Database unavailable'));
+
+        $worker = new class () extends Migrations {
+            public function resolve(Database $dbForPlatform, Document $migration): Document
+            {
+                $this->dbForPlatform = $dbForPlatform;
+                return $this->resolveExportUser($migration);
+            }
+        };
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Database unavailable');
+
+        $worker->resolve($dbForPlatform, new Document([
+            '$id' => 'migration-with-user',
+            'options' => ['userInternalId' => 42],
+        ]));
+    }
+
+    public function testNotificationAndLoggerFailuresDoNotEscape(): void
+    {
+        $reported = 0;
+        $worker = new class () extends Migrations {
+            public function notify(Document $migration, MailPublisher $publisherForMails, callable $logError): void
+            {
+                $this->logError = $logError;
+                $this->notifyExport(
+                    migration: $migration,
+                    success: true,
+                    project: new Document([]),
+                    user: new Document([]),
+                    options: ['notify' => true],
+                    publisherForMails: $publisherForMails,
+                    platform: [],
+                );
+            }
+
+            protected function sendExportEmail(
+                bool $success,
+                Document $project,
+                Document $user,
+                array $options,
+                MailPublisher $publisherForMails,
+                array $platform,
+                string $exportType = 'CSV',
+                string $downloadUrl = '',
+                float $sizeMB = 0.0,
+            ): void {
+                throw new \RuntimeException('Mail unavailable');
+            }
+        };
+
+        $worker->notify(
+            new Document([
+                '$id' => 'migration-id',
+                'source' => 'Appwrite',
+                'destination' => DestinationJSON::getName(),
+            ]),
+            $this->createStub(MailPublisher::class),
+            function () use (&$reported): void {
+                $reported++;
+                throw new \RuntimeException('Logger unavailable');
+            }
+        );
+
+        $this->assertSame(1, $reported);
+    }
+
+    public function testArtifactFinalizationFailureMarksMigrationFailed(): void
+    {
+        $source = $this->createStub(Source::class);
+        $source->method('getErrors')->willReturn([]);
+        $destination = $this->createStub(Destination::class);
+        $destination->method('getErrors')->willReturn([]);
+
+        $worker = new class ($source, $destination) extends Migrations {
+            /** @var array<string> */
+            public array $statuses = [];
+
+            public function __construct(private Source $source, private Destination $destination)
+            {
+            }
+
+            public function process(
+                Document $migration,
+                Realtime $queueForRealtime,
+                MailPublisher $publisherForMails,
+                Context $usage,
+                UsagePublisher $publisherForUsage,
+                Authorization $authorization,
+            ): void {
+                $this->project = new Document([
+                    '$id' => 'project-id',
+                    '$sequence' => 1,
+                ]);
+                $this->logError = static function (): void {
+                };
+
+                $this->processMigration(
+                    $migration,
+                    $queueForRealtime,
+                    $publisherForMails,
+                    $usage,
+                    $publisherForUsage,
+                    [],
+                    $authorization,
+                );
+            }
+
+            protected function processSource(Document $migration): Source
+            {
+                return $this->source;
+            }
+
+            protected function processDestination(Document $migration): Destination
+            {
+                return $this->destination;
+            }
+
+            protected function handleDataExportComplete(
+                Document $project,
+                Document $migration,
+                MailPublisher $publisherForMails,
+                Realtime $queueForRealtime,
+                array $platform,
+                Authorization $authorization,
+            ): void {
+                throw new \RuntimeException('Artifact unavailable');
+            }
+
+            protected function generateAPIKey(Document $project): string
+            {
+                return 'api-key';
+            }
+
+            protected function updateMigrationDocument(Document $migration, Document $project, Realtime $queueForRealtime): Document
+            {
+                $this->statuses[] = (string) $migration->getAttribute('status');
+                return $migration;
+            }
+        };
+
+        $migration = new Document([
+            '$id' => 'migration-id',
+            '$sequence' => 1,
+            'credentials' => [],
+            'destination' => DestinationJSON::getName(),
+            'resourceId' => '',
+            'resourceType' => '',
+            'resources' => [],
+            'source' => 'Test',
+        ]);
+
+        $previousHost = \getenv('_APP_MIGRATION_HOST');
+        \putenv('_APP_MIGRATION_HOST=example.test');
+
+        try {
+            $worker->process(
+                $migration,
+                $this->createStub(Realtime::class),
+                $this->createStub(MailPublisher::class),
+                $this->createStub(Context::class),
+                $this->createStub(UsagePublisher::class),
+                $this->createStub(Authorization::class),
+            );
+        } finally {
+            $this->restoreEnvironment('_APP_MIGRATION_HOST', $previousHost);
+        }
+
+        $this->assertSame('failed', $migration->getAttribute('status'));
+        $this->assertSame('finished', $migration->getAttribute('stage'));
+        $this->assertNotContains('completed', $worker->statuses);
+        $this->assertSame('failed', $worker->statuses[array_key_last($worker->statuses)]);
+        $this->assertNotEmpty($migration->getAttribute('errors'));
+    }
+
+    /**
+     * @param string|false $value
+     */
+    private function restoreEnvironment(string $name, string|false $value): void
+    {
+        if ($value === false) {
+            \putenv($name);
+            return;
+        }
+
+        \putenv($name . '=' . $value);
     }
 }

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -121,7 +121,7 @@ final class MigrationsWorkerExportTest extends TestCase
         );
     }
 
-    public function testExportCompletionNormalizesStringUserInternalId(): void
+    public function testExportCompletionNormalizesNumericStringUserInternalId(): void
     {
         $user = new Document([
             '$id' => 'user-id',
@@ -154,6 +154,45 @@ final class MigrationsWorkerExportTest extends TestCase
         $resolved = $worker->resolve($dbForPlatform, new Document([
             '$id' => 'migration-with-string-user',
             'options' => ['userInternalId' => '42'],
+        ]));
+
+        $this->assertSame('user-id', $resolved->getId());
+    }
+
+    public function testExportCompletionPreservesMongoStringUserInternalId(): void
+    {
+        $sequence = '019f70db-a902-7127-96fe-f24d908cea2c';
+        $user = new Document([
+            '$id' => 'user-id',
+            '$sequence' => $sequence,
+        ]);
+        $dbForPlatform = $this->createMock(Database::class);
+        $dbForPlatform
+            ->expects($this->once())
+            ->method('findOne')
+            ->with(
+                'users',
+                $this->callback(function (array $queries) use ($sequence): bool {
+                    $this->assertCount(1, $queries);
+                    $this->assertInstanceOf(Query::class, $queries[0]);
+                    $this->assertSame([$sequence], $queries[0]->getValues());
+
+                    return true;
+                })
+            )
+            ->willReturn($user);
+
+        $worker = new class () extends Migrations {
+            public function resolve(Database $dbForPlatform, Document $migration): Document
+            {
+                $this->dbForPlatform = $dbForPlatform;
+                return $this->resolveExportUser($migration);
+            }
+        };
+
+        $resolved = $worker->resolve($dbForPlatform, new Document([
+            '$id' => 'migration-with-mongo-user',
+            'options' => ['userInternalId' => $sequence],
         ]));
 
         $this->assertSame('user-id', $resolved->getId());

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Migration;
+
+use Appwrite\Event\Publisher\Mail as MailPublisher;
+use Appwrite\Event\Realtime;
+use Appwrite\Platform\Workers\Migrations;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\Authorization;
+
+class MigrationsWorkerExportTest extends TestCase
+{
+    /**
+     * An export initiated without a user session (e.g. via an API key) carries an
+     * empty `userInternalId`. handleDataExportComplete() must skip the completion
+     * notification in that case rather than look the user up by the integer-only
+     * `$sequence` attribute with an empty value, which throws a query validation
+     * error. Escaping processMigration()'s finally block, that exception masks the
+     * migration result and, in the shared worker, disrupts other in-flight
+     * migrations.
+     *
+     * Asserting the platform database is never queried proves the guard
+     * short-circuits before the user lookup: without the guard the worker calls
+     * findOne() (building Query::equal('$sequence', [''])), so this fails without
+     * the fix and passes with it.
+     */
+    public function testExportCompletionSkipsWhenNoInitiatingUser(): void
+    {
+        $dbForPlatform = $this->createMock(Database::class);
+        $dbForPlatform->expects($this->never())->method('findOne');
+
+        $worker = new class () extends Migrations {
+            public function callHandleDataExportComplete(
+                Database $dbForPlatform,
+                Document $migration,
+                MailPublisher $publisherForMails,
+                Realtime $queueForRealtime,
+                Authorization $authorization,
+            ): void {
+                $this->dbForPlatform = $dbForPlatform;
+                $this->handleDataExportComplete(
+                    new Document([]),
+                    $migration,
+                    $publisherForMails,
+                    $queueForRealtime,
+                    [],
+                    $authorization,
+                );
+            }
+        };
+
+        $migration = new Document([
+            '$id' => 'migration-without-user',
+            'options' => ['userInternalId' => ''],
+        ]);
+
+        $worker->callHandleDataExportComplete(
+            $dbForPlatform,
+            $migration,
+            $this->createStub(MailPublisher::class),
+            $this->createStub(Realtime::class),
+            $this->createStub(Authorization::class),
+        );
+    }
+}

--- a/tests/unit/Migration/MigrationsWorkerExportTest.php
+++ b/tests/unit/Migration/MigrationsWorkerExportTest.php
@@ -15,12 +15,62 @@ use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Migration\Destination;
+use Utopia\Migration\Destinations\CSV as DestinationCSV;
 use Utopia\Migration\Destinations\JSON as DestinationJSON;
 use Utopia\Migration\Source;
 use Utopia\Storage\Device;
 
 final class MigrationsWorkerExportTest extends TestCase
 {
+    public function testExportDestinationsWriteToMigrationScopedArtifactNames(): void
+    {
+        $worker = new class () extends Migrations {
+            public function destination(Device $deviceForFiles, Document $migration): Destination
+            {
+                $this->deviceForFiles = $deviceForFiles;
+                return $this->processDestination($migration);
+            }
+        };
+        $deviceForFiles = $this->createStub(Device::class);
+        $cases = [
+            [
+                'destination' => DestinationCSV::getName(),
+                'options' => [
+                    'bucketId' => 'default',
+                    'columns' => [],
+                    'delimiter' => ',',
+                    'enclosure' => '"',
+                    'escape' => '"',
+                    'filename' => 'same/name',
+                    'header' => true,
+                ],
+            ],
+            [
+                'destination' => DestinationJSON::getName(),
+                'options' => [
+                    'bucketId' => 'default',
+                    'columns' => [],
+                    'filename' => 'same:name',
+                ],
+            ],
+        ];
+
+        foreach ($cases as $case) {
+            $destination = $worker->destination($deviceForFiles, new Document([
+                '$id' => 'migration-id',
+                'credentials' => [],
+                'destination' => $case['destination'],
+                'options' => $case['options'],
+                'resourceId' => 'database',
+            ]));
+            $property = new \ReflectionProperty($destination, 'outputFile');
+
+            $this->assertSame('migration-id', $property->getValue($destination));
+
+            $destination->cleanUp();
+        }
+    }
+
     public function testExportCompletionFinalizesWithoutInitiatingUser(): void
     {
         $file = null;
@@ -50,11 +100,11 @@ final class MigrationsWorkerExportTest extends TestCase
         $deviceForFiles
             ->expects($this->once())
             ->method('getPath')
-            ->with('default/export.json')
-            ->willReturn('/tmp/export.json');
-        $deviceForFiles->expects($this->once())->method('getFileSize')->with('/tmp/export.json')->willReturn(256);
-        $deviceForFiles->expects($this->once())->method('getFileMimeType')->with('/tmp/export.json')->willReturn('application/json');
-        $deviceForFiles->expects($this->once())->method('getFileHash')->with('/tmp/export.json')->willReturn('signature');
+            ->with('default/migration-without-user.json')
+            ->willReturn('/tmp/migration-without-user.json');
+        $deviceForFiles->expects($this->once())->method('getFileSize')->with('/tmp/migration-without-user.json')->willReturn(256);
+        $deviceForFiles->expects($this->once())->method('getFileMimeType')->with('/tmp/migration-without-user.json')->willReturn('application/json');
+        $deviceForFiles->expects($this->once())->method('getFileHash')->with('/tmp/migration-without-user.json')->willReturn('signature');
 
         $worker = new class () extends Migrations {
             public function complete(
@@ -119,6 +169,128 @@ final class MigrationsWorkerExportTest extends TestCase
             '/v1/storage/buckets/default/files/',
             (string) $migration->getAttribute('options')['downloadUrl']
         );
+    }
+
+    public function testExportCompletionKeepsDisplayNamesButUsesUniquePhysicalPaths(): void
+    {
+        $cases = [
+            ['id' => 'same-name-one', 'name' => 'report'],
+            ['id' => 'same-name-two', 'name' => 'report'],
+            ['id' => 'sanitized-name-one', 'name' => 'sales/2026'],
+            ['id' => 'sanitized-name-two', 'name' => 'sales:2026'],
+        ];
+        $files = [];
+        $dbForPlatform = $this->createMock(Database::class);
+        $dbForPlatform->expects($this->never())->method('findOne');
+        $dbForPlatform
+            ->expects($this->exactly(\count($cases)))
+            ->method('getDocument')
+            ->with('buckets', 'default')
+            ->willReturn(new Document([
+                '$id' => 'default',
+                '$sequence' => 1,
+            ]));
+        $dbForPlatform
+            ->expects($this->exactly(\count($cases)))
+            ->method('createDocument')
+            ->with(
+                'bucket_1',
+                $this->callback(function (Document $document) use (&$files): bool {
+                    $files[] = $document;
+                    return true;
+                })
+            )
+            ->willReturnArgument(1);
+
+        $deviceForFiles = $this->createMock(Device::class);
+        $deviceForFiles
+            ->expects($this->exactly(\count($cases)))
+            ->method('getPath')
+            ->willReturnCallback(static fn (string $path): string => '/tmp/' . \basename($path));
+        $deviceForFiles
+            ->expects($this->exactly(\count($cases)))
+            ->method('getFileSize')
+            ->willReturn(256);
+        $deviceForFiles
+            ->expects($this->exactly(\count($cases)))
+            ->method('getFileMimeType')
+            ->willReturn('application/json');
+        $deviceForFiles
+            ->expects($this->exactly(\count($cases)))
+            ->method('getFileHash')
+            ->willReturnCallback(static fn (string $path): string => 'signature:' . $path);
+
+        $worker = new class () extends Migrations {
+            public function complete(
+                Database $dbForPlatform,
+                Device $deviceForFiles,
+                Document $migration,
+                MailPublisher $publisherForMails,
+                Realtime $queueForRealtime,
+                Authorization $authorization,
+            ): void {
+                $this->dbForPlatform = $dbForPlatform;
+                $this->deviceForFiles = $deviceForFiles;
+                $this->plan = [];
+                $this->handleDataExportComplete(
+                    new Document(['$id' => 'project-id']),
+                    $migration,
+                    $publisherForMails,
+                    $queueForRealtime,
+                    [],
+                    $authorization,
+                );
+            }
+
+            protected function updateMigrationDocument(Document $migration, Document $project, Realtime $queueForRealtime): Document
+            {
+                return $migration;
+            }
+        };
+
+        $previousKey = \getenv('_APP_OPENSSL_KEY_V1');
+        $previousDomain = \getenv('_APP_DOMAIN');
+        \putenv('_APP_OPENSSL_KEY_V1=test-key');
+        \putenv('_APP_DOMAIN=example.test');
+
+        try {
+            foreach ($cases as $case) {
+                $migration = new Document([
+                    '$id' => $case['id'],
+                    'destination' => DestinationJSON::getName(),
+                    'options' => [
+                        'filename' => $case['name'],
+                        'notify' => false,
+                        'userInternalId' => '',
+                    ],
+                ]);
+                $worker->complete(
+                    $dbForPlatform,
+                    $deviceForFiles,
+                    $migration,
+                    $this->createStub(MailPublisher::class),
+                    $this->createStub(Realtime::class),
+                    $this->createStub(Authorization::class),
+                );
+
+                $file = $files[\array_key_last($files)];
+                $this->assertSame($case['name'], $file->getAttribute('name'));
+                $this->assertSame('/tmp/' . $case['id'] . '.json', $file->getAttribute('path'));
+                $this->assertSame('signature:/tmp/' . $case['id'] . '.json', $file->getAttribute('signature'));
+                $this->assertStringContainsString(
+                    '/v1/storage/buckets/default/files/' . $file->getId() . '/push',
+                    (string) $migration->getAttribute('options')['downloadUrl']
+                );
+            }
+        } finally {
+            $this->restoreEnvironment('_APP_OPENSSL_KEY_V1', $previousKey);
+            $this->restoreEnvironment('_APP_DOMAIN', $previousDomain);
+        }
+
+        $this->assertCount(\count($cases), \array_unique(\array_map(
+            static fn (Document $file): string => (string) $file->getAttribute('path'),
+            $files,
+        )));
     }
 
     public function testExportCompletionNormalizesNumericStringUserInternalId(): void


### PR DESCRIPTION
## Problem

CSV and JSON export migrations can reach the worker without an initiating user, such as API-key exports, or with a numeric-string user sequence. The former must still produce a usable artifact; the latter must query the integer-only sequence attribute with an integer.

Export artifact finalization also ran after the completed status had already been persisted. Storage, file registration, JWT, or migration-update failures could therefore leave a migration reported as completed without a usable download.

Physical export paths previously depended only on the sanitized display filename. Concurrent exports with the same name, or different names that sanitize identically, could overwrite or alias the same stored object while separate file documents and signed URLs remained valid.

## Fix

- Normalize numeric-string user sequences before lookup.
- Preserve non-numeric string sequences used by MongoDB.
- Finalize API-key exports with an empty user ACL and persist the signed download URL.
- Run artifact finalization before setting the migration to completed, so operational failures persist a failed result.
- Write CSV and JSON artifacts under the unique migration ID while retaining the requested display filename in file metadata.
- Keep only email delivery best-effort.
- Contain failures from the centralized error reporter so recovery cannot disrupt the shared worker.
- Preserve operational user-lookup failures; they propagate into the failed-status path.

## Database lookup contract

Across the migration stack, canonical operational selector types are `database` for TablesDB and legacy roots, `documentsdb`, and `vectorsdb`. The public `tablesdb` alias is normalized to `database` and is not stored in selector fields.

A database history lookup is an OR across the source `resourceType/resourceId` pair, the `parentResourceType/parentResourceId` pair, and the recovered `destinationResourceType/destinationResourceId` pair. It is not a single equality that covers every migration shape.

## Test

The focused regression suite verifies:

- no-user exports create the file record with an empty ACL and persist a signed download URL;
- numeric-string sequences are queried as integers;
- MongoDB string sequences remain unchanged and resolve the initiating user;
- operational lookup failures propagate;
- mail and logger failures do not escape;
- artifact finalization failures persist failed and never completed;
- CSV and JSON destinations use migration-scoped artifact names;
- duplicate display names and sanitization-colliding names produce distinct physical paths;
- each signed URL targets the file document whose path and signature match the correct artifact;
- CSV and JSON integration imports wait for asynchronous columns to become available before enqueueing.

Local validation:

- Focused PHPUnit: 8 tests, 72 assertions
- Migration unit suite: 9 tests, 134 assertions
- composer lint
- composer refactor:check
- composer analyze: 1,615 files, no errors
- git diff --check
- Prior exact-head CI run 29595892809: 37/37 jobs green
- Current exact-head CI run 29610142244 attempt 2: full matrix green after rerunning the unrelated MongoDB TablesDB timeout
- Prior MongoDB dedicated migrations: 68 tests, 2,833 assertions
