### PR TITLE
chore: improve appwrite maintenance path

### DIFF
--- a/tests/benchmarks/http.js
+++ b/tests/benchmarks/http.js
@@ -458,7 +458,11 @@ function failResponse(response, message) {
 }
 
 function cookieHeader(response) {
-    return response.headers['Set-Cookie'] || response.headers['set-cookie'] || '';
+    const cookie = response.headers['Set-Cookie'] || response.headers['set-cookie'];
+    if (Array.isArray(cookie)) {
+        return cookie.join('; ');
+    }
+    return cookie || '';
 }
 
 function projectHeaders(projectId) {

--- a/tests/benchmarks/ws.js
+++ b/tests/benchmarks/ws.js
@@ -41,15 +41,20 @@ export default function () {
             check(payload, {
                 'connection opened': (r) => connection,
                 'message received': (r) => checked,
-                'channels are right': (r) => r === JSON.stringify({
-                    "type": "connected",
-                    "data": {
-                        "channels": [
-                            "files"
-                        ],
-                        "user": null
+                'channels are right': (r) => {
+                    if (typeof r !== 'string') {
+                        return false;
                     }
-                })
+                    try {
+                        const parsed = JSON.parse(r);
+                        return parsed.type === 'connected' &&
+                            Array.isArray(parsed.data?.channels) &&
+                            parsed.data.channels.includes('files') &&
+                            parsed.data.user === null;
+                    } catch (_) {
+                        return false;
+                    }
+                },
             })
             socket.close();
         }, 5000);


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/benchmarks/ws.js, tests/benchmarks/http.js related to TypeScript, frontend tooling, test stability, build fixes; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.