### PR TITLE
fix: add CORS headers to GraphQL endpoint

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -988,7 +988,7 @@ Http::init()
  * @see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
  */
 Http::init()
-    ->groups(['api', 'web'])
+    ->groups(['api', 'web', 'graphql'])
     ->inject('request')
     ->inject('response')
     ->inject('cors')


### PR DESCRIPTION
Adds proper CORS headers to the GraphQL endpoint for cross-origin requests.