### PR TITLE
Replace unstructured logging in screenshots worker with Span

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -10,7 +10,6 @@ use Appwrite\Role;
 use Exception;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
-use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -18,6 +17,7 @@ use Utopia\Database\Query;
 use Utopia\Fetch\Client as FetchClient;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
+use Utopia\Span\Span;
 use Utopia\Storage\Device;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
@@ -59,7 +59,7 @@ class Screenshots extends Action
         Device $deviceForFiles,
         Telemetry $telemetry
     ): void {
-        Console::log('Screenshot action started');
+        Span::add('project.id', $project->getId());
 
         $payload = $message->getPayload();
 
@@ -70,9 +70,8 @@ class Screenshots extends Action
         $screenshotMessage = Screenshot::fromArray($payload);
         $counter = $telemetry->createCounter('worker.screenshots.capture');
 
-        Console::log('Site screenshot started');
-
         $deploymentId = $screenshotMessage->deploymentId;
+        Span::add('deployment.id', $deploymentId);
         $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
         if ($deployment->isEmpty()) {
@@ -80,11 +79,14 @@ class Screenshots extends Action
         }
 
         $siteId = $deployment->getAttribute('resourceId');
+        Span::add('site.id', $siteId);
         $site = $dbForProject->getDocument('sites', $siteId);
 
         if ($site->isEmpty()) {
             throw new \Exception('Site not found');
         }
+
+        Span::add('site.framework', $site->getAttribute('framework', ''));
 
         // Realtime preparation
         $event = "sites.[siteId].deployments.[deploymentId].update";
@@ -205,6 +207,8 @@ class Screenshots extends Action
                 throw new \Exception($screenshotError);
             }
 
+            Span::add('screenshot.count', \count($screenshots));
+
             $mimeType = "image/png";
             $updates = new Document([]);
 
@@ -268,10 +272,6 @@ class Screenshots extends Action
                 'deploymentScreenshotLight' => $deployment->getAttribute('screenshotLight', ''),
             ]));
         } catch (\Throwable $th) {
-            Console::warning("Screenshot failed to generate:");
-            Console::warning($th->getMessage());
-            Console::warning($th->getTraceAsString());
-
             $date = \date('H:i:s');
             $this->appendToLogs($dbForProject, $deployment->getId(), $queueForRealtime, "[90m[$date] [90m[[0mappwrite[90m][33m Screenshot capturing failed. Deployment will continue. [0m\n");
 


### PR DESCRIPTION
## What

Replaces the unstructured `Console` logging in the screenshots worker with structured `Span::add` tracing, following the conventions already used by the Builds worker.

### Changes
- **Removed** `Console::log('Screenshot action started')` / `Console::log('Site screenshot started')` progress narration.
- **Removed** the `Console::warning` error dump (message + trace) in the catch block.
- **Added** `Span::add` for context with canonical snake_case keys:
  - `project.id`, `deployment.id`, `site.id`, `site.framework` — identifiers
  - `screenshot.count` — success outcome
- Dropped the now-unused `use Utopia\Console;` import.

## Why

The `Console::warning` dump in the catch block was redundant: the block already rethrows, and the worker harness (`app/worker.php`) calls `Span::current()?->setError($error)` when the exception bubbles up, capturing the full `Throwable` (type/message/file/line/trace) on the span canonically. Per the project tracing convention, error lifecycle is owned by the entry-point harness, not the handler.

The user-facing deployment build-log stream (`appendToLogs`) and the telemetry counter are untouched.

## Test plan
- `composer lint` → pint passed
- `composer analyze` → PHPStan level 3 clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)