### PR TITLE
Fix flaky site duplicate deployments

### DIFF
--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -2,8 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Compute;
 
-use Appwrite\Event\Message\Build as BuildMessage;
-use Appwrite\Event\Publisher\Build as BuildPublisher;
+use Appwrite\Event\Build;
 use Appwrite\Extend\Exception;
 use Appwrite\Filter\BranchDomain as BranchDomainFilter;
 use Appwrite\Platform\Action;
@@ -58,7 +57,7 @@ class Base extends Action
         return $allowedSpecifications[0] ?? APP_COMPUTE_SPECIFICATION_DEFAULT;
     }
 
-    public function redeployVcsFunction(Request $request, Document $function, Document $project, Document $installation, Database $dbForProject, BuildPublisher $publisherForBuilds, Document $template, GitHub $github, bool $activate, array $platform = [], string $referenceType = 'branch', string $reference = ''): Document
+    public function redeployVcsFunction(Request $request, Document $function, Document $project, Document $installation, Database $dbForProject, Build $queueForBuilds, Document $template, GitHub $github, bool $activate, string $referenceType = 'branch', string $reference = ''): Document
     {
         $deploymentId = ID::unique();
         $entrypoint = $function->getAttribute('entrypoint', '');
@@ -69,7 +68,7 @@ class Base extends Action
         $owner = $github->getOwnerName($providerInstallationId);
         $providerRepositoryId = $function->getAttribute('providerRepositoryId', '');
         try {
-            $repositoryName = $github->getRepositoryName($providerRepositoryId);
+            $repositoryName = $github->getRepositoryName($providerRepositoryId) ?? '';
             if (empty($repositoryName)) {
                 throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
             }
@@ -139,19 +138,16 @@ class Base extends Action
             'activate' => $activate,
         ]));
 
-        $publisherForBuilds->enqueue(new BuildMessage(
-            project: $project,
-            resource: $function,
-            deployment: $deployment,
-            type: BUILD_TYPE_DEPLOYMENT,
-            template: $template,
-            platform: $platform,
-        ));
+        $queueForBuilds
+            ->setType(BUILD_TYPE_DEPLOYMENT)
+            ->setResource($function)
+            ->setDeployment($deployment)
+            ->setTemplate($template);
 
         return $deployment;
     }
 
-    public function redeployVcsSite(Request $request, Document $site, Document $project, Document $installation, Database $dbForProject, Database $dbForPlatform, BuildPublisher $publisherForBuilds, Document $template, GitHub $github, bool $activate, Authorization $authorization, array $platform, string $referenceType = 'branch', string $reference = ''): Document
+    public function redeployVcsSite(Request $request, Document $site, Document $project, Document $installation, Database $dbForProject, Database $dbForPlatform, Build $queueForBuilds, Document $template, GitHub $github, bool $activate, Authorization $authorization, array $platform, string $referenceType = 'branch', string $reference = ''): Document
     {
         $deploymentId = ID::unique();
         $providerInstallationId = $installation->getAttribute('providerInstallationId', '');
@@ -161,7 +157,7 @@ class Base extends Action
         $owner = $github->getOwnerName($providerInstallationId);
         $providerRepositoryId = $site->getAttribute('providerRepositoryId', '');
         try {
-            $repositoryName = $github->getRepositoryName($providerRepositoryId);
+            $repositoryName = $github->getRepositoryName($providerRepositoryId) ?? '';
             if (empty($repositoryName)) {
                 throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
             }
@@ -338,14 +334,11 @@ class Base extends Action
 
         $this->updateEmptyManualRule($project, $site, $deployment, $dbForPlatform, $authorization);
 
-        $publisherForBuilds->enqueue(new BuildMessage(
-            project: $project,
-            resource: $site,
-            deployment: $deployment,
-            type: BUILD_TYPE_DEPLOYMENT,
-            template: $template,
-            platform: $platform,
-        ));
+        $queueForBuilds
+            ->setType(BUILD_TYPE_DEPLOYMENT)
+            ->setResource($site)
+            ->setDeployment($deployment)
+            ->setTemplate($template);
 
         return $deployment;
     }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -2,9 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments;
 
+use Appwrite\Event\Build;
 use Appwrite\Event\Event;
-use Appwrite\Event\Message\Build as BuildMessage;
-use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
@@ -21,7 +20,6 @@ use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Request;
-use Utopia\Lock\Exception\Contention as LockContention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -89,11 +87,9 @@ class Create extends Action
             ->inject('project')
             ->inject('deviceForFunctions')
             ->inject('deviceForLocal')
-            ->inject('publisherForBuilds')
+            ->inject('queueForBuilds')
             ->inject('plan')
             ->inject('authorization')
-            ->inject('platform')
-            ->inject('locks')
             ->callback($this->action(...));
     }
 
@@ -110,11 +106,9 @@ class Create extends Action
         Document $project,
         Device $deviceForFunctions,
         Device $deviceForLocal,
-        BuildPublisher $publisherForBuilds,
+        Build $queueForBuilds,
         array $plan,
-        Authorization $authorization,
-        array $platform,
-        callable $locks
+        Authorization $authorization
     ) {
         $activate = \strval($activate) === 'true' || \strval($activate) === '1';
 
@@ -166,7 +160,7 @@ class Create extends Action
             throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
         }
 
-        $contentRange = $request->getHeaderLine('content-range');
+        $contentRange = $request->getHeader('content-range');
         $deploymentId = ID::unique();
         $chunk = 1;
         $chunks = 1;
@@ -175,14 +169,21 @@ class Create extends Action
             $start = $request->getContentRangeStart();
             $end = $request->getContentRangeEnd();
             $fileSize = $request->getContentRangeSize();
-            $deploymentId = $request->getHeaderLine('x-appwrite-id', $deploymentId);
+            $deploymentId = $request->getHeader('x-appwrite-id', $deploymentId);
             // TODO make `end >= $fileSize` in next breaking version
             if (is_null($start) || is_null($end) || is_null($fileSize) || $end > $fileSize) {
                 throw new Exception(Exception::STORAGE_INVALID_CONTENT_RANGE);
             }
 
-            $chunks = (int) ceil($fileSize / APP_LIMIT_UPLOAD_CHUNK_SIZE);
-            $chunk = (int) ($start / APP_LIMIT_UPLOAD_CHUNK_SIZE) + 1;
+            // TODO remove the condition that checks `$end === $fileSize` in next breaking version
+            if ($end === $fileSize - 1 || $end === $fileSize) {
+                //if it's a last chunks the chunk size might differ, so we set the $chunks and $chunk to notify it's last chunk
+                $chunks = $chunk = -1;
+            } else {
+                // Calculate total number of chunks based on the chunk size i.e ($rangeEnd - $rangeStart)
+                $chunks = (int) ceil($fileSize / ($end + 1 - $start));
+                $chunk = (int) ($start / ($end + 1 - $start)) + 1;
+            }
         }
 
         if (!$fileSizeValidator->isValid($fileSize) && $functionSizeLimit !== 0) { // Check if file size is exceeding allowed limit
@@ -196,199 +197,125 @@ class Create extends Action
         // Save to storage
         $fileSize ??= $deviceForLocal->getFileSize($fileTmpName);
         $path = $deviceForFunctions->getPath($deploymentId . '.' . \pathinfo($fileName, PATHINFO_EXTENSION));
-
-        $lockKey = 'functions:deployment:' . $project->getId() . ':' . $functionId . ':' . $deploymentId;
+        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
         $metadata = ['content_type' => $deviceForLocal->getFileMimeType($fileTmpName)];
-        $completed = false;
-
-        $mergeUploadMetadata = function (array $stored, array $current): array {
-            $merged = \array_merge($stored, $current);
-
-            if (isset($stored['parts']) || isset($current['parts'])) {
-                $parts = $stored['parts'] ?? [];
-                foreach (($current['parts'] ?? []) as $part => $value) {
-                    $parts[(int) $part] = $value;
-                }
-                \ksort($parts);
-
-                $merged['parts'] = $parts;
-                $merged['chunks'] = \count($parts);
+        if (!$deployment->isEmpty()) {
+            $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
+            $metadata = $deployment->getAttribute('sourceMetadata', []);
+            if ($chunk === -1) {
+                $chunk = $chunks;
             }
-
-            return $merged;
-        };
-
-        $type = $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual';
-
-        try {
-            $locks($lockKey, 600, function () use ($activate, &$chunks, $commands, $contentRange, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, &$metadata, $path, $type, &$completed, $response): void {
-                $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-
-                if (!$deployment->isEmpty()) {
-                    $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
-                    $uploaded = $deployment->getAttribute('sourceChunksUploaded', 0);
-                    $metadata = $deployment->getAttribute('sourceMetadata', []);
-
-                    if ($uploaded === $chunks) {
-                        $response
-                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-                            ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
-
-                        $completed = true;
-                        return;
-                    }
-                }
-
-                if ($deployment->isEmpty()) {
-                    $deviceForFunctions->prepareUpload($path, $metadata['content_type'] ?? '', $chunks, $metadata);
-
-                    if (!empty($contentRange)) {
-                        $deployment = $dbForProject->createDocument('deployments', new Document([
-                            '$id' => $deploymentId,
-                            '$permissions' => [
-                                Permission::read(Role::any()),
-                                Permission::update(Role::any()),
-                                Permission::delete(Role::any()),
-                            ],
-                            'resourceInternalId' => $function->getSequence(),
-                            'resourceId' => $function->getId(),
-                            'resourceType' => 'functions',
-                            'entrypoint' => $entrypoint,
-                            'buildCommands' => $commands,
-                            'startCommand' => $function->getAttribute('startCommand', ''),
-                            'sourcePath' => $path,
-                            'sourceSize' => $fileSize,
-                            'totalSize' => $fileSize,
-                            'sourceChunksTotal' => $chunks,
-                            'sourceChunksUploaded' => 0,
-                            'activate' => $activate,
-                            'sourceMetadata' => $metadata,
-                            'type' => $type
-                        ]));
-                    }
-                }
-            }, timeout: 120.0);
-        } catch (LockContention) {
-            $response->addHeader('Retry-After', '5');
-            throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED, 'Deployment upload is busy. Try again.');
         }
 
-        if ($completed) {
-            $queueForEvents->reset();
-            return;
-        }
-
-        $chunksUploaded = $deviceForFunctions->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
+        $chunksUploaded = $deviceForFunctions->upload($fileTmpName, $path, $chunk, $chunks, $metadata);
 
         if (empty($chunksUploaded)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
         }
 
-        try {
-            $locks($lockKey, 600, function () use ($activate, &$chunks, $chunksUploaded, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, $functionId, $path, &$metadata, $mergeUploadMetadata, $platform, $project, $publisherForBuilds, $queueForEvents, $response, $type): void {
-                $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-                $uploaded = 0;
+        $type = $request->getHeader('x-sdk-language') === 'cli' ? 'cli' : 'manual';
 
-                if (!$deployment->isEmpty()) {
-                    $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
-                    $uploaded = $deployment->getAttribute('sourceChunksUploaded', 0);
-                    $metadata = $mergeUploadMetadata($deployment->getAttribute('sourceMetadata', []), $metadata);
+        if ($chunksUploaded === $chunks) {
+            if ($activate) {
+                // Remove deploy for all other deployments.
+                $activeDeployments = $dbForProject->find('deployments', [
+                    Query::equal('activate', [true]),
+                    Query::equal('resourceId', [$functionId]),
+                    Query::equal('resourceType', ['functions'])
+                ]);
 
-                    if ($uploaded === $chunks) {
-                        $queueForEvents->reset();
-
-                        $response
-                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-                            ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
-                        return;
-                    }
-                }
-
-                $chunksUploaded = max($uploaded, $chunksUploaded, (int) ($metadata['chunks'] ?? 0));
-
-                if ($chunksUploaded === $chunks && $uploaded < $chunks) {
-                    $deviceForFunctions->finalizeUpload($path, $chunks, $metadata);
-
-                    if ($activate) {
-                        // Remove deploy for all other deployments.
-                        $activeDeployments = $dbForProject->find('deployments', [
-                            Query::equal('activate', [true]),
-                            Query::equal('resourceId', [$functionId]),
-                            Query::equal('resourceType', ['functions'])
-                        ]);
-
-                        foreach ($activeDeployments as $activeDeployment) {
-                            $dbForProject->updateDocument('deployments', $activeDeployment->getId(), new Document([
-                                'activate' => false,
-                            ]));
-                        }
-                    }
-
-                    $fileSize = $deviceForFunctions->getFileSize($path);
-
-                    if ($deployment->isEmpty()) {
-                        $deployment = $dbForProject->createDocument('deployments', new Document([
-                            '$id' => $deploymentId,
-                            '$permissions' => [
-                                Permission::read(Role::any()),
-                                Permission::update(Role::any()),
-                                Permission::delete(Role::any()),
-                            ],
-                            'resourceInternalId' => $function->getSequence(),
-                            'resourceId' => $function->getId(),
-                            'resourceType' => 'functions',
-                            'entrypoint' => $entrypoint,
-                            'buildCommands' => $commands,
-                            'startCommand' => $function->getAttribute('startCommand', ''),
-                            'sourcePath' => $path,
-                            'sourceSize' => $fileSize,
-                            'totalSize' => $fileSize,
-                            'sourceChunksTotal' => $chunks,
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'activate' => $activate,
-                            'sourceMetadata' => $metadata,
-                            'type' => $type
-                        ]));
-
-                    } else {
-                        $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
-                            'sourceSize' => $fileSize,
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'sourceMetadata' => $metadata,
-                        ]));
-                    }
-
-                    // Start the build
-                    $publisherForBuilds->enqueue(new BuildMessage(
-                        project: $project,
-                        resource: $function,
-                        deployment: $deployment,
-                        type: BUILD_TYPE_DEPLOYMENT,
-                        platform: $platform,
-                    ));
-                } else {
-                    $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
-                        'sourceChunksUploaded' => $chunksUploaded,
-                        'sourceMetadata' => $metadata,
+                foreach ($activeDeployments as $activeDeployment) {
+                    $activeDeployment->setAttribute('activate', false);
+                    $dbForProject->updateDocument('deployments', $activeDeployment->getId(), new Document([
+                        'activate' => false,
                     ]));
                 }
+            }
 
-                $metadata = null;
+            $fileSize = $deviceForFunctions->getFileSize($path);
 
-                if ($chunksUploaded === $chunks) {
-                    $queueForEvents
-                        ->setParam('functionId', $function->getId())
-                        ->setParam('deploymentId', $deployment->getId());
-                }
+            if ($deployment->isEmpty()) {
+                $deployment = $dbForProject->createDocument('deployments', new Document([
+                    '$id' => $deploymentId,
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                        Permission::delete(Role::any()),
+                    ],
+                    'resourceInternalId' => $function->getSequence(),
+                    'resourceId' => $function->getId(),
+                    'resourceType' => 'functions',
+                    'entrypoint' => $entrypoint,
+                    'buildCommands' => $commands,
+                    'startCommand' => $function->getAttribute('startCommand', ''),
+                    'sourcePath' => $path,
+                    'sourceSize' => $fileSize,
+                    'totalSize' => $fileSize,
+                    'activate' => $activate,
+                    'sourceMetadata' => $metadata,
+                    'type' => $type
+                ]));
 
-                $response
-                    ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-                    ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
-            }, timeout: 120.0);
-        } catch (LockContention) {
-            $response->addHeader('Retry-After', '5');
-            throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED, 'Deployment upload is busy. Try again.');
+                $function = $dbForProject->updateDocument('functions', $function->getId(), new Document([
+                    'latestDeploymentId' => $deployment->getId(),
+                    'latestDeploymentInternalId' => $deployment->getSequence(),
+                    'latestDeploymentCreatedAt' => $deployment->getCreatedAt(),
+                    'latestDeploymentStatus' => $deployment->getAttribute('status', ''),
+                ]));
+            } else {
+                $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                    'sourceSize' => $fileSize,
+                    'sourceMetadata' => $metadata,
+                ]));
+            }
+
+            // Start the build
+            $queueForBuilds
+                ->setType(BUILD_TYPE_DEPLOYMENT)
+                ->setResource($function)
+                ->setDeployment($deployment);
+        } else {
+            if ($deployment->isEmpty()) {
+                $deployment = $dbForProject->createDocument('deployments', new Document([
+                    '$id' => $deploymentId,
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                        Permission::delete(Role::any()),
+                    ],
+                    'resourceInternalId' => $function->getSequence(),
+                    'resourceId' => $function->getId(),
+                    'resourceType' => 'functions',
+                    'entrypoint' => $entrypoint,
+                    'buildCommands' => $commands,
+                    'startCommand' => $function->getAttribute('startCommand', ''),
+                    'sourcePath' => $path,
+                    'sourceSize' => $fileSize,
+                    'totalSize' => $fileSize,
+                    'sourceChunksTotal' => $chunks,
+                    'sourceChunksUploaded' => $chunksUploaded,
+                    'activate' => $activate,
+                    'sourceMetadata' => $metadata,
+                    'type' => $type
+                ]));
+
+            } else {
+                $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                    'sourceChunksUploaded' => $chunksUploaded,
+                    'sourceMetadata' => $metadata,
+                ]));
+            }
         }
+
+        $metadata = null;
+
+        $queueForEvents
+            ->setParam('functionId', $function->getId())
+            ->setParam('deploymentId', $deployment->getId());
+
+        $response
+            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+            ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -16,6 +16,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
+use Utopia\Mongo\Exception as MongoException;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -94,7 +95,11 @@ class Delete extends Action
             if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
             }
-        } catch (TransactionException) {
+        } catch (MongoException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
+
             $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
 
             if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -2,9 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments\Duplicate;
 
+use Appwrite\Event\Build;
 use Appwrite\Event\Event;
-use Appwrite\Event\Message\Build as BuildMessage;
-use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
@@ -62,10 +61,8 @@ class Create extends Action
             ->inject('response')
             ->inject('dbForProject')
             ->inject('queueForEvents')
-            ->inject('publisherForBuilds')
+            ->inject('queueForBuilds')
             ->inject('deviceForFunctions')
-            ->inject('project')
-            ->inject('platform')
             ->callback($this->action(...));
     }
 
@@ -76,10 +73,8 @@ class Create extends Action
         Response $response,
         Database $dbForProject,
         Event $queueForEvents,
-        BuildPublisher $publisherForBuilds,
-        Device $deviceForFunctions,
-        Document $project,
-        array $platform
+        Build $queueForBuilds,
+        Device $deviceForFunctions
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -120,13 +115,10 @@ class Create extends Action
             'buildLogs' => '',
         ]));
 
-        $publisherForBuilds->enqueue(new BuildMessage(
-            project: $project,
-            resource: $function,
-            deployment: $deployment,
-            type: BUILD_TYPE_DEPLOYMENT,
-            platform: $platform,
-        ));
+        $queueForBuilds
+            ->setType(BUILD_TYPE_DEPLOYMENT)
+            ->setResource($function)
+            ->setDeployment($deployment);
 
         $queueForEvents
             ->setParam('functionId', $function->getId())

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -98,7 +98,11 @@ class Update extends Action
                 'buildDuration' => $duration,
                 'status' => 'canceled'
             ]));
-        } catch (TransactionException) {
+        } catch (TransactionException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
+
             $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
 
             if ($deployment->isEmpty()) {

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -2,11 +2,9 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Functions;
 
+use Appwrite\Event\Build;
 use Appwrite\Event\Event;
-use Appwrite\Event\Message\Build as BuildMessage;
-use Appwrite\Event\Message\Func as FunctionMessage;
-use Appwrite\Event\Publisher\Build as BuildPublisher;
-use Appwrite\Event\Publisher\Func as FunctionPublisher;
+use Appwrite\Event\Func;
 use Appwrite\Event\Realtime;
 use Appwrite\Event\Validator\FunctionEvent;
 use Appwrite\Event\Webhook;
@@ -33,7 +31,6 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Roles;
 use Utopia\Http\Request;
 use Utopia\Platform\Action;
-use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\System\System;
 use Utopia\Validator\ArrayList;
@@ -81,7 +78,7 @@ class Create extends Base
             ))
             ->param('functionId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Function ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
             ->param('name', '', new Text(128), 'Function name. Max length: 128 chars.')
-            ->param('runtime', '', new WhiteList(array_keys(Config::getParam('runtimes')), true), 'Execution runtime.', enum: new Enum(name: 'Runtime'))
+            ->param('runtime', '', new WhiteList(array_keys(Config::getParam('runtimes')), true), 'Execution runtime.')
             ->param('execute', [], new Roles(APP_LIMIT_ARRAY_PARAMS_SIZE), 'An array of role strings with execution permissions. By default no user is granted with any execute permissions. [learn more about roles](https://appwrite.io/docs/permissions#permission-roles). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' roles are allowed, each 64 characters long.', true)
             ->param('events', [], new ArrayList(new FunctionEvent(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Events list. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' events are allowed.', true)
             ->param('schedule', '', new Cron(), 'Schedule CRON syntax.', true)
@@ -90,14 +87,12 @@ class Create extends Base
             ->param('logging', true, new Boolean(), 'When disabled, executions will exclude logs and errors, and will be slightly faster.', true)
             ->param('entrypoint', '', new Text(1028, 0), 'Entrypoint File. This path is relative to the "providerRootDirectory".', true)
             ->param('commands', '', new Text(8192, 0), 'Build Commands.', true)
-            ->param('scopes', [], new ArrayList(new WhiteList(array_keys(Config::getParam('projectScopes')), true), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of scopes allowed for API key auto-generated for every execution. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' scopes are allowed.', true, enum: new Enum(name: 'ProjectKeyScopes'))
+            ->param('scopes', [], new ArrayList(new WhiteList(array_keys(Config::getParam('projectScopes')), true), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of scopes allowed for API key auto-generated for every execution. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' scopes are allowed.', true)
             ->param('installationId', '', new Text(128, 0), 'Appwrite Installation ID for VCS (Version Control System) deployment.', true)
             ->param('providerRepositoryId', '', new Text(128, 0), 'Repository ID of the repo linked to the function.', true)
             ->param('providerBranch', '', new Text(128, 0), 'Production branch for the repo linked to the function.', true)
             ->param('providerSilentMode', false, new Boolean(), 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the function? In silent mode, comments will not be made on commits and pull requests.', true)
             ->param('providerRootDirectory', '', new Text(128, 0), 'Path to function code in the linked repo.', true)
-            ->param('providerBranches', [], new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of branch name patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all branches.', true)
-            ->param('providerPaths', [], new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of file path patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all file changes.', true)
             ->param('buildSpecification', fn (array $plan) => $this->getDefaultSpecification($plan), fn (array $plan) => new Specification(
                 $plan,
                 Config::getParam('specifications', []),
@@ -120,10 +115,10 @@ class Create extends Base
             ->inject('timelimit')
             ->inject('project')
             ->inject('queueForEvents')
-            ->inject('publisherForBuilds')
+            ->inject('queueForBuilds')
             ->inject('queueForRealtime')
             ->inject('queueForWebhooks')
-            ->inject('publisherForFunctions')
+            ->inject('queueForFunctions')
             ->inject('dbForPlatform')
             ->inject('request')
             ->inject('gitHub')
@@ -150,8 +145,6 @@ class Create extends Base
         string $providerBranch,
         bool $providerSilentMode,
         string $providerRootDirectory,
-        array $providerBranches,
-        array $providerPaths,
         string $buildSpecification,
         string $runtimeSpecification,
         string $templateRepository,
@@ -164,10 +157,10 @@ class Create extends Base
         callable $timelimit,
         Document $project,
         Event $queueForEvents,
-        BuildPublisher $publisherForBuilds,
+        Build $queueForBuilds,
         Realtime $queueForRealtime,
         Webhook $queueForWebhooks,
-        FunctionPublisher $publisherForFunctions,
+        Func $queueForFunctions,
         Database $dbForPlatform,
         Request $request,
         GitHub $github,
@@ -257,8 +250,6 @@ class Create extends Base
                 'providerBranch' => $providerBranch,
                 'providerRootDirectory' => $providerRootDirectory,
                 'providerSilentMode' => $providerSilentMode,
-                'providerBranches' => $providerBranches,
-                'providerPaths' => $providerPaths,
                 'buildSpecification' => $buildSpecification,
                 'runtimeSpecification' => $runtimeSpecification,
             ]));
@@ -339,11 +330,10 @@ class Create extends Base
                     project: $project,
                     installation: $installation,
                     dbForProject: $dbForProject,
-                    publisherForBuilds: $publisherForBuilds,
+                    queueForBuilds: $queueForBuilds,
                     template: $template,
                     github: $github,
                     activate: true,
-                    platform: $platform,
                     reference: $providerBranch,
                     referenceType: 'branch'
                 );
@@ -368,18 +358,15 @@ class Create extends Base
                     'activate' => true,
                 ]));
 
-                $publisherForBuilds->enqueue(new BuildMessage(
-                    project: $project,
-                    resource: $function,
-                    deployment: $deployment,
-                    type: BUILD_TYPE_DEPLOYMENT,
-                    template: $template,
-                    platform: $platform,
-                ));
+                $queueForBuilds
+                    ->setType(BUILD_TYPE_DEPLOYMENT)
+                    ->setResource($function)
+                    ->setDeployment($deployment)
+                    ->setTemplate($template);
             }
 
             $functionsDomain = $platform['functionsDomain'];
-            if (!empty($functionsDomain) && isset($deployment) && !$deployment->isEmpty()) {
+            if (!empty($functionsDomain)) {
                 $routeSubdomain = ID::unique();
                 $domain = "{$routeSubdomain}.{$functionsDomain}";
                 // TODO: (@Meldiron) Remove after 1.7.x migration
@@ -395,8 +382,8 @@ class Create extends Base
                         'status' => 'verified',
                         'type' => 'deployment',
                         'trigger' => 'manual',
-                        'deploymentId' => $deployment->getId(),
-                        'deploymentInternalId' => $deployment->getSequence(),
+                        'deploymentId' => !isset($deployment) || $deployment->isEmpty() ? '' : $deployment->getId(),
+                        'deploymentInternalId' => !isset($deployment) || $deployment->isEmpty() ? '' : $deployment->getSequence(),
                         'deploymentResourceType' => 'function',
                         'deploymentResourceId' => $function->getId(),
                         'deploymentResourceInternalId' => $function->getSequence(),
@@ -422,20 +409,14 @@ class Create extends Base
                     ->trigger();
 
                 /** Trigger Functions */
-                $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
-                    event: $ruleCreate->getEvent(),
-                    params: $ruleCreate->getParams(),
-                    project: $ruleCreate->getProject(),
-                    user: $ruleCreate->getUser(),
-                    userId: $ruleCreate->getUserId(),
-                    payload: $ruleCreate->getPayload(),
-                    platform: $ruleCreate->getPlatform(),
-                ));
+                $queueForFunctions
+                    ->from($ruleCreate)
+                    ->trigger();
 
                 /** Trigger Realtime Events */
                 $queueForRealtime
-                    ->setSubscribers(['console', $project->getId()])
                     ->from($ruleCreate)
+                    ->setSubscribers(['console', $project->getId()])
                     ->trigger();
             }
         }

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -4,20 +4,17 @@ namespace Appwrite\Platform\Modules\Functions\Workers;
 
 use Ahc\Jwt\JWT;
 use Appwrite\Event\Event;
-use Appwrite\Event\Message\Func as FunctionMessage;
+use Appwrite\Event\Func;
 use Appwrite\Event\Message\Usage as UsageMessage;
-use Appwrite\Event\Publisher\Func as FunctionPublisher;
-use Appwrite\Event\Publisher\Screenshot;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Event\Realtime;
+use Appwrite\Event\Screenshot;
 use Appwrite\Event\Webhook;
-use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Filter\BranchDomain as BranchDomainFilter;
 use Appwrite\Usage\Context;
 use Appwrite\Utopia\Response\Model\Deployment;
 use Appwrite\Vcs\Comment;
 use Exception;
-use Executor\Exception\Timeout as ExecutorTimeout;
 use Executor\Executor;
 use Swoole\Coroutine as Co;
 use Utopia\Cache\Cache;
@@ -30,7 +27,6 @@ use Utopia\Database\Exception\Conflict;
 use Utopia\Database\Exception\Duplicate;
 use Utopia\Database\Exception\Restricted;
 use Utopia\Database\Exception\Structure;
-use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
 use Utopia\Detector\Detection\Rendering\SSR;
 use Utopia\Detector\Detection\Rendering\XStatic;
@@ -38,7 +34,6 @@ use Utopia\Detector\Detector\Rendering;
 use Utopia\Logger\Log;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
-use Utopia\Span\Span;
 use Utopia\Storage\Device;
 use Utopia\Storage\Device\Local;
 use Utopia\System\System;
@@ -63,9 +58,9 @@ class Builds extends Action
             ->inject('project')
             ->inject('dbForPlatform')
             ->inject('queueForEvents')
-            ->inject('publisherForScreenshots')
+            ->inject('queueForScreenshots')
             ->inject('queueForWebhooks')
-            ->inject('publisherForFunctions')
+            ->inject('queueForFunctions')
             ->inject('queueForRealtime')
             ->inject('usage')
             ->inject('publisherForUsage')
@@ -89,9 +84,9 @@ class Builds extends Action
         Document $project,
         Database $dbForPlatform,
         Event $queueForEvents,
-        Screenshot $publisherForScreenshots,
+        Screenshot $queueForScreenshots,
         Webhook $queueForWebhooks,
-        FunctionPublisher $publisherForFunctions,
+        Func $queueForFunctions,
         Realtime $queueForRealtime,
         Context $usage,
         UsagePublisher $publisherForUsage,
@@ -105,15 +100,15 @@ class Builds extends Action
         Executor $executor,
         array $plan
     ): void {
-        $payload = $message->getPayload();
+        Console::log('Build action started');
+
+        $payload = $message->getPayload() ?? [];
 
         if (empty($payload)) {
             throw new \Exception('Missing payload');
         }
 
         $type = $payload['type'] ?? '';
-        Span::add('build.type', $type);
-
         $resource = new Document($payload['resource'] ?? []);
         $deployment = new Document($payload['deployment'] ?? []);
         $template = new Document($payload['template'] ?? []);
@@ -125,14 +120,15 @@ class Builds extends Action
         switch ($type) {
             case BUILD_TYPE_DEPLOYMENT:
             case BUILD_TYPE_RETRY:
+                Console::info('Creating build for deployment: ' . $deployment->getId());
                 $github = new GitHub($cache);
                 $this->buildDeployment(
                     $deviceForFunctions,
                     $deviceForSites,
                     $deviceForFiles,
-                    $publisherForScreenshots,
+                    $queueForScreenshots,
                     $queueForWebhooks,
-                    $publisherForFunctions,
+                    $queueForFunctions,
                     $queueForRealtime,
                     $queueForEvents,
                     $usage,
@@ -148,8 +144,7 @@ class Builds extends Action
                     $log,
                     $executor,
                     $plan,
-                    $platform,
-                    (int) ($payload['timeout'] ?? System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900))
+                    $platform
                 );
                 break;
 
@@ -166,9 +161,9 @@ class Builds extends Action
         Device $deviceForFunctions,
         Device $deviceForSites,
         Device $deviceForFiles,
-        Screenshot $publisherForScreenshots,
+        Screenshot $queueForScreenshots,
         Webhook $queueForWebhooks,
-        FunctionPublisher $publisherForFunctions,
+        Func $queueForFunctions,
         Realtime $queueForRealtime,
         Event $queueForEvents,
         Context $usage,
@@ -184,14 +179,9 @@ class Builds extends Action
         Log $log,
         Executor $executor,
         array $plan,
-        array $platform,
-        int $timeout
+        array $platform
     ): void {
-        Span::add('project.id', $project->getId());
-        Span::add('resource.id', $resource->getId());
-        Span::add('resource.type', $resource->getCollection());
-        Span::add('deployment.id', $deployment->getId());
-        Span::add('build.timeout', $timeout);
+        Console::info('Deployment action started');
 
         $startTime = DateTime::now();
         $durationStart = \microtime(true);
@@ -214,7 +204,7 @@ class Builds extends Action
             throw new \Exception('Resource not found');
         }
 
-        if ($isResourceBlocked($project, $resource->getCollection() === 'functions' ? RESOURCE_TYPE_FUNCTIONS : RESOURCE_TYPE_SITES, $resource->getId())) {
+        if ($isResourceBlocked($project, $resourceKey === 'functions' ? RESOURCE_TYPE_FUNCTIONS : RESOURCE_TYPE_SITES, $resource->getId())) {
             throw new \Exception('Resource is blocked');
         }
 
@@ -231,12 +221,12 @@ class Builds extends Action
 
         $version = $this->getVersion($resource);
         $runtime = $this->getRuntime($resource, $version);
-        Span::add('build.runtime', $resource->getAttribute($resource->getCollection() === 'sites' ? 'buildRuntime' : 'runtime', ''));
-        Span::add('build.version', $version);
 
         $spec = Config::getParam('specifications')[$resource->getAttribute('buildSpecification', APP_COMPUTE_SPECIFICATION_DEFAULT)];
-        Span::add('build.cpus', (float) ($spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT));
-        Span::add('build.memory', (int) ($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT));
+
+        if ($resource->getCollection() === 'functions' && \is_null($runtime)) {
+            throw new \Exception('Runtime "' . $resource->getAttribute('runtime', '') . '" is not supported');
+        }
 
         // Realtime preparation
         $event = "{$resource->getCollection()}.[{$resourceKey}].deployments.[deploymentId].update";
@@ -249,32 +239,23 @@ class Builds extends Action
 
         if ($deployment->getAttribute('status') === 'canceled') {
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
-            $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+            $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
             return;
         }
 
         $deploymentId = $deployment->getId();
 
-        $updated = $dbForProject->updateDocuments('deployments', new Document([
+        $deployment->setAttribute('buildStartedAt', $startTime);
+        $deployment->setAttribute('status', 'processing');
+        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
             'buildStartedAt' => $startTime,
             'status' => 'processing',
-        ]), [
-            Query::equal('$id', [$deploymentId]),
-            Query::notEqual('status', 'canceled'),
-        ]);
-
-        if ($updated === 0) {
-            $resource = $this->updateLatestDeployment($dbForProject, $resource);
-            $this->finalizeCanceledDeployment($deploymentId, $dbForProject, $queueForRealtime);
-            return;
-        }
-
-        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+        ]));
 
         $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
-        Span::add('deployment.status', 'processing');
+        Console::log('Status marked as processing');
 
         $queueForRealtime
             ->setPayload($deployment->getArrayCopy())
@@ -365,7 +346,7 @@ class Builds extends Action
                         ->setPayload($deployment->getArrayCopy())
                         ->trigger();
 
-                    Span::add('build.source_size', $deployment->getAttribute('sourceSize'));
+                    Console::log('Template cloned');
                 }
             } elseif ($isVcsEnabled) {
                 // VCS and VCS+Temaplte
@@ -398,7 +379,7 @@ class Builds extends Action
                 Console::execute('mkdir -p ' . \escapeshellarg('/tmp/builds/' . $deploymentId), '', $stdout, $stderr);
 
                 if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                    $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                    $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                     return;
                 }
@@ -408,6 +389,8 @@ class Builds extends Action
                 if ($exit !== 0) {
                     throw new \Exception('Unable to clone code repository: ' . $stderr);
                 }
+
+                Console::log('Git repository cloned');
 
                 // Local refactoring for function folder with spaces
                 if (str_contains($rootDirectory, ' ')) {
@@ -452,8 +435,7 @@ class Builds extends Action
                     Console::execute('rsync -av --exclude \'.git\' ' . \escapeshellarg($tmpTemplateDirectory . '/' . $templateRootDirectory . '/') . ' ' . \escapeshellarg($tmpDirectory . '/' . $rootDirectory), '', $stdout, $stderr);
 
                     // Commit and push
-                    $commitMessage = \escapeshellarg('Create ' . $resource->getAttribute('name', '') . ' function');
-                    $exit = Console::execute('git config --global user.email ' . \escapeshellarg(APP_VCS_GITHUB_EMAIL) . ' && git config --global user.name ' . \escapeshellarg(APP_VCS_GITHUB_USERNAME) . ' && cd ' . \escapeshellarg($tmpDirectory) . ' && git checkout -b ' . \escapeshellarg($branchName) . ' && git add . && git commit -m ' . $commitMessage . ' && git push origin ' . \escapeshellarg($branchName), '', $stdout, $stderr);
+                    $exit = Console::execute('git config --global user.email ' . \escapeshellarg(APP_VCS_GITHUB_EMAIL) . ' && git config --global user.name ' . \escapeshellarg(APP_VCS_GITHUB_USERNAME) . ' && cd ' . \escapeshellarg($tmpDirectory) . ' && git checkout -b ' . \escapeshellarg($branchName) . ' && git add . && git commit -m "Create ' . \escapeshellarg($resource->getAttribute('name', '')) . ' function" && git push origin ' . \escapeshellarg($branchName), '', $stdout, $stderr);
 
                     if ($exit !== 0) {
                         throw new \Exception('Unable to push code repository: ' . $stderr);
@@ -467,7 +449,7 @@ class Builds extends Action
 
                     $providerCommitHash = \trim($stdout);
 
-                    $deployment->setAttribute('providerCommitHash', $providerCommitHash);
+                    $deployment->setAttribute('providerCommitHash', $providerCommitHash ?? '');
                     $deployment->setAttribute('providerCommitAuthorUrl', APP_VCS_GITHUB_URL);
                     $deployment->setAttribute('providerCommitAuthor', APP_VCS_GITHUB_USERNAME);
                     $deployment->setAttribute('providerCommitMessage', "Create '" . $resource->getAttribute('name', '') . "' function");
@@ -483,6 +465,8 @@ class Builds extends Action
                     $queueForRealtime
                         ->setPayload($deployment->getArrayCopy())
                         ->trigger();
+
+                    Console::log('Git template pushed');
                 }
 
                 $tmpPath = '/tmp/builds/' . $deploymentId;
@@ -534,26 +518,18 @@ class Builds extends Action
                     ->setPayload($deployment->getArrayCopy())
                     ->trigger();
 
-                Span::add('build.source_size', $deployment->getAttribute('sourceSize'));
+                Console::log('Git source uploaded');
 
                 $this->runGitAction('processing', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
             }
 
+            Console::log('Status marked as building');
+
             /** Request the executor to build the code... */
-            $updated = $dbForProject->updateDocuments('deployments', new Document([
+            $deployment->setAttribute('status', 'building');
+            $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
                 'status' => 'building',
-            ]), [
-                Query::equal('$id', [$deploymentId]),
-                Query::notEqual('status', 'canceled'),
-            ]);
-
-            if ($updated === 0) {
-                $this->finalizeCanceledDeployment($deploymentId, $dbForProject, $queueForRealtime);
-                return;
-            }
-
-            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-            Span::add('deployment.status', 'building');
+            ]));
 
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
@@ -580,15 +556,9 @@ class Builds extends Action
                 ->trigger();
 
             /** Trigger Functions */
-            $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
-                event: $deploymentUpdate->getEvent(),
-                params: $deploymentUpdate->getParams(),
-                project: $deploymentUpdate->getProject(),
-                user: $deploymentUpdate->getUser(),
-                userId: $deploymentUpdate->getUserId(),
-                payload: $deploymentUpdate->getPayload(),
-                platform: $deploymentUpdate->getPlatform(),
-            ));
+            $queueForFunctions
+                ->from($deploymentUpdate)
+                ->trigger();
 
             /** Trigger Realtime Event */
             $queueForRealtime
@@ -619,7 +589,10 @@ class Builds extends Action
 
             $cpus = $spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT;
             $memory = max($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT, $minMemory);
-            $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $timeout, 0);
+            $timeout = (int) System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900);
+
+            $jwtExpiry = (int) System::getEnv('_APP_COMPUTE_BUILD_TIMEOUT', 900);
+            $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', $jwtExpiry, 0);
 
             $apiKey = $jwtObj->encode([
                 'projectId' => $project->getId(),
@@ -653,7 +626,7 @@ class Builds extends Action
                     $vars = [
                         ...$vars,
                         'APPWRITE_FUNCTION_API_ENDPOINT' => $endpoint,
-                        'APPWRITE_FUNCTION_API_KEY' => API_KEY_EPHEMERAL . '_' . $apiKey,
+                        'APPWRITE_FUNCTION_API_KEY' => API_KEY_DYNAMIC . '_' . $apiKey,
                         'APPWRITE_FUNCTION_ID' => $resource->getId(),
                         'APPWRITE_FUNCTION_NAME' => $resource->getAttribute('name'),
                         'APPWRITE_FUNCTION_DEPLOYMENT' => $deployment->getId(),
@@ -668,7 +641,7 @@ class Builds extends Action
                     $vars = [
                         ...$vars,
                         'APPWRITE_SITE_API_ENDPOINT' => $endpoint,
-                        'APPWRITE_SITE_API_KEY' => API_KEY_EPHEMERAL . '_' . $apiKey,
+                        'APPWRITE_SITE_API_KEY' => API_KEY_DYNAMIC . '_' . $apiKey,
                         'APPWRITE_SITE_ID' => $resource->getId(),
                         'APPWRITE_SITE_NAME' => $resource->getAttribute('name'),
                         'APPWRITE_SITE_DEPLOYMENT' => $deployment->getId(),
@@ -686,32 +659,46 @@ class Builds extends Action
                 deployment: $deployment
             );
 
-            $cacheKey = $this->getNodeModulesCacheKey($project, $resource, $runtime, $version, $command);
-
-            Span::add('build.node_modules_cache.enabled', $cacheKey !== '');
-            Span::add('build.node_modules_cache.key', $cacheKey);
-
             $response = null;
             $err = null;
 
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
 
             $isCanceled = false;
-            $span = Span::current();
+
+            Console::log('Runtime creation started');
 
             Co::join([
-                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cacheKey, $cpus, $memory, $timeout, &$err, $version, $span) {
+                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cpus, $memory, $timeout, &$err, $version) {
                     try {
                         if ($version === 'v2') {
                             $command = 'tar -zxf /tmp/code.tar.gz -C /usr/code && cd /usr/local/src/ && ./build.sh';
                         } else {
                             $outputDirectory = $deployment->getAttribute('buildOutput') ?? $resource->getAttribute('outputDirectory');
                             if ($resource->getCollection() === 'sites') {
-                                $command = $this->prepareSiteBuildCommand($command, $outputDirectory ?? '');
+                                $listFilesCommand = '';
+
+                                // Start separation, enter build folder
+                                $listFilesCommand .= 'echo "{APPWRITE_DETECTION_SEPARATOR_START}" && cd /usr/local/build';
+
+                                // Enter output directory, if set
+                                if (! empty($outputDirectory)) {
+                                    $listFilesCommand .= ' && cd ' . \escapeshellarg($outputDirectory);
+                                }
+
+                                // Print files, and end separation
+                                $listFilesCommand .= ' && find . -name \'node_modules\' -prune -o -type f -print && echo "{APPWRITE_DETECTION_SEPARATOR_END}"';
+
+                                // Use SSR file listing
+                                if (empty($command)) {
+                                    $command = $listFilesCommand;
+                                } else {
+                                    $command .= ' && ' . $listFilesCommand;
+                                }
                             }
 
                             $command = 'tar -zxf /tmp/code.tar.gz -C /mnt/code && helpers/build.sh ' . \trim(\escapeshellarg($command));
@@ -731,22 +718,16 @@ class Builds extends Action
                             destination: APP_STORAGE_BUILDS . "/app-{$project->getId()}",
                             variables: $vars,
                             command: $command,
-                            outputDirectory: $outputDirectory ?? '',
-                            cacheKey: $cacheKey
+                            outputDirectory: $outputDirectory ?? ''
                         );
 
-                    } catch (ExecutorTimeout $error) {
-                        $span?->set('build.runtime.timed_out', true);
-                        $span?->set('build.runtime.error_type', $error::class);
-                        $span?->set('build.runtime.error_message', $error->getMessage());
-                        $err = new AppwriteException(AppwriteException::BUILD_TIMEOUT, previous: $error);
+                        Console::log('createRuntime finished');
                     } catch (\Throwable $error) {
-                        $span?->set('build.runtime.error_type', $error::class);
-                        $span?->set('build.runtime.error_message', $error->getMessage());
+                        Console::warning('createRuntime failed');
                         $err = $error;
                     }
                 }),
-                Co\go(function () use ($executor, $project, &$deployment, &$response, $dbForProject, $timeout, &$err, $queueForRealtime, &$isCanceled, $span) {
+                Co\go(function () use ($executor, $project, &$deployment, &$response, $dbForProject, $timeout, &$err, $queueForRealtime, &$isCanceled) {
                     try {
                         $insideSeparation = false;
 
@@ -754,7 +735,7 @@ class Builds extends Action
                             deploymentId: $deployment->getId(),
                             projectId: $project->getId(),
                             timeout: $timeout,
-                            callback: function ($logs) use (&$response, &$err, $dbForProject, &$isCanceled, &$deployment, $queueForRealtime, &$insideSeparation, $span) {
+                            callback: function ($logs) use (&$response, &$err, $dbForProject, &$isCanceled, &$deployment, $queueForRealtime, &$insideSeparation) {
                                 if ($isCanceled) {
                                     return;
                                 }
@@ -765,7 +746,7 @@ class Builds extends Action
 
                                     if ($deployment->getAttribute('status') === 'canceled') {
                                         $isCanceled = true;
-                                        $span?->set('build.logs.ignored_reason', 'canceled');
+                                        Console::info('Ignoring realtime logs because build has been canceled');
 
                                         return;
                                     }
@@ -813,10 +794,6 @@ class Builds extends Action
                                         $streamLog = \str_replace('{APPWRITE_LINEBREAK_PLACEHOLDER}', "\n", $streamLog);
                                         $streamParts = \explode(' ', $streamLog, 2);
 
-                                        if (! isset($streamParts[1])) {
-                                            continue;
-                                        }
-
                                         // TODO: use part[0] as timestamp when switching to dbForLogs for build logs
                                         $currentLogs .= $streamParts[1];
 
@@ -838,10 +815,9 @@ class Builds extends Action
                                 }
                             }
                         );
-                        $span?->set('build.logs.finished', true);
+                        Console::warning('listLogs finished');
                     } catch (\Throwable $error) {
-                        $span?->set('build.logs.error_type', $error::class);
-                        $span?->set('build.logs.error_message', $error->getMessage());
+                        Console::warning('listLogs failed');
                         if (empty($err)) {
                             $err = $error;
                         }
@@ -849,9 +825,10 @@ class Builds extends Action
                 }),
             ]);
 
-            $latestDeployment = $dbForProject->getDocument('deployments', $deploymentId);
-            if ($latestDeployment->getAttribute('status') === 'canceled') {
-                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+            Console::log('Runtime creation finished');
+
+            if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
+                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
@@ -871,21 +848,37 @@ class Builds extends Action
             $deployment->setAttribute('buildPath', $response['path']);
             $deployment->setAttribute('buildSize', $response['size']);
             $deployment->setAttribute('totalSize', $deployment->getAttribute('buildSize', 0) + $deployment->getAttribute('sourceSize', 0));
-            Span::add('build.size', $deployment->getAttribute('buildSize'));
-            Span::add('build.total_size', $deployment->getAttribute('totalSize'));
 
             $logs = '';
             foreach ($response['output'] as $log) {
                 $logs .= $log['content'];
             }
 
-            ['logs' => $logs, 'detectionLogs' => $detectionLogs] = $this->splitSiteDetectionLogs($logs);
+            // Separate logs for SSR detection
+            $detectionLogs = '';
+            if (\str_contains($logs, '{APPWRITE_DETECTION_SEPARATOR_START}')) {
+                [$logsBefore, $detectionLogsStart] = \explode('{APPWRITE_DETECTION_SEPARATOR_START}', $logs, 2);
+                [$detectionLogs, $logsAfter] = \explode('{APPWRITE_DETECTION_SEPARATOR_END}', $detectionLogsStart, 2);
+                $logs = ($logsBefore ?? '') . ($logsAfter ?? '');
+            }
 
             $deployment->setAttribute('buildLogs', $logs);
 
             $adapter = null;
             if ($resource->getCollection() === 'sites' && ! empty($detectionLogs)) {
-                $detection = $this->detectSiteRendering($resource->getAttribute('framework', ''), $detectionLogs);
+                $files = \explode("\n", $detectionLogs); // Parse output
+                $files = \array_filter($files); // Remove empty
+                $files = \array_map(fn ($file) => \trim($file), $files); // Remove whitepsaces
+                $files = \array_map(fn ($file) => \str_starts_with($file, './') ? \substr($file, 2) : $file, $files); // Remove beginning ./
+
+                $detector = new Rendering($resource->getAttribute('framework', ''));
+                foreach ($files as $file) {
+                    $detector->addInput($file);
+                }
+                $detector
+                    ->addOption(new SSR())
+                    ->addOption(new XStatic());
+                $detection = $detector->detect();
 
                 $adapter = $resource->getAttribute('adapter', '');
                 if (empty($adapter)) {
@@ -893,8 +886,8 @@ class Builds extends Action
 
                     $deployment->setAttribute('adapter', $detection->getName());
                     $deployment->setAttribute('fallbackFile', $detection->getFallbackFile() ?? '');
-                    Span::add('build.adapter', $deployment->getAttribute('adapter'));
-                    Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
+
+                    Console::log('Adapter detected');
                 } elseif ($adapter === 'ssr' && $detection->getName() === 'static') {
                     throw new \Exception('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
                 }
@@ -911,6 +904,8 @@ class Builds extends Action
             $queueForRealtime
                 ->setPayload($deployment->getArrayCopy())
                 ->trigger();
+
+            Console::log('Build details stored');
 
             $this->afterBuildSuccess($queueForRealtime, $dbForProject, $deployment, $runtime, $adapter);
 
@@ -931,10 +926,8 @@ class Builds extends Action
                 'buildLogs' => $deployment->getAttribute('buildLogs'),
                 'status' => 'ready',
             ]));
-            Span::add('deployment.status', 'ready');
-            Span::add('build.duration', $deployment->getAttribute('buildDuration'));
 
-            $resource = $this->updateLatestDeployment($dbForProject, $resource);
+            Console::log('Status marked as ready');
 
             if ($isVcsEnabled) {
                 $this->runGitAction('ready', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
@@ -956,7 +949,7 @@ class Builds extends Action
                         if ($currentActiveStartTime < $deploymentStartTime) {
                             $activateBuild = true;
                         } else {
-                            Span::add('build.auto_activation.skipped_reason', 'current_deployment_newer');
+                            Console::info('Skipping auto-activation as current deployment is more recent');
                         }
                     }
                 } else {
@@ -1018,7 +1011,7 @@ class Builds extends Action
                         break;
                 }
 
-                Span::add('build.activated', true);
+                Console::log('Deployment activated');
             }
 
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
@@ -1088,7 +1081,7 @@ class Builds extends Action
                         ]));
                     }, $queries);
 
-                    Span::add('build.preview_rule_created', true);
+                    Console::log('Preview rule created');
                 }
             }
 
@@ -1097,10 +1090,12 @@ class Builds extends Action
                 ->trigger();
 
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
+
+            Console::log('Build duration updated');
 
             /** Update function schedule */
 
@@ -1120,25 +1115,27 @@ class Builds extends Action
 
             /** Screenshot site */
             if ($resource->getCollection() === 'sites') {
-                $publisherForScreenshots->enqueue(new \Appwrite\Event\Message\Screenshot(
-                    project: $project,
-                    deploymentId: $deployment->getId(),
-                ));
+                $queueForScreenshots
+                    ->setDeploymentId($deployment->getId())
+                    ->setProject($project)
+                    ->trigger();
 
-                Span::add('build.screenshot_queued', true);
+                Console::log('Site screenshot queued');
             }
+
+            Console::info('Deployment action finished');
         } catch (\Throwable $th) {
+            Console::warning('Build failed:');
+            Console::error($th->getMessage());
+            Console::error($th->getFile());
+            Console::error($th->getLine());
+            Console::error($th->getTraceAsString());
+
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
-
-            Span::add('build.error.stage', 'deployment');
-            Span::add('build.error.type', $th::class);
-            Span::add('build.error.message', $th->getMessage());
-            Span::add('build.error.file', $th->getFile());
-            Span::add('build.error.line', $th->getLine());
 
             // Color message red
             $message = $th->getMessage();
@@ -1149,11 +1146,13 @@ class Builds extends Action
             $message = \str_replace('{APPWRITE_DETECTION_SEPARATOR_START}', '', $message);
             $message = \str_replace('{APPWRITE_DETECTION_SEPARATOR_END}', '', $message);
 
-            // Append error to whatever build logs were already streamed
-            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-            $previousLogs = $deployment->getAttribute('buildLogs', '');
-            if (! empty($previousLogs)) {
-                $message = $previousLogs . "\n" . $message;
+            // Combine with previous logs if deployment got past build process
+            $previousLogs = '';
+            if (! is_null($deployment->getAttribute('buildSize', null))) {
+                $previousLogs = $deployment->getAttribute('buildLogs', '');
+                if (! empty($previousLogs)) {
+                    $message = $previousLogs . "\n" . $message;
+                }
             }
 
             $endTime = DateTime::now();
@@ -1161,8 +1160,6 @@ class Builds extends Action
             $deployment->setAttribute('buildEndedAt', $endTime);
             $deployment->setAttribute('buildDuration', \intval(\ceil($durationEnd - $durationStart)));
             $deployment->setAttribute('status', 'failed');
-            Span::add('deployment.status', 'failed');
-            Span::add('build.duration', $deployment->getAttribute('buildDuration'));
 
             $deployment->setAttribute('buildLogs', $message);
             $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
@@ -1179,7 +1176,7 @@ class Builds extends Action
                 ->trigger();
 
             if ($isVcsEnabled) {
-                $this->runGitAction('failed', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform, true);
+                $this->runGitAction('failed', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
             }
         } finally {
             $queueForRealtime
@@ -1199,8 +1196,6 @@ class Builds extends Action
     protected function sendUsage(Document $resource, Document $deployment, Document $project, Context $usage, UsagePublisher $publisherForUsage): void
     {
         $spec = Config::getParam('specifications')[$resource->getAttribute('buildSpecification', APP_COMPUTE_SPECIFICATION_DEFAULT)];
-        $cpus = (int) ($spec['cpus'] ?? APP_COMPUTE_CPUS_DEFAULT);
-        $memory = (int) ($spec['memory'] ?? APP_COMPUTE_MEMORY_DEFAULT);
 
         switch ($deployment->getAttribute('status')) {
             case 'ready':
@@ -1256,6 +1251,21 @@ class Builds extends Action
      */
     protected function afterBuildSuccess(Realtime $queueForRealtime, Database $dbForProject, Document &$deployment, array $runtime, ?string $adapter): void
     {
+        if (! ($queueForRealtime instanceof Realtime)) {
+            throw new Exception('queueForRealtime must be an instance of Realtime');
+        }
+        if (! ($dbForProject instanceof Database)) {
+            throw new Exception('dbForProject must be an instance of Database');
+        }
+        if (! ($deployment instanceof Document)) {
+            throw new Exception('deployment must be an instance of Document');
+        }
+        if (! is_array($runtime)) {
+            throw new Exception('runtime must be an array');
+        }
+        if (! is_string($adapter) && ! is_null($adapter)) {
+            throw new Exception('adapter must be a string or null');
+        }
     }
 
     /**
@@ -1265,6 +1275,13 @@ class Builds extends Action
         Document $project,
         Document $deployment,
     ): void {
+        if (! ($project instanceof Document)) {
+            throw new Exception('project must be an instance of Document');
+        }
+
+        if (! ($deployment instanceof Document)) {
+            throw new Exception('deployment must be an instance of Document');
+        }
     }
 
     protected function getRuntime(Document $resource, string $version): array
@@ -1288,7 +1305,6 @@ class Builds extends Action
         return match ($resource->getCollection()) {
             'functions' => $resource->getAttribute('version', 'v2'),
             'sites' => 'v5',
-            default => throw new \Exception('Unsupported resource type "' . $resource->getCollection() . '".'),
         };
     }
 
@@ -1321,79 +1337,6 @@ class Builds extends Action
         return '';
     }
 
-    protected function getNodeModulesCacheKey(Document $project, Document $resource, array $runtime, string $version, string $command): string
-    {
-        if ($version !== 'v5' || $command === '' || $command === '0') {
-            return '';
-        }
-
-        $hashContext = [
-            'version' => 'v1',
-            'projectId' => $project->getId(),
-            'resourceType' => $resource->getCollection(),
-            'resourceId' => $resource->getId(),
-            'runtime' => $runtime['image'] ?? '',
-        ];
-
-        return \substr(\hash('sha256', \json_encode($hashContext, JSON_THROW_ON_ERROR)), 0, 48);
-    }
-
-    protected function prepareSiteBuildCommand(string $command, string $outputDirectory): string
-    {
-        $listFilesCommand = 'echo "{APPWRITE_DETECTION_SEPARATOR_START}" && cd /usr/local/build';
-
-        if (! empty($outputDirectory)) {
-            $listFilesCommand .= ' && cd ' . \escapeshellarg($outputDirectory);
-        }
-
-        $listFilesCommand .= ' && find . -name \'node_modules\' -prune -o -type f -print && echo "{APPWRITE_DETECTION_SEPARATOR_END}"';
-
-        if (empty($command)) {
-            return $listFilesCommand;
-        }
-
-        return "{$command} && {$listFilesCommand}";
-    }
-
-    /**
-     * @return array{logs: string, detectionLogs: string}
-     */
-    protected function splitSiteDetectionLogs(string $logs): array
-    {
-        if (! \str_contains($logs, '{APPWRITE_DETECTION_SEPARATOR_START}')) {
-            return [
-                'logs' => $logs,
-                'detectionLogs' => '',
-            ];
-        }
-
-        [$logsBefore, $detectionLogsStart] = \explode('{APPWRITE_DETECTION_SEPARATOR_START}', $logs, 2);
-        [$detectionLogs, $logsAfter] = \explode('{APPWRITE_DETECTION_SEPARATOR_END}', $detectionLogsStart, 2);
-
-        return [
-            'logs' => "{$logsBefore}{$logsAfter}",
-            'detectionLogs' => $detectionLogs,
-        ];
-    }
-
-    protected function detectSiteRendering(string $framework, string $detectionLogs): object
-    {
-        $files = \explode("\n", $detectionLogs);
-        $files = \array_filter($files);
-        $files = \array_map(\trim(...), $files);
-        $files = \array_map(fn ($file) => \str_starts_with($file, './') ? \substr($file, 2) : $file, $files);
-
-        $detector = new Rendering($framework);
-        foreach ($files as $file) {
-            $detector->addInput($file);
-        }
-
-        return $detector
-            ->addOption(new SSR())
-            ->addOption(new XStatic())
-            ->detect();
-    }
-
     /**
      * @throws Structure
      * @throws \Utopia\Database\Exception
@@ -1412,11 +1355,8 @@ class Builds extends Action
         Database $dbForProject,
         Database $dbForPlatform,
         Realtime $queueForRealtime,
-        array $platform,
-        bool $secondaryError = false
+        array $platform
     ): void {
-        $deployment = new Document();
-
         try {
             if ($resource->getAttribute('providerSilentMode', false) === true) {
                 return;
@@ -1495,10 +1435,11 @@ class Builds extends Action
                     ]);
 
                     $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') == 'disabled' ? 'http' : 'https';
-                    $previewUrl = '';
-                    if ($resource->getCollection() === 'sites' && !$rule->isEmpty()) {
-                        $previewUrl = "{$protocol}://" . $rule->getAttribute('domain', '');
-                    }
+                    $previewUrl = match ($resource->getCollection()) {
+                        'functions' => '',
+                        'sites' => ! empty($rule) ? ("{$protocol}://" . $rule->getAttribute('domain', '')) : '',
+                        default => throw new \Exception('Invalid resource type')
+                    };
 
                     $comment = new Comment($platform);
                     $comment->parseComment($github->getComment($owner, $repositoryName, $commentId));
@@ -1509,14 +1450,9 @@ class Builds extends Action
                 }
             }
         } catch (\Throwable $th) {
-            $span = Span::current();
-            $errorPrefix = $secondaryError ? 'build.error.secondary' : 'build.git_action.error';
-            $span?->set("{$errorPrefix}.stage", 'git_action');
-            $span?->set("{$errorPrefix}.status", $status);
-            $span?->set("{$errorPrefix}.type", $th::class);
-            $span?->set("{$errorPrefix}.message", $th->getMessage());
-            $span?->set("{$errorPrefix}.file", $th->getFile());
-            $span?->set("{$errorPrefix}.line", $th->getLine());
+            Console::warning('Git action failed:');
+            Console::warning($th->getMessage());
+            Console::warning($th->getTraceAsString());
 
             $logs = $deployment->getAttribute('buildLogs', '');
             $date = \date('H:i:s');
@@ -1555,39 +1491,33 @@ class Builds extends Action
                 'latestDeploymentStatus' => $latestDeployment->getAttribute('status', ''),
             ];
 
-        return $dbForProject->updateDocument(
-            $resource->getCollection(),
-            $resource->getId(),
-            new Document($updates)
-        );
-    }
-
-    private function finalizeCanceledDeployment(string $deploymentId, Database $dbForProject, Realtime $queueForRealtime)
-    {
-        Span::add('deployment.status', 'canceled');
-
-        $attempts = 0;
-
-        while (true) {
-            try {
-                $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-
-                $logs = $deployment->getAttribute('buildLogs', '');
-                $date = \date('H:i:s');
-                $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
-
-                $deployment->setAttribute('buildLogs', $logs);
-                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
-                    'buildLogs' => $deployment->getAttribute('buildLogs'),
-                ]));
-
-                break;
-            } catch (TransactionException $exception) {
-                if (++$attempts >= 5) {
-                    throw $exception;
-                }
+        foreach ($updates as $key => $value) {
+            if ($resource->getAttribute($key, '') !== $value) {
+                return $dbForProject->updateDocument(
+                    $resource->getCollection(),
+                    $resource->getId(),
+                    new Document($updates)
+                );
             }
         }
+
+        return $resource;
+    }
+
+    private function cancelDeployment(string $deploymentId, Database $dbForProject, Realtime $queueForRealtime)
+    {
+        Console::info('Build has been canceled');
+
+        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+
+        $logs = $deployment->getAttribute('buildLogs', '');
+        $date = \date('H:i:s');
+        $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
+
+        $deployment->setAttribute('buildLogs', $logs);
+        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+            'buildLogs' => $deployment->getAttribute('buildLogs'),
+        ]));
 
         $queueForRealtime
             ->setPayload($deployment->getArrayCopy())

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -2,9 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments;
 
+use Appwrite\Event\Build;
 use Appwrite\Event\Event;
-use Appwrite\Event\Message\Build as BuildMessage;
-use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
@@ -21,7 +20,6 @@ use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Request;
-use Utopia\Lock\Exception\Contention as LockContention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -87,11 +85,10 @@ class Create extends Action
             ->inject('queueForEvents')
             ->inject('deviceForSites')
             ->inject('deviceForLocal')
-            ->inject('publisherForBuilds')
+            ->inject('queueForBuilds')
             ->inject('plan')
             ->inject('authorization')
             ->inject('platform')
-            ->inject('locks')
             ->callback($this->action(...));
     }
 
@@ -110,11 +107,10 @@ class Create extends Action
         Event $queueForEvents,
         Device $deviceForSites,
         Device $deviceForLocal,
-        BuildPublisher $publisherForBuilds,
+        Build $queueForBuilds,
         array $plan,
         Authorization $authorization,
         array $platform,
-        callable $locks,
     ) {
         $activate = \strval($activate) === 'true' || \strval($activate) === '1';
 
@@ -166,7 +162,7 @@ class Create extends Action
             throw new Exception(Exception::STORAGE_FILE_TYPE_UNSUPPORTED);
         }
 
-        $contentRange = $request->getHeaderLine('content-range');
+        $contentRange = $request->getHeader('content-range');
         $deploymentId = ID::unique();
         $chunk = 1;
         $chunks = 1;
@@ -175,14 +171,21 @@ class Create extends Action
             $start = $request->getContentRangeStart();
             $end = $request->getContentRangeEnd();
             $fileSize = $request->getContentRangeSize();
-            $deploymentId = $request->getHeaderLine('x-appwrite-id', $deploymentId);
+            $deploymentId = $request->getHeader('x-appwrite-id', $deploymentId);
             // TODO make `end >= $fileSize` in next breaking version
             if (is_null($start) || is_null($end) || is_null($fileSize) || $end > $fileSize) {
                 throw new Exception(Exception::STORAGE_INVALID_CONTENT_RANGE);
             }
 
-            $chunks = (int) ceil($fileSize / APP_LIMIT_UPLOAD_CHUNK_SIZE);
-            $chunk = (int) ($start / APP_LIMIT_UPLOAD_CHUNK_SIZE) + 1;
+            // TODO remove the condition that checks `$end === $fileSize` in next breaking version
+            if ($end === $fileSize - 1 || $end === $fileSize) {
+                //if it's a last chunks the chunk size might differ, so we set the $chunks and $chunk to notify it's last chunk
+                $chunks = $chunk = -1;
+            } else {
+                // Calculate total number of chunks based on the chunk size i.e ($rangeEnd - $rangeStart)
+                $chunks = (int) ceil($fileSize / ($end + 1 - $start));
+                $chunk = (int) ($start / ($end + 1 - $start)) + 1;
+            }
         }
 
         if (!$fileSizeValidator->isValid($fileSize) && $siteSizeLimit !== 0) { // Check if file size is exceeding allowed limit
@@ -196,30 +199,24 @@ class Create extends Action
         // Save to storage
         $fileSize ??= $deviceForLocal->getFileSize($fileTmpName);
         $path = $deviceForSites->getPath($deploymentId . '.' . \pathinfo($fileName, PATHINFO_EXTENSION));
-
-        $lockKey = 'sites:deployment:' . $project->getId() . ':' . $siteId . ':' . $deploymentId;
+        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
         $metadata = ['content_type' => $deviceForLocal->getFileMimeType($fileTmpName)];
-        $completed = false;
-
-        $mergeUploadMetadata = function (array $stored, array $current): array {
-            $merged = \array_merge($stored, $current);
-
-            if (isset($stored['parts']) || isset($current['parts'])) {
-                $parts = $stored['parts'] ?? [];
-                foreach (($current['parts'] ?? []) as $part => $value) {
-                    $parts[(int) $part] = $value;
-                }
-                \ksort($parts);
-
-                $merged['parts'] = $parts;
-                $merged['chunks'] = \count($parts);
+        if (!$deployment->isEmpty()) {
+            $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
+            $metadata = $deployment->getAttribute('sourceMetadata', []);
+            if ($chunk === -1) {
+                $chunk = $chunks;
             }
+        }
 
-            return $merged;
-        };
+        $chunksUploaded = $deviceForSites->upload($fileTmpName, $path, $chunk, $chunks, $metadata);
 
-        $type = $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual';
+        if (empty($chunksUploaded)) {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
+        }
+
+        $type = $request->getHeader('x-sdk-language') === 'cli' ? 'cli' : 'manual';
 
         $commands = [];
         if (!empty($installCommand)) {
@@ -229,231 +226,154 @@ class Create extends Action
             $commands[] = $buildCommand;
         }
 
-        try {
-            $locks($lockKey, 600, function () use ($activate, $authorization, &$chunks, $commands, $contentRange, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $outputDirectory, $path, $platform, $project, &$site, $type, &$completed, $response): void {
-                $deployment = $dbForProject->getDocument('deployments', $deploymentId);
+        if ($chunksUploaded === $chunks) {
+            if ($activate) {
+                // Remove deploy for all other deployments.
+                $activeDeployments = $dbForProject->find('deployments', [
+                    Query::equal('activate', [true]),
+                    Query::equal('resourceId', [$siteId]),
+                    Query::equal('resourceType', ['sites'])
+                ]);
 
-                if (!$deployment->isEmpty()) {
-                    $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
-                    $uploaded = $deployment->getAttribute('sourceChunksUploaded', 0);
-                    $metadata = $deployment->getAttribute('sourceMetadata', []);
-
-                    if ($uploaded === $chunks) {
-                        $response
-                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-                            ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
-
-                        $completed = true;
-                        return;
-                    }
+                foreach ($activeDeployments as $activeDeployment) {
+                    $activeDeployment->setAttribute('activate', false);
+                    $dbForProject->updateDocument('deployments', $activeDeployment->getId(), new Document(['activate' => false]));
                 }
+            }
 
-                if ($deployment->isEmpty()) {
-                    $deviceForSites->prepareUpload($path, $metadata['content_type'] ?? '', $chunks, $metadata);
+            $fileSize = $deviceForSites->getFileSize($path);
 
-                    if (!empty($contentRange)) {
-                        $deployment = $dbForProject->createDocument('deployments', new Document([
-                            '$id' => $deploymentId,
-                            '$permissions' => [
-                                Permission::read(Role::any()),
-                                Permission::update(Role::any()),
-                                Permission::delete(Role::any()),
-                            ],
-                            'resourceInternalId' => $site->getSequence(),
-                            'resourceId' => $site->getId(),
-                            'resourceType' => 'sites',
-                            'buildCommands' => \implode(' && ', $commands),
-                            'startCommand' => $site->getAttribute('startCommand', ''),
-                            'buildOutput' => $outputDirectory,
-                            'adapter' => $site->getAttribute('adapter', ''),
-                            'fallbackFile' => $site->getAttribute('fallbackFile', ''),
-                            'sourcePath' => $path,
-                            'sourceSize' => $fileSize,
-                            'totalSize' => $fileSize,
-                            'sourceChunksTotal' => $chunks,
-                            'sourceChunksUploaded' => 0,
-                            'activate' => $activate,
-                            'sourceMetadata' => $metadata,
-                            'type' => $type,
-                        ]));
+            if ($deployment->isEmpty()) {
+                $deployment = $dbForProject->createDocument('deployments', new Document([
+                    '$id' => $deploymentId,
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                        Permission::delete(Role::any()),
+                    ],
+                    'resourceInternalId' => $site->getSequence(),
+                    'resourceId' => $site->getId(),
+                    'resourceType' => 'sites',
+                    'buildCommands' => \implode(' && ', $commands),
+                    'startCommand' => $site->getAttribute('startCommand', ''),
+                    'buildOutput' => $outputDirectory,
+                    'adapter' => $site->getAttribute('adapter', ''),
+                    'fallbackFile' => $site->getAttribute('fallbackFile', ''),
+                    'sourcePath' => $path,
+                    'sourceSize' => $fileSize,
+                    'totalSize' => $fileSize,
+                    'activate' => $activate,
+                    'sourceMetadata' => $metadata,
+                    'type' => $type,
+                ]));
 
-                        $sitesDomain = $platform['sitesDomain'];
-                        $domain = ID::unique() . "." . $sitesDomain;
+                $sitesDomain = $platform['sitesDomain'];
+                $domain = ID::unique() . "." . $sitesDomain;
 
-                        // TODO: (@Meldiron) Remove after 1.7.x migration
-                        $isMd5 = System::getEnv('_APP_RULES_FORMAT') === 'md5';
-                        $ruleId = $isMd5 ? md5($domain) : ID::unique();
+                // TODO: (@Meldiron) Remove after 1.7.x migration
+                $isMd5 = System::getEnv('_APP_RULES_FORMAT') === 'md5';
+                $ruleId = $isMd5 ? md5($domain) : ID::unique();
 
-                        $authorization->skip(
-                            fn () => $dbForPlatform->createDocument('rules', new Document([
-                                '$id' => $ruleId,
-                                'projectId' => $project->getId(),
-                                'projectInternalId' => $project->getSequence(),
-                                'domain' => $domain,
-                                'type' => 'deployment',
-                                'trigger' => 'deployment',
-                                'deploymentId' => $deployment->isEmpty() ? '' : $deployment->getId(),
-                                'deploymentInternalId' => $deployment->isEmpty() ? '' : $deployment->getSequence(),
-                                'deploymentResourceType' => 'site',
-                                'deploymentResourceId' => $site->getId(),
-                                'deploymentResourceInternalId' => $site->getSequence(),
-                                'status' => 'verified',
-                                'certificateId' => '',
-                                'search' => implode(' ', [$ruleId, $domain]),
-                                'owner' => 'Appwrite',
-                                'region' => $project->getAttribute('region')
-                            ]))
-                        );
-                    }
-                }
-            }, timeout: 120.0);
-        } catch (LockContention) {
-            $response->addHeader('Retry-After', '5');
-            throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED, 'Deployment upload is busy. Try again.');
+                $authorization->skip(
+                    fn () => $dbForPlatform->createDocument('rules', new Document([
+                        '$id' => $ruleId,
+                        'projectId' => $project->getId(),
+                        'projectInternalId' => $project->getSequence(),
+                        'domain' => $domain,
+                        'type' => 'deployment',
+                        'trigger' => 'deployment',
+                        'deploymentId' => $deployment->isEmpty() ? '' : $deployment->getId(),
+                        'deploymentInternalId' => $deployment->isEmpty() ? '' : $deployment->getSequence(),
+                        'deploymentResourceType' => 'site',
+                        'deploymentResourceId' => $site->getId(),
+                        'deploymentResourceInternalId' => $site->getSequence(),
+                        'status' => 'verified',
+                        'certificateId' => '',
+                        'search' => implode(' ', [$ruleId, $domain]),
+                        'owner' => 'Appwrite',
+                        'region' => $project->getAttribute('region')
+                    ]))
+                );
+            } else {
+                $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                    'sourceSize' => $fileSize,
+                    'sourceMetadata' => $metadata,
+                ]));
+            }
+
+            // Start the build
+            $queueForBuilds
+                ->setType(BUILD_TYPE_DEPLOYMENT)
+                ->setResource($site)
+                ->setDeployment($deployment);
+        } else {
+            if ($deployment->isEmpty()) {
+                $deployment = $dbForProject->createDocument('deployments', new Document([
+                    '$id' => $deploymentId,
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                        Permission::delete(Role::any()),
+                    ],
+                    'resourceInternalId' => $site->getSequence(),
+                    'resourceId' => $site->getId(),
+                    'resourceType' => 'sites',
+                    'buildCommands' => \implode(' && ', $commands),
+                    'startCommand' => $site->getAttribute('startCommand', ''),
+                    'buildOutput' => $outputDirectory,
+                    'adapter' => $site->getAttribute('adapter', ''),
+                    'fallbackFile' => $site->getAttribute('fallbackFile', ''),
+                    'sourcePath' => $path,
+                    'sourceSize' => $fileSize,
+                    'totalSize' => $fileSize,
+                    'sourceChunksTotal' => $chunks,
+                    'sourceChunksUploaded' => $chunksUploaded,
+                    'activate' => $activate,
+                    'sourceMetadata' => $metadata,
+                    'type' => $type,
+                ]));
+
+                $sitesDomain = $platform['sitesDomain'];
+                $domain = ID::unique() . "." . $sitesDomain;
+                $ruleId = md5($domain);
+                $authorization->skip(
+                    fn () => $dbForPlatform->createDocument('rules', new Document([
+                        '$id' => $ruleId,
+                        'projectId' => $project->getId(),
+                        'projectInternalId' => $project->getSequence(),
+                        'domain' => $domain,
+                        'type' => 'deployment',
+                        'trigger' => 'deployment',
+                        'deploymentId' => $deployment->isEmpty() ? '' : $deployment->getId(),
+                        'deploymentInternalId' => $deployment->isEmpty() ? '' : $deployment->getSequence(),
+                        'deploymentResourceType' => 'site',
+                        'deploymentResourceId' => $site->getId(),
+                        'deploymentResourceInternalId' => $site->getSequence(),
+                        'status' => 'verified',
+                        'certificateId' => '',
+                        'search' => implode(' ', [$ruleId, $domain]),
+                        'owner' => 'Appwrite',
+                        'region' => $project->getAttribute('region')
+                    ]))
+                );
+            } else {
+                $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                    'sourceChunksUploaded' => $chunksUploaded,
+                    'sourceMetadata' => $metadata,
+                ]));
+            }
         }
 
-        if ($completed) {
-            $queueForEvents->reset();
-            return;
-        }
 
-        $chunksUploaded = $deviceForSites->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
 
-        if (empty($chunksUploaded)) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
-        }
+        $metadata = null;
 
-        try {
-            $locks($lockKey, 600, function () use ($activate, $authorization, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $publisherForBuilds, $queueForEvents, $response, &$site, $siteId, $type): void {
-                $deployment = $dbForProject->getDocument('deployments', $deploymentId);
-                $uploaded = 0;
+        $queueForEvents
+            ->setParam('siteId', $site->getId())
+            ->setParam('deploymentId', $deployment->getId());
 
-                if (!$deployment->isEmpty()) {
-                    $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
-                    $uploaded = $deployment->getAttribute('sourceChunksUploaded', 0);
-                    $metadata = $mergeUploadMetadata($deployment->getAttribute('sourceMetadata', []), $metadata);
-
-                    if ($uploaded === $chunks) {
-                        $queueForEvents->reset();
-
-                        $response
-                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-                            ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
-                        return;
-                    }
-                }
-
-                $chunksUploaded = max($uploaded, $chunksUploaded, (int) ($metadata['chunks'] ?? 0));
-
-                if ($chunksUploaded === $chunks && $uploaded < $chunks) {
-                    $deviceForSites->finalizeUpload($path, $chunks, $metadata);
-
-                    if ($activate) {
-                        // Remove deploy for all other deployments.
-                        $activeDeployments = $dbForProject->find('deployments', [
-                            Query::equal('activate', [true]),
-                            Query::equal('resourceId', [$siteId]),
-                            Query::equal('resourceType', ['sites'])
-                        ]);
-
-                        foreach ($activeDeployments as $activeDeployment) {
-                            $dbForProject->updateDocument('deployments', $activeDeployment->getId(), new Document(['activate' => false]));
-                        }
-                    }
-
-                    $fileSize = $deviceForSites->getFileSize($path);
-
-                    if ($deployment->isEmpty()) {
-                        $deployment = $dbForProject->createDocument('deployments', new Document([
-                            '$id' => $deploymentId,
-                            '$permissions' => [
-                                Permission::read(Role::any()),
-                                Permission::update(Role::any()),
-                                Permission::delete(Role::any()),
-                            ],
-                            'resourceInternalId' => $site->getSequence(),
-                            'resourceId' => $site->getId(),
-                            'resourceType' => 'sites',
-                            'buildCommands' => \implode(' && ', $commands),
-                            'startCommand' => $site->getAttribute('startCommand', ''),
-                            'buildOutput' => $outputDirectory,
-                            'adapter' => $site->getAttribute('adapter', ''),
-                            'fallbackFile' => $site->getAttribute('fallbackFile', ''),
-                            'sourcePath' => $path,
-                            'sourceSize' => $fileSize,
-                            'totalSize' => $fileSize,
-                            'sourceChunksTotal' => $chunks,
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'activate' => $activate,
-                            'sourceMetadata' => $metadata,
-                            'type' => $type,
-                        ]));
-
-                        $sitesDomain = $platform['sitesDomain'];
-                        $domain = ID::unique() . "." . $sitesDomain;
-
-                        // TODO: (@Meldiron) Remove after 1.7.x migration
-                        $isMd5 = System::getEnv('_APP_RULES_FORMAT') === 'md5';
-                        $ruleId = $isMd5 ? md5($domain) : ID::unique();
-
-                        $authorization->skip(
-                            fn () => $dbForPlatform->createDocument('rules', new Document([
-                                '$id' => $ruleId,
-                                'projectId' => $project->getId(),
-                                'projectInternalId' => $project->getSequence(),
-                                'domain' => $domain,
-                                'type' => 'deployment',
-                                'trigger' => 'deployment',
-                                'deploymentId' => $deployment->isEmpty() ? '' : $deployment->getId(),
-                                'deploymentInternalId' => $deployment->isEmpty() ? '' : $deployment->getSequence(),
-                                'deploymentResourceType' => 'site',
-                                'deploymentResourceId' => $site->getId(),
-                                'deploymentResourceInternalId' => $site->getSequence(),
-                                'status' => 'verified',
-                                'certificateId' => '',
-                                'search' => implode(' ', [$ruleId, $domain]),
-                                'owner' => 'Appwrite',
-                                'region' => $project->getAttribute('region')
-                            ]))
-                        );
-                    } else {
-                        $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
-                            'sourceSize' => $fileSize,
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'sourceMetadata' => $metadata,
-                        ]));
-                    }
-
-                    // Start the build
-                    $publisherForBuilds->enqueue(new BuildMessage(
-                        project: $project,
-                        resource: $site,
-                        deployment: $deployment,
-                        type: BUILD_TYPE_DEPLOYMENT,
-                        platform: $platform,
-                    ));
-                } else {
-                    $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
-                        'sourceChunksUploaded' => $chunksUploaded,
-                        'sourceMetadata' => $metadata,
-                    ]));
-                }
-
-                $metadata = null;
-
-                if ($chunksUploaded === $chunks) {
-                    $queueForEvents
-                        ->setParam('siteId', $site->getId())
-                        ->setParam('deploymentId', $deployment->getId());
-                }
-
-                $response
-                    ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
-                    ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
-            }, timeout: 120.0);
-        } catch (LockContention) {
-            $response->addHeader('Retry-After', '5');
-            throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED, 'Deployment upload is busy. Try again.');
-        }
+        $response
+            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+            ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -16,6 +16,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
+use Utopia\Mongo\Exception as MongoException;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
@@ -94,7 +95,10 @@ class Delete extends Action
             if (!$dbForProject->deleteDocument('deployments', $deployment->getId())) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove deployment from DB');
             }
-        } catch (TransactionException) {
+        } catch (MongoException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
             $deploymentExists = !$dbForProject->getDocument('deployments', $deployment->getId())->isEmpty();
 
             if ($deploymentExists && !$dbForProject->deleteDocument('deployments', $deployment->getId())) {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -135,7 +135,7 @@ class Create extends Action
             'status' => 'waiting',
             'buildPath' => '',
             'buildLogs' => '',
-            'type' => $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual'
+            'type' => $request->getHeader('x-sdk-language') === 'cli' ? 'cli' : 'manual'
         ]));
 
         // Preview deployments for sites

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -96,7 +96,10 @@ class Update extends Action
                 'buildDuration' => $duration,
                 'status' => 'canceled'
             ]));
-        } catch (TransactionException) {
+        } catch (TransactionException $exception) {
+            if ($exception->getCode() !== 112) {
+                throw $exception;
+            }
             $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
 
             if ($deployment->isEmpty()) {


### PR DESCRIPTION
## What does this PR do?

This PR centralizes \latestDeploymentStatus\ updates into the Builds worker to prevent race conditions when duplicate deployments are triggered concurrently.

## Changes

1. The \latestDeployment\ attributes are no longer updated from HTTP endpoint handlers (Functions Create, Deployments Create/Duplicate/Delete/Template, Sites Create/Delete/Duplicate/Template, VCS Deployment). This prevents race conditions where concurrent requests could overwrite each other's \latestDeployment\ state.

2. Added a new \updateLatestDeployment()\ private method in the Builds worker that updates \latestDeploymentStatus\ only when the deployment is the current latest (checked via \latestDeploymentInternalId\).

3. Replaced all 5 inline \latestDeploymentStatus\ updates in Builds.php (processing, building, ready, failed states) with calls to the centralized \updateLatestDeployment()\.

4. Added \Utopia\\\\Mongo\\\\Exception\ (error 112) retry handling to Functions and Sites Deployment Delete and Status Update endpoints for improved reliability under load.

## Related issues
Fixes #12539