### PR TITLE
fix(sqlite): resolve split-brain and unfiltered fulltext index issues (PR #12180 fixes)

### DIFF
--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -427,6 +427,21 @@ $register->set('db', function () {
         case 'postgresql':
             $dsn = "pgsql:host={$dbHost};port={$dbPort};dbname={$dbSchema};connect_timeout=3";
             return new PDO($dsn, $dbUser, $dbPass, SQL::getPDOAttributes());
+        case 'sqlite':
+            $path = System::getEnv('_APP_DB_SQLITE_PATH', '/tmp/appwrite.db');
+            $dir = \dirname($path);
+            $path = "{$dir}/console.db";
+            $pdo = new PDO("sqlite:{$path}", null, null, SQL::getPDOAttributes());
+            $pdo->query('PRAGMA journal_mode=WAL');
+            $pdo->query('PRAGMA busy_timeout=60000');
+            $pdo->query('PRAGMA synchronous=OFF');
+            $pdo->query('PRAGMA temp_store=MEMORY');
+            $pdo->query('PRAGMA cache_size=-262144');
+            $pdo->query('PRAGMA mmap_size=2147483648');
+            $pdo->query('PRAGMA wal_autocheckpoint=10000');
+            $pdo->query('PRAGMA journal_size_limit=67108864');
+            $pdo->query('PRAGMA foreign_keys=ON');
+            return $pdo;
         default:
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Invalid database adapter');
     }

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
@@ -203,8 +203,20 @@ class Create extends Action
             }
 
             $adapter = new AdapterDatabase($dbForProject);
-            $audit = new Audit($adapter);
-            $audit->setup();
+            try {
+                $indexDocs = array_filter(
+                    $adapter->getIndexDocuments(),
+                    fn ($doc) => $doc->getAttribute('type') !== Database::INDEX_FULLTEXT
+                        || $dbForProject->getAdapter()->getSupportForFulltextIndex()
+                );
+                $dbForProject->createCollection(
+                    $adapter->getCollectionName(),
+                    $adapter->getAttributeDocuments(),
+                    $indexDocs,
+                );
+            } catch (Duplicate) {
+                // Audit collection already exists
+            }
 
             if ($create) {
                 /** @var array $collections */


### PR DESCRIPTION
Fixes the P1 issues identified in PR #12180 Greptile review.

## Changes

1. **Fix split-brain SQLite path** in \pp/init/registers.php\:
   - Changed \db\ register to use \{_APP_DB_SQLITE_PATH dir}/console.db\ instead of raw \_APP_DB_SQLITE_PATH\
   - Matches pool-based key naming (\{key}.db\) — now workers, CLI, and pools share same file

2. **Filter fulltext indexes** in \pp/http.php\ (2 locations):
   - Skip \INDEX_FULLTEXT\ when adapter doesn't support it via \getSupportForFulltextIndex()\
   - Applied to both \dbForPlatform\ and \dbForProject\ audit collection setup

3. **Filter fulltext indexes** in \src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php\:
   - Same filter for project-creation audit collection setup