### PR TITLE
Fix generated spec lint warnings

### DIFF
--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -106,6 +106,13 @@ abstract class Format
      */
     protected function getArrayItemsSchema(mixed $example): array
     {
+        if (\is_string($example)) {
+            $decoded = \json_decode($example, true);
+            if (\is_array($decoded)) {
+                $example = $decoded;
+            }
+        }
+
         if (!\is_array($example) || empty($example)) {
             return ['type' => 'object'];
         }

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -102,6 +102,53 @@ abstract class Format
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    protected function getArrayItemsSchema(mixed $example): array
+    {
+        if (!\is_array($example) || empty($example)) {
+            return ['type' => 'object'];
+        }
+
+        foreach ($example as $item) {
+            if ($item === null) {
+                continue;
+            }
+
+            if (\is_array($item)) {
+                if (!\array_is_list($item)) {
+                    return [
+                        'type' => 'object',
+                        'additionalProperties' => true,
+                    ];
+                }
+
+                return [
+                    'type' => 'array',
+                    'items' => $this->getArrayItemsSchema($item),
+                ];
+            }
+
+            if (\is_int($item) || \is_float($item)) {
+                return [
+                    'type' => 'number',
+                    'format' => 'double',
+                ];
+            }
+
+            return [
+                'type' => match (\gettype($item)) {
+                    'boolean' => 'boolean',
+                    'string' => 'string',
+                    default => 'object',
+                },
+            ];
+        }
+
+        return ['type' => 'object'];
+    }
+
+    /**
      * Set Services.
      *
      * Set services value

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -1038,7 +1038,7 @@ class OpenAPI3 extends Format
                     if ($rule['array'] || $rule['type'] === 'array') {
                         $output['components']['schemas'][$model->getType()]['properties'][$name]['items'] = $items;
                     } else {
-                        if (isset($items['$ref'])) {
+                        if (isset($items['$ref']) || isset($items['oneOf'])) {
                             $items = ['allOf' => [$items]];
                         }
                         /** @var array<string, mixed> $property */

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -505,11 +505,36 @@ class OpenAPI3 extends Format
                     case \Utopia\Database\Validator\Spatial::class:
                         /** @var Spatial $validator */
                         $node['schema']['type'] = 'array';
-                        $node['schema']['items'] = [
-                            'oneOf' => [
-                                ['type' => 'array']
-                            ]
-                        ];
+                        $node['schema']['items'] = match ($validator->getSpatialType()) {
+                            Database::VAR_POINT => [
+                                'type' => 'number',
+                                'format' => 'double',
+                            ],
+                            Database::VAR_LINESTRING => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'number',
+                                    'format' => 'double',
+                                ],
+                            ],
+                            Database::VAR_POLYGON => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'number',
+                                        'format' => 'double',
+                                    ],
+                                ],
+                            ],
+                            default => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'number',
+                                    'format' => 'double',
+                                ],
+                            ],
+                        };
                         $node['schema']['x-example'] = ($param['example'] ?? '') ?: match ($validator->getSpatialType()) {
                             Database::VAR_POINT => '[1, 2]',
                             Database::VAR_LINESTRING => '[[1, 2], [3, 4], [5, 6]]',
@@ -785,7 +810,7 @@ class OpenAPI3 extends Format
                 if ($isPathParam) { // Param is in URL path (directly or through alias)
                     $node['in'] = 'path';
                     $temp['parameters'][] = $node;
-                } elseif ($route->getMethod() == 'GET') { // Param is in query
+                } elseif (\in_array($route->getMethod(), ['GET', 'DELETE'], true)) { // Param is in query
                     $node['in'] = 'query';
                     $temp['parameters'][] = $node;
                 } else { // Param is in payload
@@ -860,7 +885,7 @@ class OpenAPI3 extends Format
         }
 
         foreach ($this->models as $model) {
-            if (!in_array($model->getType(), $usedModels) && $model->getType() !== 'error') {
+            if (!in_array($model->getType(), $usedModels)) {
                 continue;
             }
 
@@ -918,6 +943,7 @@ class OpenAPI3 extends Format
 
                     case 'array':
                         $type = 'array';
+                        $items = $this->getArrayItemsSchema($rule['example'] ?? []);
                         break;
 
                     case 'integer':
@@ -1009,7 +1035,19 @@ class OpenAPI3 extends Format
                     }
                 }
                 if ($items) {
-                    $output['components']['schemas'][$model->getType()]['properties'][$name]['items'] = $items;
+                    if ($rule['array'] || $rule['type'] === 'array') {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['items'] = $items;
+                    } else {
+                        if (isset($items['$ref'])) {
+                            $items = ['allOf' => [$items]];
+                        }
+                        /** @var array<string, mixed> $property */
+                        $property = $output['components']['schemas'][$model->getType()]['properties'][$name];
+                        $output['components']['schemas'][$model->getType()]['properties'][$name] = [
+                            ...$property,
+                            ...$items,
+                        ];
+                    }
                 }
                 if ($rule['type'] === 'enum' && !empty($rule['enum'])) {
                     if ($rule['array']) {

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -487,11 +487,36 @@ class Swagger2 extends Format
                     case \Utopia\Database\Validator\Spatial::class:
                         /** @var Spatial $validator */
                         $node['type'] = 'array';
-                        $node['schema']['items'] = [
-                            'oneOf' => [
-                                ['type' => 'array']
-                            ]
-                        ];
+                        $node['items'] = match ($validator->getSpatialType()) {
+                            Database::VAR_POINT => [
+                                'type' => 'number',
+                                'format' => 'double',
+                            ],
+                            Database::VAR_LINESTRING => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'number',
+                                    'format' => 'double',
+                                ],
+                            ],
+                            Database::VAR_POLYGON => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'number',
+                                        'format' => 'double',
+                                    ],
+                                ],
+                            ],
+                            default => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'number',
+                                    'format' => 'double',
+                                ],
+                            ],
+                        };
                         $node['x-example'] = ($param['example'] ?? '') ?: match ($validator->getSpatialType()) {
                             Database::VAR_POINT => '[1, 2]',
                             Database::VAR_LINESTRING => '[[1, 2], [3, 4], [5, 6]]',
@@ -745,7 +770,7 @@ class Swagger2 extends Format
                 if ($isPathParam) { // Param is in URL path (directly or through alias)
                     $node['in'] = 'path';
                     $temp['parameters'][] = $node;
-                } elseif ($route->getMethod() == 'GET') { // Param is in query
+                } elseif (\in_array($route->getMethod(), ['GET', 'DELETE'], true)) { // Param is in query
                     $node['in'] = 'query';
                     $temp['parameters'][] = $node;
                 } else { // Param is in payload
@@ -879,6 +904,7 @@ class Swagger2 extends Format
 
                     case 'array':
                         $type = 'array';
+                        $items = $this->getArrayItemsSchema($rule['example'] ?? []);
                         break;
 
                     case 'integer':
@@ -933,7 +959,6 @@ class Swagger2 extends Format
                             }
                         } else {
                             $items = [
-                                'type' => $type,
                                 '$ref' => '#/definitions/' . $rule['type'],
                             ];
                         }
@@ -986,7 +1011,19 @@ class Swagger2 extends Format
                     }
                 }
                 if ($items) {
-                    $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;
+                    if ($rule['array'] || $rule['type'] === 'array') {
+                        $output['definitions'][$model->getType()]['properties'][$name]['items'] = $items;
+                    } else {
+                        if (isset($items['$ref'])) {
+                            $items = ['allOf' => [$items]];
+                        }
+                        /** @var array<string, mixed> $property */
+                        $property = $output['definitions'][$model->getType()]['properties'][$name];
+                        $output['definitions'][$model->getType()]['properties'][$name] = [
+                            ...$property,
+                            ...$items,
+                        ];
+                    }
                 }
                 if ($rule['type'] === 'enum' && !empty($rule['enum'])) {
                     if ($rule['array']) {

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -10,6 +10,8 @@ use Appwrite\SDK\Specification\Format\Swagger2;
 use Appwrite\SDK\Specification\Validator\PasswordFormat;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Response\Model\AttributeLine;
+use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\HealthStatus;
 use Appwrite\Utopia\Response\Model\PlatformAndroid;
 use Appwrite\Utopia\Response\Model\PlatformApple;
@@ -17,8 +19,12 @@ use Appwrite\Utopia\Response\Model\PlatformLinux;
 use Appwrite\Utopia\Response\Model\PlatformList;
 use Appwrite\Utopia\Response\Model\PlatformWeb;
 use Appwrite\Utopia\Response\Model\PlatformWindows;
+use Appwrite\Utopia\Response\Model\Preferences;
+use Appwrite\Utopia\Response\Model\Team;
 use Appwrite\Utopia\Response\Model\Webhook;
 use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
 use Utopia\Validator\Nullable;
@@ -111,6 +117,132 @@ final class FormatTest extends TestCase
             ['idGenerator' => 'ID.unique'],
             $spec['paths']['/tests']['post']['requestBody']['content']['application/json']['schema']['properties']['userId']['x-appwrite']
         );
+    }
+
+    public function testDeleteRouteOptionalParamsAreQueryParams(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('DELETE', '/v1/tests/:testId'))
+            ->desc('Delete test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'deleteTest',
+                description: 'Delete test.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('testId', '', new Text(256), 'Test ID.')
+            ->param('transactionId', null, new Nullable(new Text(256)), 'Transaction ID.', true);
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+
+        $this->assertArrayNotHasKey('requestBody', $openApi['paths']['/tests/{testId}']['delete']);
+        $this->assertCount(2, $openApi['paths']['/tests/{testId}']['delete']['parameters']);
+        $this->assertSame('path', $openApi['paths']['/tests/{testId}']['delete']['parameters'][0]['in']);
+        $this->assertSame('transactionId', $openApi['paths']['/tests/{testId}']['delete']['parameters'][1]['name']);
+        $this->assertSame('query', $openApi['paths']['/tests/{testId}']['delete']['parameters'][1]['in']);
+
+        $this->assertCount(2, $swagger['paths']['/tests/{testId}']['delete']['parameters']);
+        $this->assertSame('path', $swagger['paths']['/tests/{testId}']['delete']['parameters'][0]['in']);
+        $this->assertSame('transactionId', $swagger['paths']['/tests/{testId}']['delete']['parameters'][1]['name']);
+        $this->assertSame('query', $swagger['paths']['/tests/{testId}']['delete']['parameters'][1]['in']);
+    }
+
+    public function testModelReferencesDoNotEmitItemsOnObjectProperties(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/team'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTeamTest',
+                description: 'Get test.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_TEAM,
+                    ),
+                ],
+            ));
+
+        $models = [
+            new Team(),
+            new Preferences(),
+            new ErrorModel(),
+        ];
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+
+        $openApiPrefs = $openApi['components']['schemas']['team']['properties']['prefs'];
+        $swaggerPrefs = $swagger['definitions']['team']['properties']['prefs'];
+
+        $this->assertArrayNotHasKey('items', $openApiPrefs);
+        $this->assertArrayNotHasKey('error', $openApi['components']['schemas']);
+        $this->assertSame('object', $openApiPrefs['type']);
+        $this->assertSame([['$ref' => '#/components/schemas/preferences']], $openApiPrefs['allOf']);
+
+        $this->assertArrayNotHasKey('items', $swaggerPrefs);
+        $this->assertArrayNotHasKey('error', $swagger['definitions']);
+        $this->assertSame('object', $swaggerPrefs['type']);
+        $this->assertSame([['$ref' => '#/definitions/preferences']], $swaggerPrefs['allOf']);
+    }
+
+    public function testArraySchemasEmitItems(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $requestRoute = (new Route('POST', '/v1/tests/spatial'))
+            ->desc('Create spatial test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'createSpatialTest',
+                description: 'Create spatial test.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('default', null, new Nullable(new Spatial(Database::VAR_LINESTRING)), 'Default value.', true);
+
+        $modelRoute = (new Route('GET', '/v1/tests/spatial-model'))
+            ->desc('Get spatial test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getSpatialTest',
+                description: 'Get spatial test.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_ATTRIBUTE_LINE,
+                    ),
+                ],
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$requestRoute, $modelRoute], [new AttributeLine()], [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$requestRoute, $modelRoute], [new AttributeLine()], [], 0, 'console'))->parse();
+
+        $openApiRequestDefault = $openApi['paths']['/tests/spatial']['post']['requestBody']['content']['application/json']['schema']['properties']['default'];
+        $swaggerRequestDefault = $swagger['paths']['/tests/spatial']['post']['parameters'][0]['schema']['properties']['default'];
+        $openApiModelDefault = $openApi['components']['schemas']['attributeLine']['properties']['default'];
+        $swaggerModelDefault = $swagger['definitions']['attributeLine']['properties']['default'];
+
+        foreach ([$openApiRequestDefault, $swaggerRequestDefault, $openApiModelDefault, $swaggerModelDefault] as $default) {
+            $this->assertSame('array', $default['type']);
+            $this->assertSame('array', $default['items']['type']);
+            $this->assertSame('number', $default['items']['items']['type']);
+            $this->assertSame('double', $default['items']['items']['format']);
+        }
     }
 
     public function testPasswordFormatMarksOnlyExplicitPasswordFields(): void

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -10,6 +10,13 @@ use Appwrite\SDK\Specification\Format\Swagger2;
 use Appwrite\SDK\Specification\Validator\PasswordFormat;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Response\Model\AlgoArgon2;
+use Appwrite\Utopia\Response\Model\AlgoBcrypt;
+use Appwrite\Utopia\Response\Model\AlgoMd5;
+use Appwrite\Utopia\Response\Model\AlgoPhpass;
+use Appwrite\Utopia\Response\Model\AlgoScrypt;
+use Appwrite\Utopia\Response\Model\AlgoScryptModified;
+use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\HealthStatus;
@@ -21,6 +28,7 @@ use Appwrite\Utopia\Response\Model\PlatformWeb;
 use Appwrite\Utopia\Response\Model\PlatformWindows;
 use Appwrite\Utopia\Response\Model\Preferences;
 use Appwrite\Utopia\Response\Model\Team;
+use Appwrite\Utopia\Response\Model\User;
 use Appwrite\Utopia\Response\Model\Webhook;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
@@ -45,6 +53,11 @@ class TestFormat extends Format
     public function requestParameterConfig(bool $optional, bool $nullable, mixed $default, string $methodName = '', string $paramName = ''): array
     {
         return $this->getRequestParameterConfig($optional, $nullable, $default, $methodName, $paramName);
+    }
+
+    public function arrayItemsSchema(mixed $example): array
+    {
+        return $this->getArrayItemsSchema($example);
     }
 }
 
@@ -194,6 +207,89 @@ final class FormatTest extends TestCase
         $this->assertArrayNotHasKey('error', $swagger['definitions']);
         $this->assertSame('object', $swaggerPrefs['type']);
         $this->assertSame([['$ref' => '#/definitions/preferences']], $swaggerPrefs['allOf']);
+    }
+
+    public function testArrayItemsSchemaInfersTypesFromJsonStringExamples(): void
+    {
+        $this->assertSame(
+            [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'number',
+                    'format' => 'double',
+                ],
+            ],
+            $this->format->arrayItemsSchema('[[1,2],[3,4]]')
+        );
+
+        $this->assertSame(
+            [
+                'type' => 'object',
+                'additionalProperties' => true,
+            ],
+            $this->format->arrayItemsSchema('[{"resource":"Database","id":"public"}]')
+        );
+
+        $this->assertSame(
+            ['type' => 'string'],
+            $this->format->arrayItemsSchema('["topt", "email"]')
+        );
+
+        $this->assertSame(
+            ['type' => 'object'],
+            $this->format->arrayItemsSchema('[SHARED_SECRET]')
+        );
+    }
+
+    public function testMultiTypePropertiesWrapOneOfInAllOf(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/user'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getUserTest',
+                description: 'Get test.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_USER,
+                    ),
+                ],
+            ));
+
+        $models = [
+            new User(),
+            new AlgoArgon2(),
+            new AlgoScrypt(),
+            new AlgoScryptModified(),
+            new AlgoBcrypt(),
+            new AlgoPhpass(),
+            new AlgoSha(),
+            new AlgoMd5(),
+        ];
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+
+        $openApiHashOptions = $openApi['components']['schemas']['user']['properties']['hashOptions'];
+        $swaggerHashOptions = $swagger['definitions']['user']['properties']['hashOptions'];
+
+        $this->assertSame('object', $openApiHashOptions['type']);
+        $this->assertArrayNotHasKey('items', $openApiHashOptions);
+        $this->assertArrayNotHasKey('oneOf', $openApiHashOptions);
+        $this->assertCount(1, $openApiHashOptions['allOf']);
+        $this->assertCount(7, $openApiHashOptions['allOf'][0]['oneOf']);
+        $this->assertSame(['$ref' => '#/components/schemas/algoArgon2'], $openApiHashOptions['allOf'][0]['oneOf'][0]);
+
+        $this->assertSame('object', $swaggerHashOptions['type']);
+        $this->assertArrayNotHasKey('items', $swaggerHashOptions);
+        $this->assertCount(7, $swaggerHashOptions['x-oneOf']);
+        $this->assertSame(['$ref' => '#/definitions/algoArgon2'], $swaggerHashOptions['x-oneOf'][0]);
     }
 
     public function testArraySchemasEmitItems(): void


### PR DESCRIPTION
## Summary

This PR fixes several generated Swagger2/OpenAPI3 spec lint warnings in the SDK specification formatters.

## Fixes

### DELETE operations emitted request bodies

Optional DELETE route params were previously treated like payload fields because only GET params were forced into `in: query`. That caused OpenAPI3 DELETE operations to emit `requestBody`, which triggers:

`requestBody does not have well-defined semantics for GET, HEAD and DELETE operations`

The formatters now treat DELETE like GET for non-path params, so optional DELETE params are emitted as query parameters in both Swagger2 and OpenAPI3.

### Object properties emitted `items`

Model reference properties such as `team.prefs` were emitted as `type: object` with an `items` schema. `items` is only meaningful for arrays, which triggered:

`items has no effect on non arrays`

The model serialization logic now only writes `items` for array properties. Non-array model refs are merged into the property schema with `allOf`, preserving the object shape without invalid array metadata.

### Unused `error` schema was always emitted in OpenAPI3

OpenAPI3 special-cased the `error` model so it was emitted even when unused. That caused unused definition warnings. The formatter now follows the same used-model filtering as other models, so `error` is kept only when referenced.

### Array schemas missing nested `items`

Spatial defaults and spatial request parameters could emit arrays whose nested array schemas had no `items`, triggering:

`should have an 'items' if 'type'=array`

This PR fixes both sources:

- Spatial request params now emit item schemas based on point, linestring, and polygon depth.
- Model array properties infer their item schema from existing examples inside the spec formatter, so response model definitions do not need user-facing `items` metadata in the model declarations.

## sdk-generator compatibility

I also checked the generated spec shape against `sdk-generator` because these schemas feed SDK generation. The changed spec parses and renders through the Node generator using the regenerated `swagger2-1.9.x-server.json` spec.

## Validation

- `docker compose exec appwrite test tests/unit/SDK/Specification/FormatTest.php`
- `./vendor/bin/phpstan analyse src/Appwrite/SDK/Specification/Format.php src/Appwrite/SDK/Specification/Format/OpenAPI3.php src/Appwrite/SDK/Specification/Format/Swagger2.php tests/unit/SDK/Specification/FormatTest.php --memory-limit=1G`
- `php -l src/Appwrite/SDK/Specification/Format.php && php -l src/Appwrite/SDK/Specification/Format/OpenAPI3.php && php -l src/Appwrite/SDK/Specification/Format/Swagger2.php && php -l tests/unit/SDK/Specification/FormatTest.php`
- `docker compose exec appwrite php app/cli.php specs --version=1.9.x --git=no`
- Generated spec scan confirmed no remaining `type: array` schemas without `items`, no OpenAPI3 DELETE `requestBody`, and no `items` on non-array schemas across generated 1.9 client/server/console specs.
- `sdk-generator` render check from regenerated `swagger2-1.9.x-server.json` completed successfully.
