### PR TITLE
Make webhooks worker coroutine-safe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -386,7 +386,7 @@ services:
     environment:
       - _APP_ENV
       - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
+      - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -20,7 +20,6 @@ use Utopia\System\System;
 
 class Webhooks extends Action
 {
-    private array $errors = [];
     private const MAX_FILE_SIZE = 5242880; // 5 MB
 
     public static function getName(): string
@@ -58,10 +57,7 @@ class Webhooks extends Action
      */
     public function action(Message $message, Document $project, Database $dbForPlatform, MailPublisher $publisherForMails, UsagePublisher $publisherForUsage, Log $log, array $plan): void
     {
-        $this->errors = [];
         $payload = $message->getPayload();
-
-
 
         if (empty($payload)) {
             throw new Exception('Missing payload');
@@ -73,14 +69,18 @@ class Webhooks extends Action
 
         $log->addTag('projectId', $project->getId());
 
+        $errors = [];
         foreach ($project->getAttribute('webhooks', []) as $webhook) {
             if (array_intersect($webhook->getAttribute('events', []), $events)) {
-                $this->execute($events, $webhookPayload, $webhook, $user, $project, $dbForPlatform, $publisherForMails, $publisherForUsage, $plan);
+                $error = $this->execute($events, $webhookPayload, $webhook, $user, $project, $dbForPlatform, $publisherForMails, $publisherForUsage, $plan);
+                if ($error !== null) {
+                    $errors[] = $error;
+                }
             }
         }
 
-        if (!empty($this->errors)) {
-            throw new Exception(\implode(" / \n\n", $this->errors));
+        if (!empty($errors)) {
+            throw new Exception(\implode(" / \n\n", $errors));
         }
     }
 
@@ -93,12 +93,12 @@ class Webhooks extends Action
      * @param Database $dbForPlatform
      * @param MailPublisher $publisherForMails
      * @param array $plan
-     * @return void
+     * @return string|null The error log if the delivery failed, otherwise null
      */
-    private function execute(array $events, string $payload, Document $webhook, Document $user, Document $project, Database $dbForPlatform, MailPublisher $publisherForMails, UsagePublisher $publisherForUsage, array $plan): void
+    private function execute(array $events, string $payload, Document $webhook, Document $user, Document $project, Database $dbForPlatform, MailPublisher $publisherForMails, UsagePublisher $publisherForUsage, array $plan): ?string
     {
         if ($webhook->getAttribute('enabled') !== true) {
-            return;
+            return null;
         }
 
         $url = \rawurldecode($webhook->getAttribute('url'));
@@ -107,8 +107,7 @@ class Webhooks extends Action
             $host = \parse_url($url, PHP_URL_HOST) ?? '';
             $hostnameValidator = new PublicHostname();
             if (!$hostnameValidator->isValid($host)) {
-                $this->errors[] = 'Webhook target ' . $host . ' rejected: ' . $hostnameValidator->getDescription();
-                return;
+                return 'Webhook target ' . $host . ' rejected: ' . $hostnameValidator->getDescription();
             }
         }
 
@@ -159,6 +158,8 @@ class Webhooks extends Action
         $curlError = \curl_error($ch);
         $statusCode = \curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
 
+        $error = null;
+
         if (!empty($curlError) || $statusCode >= 400) {
             $dbForPlatform->increaseDocumentAttribute('webhooks', $webhook->getId(), 'attempts', 1);
             $webhook = $dbForPlatform->getDocument('webhooks', $webhook->getId());
@@ -189,7 +190,7 @@ class Webhooks extends Action
             $dbForPlatform->updateDocument('webhooks', $webhook->getId(), new Document($updatePayload));
             $dbForPlatform->purgeCachedDocument('projects', $project->getId());
 
-            $this->errors[] = $logs;
+            $error = $logs;
             $usage = (new UsageContext())
                 ->addMetric(METRIC_WEBHOOKS_FAILED, 1)
                 ->addMetric(str_replace('{webhookInternalId}', $webhook->getSequence(), METRIC_WEBHOOK_ID_FAILED), 1);
@@ -207,6 +208,8 @@ class Webhooks extends Action
             project: $project,
             metrics: $usage->getMetrics(),
         ));
+
+        return $error;
     }
 
     /**


### PR DESCRIPTION
## What

Makes the `webhooks` worker coroutine-safe and enables concurrency for it.

## Why

`app/worker.php` runs workers under Swoole coroutines and reuses a **single Action instance** across all messages. The webhooks worker held per-message state on that shared instance:

```php
private array $errors = [];
```

`action()` reset `$this->errors = []` at the start and `execute()` appended to it. With `_APP_WORKER_MAX_COROUTINES > 1`, one message's reset/append races against another's — errors get lost or thrown against the wrong message. This is the only worker that carried accidental mutable per-message instance state.

## How

- Removed the `private array $errors` property.
- `action()` now builds a local `$errors = []` per invocation and collects the return value of each `execute()`.
- `execute()` returns `?string` — the failure log, or `null` on success/skip — instead of mutating instance state.
- With the race gone, bumped `appwrite-worker-webhooks` to `_APP_WORKER_MAX_COROUTINES=8` in `docker-compose.yml`, matching the other concurrent workers (deletes, builds, screenshots, certificates, executions, functions).

Everything else in the worker already operates on locals and per-coroutine injected resources, so no further changes were needed.

## Checks

- `composer lint src/Appwrite/Platform/Workers/Webhooks.php` → passed
- `composer analyze` (PHPStan level 3) → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)