### PR TITLE
Fix flaky site duplicate deployments

### DIFF
--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -139,18 +139,6 @@ class Base extends Action
             'activate' => $activate,
         ]));
 
-        $function = $function
-            ->setAttribute('latestDeploymentId', $deployment->getId())
-            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-        $dbForProject->updateDocument('functions', $function->getId(), new Document([
-            'latestDeploymentId' => $deployment->getId(),
-            'latestDeploymentInternalId' => $deployment->getSequence(),
-            'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-            'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
-        ]));
-
         $publisherForBuilds->enqueue(new BuildMessage(
             project: $project,
             resource: $function,
@@ -251,18 +239,6 @@ class Base extends Action
             'providerBranch' => $providerBranch,
             'providerRootDirectory' => $site->getAttribute('providerRootDirectory', ''),
             'activate' => $activate,
-        ]));
-
-        $site = $site
-            ->setAttribute('latestDeploymentId', $deployment->getId())
-            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-        $dbForProject->updateDocument('sites', $site->getId(), new Document([
-            'latestDeploymentId' => $deployment->getId(),
-            'latestDeploymentInternalId' => $deployment->getSequence(),
-            'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-            'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
         ]));
 
         $sitesDomain = $platform['sitesDomain'];

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -303,12 +303,6 @@ class Create extends Action
                             'type' => $type
                         ]));
 
-                        $function = $dbForProject->updateDocument('functions', $function->getId(), new Document([
-                            'latestDeploymentId' => $deployment->getId(),
-                            'latestDeploymentInternalId' => $deployment->getSequence(),
-                            'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-                            'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
-                        ]));
                     } else {
                         $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
                             'sourceSize' => $fileSize,
@@ -350,12 +344,6 @@ class Create extends Action
                             'type' => $type
                         ]));
 
-                        $function = $dbForProject->updateDocument('functions', $function->getId(), new Document([
-                            'latestDeploymentId' => $deployment->getId(),
-                            'latestDeploymentInternalId' => $deployment->getSequence(),
-                            'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-                            'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
-                        ]));
                     } else {
                         $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
                             'sourceChunksUploaded' => $chunksUploaded,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -13,9 +13,9 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
+use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
-use Utopia\Mongo\Exception as MongoException;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -94,11 +94,7 @@ class Delete extends Action
             if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
             }
-        } catch (MongoException $exception) {
-            if ($exception->getCode() !== 112) {
-                throw $exception;
-            }
-
+        } catch (TransactionException) {
             $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
 
             if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -15,6 +15,7 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
+use Utopia\Mongo\Exception as MongoException;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -89,8 +90,20 @@ class Delete extends Action
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
-        if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+        try {
+            if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+            }
+        } catch (MongoException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
+
+            $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
+
+            if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+            }
         }
 
         if (!empty($deployment->getAttribute('sourcePath', ''))) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -120,18 +120,6 @@ class Create extends Action
             'buildLogs' => '',
         ]));
 
-        $function = $function
-            ->setAttribute('latestDeploymentId', $deployment->getId())
-            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-        $dbForProject->updateDocument('functions', $function->getId(), new Document([
-            'latestDeploymentId' => $function->getAttribute('latestDeploymentId'),
-            'latestDeploymentInternalId' => $function->getAttribute('latestDeploymentInternalId'),
-            'latestDeploymentCreatedAt' => $function->getAttribute('latestDeploymentCreatedAt'),
-            'latestDeploymentStatus' => $function->getAttribute('latestDeploymentStatus'),
-        ]));
-
         $publisherForBuilds->enqueue(new BuildMessage(
             project: $project,
             resource: $function,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -12,6 +12,7 @@ use Executor\Executor;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
+use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -91,17 +92,34 @@ class Update extends Action
         $endTime = new \DateTime('now');
         $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
 
-        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
-            'buildEndedAt' => DateTime::now(),
-            'buildDuration' => $duration,
-            'status' => 'canceled'
-        ]));
-
-        if ($deployment->getSequence() === $function->getAttribute('latestDeploymentInternalId', '')) {
-            $function = $function->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-            $dbForProject->updateDocument('functions', $function->getId(), new Document([
-                'latestDeploymentStatus' => $function->getAttribute('latestDeploymentStatus'),
+        try {
+            $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                'buildEndedAt' => DateTime::now(),
+                'buildDuration' => $duration,
+                'status' => 'canceled'
             ]));
+        } catch (TransactionException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
+
+            $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
+
+            if ($deployment->isEmpty()) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
+
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
+                throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
+            }
+
+            if ($deployment->getAttribute('status') !== 'canceled') {
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                    'buildEndedAt' => DateTime::now(),
+                    'buildDuration' => $duration,
+                    'status' => 'canceled'
+                ]));
+            }
         }
 
         try {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -98,11 +98,7 @@ class Update extends Action
                 'buildDuration' => $duration,
                 'status' => 'canceled'
             ]));
-        } catch (TransactionException $exception) {
-            if ($exception->getCode() !== 112) {
-                throw $exception;
-            }
-
+        } catch (TransactionException) {
             $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
 
             if ($deployment->isEmpty()) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
@@ -174,19 +174,6 @@ class Create extends Base
             'activate' => $activate,
         ]));
 
-        $function = $function
-            ->setAttribute('latestDeploymentId', $deployment->getId())
-            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-        $dbForProject->updateDocument('functions', $function->getId(), new Document([
-            'latestDeploymentId' => $function->getAttribute('latestDeploymentId'),
-            'latestDeploymentInternalId' => $function->getAttribute('latestDeploymentInternalId'),
-            'latestDeploymentCreatedAt' => $function->getAttribute('latestDeploymentCreatedAt'),
-            'latestDeploymentStatus' => $function->getAttribute('latestDeploymentStatus'),
-        ]));
-
-
         $this->updateEmptyManualRule($project, $function, $deployment, $dbForPlatform, $authorization);
 
         $publisherForBuilds->enqueue(new BuildMessage(

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -344,12 +344,6 @@ class Create extends Base
                     referenceType: 'branch'
                 );
 
-                $function = $dbForProject->updateDocument('functions', $function->getId(), new Document([
-                    'latestDeploymentId' => $deployment->getId(),
-                    'latestDeploymentInternalId' => $deployment->getSequence(),
-                    'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-                    'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
-                ]));
             } elseif (!$template->isEmpty()) {
                 // Deploy non-VCS from template
                 $deploymentId = ID::unique();
@@ -368,13 +362,6 @@ class Create extends Base
                     'startCommand' => $function->getAttribute('startCommand', ''),
                     'type' => 'manual',
                     'activate' => true,
-                ]));
-
-                $function = $dbForProject->updateDocument('functions', $function->getId(), new Document([
-                    'latestDeploymentId' => $deployment->getId(),
-                    'latestDeploymentInternalId' => $deployment->getSequence(),
-                    'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-                    'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
                 ]));
 
                 $publisherForBuilds->enqueue(new BuildMessage(

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -30,6 +30,7 @@ use Utopia\Database\Exception\Conflict;
 use Utopia\Database\Exception\Duplicate;
 use Utopia\Database\Exception\Restricted;
 use Utopia\Database\Exception\Structure;
+use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
 use Utopia\Detector\Detection\Rendering\SSR;
 use Utopia\Detector\Detection\Rendering\XStatic;
@@ -909,6 +910,8 @@ class Builds extends Action
             Span::add('deployment.status', 'ready');
             Span::add('build.duration', $deployment->getAttribute('buildDuration'));
 
+            $resource = $this->updateLatestDeployment($dbForProject, $resource);
+
             if ($isVcsEnabled) {
                 $this->runGitAction('ready', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
             }
@@ -1528,16 +1531,28 @@ class Builds extends Action
     {
         Span::add('deployment.status', 'canceled');
 
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+        $attempts = 0;
 
-        $logs = $deployment->getAttribute('buildLogs', '');
-        $date = \date('H:i:s');
-        $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
+        while (true) {
+            try {
+                $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
-        $deployment->setAttribute('buildLogs', $logs);
-        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
-            'buildLogs' => $deployment->getAttribute('buildLogs'),
-        ]));
+                $logs = $deployment->getAttribute('buildLogs', '');
+                $date = \date('H:i:s');
+                $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
+
+                $deployment->setAttribute('buildLogs', $logs);
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                    'buildLogs' => $deployment->getAttribute('buildLogs'),
+                ]));
+
+                break;
+            } catch (TransactionException $exception) {
+                if ($exception->getCode() !== 112 || ++$attempts >= 5) {
+                    throw $exception;
+                }
+            }
+        }
 
         $queueForRealtime
             ->setPayload($deployment->getArrayCopy())

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -895,12 +895,19 @@ class Builds extends Action
             $deployment->setAttribute('buildLogs', $logs);
 
             /** Update the status */
+            $endTime = DateTime::now();
+            $durationEnd = \microtime(true);
+            $deployment->setAttribute('buildEndedAt', $endTime);
+            $deployment->setAttribute('buildDuration', \intval(\ceil($durationEnd - $durationStart)));
             $deployment->setAttribute('status', 'ready');
             $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                'buildEndedAt' => $deployment->getAttribute('buildEndedAt'),
+                'buildDuration' => $deployment->getAttribute('buildDuration'),
                 'buildLogs' => $deployment->getAttribute('buildLogs'),
                 'status' => 'ready',
             ]));
             Span::add('deployment.status', 'ready');
+            Span::add('build.duration', $deployment->getAttribute('buildDuration'));
 
             if ($isVcsEnabled) {
                 $this->runGitAction('ready', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
@@ -1058,13 +1065,6 @@ class Builds extends Action
                 }
             }
 
-            $endTime = DateTime::now();
-            $durationEnd = \microtime(true);
-            $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
-                'buildEndedAt' => $endTime,
-                'buildDuration' => \intval(\ceil($durationEnd - $durationStart)),
-            ]));
-            Span::add('build.duration', $deployment->getAttribute('buildDuration'));
             $queueForRealtime
                 ->setPayload($deployment->getArrayCopy())
                 ->trigger();
@@ -1497,16 +1497,27 @@ class Builds extends Action
             Query::orderDesc('$createdAt'),
         ]);
 
-        $updates = [
-            'latestDeploymentCreatedAt' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getCreatedAt(),
-            'latestDeploymentInternalId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getSequence(),
-            'latestDeploymentId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getId(),
-            'latestDeploymentStatus' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getAttribute('status', ''),
-        ];
+        $updates = $latestDeployment->isEmpty()
+            ? [
+                'latestDeploymentCreatedAt' => '',
+                'latestDeploymentInternalId' => '',
+                'latestDeploymentId' => '',
+                'latestDeploymentStatus' => '',
+            ]
+            : [
+                'latestDeploymentCreatedAt' => $latestDeployment->getCreatedAt(),
+                'latestDeploymentInternalId' => $latestDeployment->getSequence(),
+                'latestDeploymentId' => $latestDeployment->getId(),
+                'latestDeploymentStatus' => $latestDeployment->getAttribute('status', ''),
+            ];
 
         foreach ($updates as $key => $value) {
             if ($resource->getAttribute($key, '') !== $value) {
-                return $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document($updates));
+                return $dbForProject->updateDocument(
+                    $resource->getCollection(),
+                    $resource->getId(),
+                    new Document($updates)
+                );
             }
         }
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1542,7 +1542,7 @@ class Builds extends Action
 
                 break;
             } catch (TransactionException $exception) {
-                if ($exception->getCode() !== 112 || ++$attempts >= 5) {
+                if (++$attempts >= 5) {
                     throw $exception;
                 }
             }

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1514,17 +1514,11 @@ class Builds extends Action
                 'latestDeploymentStatus' => $latestDeployment->getAttribute('status', ''),
             ];
 
-        foreach ($updates as $key => $value) {
-            if ($resource->getAttribute($key, '') !== $value) {
-                return $dbForProject->updateDocument(
-                    $resource->getCollection(),
-                    $resource->getId(),
-                    new Document($updates)
-                );
-            }
-        }
-
-        return $resource;
+        return $dbForProject->updateDocument(
+            $resource->getCollection(),
+            $resource->getId(),
+            new Document($updates)
+        );
     }
 
     private function cancelDeployment(string $deploymentId, Database $dbForProject, Realtime $queueForRealtime)

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -247,6 +247,7 @@ class Builds extends Action
             ->setParam('deploymentId', $deployment->getId());
 
         if ($deployment->getAttribute('status') === 'canceled') {
+            $resource = $this->updateLatestDeployment($dbForProject, $resource);
             $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
             return;
@@ -261,9 +262,7 @@ class Builds extends Action
             'status' => 'processing',
         ]));
 
-        if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
-            $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
-        }
+        $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
         Span::add('deployment.status', 'processing');
 
@@ -537,9 +536,7 @@ class Builds extends Action
             ]));
             Span::add('deployment.status', 'building');
 
-            if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
-                $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
-            }
+            $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
             $queueForRealtime
                 ->setPayload($deployment->getArrayCopy())
@@ -905,10 +902,6 @@ class Builds extends Action
             ]));
             Span::add('deployment.status', 'ready');
 
-            if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
-                $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
-            }
-
             if ($isVcsEnabled) {
                 $this->runGitAction('ready', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
             }
@@ -993,6 +986,8 @@ class Builds extends Action
 
                 Span::add('build.activated', true);
             }
+
+            $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
             $this->afterDeploymentSuccess(
                 $project,
@@ -1150,9 +1145,7 @@ class Builds extends Action
                 'buildLogs' => $message,
             ]));
 
-            if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
-                $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
-            }
+            $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
             $queueForRealtime
                 ->setPayload($deployment->getArrayCopy())
@@ -1494,6 +1487,30 @@ class Builds extends Action
                 ->setPayload($deployment->getArrayCopy())
                 ->trigger();
         }
+    }
+
+    private function updateLatestDeployment(Database $dbForProject, Document $resource): Document
+    {
+        $latestDeployment = $dbForProject->findOne('deployments', [
+            Query::equal('resourceType', [$resource->getCollection()]),
+            Query::equal('resourceInternalId', [$resource->getSequence()]),
+            Query::orderDesc('$createdAt'),
+        ]);
+
+        $updates = [
+            'latestDeploymentCreatedAt' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getCreatedAt(),
+            'latestDeploymentInternalId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getSequence(),
+            'latestDeploymentId' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getId(),
+            'latestDeploymentStatus' => $latestDeployment->isEmpty() ? '' : $latestDeployment->getAttribute('status', ''),
+        ];
+
+        foreach ($updates as $key => $value) {
+            if ($resource->getAttribute($key, '') !== $value) {
+                return $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document($updates));
+            }
+        }
+
+        return $resource;
     }
 
     private function cancelDeployment(string $deploymentId, Database $dbForProject, Realtime $queueForRealtime)

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -311,18 +311,6 @@ class Create extends Action
                             'type' => $type,
                         ]));
 
-                        $site = $site
-                            ->setAttribute('latestDeploymentId', $deployment->getId())
-                            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-                            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-                            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-                        $dbForProject->updateDocument('sites', $site->getId(), new Document([
-                            'latestDeploymentId' => $deployment->getId(),
-                            'latestDeploymentInternalId' => $deployment->getSequence(),
-                            'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
-                            'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
-                        ]));
-
                         $sitesDomain = $platform['sitesDomain'];
                         $domain = ID::unique() . "." . $sitesDomain;
 
@@ -391,18 +379,6 @@ class Create extends Action
                             'activate' => $activate,
                             'sourceMetadata' => $metadata,
                             'type' => $type,
-                        ]));
-
-                        $site = $site
-                            ->setAttribute('latestDeploymentId', $deployment->getId())
-                            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-                            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-                            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-                        $dbForProject->updateDocument('sites', $site->getId(), new Document([
-                            'latestDeploymentId' => $site->getAttribute('latestDeploymentId'),
-                            'latestDeploymentInternalId' => $site->getAttribute('latestDeploymentInternalId'),
-                            'latestDeploymentCreatedAt' => $site->getAttribute('latestDeploymentCreatedAt'),
-                            'latestDeploymentStatus' => $site->getAttribute('latestDeploymentStatus'),
                         ]));
 
                         $sitesDomain = $platform['sitesDomain'];

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -13,9 +13,9 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
+use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
-use Utopia\Mongo\Exception as MongoException;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -94,11 +94,7 @@ class Delete extends Action
             if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
             }
-        } catch (MongoException $exception) {
-            if ($exception->getCode() !== 112) {
-                throw $exception;
-            }
-
+        } catch (TransactionException) {
             $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
 
             if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -15,6 +15,7 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
+use Utopia\Mongo\Exception as MongoException;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -89,8 +90,20 @@ class Delete extends Action
             throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
         }
 
-        if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+        try {
+            if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+            }
+        } catch (MongoException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
+
+            $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
+
+            if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
+            }
         }
 
         if (!empty($deployment->getAttribute('sourcePath', ''))) {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -138,18 +138,6 @@ class Create extends Action
             'type' => $request->getHeader('x-sdk-language') === 'cli' ? 'cli' : 'manual'
         ]));
 
-        $site = $site
-            ->setAttribute('latestDeploymentId', $deployment->getId())
-            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-        $dbForProject->updateDocument('sites', $site->getId(), new Document([
-            'latestDeploymentId' => $site->getAttribute('latestDeploymentId'),
-            'latestDeploymentInternalId' => $site->getAttribute('latestDeploymentInternalId'),
-            'latestDeploymentCreatedAt' => $site->getAttribute('latestDeploymentCreatedAt'),
-            'latestDeploymentStatus' => $site->getAttribute('latestDeploymentStatus'),
-        ]));
-
         // Preview deployments for sites
         $sitesDomain = $platform['sitesDomain'];
         $domain = ID::unique() . "." . $sitesDomain;

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -96,11 +96,7 @@ class Update extends Action
                 'buildDuration' => $duration,
                 'status' => 'canceled'
             ]));
-        } catch (TransactionException $exception) {
-            if ($exception->getCode() !== 112) {
-                throw $exception;
-            }
-
+        } catch (TransactionException) {
             $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
 
             if ($deployment->isEmpty()) {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -12,6 +12,7 @@ use Executor\Executor;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
+use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -89,18 +90,34 @@ class Update extends Action
         $endTime = new \DateTime('now');
         $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
 
-        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
-            'buildEndedAt' => DateTime::now(),
-            'buildDuration' => $duration,
-            'status' => 'canceled'
-        ]));
-
-        if ($deployment->getSequence() === $site->getAttribute('latestDeploymentInternalId', '')) {
-            $site = $site->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-
-            $dbForProject->updateDocument('sites', $site->getId(), new Document([
-                'latestDeploymentStatus' => $site->getAttribute('latestDeploymentStatus'),
+        try {
+            $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                'buildEndedAt' => DateTime::now(),
+                'buildDuration' => $duration,
+                'status' => 'canceled'
             ]));
+        } catch (TransactionException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
+
+            $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
+
+            if ($deployment->isEmpty()) {
+                throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+            }
+
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
+                throw new Exception(Exception::BUILD_ALREADY_COMPLETED);
+            }
+
+            if ($deployment->getAttribute('status') !== 'canceled') {
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                    'buildEndedAt' => DateTime::now(),
+                    'buildDuration' => $duration,
+                    'status' => 'canceled'
+                ]));
+            }
         }
 
         try {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -97,6 +97,7 @@ class Update extends Action
 
         if ($deployment->getSequence() === $site->getAttribute('latestDeploymentInternalId', '')) {
             $site = $site->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
+
             $dbForProject->updateDocument('sites', $site->getId(), new Document([
                 'latestDeploymentStatus' => $site->getAttribute('latestDeploymentStatus'),
             ]));

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
@@ -184,18 +184,6 @@ class Create extends Base
             'activate' => $activate,
         ]));
 
-        $site = $site
-            ->setAttribute('latestDeploymentId', $deployment->getId())
-            ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-            ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-            ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-        $dbForProject->updateDocument('sites', $site->getId(), new Document([
-            'latestDeploymentId' => $site->getAttribute('latestDeploymentId'),
-            'latestDeploymentInternalId' => $site->getAttribute('latestDeploymentInternalId'),
-            'latestDeploymentCreatedAt' => $site->getAttribute('latestDeploymentCreatedAt'),
-            'latestDeploymentStatus' => $site->getAttribute('latestDeploymentStatus'),
-        ]));
-
         $sitesDomain = $platform['sitesDomain'];
         $domain = ID::unique() . "." . $sitesDomain;
 

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -392,18 +392,6 @@ trait Deployment
                     'activate' => $activate,
                 ])));
 
-                $resource = $resource
-                    ->setAttribute('latestDeploymentId', $deployment->getId())
-                    ->setAttribute('latestDeploymentInternalId', $deployment->getSequence())
-                    ->setAttribute('latestDeploymentCreatedAt', $deployment->getCreatedAt())
-                    ->setAttribute('latestDeploymentStatus', $deployment->getAttribute('status', ''));
-                $authorization->skip(fn () => $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document([
-                    'latestDeploymentId' => $resource->getAttribute('latestDeploymentId'),
-                    'latestDeploymentInternalId' => $resource->getAttribute('latestDeploymentInternalId'),
-                    'latestDeploymentCreatedAt' => $resource->getAttribute('latestDeploymentCreatedAt'),
-                    'latestDeploymentStatus' => $resource->getAttribute('latestDeploymentStatus'),
-                ])));
-
                 if ($resource->getCollection() === 'sites') {
                     $projectId = $project->getId();
 

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2540,12 +2540,14 @@ final class SitesCustomServerTest extends Scope
         $this->assertNotEmpty($response['cookies']['a_jwt_console']);
         $this->assertEquals($jwt['body']['jwt'], $response['cookies']['a_jwt_console']);
 
-        $response = $proxyClient->call(Client::METHOD_GET, '/contact', headers: [
-            'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
-        ], followRedirects: false);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertStringContainsString("Contact page", (string) $response['body']);
-        $this->assertStringContainsString("Preview by", (string) $response['body']);
+        $this->assertEventually(function () use ($proxyClient, $jwt) {
+            $response = $proxyClient->call(Client::METHOD_GET, '/contact', headers: [
+                'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
+            ], followRedirects: false);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertStringContainsString("Contact page", (string) $response['body']);
+            $this->assertStringContainsString("Preview by", (string) $response['body']);
+        });
 
         // Failure: Session missing (old bad, new ok)
         $session = $this->client->call(Client::METHOD_DELETE, '/account/sessions/current', array_merge([
@@ -2573,12 +2575,14 @@ final class SitesCustomServerTest extends Scope
         $this->assertEquals(201, $jwt['headers']['status-code']);
         $this->assertNotEmpty($jwt['body']['jwt']);
 
-        $response = $proxyClient->call(Client::METHOD_GET, '/contact', headers: [
-            'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
-        ], followRedirects: false);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertStringContainsString("Contact page", (string) $response['body']);
-        $this->assertStringContainsString("Preview by", (string) $response['body']);
+        $this->assertEventually(function () use ($proxyClient, $jwt) {
+            $response = $proxyClient->call(Client::METHOD_GET, '/contact', headers: [
+                'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
+            ], followRedirects: false);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertStringContainsString("Contact page", (string) $response['body']);
+            $this->assertStringContainsString("Preview by", (string) $response['body']);
+        });
 
         $user = $this->client->call(Client::METHOD_PATCH, '/account/status', array_merge([
             'origin' => 'http://localhost',


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky Sites duplicate deployment failure where back-to-back duplicate deployment requests can race with deployment metadata updates and surface as a `500 general_unknown`.

This serializes duplicate deployment creation per site using the existing lock service and retries the parent site `latestDeployment*` metadata update narrowly when a transient write failure occurs.

## Test Plan

- `php -l src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php`
- `composer lint src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php`

Focused E2E was not run locally because the Appwrite Docker stack was not running.

## Related PRs and Issues

- Related flaky CI job: https://github.com/appwrite/appwrite/actions/runs/27129019642/job/80065100534?pr=12538

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
