### PR TITLE
Fix execution ownership validation (&& -> ||)

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -86,7 +86,7 @@ class Delete extends Base
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
 
-        if ($execution->getAttribute('resourceType') !== 'functions' && $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
+        if ($execution->getAttribute('resourceType') !== 'functions' || $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
         $status = $execution->getAttribute('status');


### PR DESCRIPTION
## What does this PR do?
When validating execution ownership in the function execution delete endpoint, the condition incorrectly used AND (&&) instead of OR (||). This meant that only executions matching BOTH the wrong resource type AND the wrong resource ID would be rejected, allowing cross-function execution deletion.

## Related issues
Fixes #12537