### PR TITLE
Fix create execution request type metadata

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -81,7 +81,6 @@ class Create extends Base
                         model: Response::MODEL_EXECUTION,
                     )
                 ],
-                requestType: ContentType::MULTIPART,
             ))
             ->param('functionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Function ID.', false, ['dbForProject'])
             ->param('body', '', new Text(10485760, 0), 'HTTP body of execution. Default value is empty string.', true)


### PR DESCRIPTION
## What does this PR do?

Removes the explicit multipart request type override from the create execution SDK metadata so it falls back to the default JSON request type.

## Test Plan

- `php -l src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php`
- `git diff --check -- src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php`

## Related PRs and Issues

- None

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
