### PR TITLE
Bump appwrite/base to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:1.4.1 AS base
+FROM appwrite/base:1.4.2 AS base
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
## What

Bump the build base image in `Dockerfile` from `appwrite/base:1.4.1` → `appwrite/base:1.4.2`.

## Why

`appwrite/base:1.4.2` ([appwrite/docker-base#72](https://github.com/appwrite/docker-base/pull/72)) bumps the pinned `php:8.5-alpine` digest to pick up patched Alpine packages, clearing these open CVEs:

| Package | Fixed version | CVEs |
|---|---|---|
| libxml2 | 2.13.9-r1 | CVE-2026-6732 (HIGH) |
| nghttp2-libs | 1.69.0-r0 | CVE-2026-27135 (HIGH) |
| curl/libcurl | 8.19.0-r0 | CVE-2026-1965/3783/3784/3805, CVE-2025-14017/14524/14819 |
| xz/xz-libs | 5.8.3-r0 | CVE-2026-34743 |

No application changes — base image bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)