### PR TITLE
Clean up expired OAuth2 grants

### DIFF
--- a/app/config/collections/common.php
+++ b/app/config/collections/common.php
@@ -603,6 +603,13 @@ return [
                 'lengths' => [Database::LENGTH_KEY],
                 'orders' => [Database::ORDER_ASC],
             ],
+            [
+                '$id' => ID::custom('_key_type_expire'),
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['type', 'expire'],
+                'lengths' => [],
+                'orders' => [Database::ORDER_ASC, Database::ORDER_ASC],
+            ],
         ],
     ],
 

--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -213,6 +213,15 @@ class V24 extends Migration
                     $this->dbForProject->purgeCachedCollection($id);
                     break;
 
+                case 'tokens':
+                    try {
+                        $this->createIndexFromCollection($this->dbForProject, $id, '_key_type_expire');
+                    } catch (Throwable $th) {
+                        Console::warning("Failed to create index \"_key_type_expire\" from {$id}: {$th->getMessage()}");
+                    }
+                    $this->dbForProject->purgeCachedCollection($id);
+                    break;
+
                 case 'databases':
                     if ($collectionType === 'projects') {
                         try {

--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -221,6 +221,7 @@ class Deletes extends Action
                 $this->deleteAuditLogs($project, $getAudit, $auditRetention);
                 $this->deleteUsageStats($project, $getProjectDB, $getLogsDB, $hourlyUsageRetentionDatetime);
                 $this->deleteExpiredSessions($project, $getProjectDB);
+                $this->deleteExpiredOAuth2Grants($project, $getProjectDB);
                 $this->deleteExpiredTransactions($project, $getProjectDB);
                 $this->deleteExpiredPresences($project, $getProjectDB, $publisherForUsage);
                 $this->deleteOldDeployments($publisherForDeletes, $project, $getProjectDB);
@@ -1144,6 +1145,27 @@ class Deletes extends Action
             Query::lessThan('$createdAt', $expired),
             Query::orderDesc('$createdAt'),
             Query::orderDesc(),
+        ], $dbForProject);
+    }
+
+    /**
+     * @param Document $project
+     * @param callable $getProjectDB
+     * @return void
+     * @throws Exception|Throwable
+     */
+    private function deleteExpiredOAuth2Grants(Document $project, callable $getProjectDB): void
+    {
+        Console::info('Delete expired OAuth2 grants');
+
+        $dbForProject = $getProjectDB($project);
+
+        $this->deleteByGroup('tokens', [
+            Query::select([...$this->selects, 'expire']),
+            Query::equal('type', [TOKEN_TYPE_OAUTH2]),
+            Query::lessThan('expire', DateTime::format(new \DateTime())),
+            Query::orderAsc('expire'),
+            Query::orderAsc(),
         ], $dbForProject);
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds maintenance cleanup for expired OAuth2 token-flow grants. OAuth2 token grants are stored as `tokens` documents with `TOKEN_TYPE_OAUTH2`; consumed grants are already deleted when exchanged for a session, but unconsumed expired grants could remain. This PR deletes only expired OAuth2 grants during the existing maintenance delete worker path and adds a compound `type, expire` index for efficient cleanup.

## Test Plan

- `composer lint app/config/collections/common.php`
- `composer lint src/Appwrite/Platform/Workers/Deletes.php`
- `composer lint src/Appwrite/Migration/Version/V24.php`
- `vendor/bin/phpunit tests/unit/General/CollectionsTest.php`
- `composer analyze` was run and completed with existing unrelated PHPStan errors in span/queue bootstrap files (`app/http.php`, `app/init/registers.php`, `app/init/span.php`, `app/realtime.php`, `app/worker.php`, `src/Appwrite/Platform/Tasks/Interval.php`).

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API metadata (desc, label, params, etc.), does it also include updated API specs and example docs? N/A - no API metadata changed.
