### PR TITLE
Fix flaky webhook and site deployment tests

### DIFF
--- a/tests/e2e/Services/ProjectWebhooks/WebhooksBase.php
+++ b/tests/e2e/Services/ProjectWebhooks/WebhooksBase.php
@@ -26,6 +26,15 @@ trait WebhooksBase
 
             $this->assertEquals(200, $deployment['headers']['status-code']);
             $this->assertEquals('ready', $deployment['body']['status'], \json_encode($deployment['body']));
+
+            $function = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+
+            $this->assertEquals(200, $function['headers']['status-code']);
+            $this->assertEquals($deploymentId, $function['body']['deploymentId'] ?? '', \json_encode($function['body']));
         }, 120000, 500);
     }
 

--- a/tests/e2e/Services/ProjectWebhooks/WebhooksBase.php
+++ b/tests/e2e/Services/ProjectWebhooks/WebhooksBase.php
@@ -35,7 +35,7 @@ trait WebhooksBase
 
             $this->assertEquals(200, $function['headers']['status-code']);
             $this->assertEquals($deploymentId, $function['body']['deploymentId'] ?? '', \json_encode($function['body']));
-        }, 120000, 500);
+        }, 240000, 500);
     }
 
     /**

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2340,15 +2340,18 @@ final class SitesCustomServerTest extends Scope
 
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
-        $deploymentId2 = $deployment['body']['$id'];
-        $this->assertNotEmpty($deploymentId2);
+        $cliDeploymentId = $deployment['body']['$id'];
+        $this->assertNotEmpty($cliDeploymentId);
 
-        $deployment = $this->getDeployment($siteId, $deploymentId2);
+        $deployment = $this->getDeployment($siteId, $cliDeploymentId);
         $this->assertEquals(200, $deployment['headers']['status-code']);
         $this->assertGreaterThan(0, $deployment['body']['sourceSize']);
         $this->assertEquals(0, $deployment['body']['buildSize']);
         $this->assertEquals($deployment['body']['sourceSize'], $deployment['body']['totalSize']);
         $this->assertEquals('cli', $deployment['body']['type']);
+
+        $this->waitDeploymentReady($siteId, $cliDeploymentId);
+        $this->waitDeploymentActivated($siteId, $cliDeploymentId);
 
         // create another duplicate deployment with manual trigger
         $deployment = $this->client->call(Client::METHOD_POST, '/sites/' . $siteId . '/deployments/duplicate', array_merge([
@@ -2360,25 +2363,23 @@ final class SitesCustomServerTest extends Scope
 
         $this->assertEquals(202, $deployment['headers']['status-code']);
 
-        $deploymentId2 = $deployment['body']['$id'];
-        $this->assertNotEmpty($deploymentId2);
+        $manualDeploymentId = $deployment['body']['$id'];
+        $this->assertNotEmpty($manualDeploymentId);
 
-        $deployment = $this->getDeployment($siteId, $deploymentId2);
+        $deployment = $this->getDeployment($siteId, $manualDeploymentId);
         $this->assertEquals(200, $deployment['headers']['status-code']);
         $this->assertGreaterThan(0, $deployment['body']['sourceSize']);
         $this->assertEquals(0, $deployment['body']['buildSize']);
         $this->assertEquals($deployment['body']['sourceSize'], $deployment['body']['totalSize']);
         $this->assertEquals('manual', $deployment['body']['type']);
 
-        $this->assertEventually(function () use ($siteId, $deploymentId2) {
-            $site = $this->getSite($siteId);
-            $this->assertEquals($deploymentId2, $site['body']['deploymentId']);
-        }, 120000, 500);
+        $this->waitDeploymentReady($siteId, $manualDeploymentId);
+        $this->waitDeploymentActivated($siteId, $manualDeploymentId);
 
         $response = $proxyClient->call(Client::METHOD_GET, '/not-found');
         $this->assertStringContainsString("Index page", (string) $response['body']);
 
-        $deployment = $this->getDeployment($siteId, $deploymentId2);
+        $deployment = $this->getDeployment($siteId, $manualDeploymentId);
         $this->assertEquals(200, $deployment['headers']['status-code']);
         $this->assertGreaterThan(0, $deployment['body']['sourceSize']);
         $this->assertGreaterThan(0, $deployment['body']['buildSize']);

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -1759,6 +1759,11 @@ final class SitesCustomServerTest extends Scope
             $deployment = $this->getDeployment($siteId, $deploymentId);
 
             $this->assertEquals('ready', $deployment['body']['status']);
+            $this->assertTrue(
+                \str_contains((string) $deployment['body']['buildLogs'], 'Screenshot capturing finished.')
+                || \str_contains((string) $deployment['body']['buildLogs'], 'Screenshot capturing failed.'),
+                'Screenshot worker did not finish: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT)
+            );
         }, 120000, 500);
 
         /**


### PR DESCRIPTION
## What does this PR do?

Fixes flaky E2E tests by waiting for the resource state that the tested endpoint actually depends on.

- Project webhooks: waits longer for function deployment activation, not only deployment build readiness. The execution endpoint reads the active deployment from the function document, and CI can take longer than the previous wait to move a deployment from `building` to `ready` and activate it.
- Sites duplicate deployments: waits for the CLI duplicate deployment to finish and activate before creating the manual duplicate. The test still verifies both `cli` and `manual` duplicate types, but no longer relies on async build queue ordering.
- Sites deployment deletion: waits for the screenshot worker to reach a terminal log state before deleting the deployment. The build worker marks a site deployment `ready` before the screenshot worker finishes, and screenshot generation can either succeed or fail depending on the test environment.

## Test Plan

- `composer lint tests/e2e/Services/ProjectWebhooks/WebhooksBase.php`
- `docker compose exec appwrite test tests/e2e/Services/ProjectWebhooks/WebhooksCustomServerTest.php --filter=testUpdateDeployment`
- `docker compose exec appwrite test tests/e2e/Services/ProjectWebhooks/WebhooksCustomServerTest.php --filter=testExecutions`
- `composer lint tests/e2e/Services/Sites/SitesCustomServerTest.php`
- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesCustomServerTest.php --filter=testDuplicateDeployment`
- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesCustomServerTest.php --filter=testDeleteDeployment`
- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesCustomServerTest.php --filter='test(Delete|Duplicate)Deployment'`

## Related PRs and Issues

- #12539

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
