### PR TITLE
Fix execution ownership validation in delete execution endpoint

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -86,7 +86,7 @@ class Delete extends Base
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
 
-        if ($execution->getAttribute('resourceType') !== 'functions' && $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
+        if ($execution->getAttribute('resourceType') !== 'functions' || $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
         $status = $execution->getAttribute('status');


### PR DESCRIPTION
## What does this PR do?

This PR fixes an ownership validation issue in the function execution delete endpoint.

The validation condition used `&&`, which allowed an execution belonging to a different function to pass the ownership check when the resource type was `functions`.

The condition has been updated to use `||` so that any mismatch correctly throws `EXECUTION_NOT_FOUND`.

## Test Plan

- Located the ownership validation check in `src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php`.
- Replaced `&&` with `||` in the validation condition.
- Verified the change using `git diff`.
- Confirmed that executions belonging to a different function will now fail the ownership validation check and return `EXECUTION_NOT_FOUND`.

## Related PRs and Issues

Fixes #12517

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (Not applicable)