### PR TITLE
Fix create execution request content type

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -81,7 +81,7 @@ class Create extends Base
                         model: Response::MODEL_EXECUTION,
                     )
                 ],
-                contentType: ContentType::MULTIPART,
+                requestType: ContentType::MULTIPART,
             ))
             ->param('functionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Function ID.', false, ['dbForProject'])
             ->param('body', '', new Text(10485760, 0), 'HTTP body of execution. Default value is empty string.', true)


### PR DESCRIPTION
## What does this PR do?

Fixes the SDK metadata for `functions.createExecution` so multipart applies to the request body instead of the response content type.

`createExecution` accepts multipart form data for execution parameters, but returns the `Execution` model as JSON. Using `contentType: ContentType::MULTIPART` caused generated specs/SDKs to advertise `Accept: multipart/form-data`, which can break JSON response parsing.

## Test Plan

- `composer lint src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php`
- `git diff --check`
- `docker compose exec appwrite specs --version=1.9.x --git=no`
- Verified `functionsCreateExecution` generated specs now use `consumes: ["multipart/form-data"]` and `produces: ["application/json"]`.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
