### PR TITLE
Refactor Projects permission test coverage

### DIFF
--- a/.codex/skills/appwrite-testing/SKILL.md
+++ b/.codex/skills/appwrite-testing/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: appwrite-testing
+description: Choose, write, and review tests in the Appwrite server repository using a pragmatic test pyramid. Use when adding or changing PHPUnit tests, deciding between unit and e2e coverage, moving duplicated high-level coverage lower, testing API endpoints, workers, queues, permissions, auth/scopes, persistence, serialization, retry logic, validators, security regressions, or Swoole-sensitive behavior.
+---
+
+# Appwrite Testing
+
+## Core Rule
+
+Keep the test suite pyramid-shaped: many fast unit tests, fewer service/API e2e tests, and very few broad workflow tests. Push each assertion to the lowest level that still proves the behavior.
+
+Prefer fast feedback over formal labels. A narrow integration-style unit test with deterministic fakes is better than a slow e2e test when it proves the same behavior.
+
+## Choose The Test Level
+
+Use `tests/unit/...` for:
+
+- Pure validators, helpers, mappers, parsers, filters, retry classifiers, event builders, URL/security checks, and branching logic.
+- Worker building blocks that can be called with fake adapters, in-memory collaborators, or scripted test doubles.
+- Regression cases where inputs and observable outputs can be asserted without HTTP, Docker services, queues, Swoole coroutines, or real network calls.
+- Boundary serialization/deserialization when the external side can be represented with a deterministic fake response or document.
+
+Use `tests/e2e/Services/{Service}` for:
+
+- HTTP route behavior, status codes, headers, cookies, response shape, SDK-visible contracts, and request validation through the real API path.
+- Auth, scope, permission, project mode, platform, and side-specific behavior that depends on Appwrite's request lifecycle.
+- Persistence, queue-visible behavior, worker integration, database adapter behavior, and DI/wiring that unit tests cannot prove.
+- A small number of high-value service workflows that represent user-visible behavior across multiple Appwrite subsystems.
+
+Avoid broad e2e coverage for every edge case. Cover edge cases in unit tests and keep e2e focused on the integration contract that lower layers cannot exercise.
+
+## Appwrite Patterns
+
+Structure tests as Arrange, Act, Assert. Test observable behavior, not the order of private calls or internal implementation details.
+
+Write unit tests with `PHPUnit\Framework\TestCase` under the matching namespace in `tests/unit`. Use data providers for matrices. Prefer named fake classes over anonymous mocks when PHPStan clarity matters.
+
+Write service e2e tests with `Tests\E2E\Client` and the existing scope traits such as `Scope`, `ProjectCustom`, `SideClient`, `SideServer`, or `ProjectConsole`. Reuse local service base traits when they exist.
+
+Use deterministic test doubles for network, queue, mail, storage, database, and third-party boundaries whenever the point of the test is local behavior. Never call production third-party services from automated tests.
+
+Generate unique IDs, emails, and names for e2e data to survive parallel runs. Cache setup data only when the test does not require precise counts or fresh state.
+
+Keep assertions precise: status code, body fields, error type/message, permission outcome, retry count, adapter call count, or persisted value. Avoid asserting incidental full documents when a sparse behavior assertion is enough.
+
+## Duplication Policy
+
+If a higher-level test finds a bug and no lower-level test fails, add a lower-level regression test where practical.
+
+Do not repeat all conditional branches at e2e level once unit tests cover them. The e2e test should prove routing, auth, serialization, persistence, or wiring only.
+
+Delete or avoid high-level tests that no longer add confidence beyond lower-level coverage. Keep tests readable even if that means some local duplication in setup.
+
+## Swoole And Workers
+
+Be careful with Swoole coroutines in unit tests. Do not run coroutine integrations inside the shared unit process unless existing nearby tests prove the pattern is safe.
+
+For workers, unit-test pure pieces such as batching, classification, cursor construction, retry/backoff decisions, and adapter interaction with fakes. Cover coroutine scheduling, queues, and full worker lifecycle through e2e or existing integration patterns.
+
+Avoid sleeps and timing-sensitive assertions. If timing is unavoidable, isolate it, make it generous, and prefer polling helpers already used in the suite.
+
+## Commands
+
+Run focused checks first:
+
+```bash
+docker compose exec appwrite test tests/unit/
+docker compose exec appwrite test tests/e2e/Services/[Service]
+docker compose exec appwrite test tests/e2e/Services/[Service] --filter=[Method]
+composer lint <file>
+composer analyze
+```
+
+Use the narrowest command that validates the change, then broaden only when the touched behavior crosses module, API, worker, or shared-helper boundaries.

--- a/.codex/skills/appwrite-testing/agents/openai.yaml
+++ b/.codex/skills/appwrite-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Appwrite Testing"
+  short_description: "Choose and write Appwrite tests using a pragmatic test pyramid."
+  default_prompt: "Use the Appwrite testing skill to choose the right test level and add focused PHPUnit coverage for this change."

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -7407,28 +7407,12 @@ final class ProjectsConsoleClientTest extends Scope
                 'successProjectIds' => [$projectIdA, $projectIdB],
             ],
             [
-                'roles' => ["developer"],
-                'successProjectIds' => [$projectIdA, $projectIdB],
-            ],
-            [
                 'roles' => ["project-$projectIdA-owner"],
-                'successProjectIds' => [$projectIdA],
-            ],
-            [
-                'roles' => ["project-$projectIdB-owner"],
-                'successProjectIds' => [$projectIdB],
-            ],
-            [
-                'roles' => ["project-$projectIdA-developer"],
                 'successProjectIds' => [$projectIdA],
             ],
             [
                 'roles' => ["project-$projectIdB-developer"],
                 'successProjectIds' => [$projectIdB],
-            ],
-            [
-                'roles' => ["developer", "project-$projectIdA-owner"],
-                'successProjectIds' => [$projectIdA, $projectIdB],
             ]
         ];
 
@@ -7495,22 +7479,7 @@ final class ProjectsConsoleClientTest extends Scope
                 'failureProjectIds' => [],
             ],
             [
-                'roles' => ["developer"],
-                'successProjectIds' => [$projectIdA, $projectIdB],
-                'failureProjectIds' => [],
-            ],
-            [
                 'roles' => ["project-$projectIdA-owner"],
-                'successProjectIds' => [$projectIdA],
-                'failureProjectIds' => [$projectIdB],
-            ],
-            [
-                'roles' => ["project-$projectIdB-owner"],
-                'successProjectIds' => [$projectIdB],
-                'failureProjectIds' => [$projectIdA],
-            ],
-            [
-                'roles' => ["project-$projectIdA-developer"],
                 'successProjectIds' => [$projectIdA],
                 'failureProjectIds' => [$projectIdB],
             ],
@@ -7518,11 +7487,6 @@ final class ProjectsConsoleClientTest extends Scope
                 'roles' => ["project-$projectIdB-developer"],
                 'successProjectIds' => [$projectIdB],
                 'failureProjectIds' => [$projectIdA],
-            ],
-            [
-                'roles' => ["developer", "project-$projectIdA-owner"],
-                'successProjectIds' => [$projectIdA, $projectIdB],
-                'failureProjectIds' => [],
             ]
         ];
 
@@ -7625,11 +7589,6 @@ final class ProjectsConsoleClientTest extends Scope
                 'successProjectIds' => [$projectIdD],
                 'failureProjectIds' => [$projectIdE],
             ],
-            [
-                'roles' => ["project-$projectIdE-owner"],
-                'successProjectIds' => [$projectIdE],
-                'failureProjectIds' => [],
-            ],
         ];
 
         // Setup session
@@ -7703,21 +7662,6 @@ final class ProjectsConsoleClientTest extends Scope
                 'failureProjectIds' => [],
             ],
             [
-                'roles' => ["developer"],
-                'successProjectIds' => [$projectIdA, $projectIdB],
-                'failureProjectIds' => [],
-            ],
-            [
-                'roles' => ["project-$projectIdA-owner"],
-                'successProjectIds' => [$projectIdA],
-                'failureProjectIds' => [$projectIdB],
-            ],
-            [
-                'roles' => ["project-$projectIdB-owner"],
-                'successProjectIds' => [$projectIdB],
-                'failureProjectIds' => [$projectIdA],
-            ],
-            [
                 'roles' => ["project-$projectIdA-developer"],
                 'successProjectIds' => [$projectIdA],
                 'failureProjectIds' => [$projectIdB],
@@ -7726,11 +7670,6 @@ final class ProjectsConsoleClientTest extends Scope
                 'roles' => ["project-$projectIdB-developer"],
                 'successProjectIds' => [$projectIdB],
                 'failureProjectIds' => [$projectIdA],
-            ],
-            [
-                'roles' => ["developer", "project-$projectIdA-owner"],
-                'successProjectIds' => [$projectIdA, $projectIdB],
-                'failureProjectIds' => [],
             ]
         ];
 

--- a/tests/unit/Platform/PermissionTest.php
+++ b/tests/unit/Platform/PermissionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use Appwrite\Platform\Permission;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Helpers\Permission as DbPermission;
+use Utopia\Database\Helpers\Role;
+
+final class PermissionTest extends TestCase
+{
+    public function testGetPermissionsIncludesTeamAndProjectSpecificRoles(): void
+    {
+        $permissions = $this->subject()->getPermissions('team1', 'project1');
+
+        $this->assertSame([
+            DbPermission::read(Role::team('team1', 'owner')),
+            DbPermission::read(Role::team('team1', 'developer')),
+            DbPermission::update(Role::team('team1', 'owner')),
+            DbPermission::update(Role::team('team1', 'developer')),
+            DbPermission::delete(Role::team('team1', 'owner')),
+            DbPermission::delete(Role::team('team1', 'developer')),
+            DbPermission::read(Role::team('team1', 'project-project1-owner')),
+            DbPermission::read(Role::team('team1', 'project-project1-developer')),
+            DbPermission::update(Role::team('team1', 'project-project1-owner')),
+            DbPermission::update(Role::team('team1', 'project-project1-developer')),
+            DbPermission::delete(Role::team('team1', 'project-project1-owner')),
+            DbPermission::delete(Role::team('team1', 'project-project1-developer')),
+        ], $permissions);
+    }
+
+    public function testGetPermissionsDoesNotGrantUnrelatedProjectRoles(): void
+    {
+        $permissions = $this->subject()->getPermissions('team1', 'project1');
+
+        $this->assertNotContains(DbPermission::read(Role::team('team1', 'project-project2-owner')), $permissions);
+        $this->assertNotContains(DbPermission::update(Role::team('team1', 'project-project2-developer')), $permissions);
+        $this->assertNotContains(DbPermission::delete(Role::team('team2', 'project-project1-owner')), $permissions);
+    }
+
+    private function subject(): object
+    {
+        return new class () {
+            use Permission;
+        };
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Refactors Projects permission test coverage toward the test pyramid:

- Adds unit coverage for `Appwrite\Platform\Permission::getPermissions()` so team-wide and project-specific permission strings are verified at the shared platform layer.
- Reduces duplicated project-specific role matrix scenarios in `ProjectsConsoleClientTest` from 25 to 12 e2e cases, keeping e2e focused on API-level permission wiring.
- Adds a repo-local Appwrite testing skill with guidance for choosing unit vs e2e coverage.

## Test Plan

- `python3 /Users/chiragaggarwal/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/appwrite-testing` via temporary venv with PyYAML: passed
- `docker compose exec appwrite test tests/unit/Platform/PermissionTest.php`: passed
- `composer lint tests/unit/Platform/PermissionTest.php`: passed
- `composer lint tests/e2e/Services/Projects/ProjectsConsoleClientTest.php`: passed
- `docker compose exec appwrite test tests/e2e/Services/Projects --filter testProjectSpecificPermissionsForListProjects`: passed
- `docker compose exec appwrite test tests/e2e/Services/Projects --filter ProjectSpecificPermissions`: update/delete/project-resource tests passed; list test failed during membership email setup with "No email found" before reaching the refactored assertions

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
