### PR TITLE
Fix flaky storage preview cache hit test

### DIFF
--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1016,7 +1016,20 @@ trait StorageBase
         $this->assertEquals(200, $cachedPreview['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
         $this->assertStringStartsWith('private, max-age=', $cachedPreview['headers']['cache-control']);
-        $this->assertEquals($preview['body'], $cachedPreview['body']);
+        $this->assertNotEmpty($cachedPreview['body']);
+
+        $cachedPreviewAgain = $this->client->call(
+            Client::METHOD_GET,
+            '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
+            $headers,
+            $params
+        );
+
+        $this->assertEquals(200, $cachedPreviewAgain['headers']['status-code']);
+        $this->assertEquals('image/png', $cachedPreviewAgain['headers']['content-type']);
+        $this->assertStringStartsWith('private, max-age=', $cachedPreviewAgain['headers']['cache-control']);
+        $this->assertEquals('hit', $cachedPreviewAgain['headers']['x-appwrite-cache']);
+        $this->assertEquals($cachedPreview['body'], $cachedPreviewAgain['body']);
     }
 
     public function testFilePreviewZstdCompression(): void


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky storage E2E assertion in `testFilePreviewCacheControlOnCacheHit`.

The test compared the first cache-miss preview body with the eventual cache-hit body. PNG previews generated by Imagick include timestamp metadata, and cache persistence happens during the API shutdown hook after the miss response is sent. A fast retry can therefore render/cache a later PNG whose visible image is equivalent but whose binary metadata timestamp differs by a second.

This PR keeps the cache behavior coverage but changes the byte-for-byte assertion to compare two confirmed cache-hit responses instead of comparing the initial miss response against the cached artifact.

## Test Plan

- `composer lint tests/e2e/Services/Storage/StorageBase.php`
- Attempted targeted E2E:
  - `docker compose exec appwrite test tests/e2e/Services/Storage/StorageCustomClientTest.php --filter=testFilePreviewCacheControlOnCacheHit`
  - Could not run locally because the `appwrite` Docker service is not running.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
