### PR TITLE
Fix function execution delete ownership check

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -86,7 +86,7 @@ class Delete extends Base
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
 
-        if ($execution->getAttribute('resourceType') !== 'functions' && $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
+        if ($execution->getAttribute('resourceType') !== 'functions' || $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
         $status = $execution->getAttribute('status');

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1844,6 +1844,63 @@ final class FunctionsCustomServerTest extends Scope
         $this->assertStringContainsString('Can\'t delete ongoing execution.', (string) $execution['body']['message']);
     }
 
+    public function testDeleteExecutionRejectsExecutionFromAnotherFunction(): void
+    {
+        $functionA = $this->setupTestDeployment();
+
+        $functionB = $this->createFunction([
+            'functionId' => ID::unique(),
+            'name' => 'Second Function',
+            'runtime' => 'node-22',
+            'entrypoint' => 'index.js',
+            'timeout' => 15,
+        ]);
+
+        $this->assertEquals(201, $functionB['headers']['status-code']);
+        $functionBId = $functionB['body']['$id'] ?? '';
+
+        $deploymentB = $this->createDeployment($functionBId, [
+            'code' => $this->packageFunction('basic'),
+            'activate' => true,
+        ]);
+
+        $this->assertEquals(202, $deploymentB['headers']['status-code']);
+        $deploymentBId = $deploymentB['body']['$id'] ?? '';
+
+        $this->assertEventually(function () use ($functionBId, $deploymentBId) {
+            $deployment = $this->getDeployment($functionBId, $deploymentBId);
+            $this->assertEquals('ready', $deployment['body']['status']);
+        }, 50000, 500);
+
+        $executionB = $this->createExecution($functionBId, [
+            'async' => 'false',
+        ]);
+
+        $this->assertEquals(201, $executionB['headers']['status-code']);
+        $executionBId = $executionB['body']['$id'] ?? '';
+
+        $execution = $this->client->call(Client::METHOD_DELETE, '/functions/' . $functionA['functionId'] . '/executions/' . $executionBId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(404, $execution['headers']['status-code']);
+        $this->assertStringContainsString('Execution with the requested ID could not be found', (string) $execution['body']['message']);
+
+        $execution = $this->getExecution($functionBId, $executionBId);
+
+        $this->assertEquals(200, $execution['headers']['status-code']);
+        $this->assertEquals($executionBId, $execution['body']['$id']);
+
+        $execution = $this->client->call(Client::METHOD_DELETE, '/functions/' . $functionBId . '/executions/' . $executionBId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(204, $execution['headers']['status-code']);
+        $this->cleanupFunction($functionBId);
+    }
+
 
 
     public function testUpdateSpecs(): void


### PR DESCRIPTION
## What does this PR do?

Fixes the function execution delete ownership check.

Previously, `DELETE /v1/functions/{functionId}/executions/{executionId}` used `&&` when checking whether an execution belongs to the requested function. Because all function executions have `resourceType = functions`, an execution from another function could incorrectly pass the check and be deleted through the wrong function route.

This PR changes the condition to use `||`, matching the behavior of the get execution endpoint, and adds an E2E regression test for this case.

---

## Test Plan

Ran the focused E2E regression test:

```bash
docker compose exec appwrite test /usr/src/code/tests/e2e/Services/Functions/FunctionsCustomServerTest.php --filter testDeleteExecutionRejectsExecutionFromAnotherFunction
```

Result:

```txt
OK (1 test, 61 assertions)
```

Also manually reproduced the issue locally before the fix by:

1. Creating two functions in the same project.
2. Creating an execution under Function B.
3. Calling:

```http
DELETE /v1/functions/{functionAId}/executions/{executionFromFunctionBId}
```

4. Confirming it returned `204` before the fix.
5. Confirming the regression test now expects `404` and the execution remains available under Function B.

---

## Related PRs and Issues

- Closes #ISSUE_NUMBER

---

## Checklist

- [x] Have you read the Contributing Guidelines on issues  
  (https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?  
  N/A — no API metadata changed.