### PR TITLE
Fix function execution lint

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -13,7 +13,6 @@ use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Functions\Validator\Headers;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
-use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Usage\Context;


### PR DESCRIPTION
## What does this PR do?

Removes an unused `ContentType` import from the function execution create endpoint so the file passes Pint lint checks.

## Test Plan

- `composer lint src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php`

## Related PRs and Issues

- N/A

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
