### PR TITLE
Revert "Remove php-retry from CI workflows"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,11 +327,18 @@ jobs:
         run: docker compose exec -T appwrite vars
 
       - name: Run Unit Tests
-        timeout-minutes: 15
-        run: >-
-          docker compose exec
-          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite test /usr/src/code/tests/unit
+        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 60
+          timeout_minutes: 15
+          job_id: ${{ job.check_run_id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          test_dir: tests/unit
+          command: >-
+            docker compose exec
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+            appwrite test /usr/src/code/tests/unit
 
   e2e_general:
     name: Tests / E2E / General
@@ -378,11 +385,18 @@ jobs:
           done
 
       - name: Run General Tests
-        timeout-minutes: 15
-        run: >-
-          docker compose exec -T
-          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite test /usr/src/code/tests/e2e/General
+        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 60
+          timeout_minutes: 15
+          job_id: ${{ job.check_run_id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          test_dir: tests/e2e/General
+          command: >-
+            docker compose exec -T
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+            appwrite test /usr/src/code/tests/e2e/General
 
       - name: Failure Logs
         if: failure()
@@ -505,26 +519,33 @@ jobs:
           done
 
       - name: Run tests
-        timeout-minutes: ${{ matrix.timeout_minutes || 20 }}
-        run: |
-          SERVICE_PATH="/usr/src/code/tests/e2e/Services/${{ matrix.service }}"
+        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 60
+          timeout_minutes: ${{ matrix.timeout_minutes || 20 }}
+          job_id: ${{ job.check_run_id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          test_dir: tests/e2e/Services/${{ matrix.service }}
+          command: |
+            SERVICE_PATH="/usr/src/code/tests/e2e/Services/${{ matrix.service }}"
 
-          # Services that rely on sequential test method execution (shared static state)
-          FUNCTIONAL_FLAG="--functional"
-          case "${{ matrix.service }}" in
-            Databases|TablesDB|Functions|Realtime|GraphQL|ProjectWebhooks) FUNCTIONAL_FLAG="" ;;
-          esac
+            # Services that rely on sequential test method execution (shared static state)
+            FUNCTIONAL_FLAG="--functional"
+            case "${{ matrix.service }}" in
+              Databases|TablesDB|Functions|Realtime|GraphQL|ProjectWebhooks) FUNCTIONAL_FLAG="" ;;
+            esac
 
-          PARATEST_PROCESSES="${{ matrix.paratest_processes }}"
-          if [ -z "$PARATEST_PROCESSES" ]; then
-            PARATEST_PROCESSES="$(nproc)"
-          fi
+            PARATEST_PROCESSES="${{ matrix.paratest_processes }}"
+            if [ -z "$PARATEST_PROCESSES" ]; then
+              PARATEST_PROCESSES="$(nproc)"
+            fi
 
-          docker compose exec -T \
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
-            -e _TESTS_OAUTH2_GITHUB_CLIENT_ID="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_ID }}" \
-            -e _TESTS_OAUTH2_GITHUB_CLIENT_SECRET="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_SECRET }}" \
-            appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service }}/junit.xml
+            docker compose exec -T \
+              -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
+              -e _TESTS_OAUTH2_GITHUB_CLIENT_ID="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_ID }}" \
+              -e _TESTS_OAUTH2_GITHUB_CLIENT_SECRET="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_SECRET }}" \
+              appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service }}/junit.xml
 
       - name: Failure Logs
         if: failure()
@@ -580,11 +601,18 @@ jobs:
           docker compose up -d --quiet-pull --wait
 
       - name: Run tests
-        timeout-minutes: 15
-        run: >-
-          docker compose exec -T
-          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite test /usr/src/code/tests/e2e --group=abuseEnabled
+        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 60
+          timeout_minutes: 15
+          job_id: ${{ job.check_run_id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          test_dir: tests/e2e
+          command: >-
+            docker compose exec -T
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+            appwrite test /usr/src/code/tests/e2e --group=abuseEnabled
 
       - name: Failure Logs
         if: failure()
@@ -645,11 +673,18 @@ jobs:
           done
 
       - name: Run tests
-        timeout-minutes: 15
-        run: >-
-          docker compose exec -T
-          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite test /usr/src/code/tests/e2e/Services/Sites --group=screenshots
+        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 60
+          timeout_minutes: 15
+          job_id: ${{ job.check_run_id }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          test_dir: tests/e2e/Services/Sites
+          command: >-
+            docker compose exec -T
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+            appwrite test /usr/src/code/tests/e2e/Services/Sites --group=screenshots
 
       - name: Failure Logs
         if: failure()

--- a/tests/e2e/Services/Databases/VectorsDB/DatabasesConsoleClientTest.php
+++ b/tests/e2e/Services/Databases/VectorsDB/DatabasesConsoleClientTest.php
@@ -4,7 +4,6 @@ namespace Tests\E2E\Services\Databases\VectorsDB;
 
 use PHPUnit\Framework\Attributes\Depends;
 use Tests\E2E\Client;
-use Tests\E2E\Scopes\ApiVectorsDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideConsole;
@@ -16,7 +15,6 @@ class DatabasesConsoleClientTest extends Scope
 {
     use ProjectCustom;
     use SideConsole;
-    use ApiVectorsDB;
 
     public function testCreateCollection(): array
     {

--- a/tests/e2e/Services/Databases/VectorsDB/DatabasesCustomClientTest.php
+++ b/tests/e2e/Services/Databases/VectorsDB/DatabasesCustomClientTest.php
@@ -3,7 +3,6 @@
 namespace Tests\E2E\Services\Databases\VectorsDB;
 
 use Tests\E2E\Client;
-use Tests\E2E\Scopes\ApiVectorsDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideClient;
@@ -17,7 +16,6 @@ class DatabasesCustomClientTest extends Scope
     use DatabasesBase;
     use ProjectCustom;
     use SideClient;
-    use ApiVectorsDB;
 
     public function testAllowedPermissions(): void
     {

--- a/tests/e2e/Services/Databases/VectorsDB/DatabasesCustomServerTest.php
+++ b/tests/e2e/Services/Databases/VectorsDB/DatabasesCustomServerTest.php
@@ -6,7 +6,6 @@ namespace Tests\E2E\Services\Databases\VectorsDB;
 
 use PHPUnit\Framework\Attributes\Depends;
 use Tests\E2E\Client;
-use Tests\E2E\Scopes\ApiVectorsDB;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideServer;
@@ -20,7 +19,6 @@ class DatabasesCustomServerTest extends Scope
     use DatabasesBase;
     use ProjectCustom;
     use SideServer;
-    use ApiVectorsDB;
 
     public function testListDatabases(): array
     {


### PR DESCRIPTION
## What does this PR do?

Reverts #12493, restoring the `itznotabug/php-retry` GitHub Action usage in CI workflow test steps and removing the temporary VectorsDB test skips added by that PR.

This reverts commit 80116398fe783d84b16f69f2e9e7ce435835971e.

## Test Plan

- Ran `git diff --check origin/1.9.x..HEAD`.
- Parsed `.github/workflows/ci.yml` with Ruby YAML.
- Ran `composer lint` on the three touched VectorsDB E2E test files.

## Related PRs and Issues

- Reverts #12493

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
