### PR TITLE
Add project path auth scheme to specs

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -139,11 +139,15 @@ class Specs extends Action
                     'description' => 'Your project ID',
                     'in' => 'header',
                 ],
-                'ProjectQuery' => [
+                'ProjectPath' => [
                     'type' => 'apiKey',
                     'name' => 'project',
                     'description' => 'Your project ID',
                     'in' => 'query',
+                    'x-appwrite' => [
+                        'location' => 'path',
+                        'param' => 'project_id',
+                    ],
                 ],
                 'JWT' => [
                     'type' => 'apiKey',
@@ -201,11 +205,15 @@ class Specs extends Action
                     'description' => 'Your project ID',
                     'in' => 'header',
                 ],
-                'ProjectQuery' => [
+                'ProjectPath' => [
                     'type' => 'apiKey',
                     'name' => 'project',
                     'description' => 'Your project ID',
                     'in' => 'query',
+                    'x-appwrite' => [
+                        'location' => 'path',
+                        'param' => 'project_id',
+                    ],
                 ],
                 'Key' => [
                     'type' => 'apiKey',
@@ -275,11 +283,15 @@ class Specs extends Action
                     'description' => 'Your project ID',
                     'in' => 'header',
                 ],
-                'ProjectQuery' => [
+                'ProjectPath' => [
                     'type' => 'apiKey',
                     'name' => 'project',
                     'description' => 'Your project ID',
                     'in' => 'query',
+                    'x-appwrite' => [
+                        'location' => 'path',
+                        'param' => 'project_id',
+                    ],
                 ],
                 'Key' => [
                     'type' => 'apiKey',

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -81,28 +81,20 @@ class OpenAPI3 extends Format
             ],
         ];
 
-        if (isset($output['components']['securitySchemes']['Project'])) {
-            $output['components']['securitySchemes']['Project']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
-        }
-
-        if (isset($output['components']['securitySchemes']['ProjectQuery'])) {
-            $output['components']['securitySchemes']['ProjectQuery']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
-        }
-
-        if (isset($output['components']['securitySchemes']['Key'])) {
-            $output['components']['securitySchemes']['Key']['x-appwrite'] = ['demo' => '<YOUR_API_KEY>'];
-        }
-
-        if (isset($output['components']['securitySchemes']['JWT'])) {
-            $output['components']['securitySchemes']['JWT']['x-appwrite'] = ['demo' => '<YOUR_JWT>'];
-        }
-
-        if (isset($output['components']['securitySchemes']['Locale'])) {
-            $output['components']['securitySchemes']['Locale']['x-appwrite'] = ['demo' => 'en'];
-        }
-
-        if (isset($output['components']['securitySchemes']['Mode'])) {
-            $output['components']['securitySchemes']['Mode']['x-appwrite'] = ['demo' => ''];
+        foreach ([
+            'Project' => '<YOUR_PROJECT_ID>',
+            'ProjectPath' => '<YOUR_PROJECT_ID>',
+            'Key' => '<YOUR_API_KEY>',
+            'JWT' => '<YOUR_JWT>',
+            'Locale' => 'en',
+            'Mode' => '',
+        ] as $key => $demo) {
+            if (isset($output['components']['securitySchemes'][$key])) {
+                $output['components']['securitySchemes'][$key]['x-appwrite'] = \array_merge(
+                    $output['components']['securitySchemes'][$key]['x-appwrite'] ?? [],
+                    ['demo' => $demo]
+                );
+            }
         }
 
         $usedModels = [];

--- a/src/Appwrite/SDK/Specification/Format/Swagger2.php
+++ b/src/Appwrite/SDK/Specification/Format/Swagger2.php
@@ -70,28 +70,20 @@ class Swagger2 extends Format
             ],
         ];
 
-        if (isset($output['securityDefinitions']['Project'])) {
-            $output['securityDefinitions']['Project']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
-        }
-
-        if (isset($output['securityDefinitions']['ProjectQuery'])) {
-            $output['securityDefinitions']['ProjectQuery']['x-appwrite'] = ['demo' => '<YOUR_PROJECT_ID>'];
-        }
-
-        if (isset($output['securityDefinitions']['Key'])) {
-            $output['securityDefinitions']['Key']['x-appwrite'] = ['demo' => '<YOUR_API_KEY>'];
-        }
-
-        if (isset($output['securityDefinitions']['JWT'])) {
-            $output['securityDefinitions']['JWT']['x-appwrite'] = ['demo' => '<YOUR_JWT>'];
-        }
-
-        if (isset($output['securityDefinitions']['Locale'])) {
-            $output['securityDefinitions']['Locale']['x-appwrite'] = ['demo' => 'en'];
-        }
-
-        if (isset($output['securityDefinitions']['Mode'])) {
-            $output['securityDefinitions']['Mode']['x-appwrite'] = ['demo' => ''];
+        foreach ([
+            'Project' => '<YOUR_PROJECT_ID>',
+            'ProjectPath' => '<YOUR_PROJECT_ID>',
+            'Key' => '<YOUR_API_KEY>',
+            'JWT' => '<YOUR_JWT>',
+            'Locale' => 'en',
+            'Mode' => '',
+        ] as $key => $demo) {
+            if (isset($output['securityDefinitions'][$key])) {
+                $output['securityDefinitions'][$key]['x-appwrite'] = \array_merge(
+                    $output['securityDefinitions'][$key]['x-appwrite'] ?? [],
+                    ['demo' => $demo]
+                );
+            }
         }
 
         $usedModels = [];


### PR DESCRIPTION
## What does this PR do?

Adds a `ProjectPath` auth scheme for generated API specs so endpoints can declare that the SDK client project config should be injected into a path parameter such as `{project_id}`.

This also removes the old `ProjectQuery` scheme and preserves existing `x-appwrite` metadata when adding demo values to Swagger 2 and OpenAPI 3 security schemes.

## Test Plan

- `php -l src/Appwrite/Platform/Tasks/Specs.php`
- `php -l src/Appwrite/SDK/Specification/Format/Swagger2.php`
- `php -l src/Appwrite/SDK/Specification/Format/OpenAPI3.php`
- Verified from the Cloud repo with the patched vendor dependency that OAuth2 specs now emit `/oauth2/{project_id}/...`, use `ProjectPath`, and no longer include `ProjectQuery`.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
