### PR TITLE
Fix build log stream parsing warning

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -809,6 +809,10 @@ class Builds extends Action
                                         $streamLog = \str_replace('{APPWRITE_LINEBREAK_PLACEHOLDER}', "\n", $streamLog);
                                         $streamParts = \explode(' ', $streamLog, 2);
 
+                                        if (! isset($streamParts[1])) {
+                                            continue;
+                                        }
+
                                         // TODO: use part[0] as timestamp when switching to dbForLogs for build logs
                                         $currentLogs .= $streamParts[1];
 


### PR DESCRIPTION
## What does this PR do?

Fixes a warning in the Functions build worker when streamed executor log chunks do not contain the expected timestamp/content separator. The worker now skips malformed stream entries before reading the content part, avoiding an undefined array key warning.

## Test Plan

- `composer lint src/Appwrite/Platform/Modules/Functions/Workers/Builds.php`

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
