### PR TITLE
Resolve locks through lock pool

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -12,7 +12,7 @@ use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception as AppwriteException;
-use Appwrite\Locking\Lock;
+use Appwrite\Locking\PlatformLock;
 use Appwrite\Network\Cors;
 use Appwrite\Platform\Appwrite;
 use Appwrite\SDK\Method;
@@ -76,7 +76,7 @@ use Utopia\Validator\Text;
 
 Config::setParam('cookieSamesite', Response::COOKIE_SAMESITE_NONE);
 
-function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, Authorization $authorization, ?Key $apiKey, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, Lock $lock)
+function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, Authorization $authorization, ?Key $apiKey, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, PlatformLock $platformLock)
 {
     $host = $request->getHostname();
     if (!empty($previewHostname)) {
@@ -145,7 +145,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
     if (!$project->isEmpty() && $project->getId() !== 'console') {
         $accessedAt = $project->getAttribute('accessedAt', 0);
         if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $accessedAt) {
-            $lock->set('projects', $project->getId(), 'accessedAt', DateTime::now());
+            $platformLock->set('projects', $project->getId(), 'accessedAt', DateTime::now());
         }
 
         /**
@@ -839,9 +839,9 @@ Http::init()
     ->inject('authorization')
     ->inject('publisherForDeletes')
     ->inject('executionsRetentionCount')
-    ->inject('lock')
+    ->inject('platformLock')
     ->inject('params')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, Lock $lock, array $params) {
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Document $project, Database $dbForPlatform, callable $getProjectDB, Locale $locale, array $localeCodes, Reader $geodb, Event $queueForEvents, Bus $bus, Executor $executor, array $platform, callable $isResourceBlocked, string $previewHostname, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, PlatformLock $platformLock, array $params) {
         /*
         * Appwrite Router
         */
@@ -849,7 +849,7 @@ Http::init()
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!\in_array($hostname, $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $lock)) {
+            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $platformLock)) {
                 $utopia->match($request)?->route->label('router', true);
             }
         }
@@ -1152,15 +1152,15 @@ Http::options()
     ->inject('authorization')
     ->inject('publisherForDeletes')
     ->inject('executionsRetentionCount')
-    ->inject('lock')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Database $dbForPlatform, callable $getProjectDB, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, Document $project, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, Lock $lock) {
+    ->inject('platformLock')
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Database $dbForPlatform, callable $getProjectDB, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, Document $project, Document $devKey, ?Key $apiKey, Cors $cors, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, PlatformLock $platformLock) {
         /*
         * Appwrite Router
         */
         $platformHostnames = $platform['hostnames'] ?? [];
         // Only run Router when external domain
         if (!in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $lock)) {
+            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $platformLock)) {
                 $utopia->match($request)?->route->label('router', true);
             }
         }
@@ -1555,14 +1555,14 @@ Http::get('/robots.txt')
     ->inject('authorization')
     ->inject('publisherForDeletes')
     ->inject('executionsRetentionCount')
-    ->inject('lock')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Database $dbForPlatform, callable $getProjectDB, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, ?Key $apiKey, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, Lock $lock) {
+    ->inject('platformLock')
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Database $dbForPlatform, callable $getProjectDB, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, ?Key $apiKey, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, PlatformLock $platformLock) {
         $platformHostnames = $platform['hostnames'] ?? [];
         if (in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
             $template = new View(__DIR__ . '/../views/general/robots.phtml');
             $response->text($template->render(false));
         } else {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $lock)) {
+            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $platformLock)) {
                 $utopia->match($request)?->route->label('router', true);
             }
         }
@@ -1590,14 +1590,14 @@ Http::get('/humans.txt')
     ->inject('authorization')
     ->inject('publisherForDeletes')
     ->inject('executionsRetentionCount')
-    ->inject('lock')
-    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Database $dbForPlatform, callable $getProjectDB, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, ?Key $apiKey, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, Lock $lock) {
+    ->inject('platformLock')
+    ->action(function (Http $utopia, SwooleRequest $swooleRequest, Request $request, Response $response, Log $log, Database $dbForPlatform, callable $getProjectDB, Event $queueForEvents, Bus $bus, Executor $executor, Reader $geodb, callable $isResourceBlocked, array $platform, string $previewHostname, ?Key $apiKey, Authorization $authorization, DeletePublisher $publisherForDeletes, int $executionsRetentionCount, PlatformLock $platformLock) {
         $platformHostnames = $platform['hostnames'] ?? [];
         if (in_array($request->getHostname(), $platformHostnames) || !empty($previewHostname)) {
             $template = new View(__DIR__ . '/../views/general/humans.phtml');
             $response->text($template->render(false));
         } else {
-            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $lock)) {
+            if (router($utopia, $dbForPlatform, $getProjectDB, $swooleRequest, $request, $response, $log, $queueForEvents, $bus, $executor, $geodb, $isResourceBlocked, $platform, $previewHostname, $authorization, $apiKey, $publisherForDeletes, $executionsRetentionCount, $platformLock)) {
                 $utopia->match($request)?->route->label('router', true);
             }
         }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -17,6 +17,7 @@ use Appwrite\Extend\Exception;
 use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Functions\EventProcessor;
 use Appwrite\Locking\Lock;
+use Appwrite\Locking\PlatformLock;
 use Appwrite\Platform\Modules\Storage\Config\CacheControl;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Appwrite\SDK\Method;
@@ -101,7 +102,8 @@ Http::init()
     ->inject('apiKey')
     ->inject('authorization')
     ->inject('lock')
-    ->action(function (Route $route, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, Lock $lock) {
+    ->inject('platformLock')
+    ->action(function (Route $route, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, Lock $lock, PlatformLock $platformLock) {
 
         /**
          * Handle user authentication and session validation.
@@ -388,7 +390,7 @@ Http::init()
         if ($project->getId() !== 'console') {
             $accessedAt = $project->getAttribute('accessedAt', 0);
             if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $accessedAt) {
-                $lock->set('projects', $project->getId(), 'accessedAt', DateTime::now());
+                $platformLock->set('projects', $project->getId(), 'accessedAt', DateTime::now());
             }
         }
 
@@ -405,7 +407,7 @@ Http::init()
                         'accessedAt' => $user->getAttribute('accessedAt')
                     ]));
                 } else {
-                    $lock->set('users', $user->getId(), 'accessedAt', $user->getAttribute('accessedAt'));
+                    $platformLock->set('users', $user->getId(), 'accessedAt', $user->getAttribute('accessedAt'));
                 }
             }
         }

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -44,6 +44,7 @@ use Utopia\DI\Container;
 use Utopia\Domains\Domain;
 use Utopia\Http\Http;
 use Utopia\Locale\Locale;
+use Utopia\Lock\Distributed as DistributedLock;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
 use Utopia\Pools\Group;
@@ -67,9 +68,19 @@ return function (Container $context): void {
 
     $context->set('logger', fn ($register) => $register->get('logger'), ['register']);
 
-    $context->set('lock', function (\Redis $redis, Telemetry $telemetry, Database $dbForPlatform, Authorization $authorization, Log $log, ?Logger $logger, Document $project): Lock {
-        return new Lock($redis, $telemetry, $dbForPlatform, $authorization, $log, $logger, $project);
-    }, ['redis', 'telemetry', 'dbForPlatform', 'authorization', 'log', 'logger', 'project']);
+    $context->set('lock', function (Group $pools, Telemetry $telemetry, Database $dbForPlatform, Authorization $authorization, Log $log, ?Logger $logger, Document $project): Lock {
+        return new Lock(
+            fn (string $key, int $ttl, Closure $callback): mixed => $pools->get('lock')->use(
+                fn (\Redis $redis): mixed => $callback(new DistributedLock($redis, $key, $ttl))
+            ),
+            $telemetry,
+            $dbForPlatform,
+            $authorization,
+            $log,
+            $logger,
+            $project
+        );
+    }, ['pools', 'telemetry', 'dbForPlatform', 'authorization', 'log', 'logger', 'project']);
 
     $context->set('authorization', fn () => new Authorization(), []);
 

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -15,6 +15,7 @@ use Appwrite\Extend\Exception;
 use Appwrite\Functions\EventProcessor;
 use Appwrite\GraphQL\Schema;
 use Appwrite\Locking\Lock;
+use Appwrite\Locking\PlatformLock;
 use Appwrite\Network\Cors;
 use Appwrite\Network\Platform;
 use Appwrite\Network\Validator\Origin;
@@ -68,19 +69,23 @@ return function (Container $context): void {
 
     $context->set('logger', fn ($register) => $register->get('logger'), ['register']);
 
-    $context->set('lock', function (Group $pools, Telemetry $telemetry, Database $dbForPlatform, Authorization $authorization, Log $log, ?Logger $logger, Document $project): Lock {
+    $context->set('lock', function (Group $pools, Telemetry $telemetry, Log $log, ?Logger $logger, Document $project): Lock {
         return new Lock(
             fn (string $key, int $ttl, Closure $callback): mixed => $pools->get('lock')->use(
                 fn (\Redis $redis): mixed => $callback(new DistributedLock($redis, $key, $ttl))
             ),
             $telemetry,
-            $dbForPlatform,
-            $authorization,
             $log,
             $logger,
             $project
         );
-    }, ['pools', 'telemetry', 'dbForPlatform', 'authorization', 'log', 'logger', 'project']);
+    }, ['pools', 'telemetry', 'log', 'logger', 'project']);
+
+    $context->set('platformLock', fn (Lock $lock, Database $dbForPlatform, Authorization $authorization): PlatformLock => new PlatformLock(
+        $lock,
+        $dbForPlatform,
+        $authorization,
+    ), ['lock', 'dbForPlatform', 'authorization']);
 
     $context->set('authorization', fn () => new Authorization(), []);
 

--- a/src/Appwrite/Locking/Lock.php
+++ b/src/Appwrite/Locking/Lock.php
@@ -9,7 +9,7 @@ use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
-use Utopia\Lock\Distributed as DistributedLock;
+use Utopia\Lock\Lock as LockBackend;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
 use Utopia\System\System;
@@ -44,8 +44,13 @@ final class Lock
     /** @var array<string,int> */
     private static array $lastReportAt = [];
 
+    /**
+     * @var Closure(string, int, Closure(LockBackend): mixed): mixed
+     */
+    private readonly Closure $withLock;
+
     public function __construct(
-        private readonly \Redis $redis,
+        Closure $withLock,
         Telemetry $telemetry,
         private readonly Database $dbForPlatform,
         private readonly Authorization $authorization,
@@ -53,6 +58,7 @@ final class Lock
         private readonly ?Logger $logger,
         Document $project,
     ) {
+        $this->withLock = $withLock;
         $this->enabled = System::getEnv('_APP_LOCKING_ENABLED', 'enabled') !== 'disabled';
         $this->attempts = $telemetry->createCounter('lock.attempts', null, 'Distributed lock acquire outcomes');
         $sequence = $project->getSequence();
@@ -142,40 +148,41 @@ final class Lock
             return $fn();
         }
 
-        $lock = new DistributedLock($this->redis, $key, $ttl);
         $labels = ['target' => $target, 'project' => $this->projectInternalId];
 
-        try {
-            $acquired = $orFail ? $lock->acquire($waitTimeout) : $lock->tryAcquire();
-        } catch (\RedisException $e) {
-            $this->attempts->add(1, ['outcome' => self::OUTCOME_BACKEND_ERROR, ...$labels]);
-            $this->reportError(self::OUTCOME_BACKEND_ERROR, $key, $target, $e);
-
-            return $fn();
-        }
-
-        if (! $acquired) {
-            if ($orFail) {
-                $this->attempts->add(1, ['outcome' => self::OUTCOME_CONTENDED, ...$labels]);
-                // No custom message — the lock key embeds collection + document id.
-                throw new Exception(Exception::GENERAL_RESOURCE_LOCKED);
-            }
-            $this->attempts->add(1, ['outcome' => self::OUTCOME_SKIPPED, ...$labels]);
-
-            return null;
-        }
-
-        $this->attempts->add(1, ['outcome' => self::OUTCOME_ACQUIRED, ...$labels]);
-        try {
-            return $fn();
-        } finally {
+        return ($this->withLock)($key, $ttl, function (LockBackend $lock) use ($key, $target, $fn, $orFail, $waitTimeout, $labels) {
             try {
-                $lock->release();
-            } catch (Throwable $e) {
-                $this->attempts->add(1, ['outcome' => self::OUTCOME_RELEASE_ERROR, ...$labels]);
-                $this->reportError(self::OUTCOME_RELEASE_ERROR, $key, $target, $e);
+                $acquired = $orFail ? $lock->acquire($waitTimeout) : $lock->tryAcquire();
+            } catch (\RedisException $e) {
+                $this->attempts->add(1, ['outcome' => self::OUTCOME_BACKEND_ERROR, ...$labels]);
+                $this->reportError(self::OUTCOME_BACKEND_ERROR, $key, $target, $e);
+
+                return $fn();
             }
-        }
+
+            if (! $acquired) {
+                if ($orFail) {
+                    $this->attempts->add(1, ['outcome' => self::OUTCOME_CONTENDED, ...$labels]);
+                    // No custom message: the lock key embeds collection and document ID.
+                    throw new Exception(Exception::GENERAL_RESOURCE_LOCKED);
+                }
+                $this->attempts->add(1, ['outcome' => self::OUTCOME_SKIPPED, ...$labels]);
+
+                return;
+            }
+
+            $this->attempts->add(1, ['outcome' => self::OUTCOME_ACQUIRED, ...$labels]);
+            try {
+                return $fn();
+            } finally {
+                try {
+                    $lock->release();
+                } catch (Throwable $e) {
+                    $this->attempts->add(1, ['outcome' => self::OUTCOME_RELEASE_ERROR, ...$labels]);
+                    $this->reportError(self::OUTCOME_RELEASE_ERROR, $key, $target, $e);
+                }
+            }
+        });
     }
 
     /**

--- a/src/Appwrite/Locking/Lock.php
+++ b/src/Appwrite/Locking/Lock.php
@@ -6,10 +6,8 @@ use Appwrite\Extend\Exception;
 use Closure;
 use Throwable;
 use Utopia\Console;
-use Utopia\Database\Database;
 use Utopia\Database\Document;
-use Utopia\Database\Validator\Authorization;
-use Utopia\Lock\Lock as LockBackend;
+use Utopia\Lock\Lock as UtopiaLock;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
 use Utopia\System\System;
@@ -45,15 +43,13 @@ final class Lock
     private static array $lastReportAt = [];
 
     /**
-     * @var Closure(string, int, Closure(LockBackend): mixed): mixed
+     * @var Closure(string, int, Closure(UtopiaLock): mixed): mixed
      */
     private readonly Closure $withLock;
 
     public function __construct(
         Closure $withLock,
         Telemetry $telemetry,
-        private readonly Database $dbForPlatform,
-        private readonly Authorization $authorization,
         private readonly Log $log,
         private readonly ?Logger $logger,
         Document $project,
@@ -66,35 +62,12 @@ final class Lock
     }
 
     /**
-     * Throttled single-attribute write under a per-attribute skip-on-contention
-     * lock with authorization bypass. For idempotent timestamp-style updates
-     * (accessedAt, mcpAccessedAt) where regional pods writing the same value
-     * would thrash the platform DB.
-     */
-    public function set(
-        string $collection,
-        string $id,
-        string $attribute,
-        string $value,
-    ): void {
-        $key = "lock:platform:{$this->projectInternalId}:{$collection}:{$id}:{$attribute}";
-        $this->execute($key, $collection, function () use ($collection, $id, $attribute, $value) {
-            $this->authorization->skip(fn () => $this->dbForPlatform->updateDocument(
-                $collection,
-                $id,
-                new Document([$attribute => $value])
-            ));
-        });
-    }
-
-    /**
      * Skip-on-contention lock around an arbitrary callback for a platform
      * document. For idempotent multi-statement writes that don't fit `set`.
      */
     public function run(string $collection, string $id, Closure $fn): void
     {
-        $key = "lock:platform:{$this->projectInternalId}:{$collection}:{$id}";
-        $this->execute($key, $collection, $fn);
+        $this->execute($this->key($collection, $id), $collection, $fn);
     }
 
     /**
@@ -104,9 +77,7 @@ final class Lock
      */
     public function runOrFail(string $collection, string $id, Closure $fn): mixed
     {
-        $key = "lock:platform:{$this->projectInternalId}:{$collection}:{$id}";
-
-        return $this->execute($key, $collection, $fn, ttl: self::FAIL_TTL_SECONDS, orFail: true);
+        return $this->execute($this->key($collection, $id), $collection, $fn, ttl: self::FAIL_TTL_SECONDS, orFail: true);
     }
 
     /**
@@ -149,40 +120,54 @@ final class Lock
         }
 
         $labels = ['target' => $target, 'project' => $this->projectInternalId];
+        $lockCallbackStarted = false;
 
-        return ($this->withLock)($key, $ttl, function (LockBackend $lock) use ($key, $target, $fn, $orFail, $waitTimeout, $labels) {
-            try {
-                $acquired = $orFail ? $lock->acquire($waitTimeout) : $lock->tryAcquire();
-            } catch (\RedisException $e) {
-                $this->attempts->add(1, ['outcome' => self::OUTCOME_BACKEND_ERROR, ...$labels]);
-                $this->reportError(self::OUTCOME_BACKEND_ERROR, $key, $target, $e);
+        try {
+            return ($this->withLock)($key, $ttl, function (UtopiaLock $lock) use ($key, $target, $fn, $orFail, $waitTimeout, $labels, &$lockCallbackStarted) {
+                $lockCallbackStarted = true;
 
-                return $fn();
-            }
-
-            if (! $acquired) {
-                if ($orFail) {
-                    $this->attempts->add(1, ['outcome' => self::OUTCOME_CONTENDED, ...$labels]);
-                    // No custom message: the lock key embeds collection and document ID.
-                    throw new Exception(Exception::GENERAL_RESOURCE_LOCKED);
-                }
-                $this->attempts->add(1, ['outcome' => self::OUTCOME_SKIPPED, ...$labels]);
-
-                return;
-            }
-
-            $this->attempts->add(1, ['outcome' => self::OUTCOME_ACQUIRED, ...$labels]);
-            try {
-                return $fn();
-            } finally {
                 try {
-                    $lock->release();
-                } catch (Throwable $e) {
-                    $this->attempts->add(1, ['outcome' => self::OUTCOME_RELEASE_ERROR, ...$labels]);
-                    $this->reportError(self::OUTCOME_RELEASE_ERROR, $key, $target, $e);
+                    $acquired = $orFail ? $lock->acquire($waitTimeout) : $lock->tryAcquire();
+                } catch (\RedisException $e) {
+                    $this->attempts->add(1, ['outcome' => self::OUTCOME_BACKEND_ERROR, ...$labels]);
+                    $this->reportError(self::OUTCOME_BACKEND_ERROR, $key, $target, $e);
+
+                    return $fn();
                 }
+
+                if (! $acquired) {
+                    if ($orFail) {
+                        $this->attempts->add(1, ['outcome' => self::OUTCOME_CONTENDED, ...$labels]);
+                        // No custom message: the lock key embeds collection and document ID.
+                        throw new Exception(Exception::GENERAL_RESOURCE_LOCKED);
+                    }
+                    $this->attempts->add(1, ['outcome' => self::OUTCOME_SKIPPED, ...$labels]);
+
+                    return;
+                }
+
+                $this->attempts->add(1, ['outcome' => self::OUTCOME_ACQUIRED, ...$labels]);
+                try {
+                    return $fn();
+                } finally {
+                    try {
+                        $lock->release();
+                    } catch (Throwable $e) {
+                        $this->attempts->add(1, ['outcome' => self::OUTCOME_RELEASE_ERROR, ...$labels]);
+                        $this->reportError(self::OUTCOME_RELEASE_ERROR, $key, $target, $e);
+                    }
+                }
+            });
+        } catch (\RedisException $e) {
+            if ($lockCallbackStarted) {
+                throw $e;
             }
-        });
+
+            $this->attempts->add(1, ['outcome' => self::OUTCOME_BACKEND_ERROR, ...$labels]);
+            $this->reportError(self::OUTCOME_BACKEND_ERROR, $key, $target, $e);
+
+            return $fn();
+        }
     }
 
     /**
@@ -195,6 +180,17 @@ final class Lock
         $parts = explode(':', $key, 5);
 
         return $parts[3] ?? 'unknown';
+    }
+
+    /**
+     * Shared platform lock key builder. Exposed so higher-level decorators can
+     * keep the platform key shape centralized while adding narrower scopes.
+     */
+    public function key(string $collection, string $id, ?string $attribute = null): string
+    {
+        $key = "lock:platform:{$this->projectInternalId}:{$collection}:{$id}";
+
+        return $attribute === null ? $key : "{$key}:{$attribute}";
     }
 
     /**

--- a/src/Appwrite/Locking/PlatformLock.php
+++ b/src/Appwrite/Locking/PlatformLock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Appwrite\Locking;
+
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\Authorization;
+
+final class PlatformLock
+{
+    public function __construct(
+        private readonly Lock $lock,
+        private readonly Database $dbForPlatform,
+        private readonly Authorization $authorization,
+    ) {
+    }
+
+    /**
+     * Throttled single-attribute write under a per-attribute skip-on-contention
+     * lock with authorization bypass. For idempotent timestamp-style updates
+     * (accessedAt, mcpAccessedAt) where regional pods writing the same value
+     * would thrash the platform DB.
+     */
+    public function set(
+        string $collection,
+        string $id,
+        string $attribute,
+        string $value,
+    ): void {
+        $this->lock->withKey(
+            $this->lock->key($collection, $id, $attribute),
+            function () use ($collection, $id, $attribute, $value): void {
+                $this->authorization->skip(fn () => $this->dbForPlatform->updateDocument(
+                    $collection,
+                    $id,
+                    new Document([$attribute => $value])
+                ));
+            },
+            target: $collection,
+        );
+    }
+}

--- a/tests/unit/Locking/LockTest.php
+++ b/tests/unit/Locking/LockTest.php
@@ -8,10 +8,8 @@ use Appwrite\Extend\Exception;
 use Appwrite\Locking\Lock;
 use PHPUnit\Framework\TestCase;
 use Utopia\Config\Config;
-use Utopia\Database\Database;
 use Utopia\Database\Document;
-use Utopia\Database\Validator\Authorization;
-use Utopia\Lock\Lock as LockBackend;
+use Utopia\Lock\Lock as UtopiaLock;
 use Utopia\Logger\Log;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
 
@@ -23,8 +21,6 @@ final class LockTest extends TestCase
     private array $heldLocks = [];
 
     private Document $project;
-
-    private Authorization $authorization;
 
     private Log $log;
 
@@ -45,17 +41,14 @@ final class LockTest extends TestCase
             '$id' => 'test-project',
             '$sequence' => self::PROJECT_SEQUENCE,
         ]);
-        $this->authorization = new Authorization();
         $this->log = new Log();
     }
 
-    private function makeLock(?Database $db = null, ?Authorization $auth = null): Lock
+    private function makeLock(): Lock
     {
         return new Lock(
             $this->withLock(),
             new NoTelemetry(),
-            $db ?? $this->createStub(Database::class),
-            $auth ?? $this->authorization,
             $this->log,
             null,
             $this->project,
@@ -65,57 +58,6 @@ final class LockTest extends TestCase
     private function withLock(): \Closure
     {
         return fn (string $key, int $ttl, \Closure $callback): mixed => $callback(new MemoryLock($key, $this->heldLocks));
-    }
-
-    public function test_set_uses_per_attribute_key_and_auth_skipped_update(): void
-    {
-        $captured = null;
-        $db = $this->createMock(Database::class);
-        $db->expects($this->once())
-            ->method('updateDocument')
-            ->with('projects', 'p1', $this->callback(function (Document $doc) use (&$captured) {
-                $captured = $doc->getArrayCopy();
-
-                return true;
-            }))
-            ->willReturnArgument(2);
-
-        $lock = $this->makeLock($db);
-        $lock->set('projects', 'p1', 'accessedAt', '2024-06-01 12:00:00');
-
-        $this->assertSame(['accessedAt' => '2024-06-01 12:00:00'], $captured);
-        $this->assertArrayNotHasKey(self::KEY_PREFIX.'projects:p1:accessedAt', $this->heldLocks);
-    }
-
-    public function test_set_skips_on_contention(): void
-    {
-        $key = self::KEY_PREFIX.'projects:p1:accessedAt';
-        $this->heldLocks[$key] = true;
-
-        $db = $this->createMock(Database::class);
-        $db->expects($this->never())->method('updateDocument');
-
-        $lock = $this->makeLock($db);
-        $lock->set('projects', 'p1', 'accessedAt', '2024-06-01 12:00:00');
-
-        $this->assertArrayHasKey($key, $this->heldLocks);
-    }
-
-    public function test_set_different_attributes_do_not_compete(): void
-    {
-        $heldKey = self::KEY_PREFIX.'projects:p1:accessedAt';
-        $this->heldLocks[$heldKey] = true;
-
-        $db = $this->createMock(Database::class);
-        $db->expects($this->once())
-            ->method('updateDocument')
-            ->with('projects', 'p1', $this->isInstanceOf(Document::class))
-            ->willReturnArgument(2);
-
-        $lock = $this->makeLock($db);
-        $lock->set('projects', 'p1', 'mcpAccessedAt', '2024-06-01 12:00:00');
-
-        $this->assertArrayHasKey($heldKey, $this->heldLocks);
     }
 
     public function test_run_uses_per_document_key_and_invokes_callback(): void
@@ -143,6 +85,42 @@ final class LockTest extends TestCase
 
         $this->assertFalse($called);
         $this->assertArrayHasKey($key, $this->heldLocks);
+    }
+
+    public function test_backend_acquire_error_runs_callback_unlocked(): void
+    {
+        $lock = new Lock(
+            fn (string $key, int $ttl, \Closure $callback): mixed => $callback(new FailingLock(new \RedisException('redis unavailable'))),
+            new NoTelemetry(),
+            $this->log,
+            null,
+            $this->project,
+        );
+
+        $called = false;
+        $lock->run('keys', 'k1', function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+
+    public function test_pool_checkout_error_runs_callback_unlocked(): void
+    {
+        $lock = new Lock(
+            fn (string $key, int $ttl, \Closure $callback): mixed => throw new \RedisException('redis unavailable'),
+            new NoTelemetry(),
+            $this->log,
+            null,
+            $this->project,
+        );
+
+        $called = false;
+        $lock->run('keys', 'k1', function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
     }
 
     public function test_run_or_fail_throws_on_contention(): void
@@ -220,8 +198,6 @@ final class LockTest extends TestCase
         $lock = new Lock(
             $this->withLock(),
             new NoTelemetry(),
-            $this->createStub(Database::class),
-            $this->authorization,
             $this->log,
             null,
             $emptyProject,
@@ -240,7 +216,7 @@ final class LockTest extends TestCase
     }
 }
 
-final class MemoryLock implements LockBackend
+final class MemoryLock implements UtopiaLock
 {
     private bool $acquired = false;
 
@@ -291,5 +267,31 @@ final class MemoryLock implements LockBackend
         } finally {
             $this->release();
         }
+    }
+}
+
+final class FailingLock implements UtopiaLock
+{
+    public function __construct(private readonly \RedisException $error)
+    {
+    }
+
+    public function acquire(float $timeout = 0.0): bool
+    {
+        throw $this->error;
+    }
+
+    public function tryAcquire(): bool
+    {
+        throw $this->error;
+    }
+
+    public function release(): void
+    {
+    }
+
+    public function withLock(callable $callback, float $timeout = 0.0): mixed
+    {
+        throw $this->error;
     }
 }

--- a/tests/unit/Locking/LockTest.php
+++ b/tests/unit/Locking/LockTest.php
@@ -7,17 +7,20 @@ namespace Tests\Unit\Locking;
 use Appwrite\Extend\Exception;
 use Appwrite\Locking\Lock;
 use PHPUnit\Framework\TestCase;
-use Redis;
+use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
-use Utopia\DSN\DSN;
+use Utopia\Lock\Lock as LockBackend;
 use Utopia\Logger\Log;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
 
 final class LockTest extends TestCase
 {
-    private Redis $redis;
+    /**
+     * @var array<string, bool>
+     */
+    private array $heldLocks = [];
 
     private Document $project;
 
@@ -35,64 +38,21 @@ final class LockTest extends TestCase
 
     protected function setUp(): void
     {
-        [$host, $port] = $this->getRedisConnection();
+        Config::setParam('errors', require __DIR__.'/../../../app/config/errors.php');
 
-        $this->redis = new Redis();
-        $this->redis->connect($host, $port, 1.0);
-
+        $this->heldLocks = [];
         $this->project = new Document([
             '$id' => 'test-project',
             '$sequence' => self::PROJECT_SEQUENCE,
         ]);
         $this->authorization = new Authorization();
         $this->log = new Log();
-
-        $this->cleanupKeys();
-    }
-
-    /**
-     * @return array{0: string, 1: int}
-     */
-    private function getRedisConnection(): array
-    {
-        $dsn = \getenv('_APP_CONNECTIONS_CACHE') ?: '';
-
-        if ($dsn !== '') {
-            $dsn = \explode(',', $dsn, 2)[0];
-            $dsn = \explode('=', $dsn, 2)[1] ?? $dsn;
-            $parsed = new DSN($dsn);
-
-            return [$parsed->getHost(), (int) ($parsed->getPort() ?? '6379')];
-        }
-
-        return [
-            \getenv('_APP_REDIS_HOST') ?: 'redis',
-            (int) (\getenv('_APP_REDIS_PORT') ?: 6379),
-        ];
-    }
-
-    protected function tearDown(): void
-    {
-        if (isset($this->redis) && $this->redis->isConnected()) {
-            $this->cleanupKeys();
-        }
-    }
-
-    private function cleanupKeys(): void
-    {
-        foreach ($this->redis->keys(self::KEY_PREFIX.'*') as $key) {
-            $this->redis->del($key);
-        }
-        // also clean keys produced by withKey() tests
-        foreach ($this->redis->keys('lock:test:*') as $key) {
-            $this->redis->del($key);
-        }
     }
 
     private function makeLock(?Database $db = null, ?Authorization $auth = null): Lock
     {
         return new Lock(
-            $this->redis,
+            $this->withLock(),
             new NoTelemetry(),
             $db ?? $this->createStub(Database::class),
             $auth ?? $this->authorization,
@@ -100,6 +60,11 @@ final class LockTest extends TestCase
             null,
             $this->project,
         );
+    }
+
+    private function withLock(): \Closure
+    {
+        return fn (string $key, int $ttl, \Closure $callback): mixed => $callback(new MemoryLock($key, $this->heldLocks));
     }
 
     public function test_set_uses_per_attribute_key_and_auth_skipped_update(): void
@@ -119,13 +84,13 @@ final class LockTest extends TestCase
         $lock->set('projects', 'p1', 'accessedAt', '2024-06-01 12:00:00');
 
         $this->assertSame(['accessedAt' => '2024-06-01 12:00:00'], $captured);
-        $this->assertSame(0, $this->redis->exists(self::KEY_PREFIX.'projects:p1:accessedAt'));
+        $this->assertArrayNotHasKey(self::KEY_PREFIX.'projects:p1:accessedAt', $this->heldLocks);
     }
 
     public function test_set_skips_on_contention(): void
     {
         $key = self::KEY_PREFIX.'projects:p1:accessedAt';
-        $this->redis->set($key, 'other-owner', ['NX', 'EX' => 30]);
+        $this->heldLocks[$key] = true;
 
         $db = $this->createMock(Database::class);
         $db->expects($this->never())->method('updateDocument');
@@ -133,16 +98,14 @@ final class LockTest extends TestCase
         $lock = $this->makeLock($db);
         $lock->set('projects', 'p1', 'accessedAt', '2024-06-01 12:00:00');
 
-        $this->assertSame('other-owner', $this->redis->get($key));
+        $this->assertArrayHasKey($key, $this->heldLocks);
     }
 
     public function test_set_different_attributes_do_not_compete(): void
     {
-        // Hold accessedAt
         $heldKey = self::KEY_PREFIX.'projects:p1:accessedAt';
-        $this->redis->set($heldKey, 'other-owner', ['NX', 'EX' => 30]);
+        $this->heldLocks[$heldKey] = true;
 
-        // mcpAccessedAt should still be acquirable
         $db = $this->createMock(Database::class);
         $db->expects($this->once())
             ->method('updateDocument')
@@ -152,7 +115,7 @@ final class LockTest extends TestCase
         $lock = $this->makeLock($db);
         $lock->set('projects', 'p1', 'mcpAccessedAt', '2024-06-01 12:00:00');
 
-        $this->assertSame('other-owner', $this->redis->get($heldKey));
+        $this->assertArrayHasKey($heldKey, $this->heldLocks);
     }
 
     public function test_run_uses_per_document_key_and_invokes_callback(): void
@@ -164,13 +127,13 @@ final class LockTest extends TestCase
         });
 
         $this->assertTrue($called);
-        $this->assertSame(0, $this->redis->exists(self::KEY_PREFIX.'keys:k1'));
+        $this->assertArrayNotHasKey(self::KEY_PREFIX.'keys:k1', $this->heldLocks);
     }
 
     public function test_run_skips_on_contention(): void
     {
         $key = self::KEY_PREFIX.'keys:k1';
-        $this->redis->set($key, 'other-owner', ['NX', 'EX' => 30]);
+        $this->heldLocks[$key] = true;
 
         $called = false;
         $lock = $this->makeLock();
@@ -179,13 +142,13 @@ final class LockTest extends TestCase
         });
 
         $this->assertFalse($called);
-        $this->assertSame('other-owner', $this->redis->get($key));
+        $this->assertArrayHasKey($key, $this->heldLocks);
     }
 
     public function test_run_or_fail_throws_on_contention(): void
     {
         $key = self::KEY_PREFIX.'projects:p1';
-        $this->redis->set($key, 'other-owner', ['NX', 'EX' => 30]);
+        $this->heldLocks[$key] = true;
 
         $lock = $this->makeLock();
 
@@ -204,7 +167,7 @@ final class LockTest extends TestCase
         $result = $lock->runOrFail('projects', 'p1', fn () => 'ok');
 
         $this->assertSame('ok', $result);
-        $this->assertSame(0, $this->redis->exists(self::KEY_PREFIX.'projects:p1'));
+        $this->assertArrayNotHasKey(self::KEY_PREFIX.'projects:p1', $this->heldLocks);
     }
 
     public function test_with_key_uses_raw_key(): void
@@ -217,13 +180,13 @@ final class LockTest extends TestCase
         });
 
         $this->assertTrue($called);
-        $this->assertSame(0, $this->redis->exists($custom));
+        $this->assertArrayNotHasKey($custom, $this->heldLocks);
     }
 
     public function test_with_key_or_fail_flag_throws_on_contention(): void
     {
         $custom = 'lock:test:contended';
-        $this->redis->set($custom, 'other', ['NX', 'EX' => 30]);
+        $this->heldLocks[$custom] = true;
 
         $lock = $this->makeLock();
         $this->expectException(Exception::class);
@@ -235,9 +198,8 @@ final class LockTest extends TestCase
         $previous = \getenv('_APP_LOCKING_ENABLED');
         \putenv('_APP_LOCKING_ENABLED=disabled');
         try {
-            // Even when the key is already held, the callback must still run.
             $key = self::KEY_PREFIX.'keys:k1';
-            $this->redis->set($key, 'other-owner', ['NX', 'EX' => 30]);
+            $this->heldLocks[$key] = true;
 
             $called = false;
             $lock = $this->makeLock();
@@ -246,7 +208,7 @@ final class LockTest extends TestCase
             });
 
             $this->assertTrue($called);
-            $this->assertSame('other-owner', $this->redis->get($key));
+            $this->assertArrayHasKey($key, $this->heldLocks);
         } finally {
             $previous === false ? \putenv('_APP_LOCKING_ENABLED') : \putenv('_APP_LOCKING_ENABLED='.$previous);
         }
@@ -256,7 +218,7 @@ final class LockTest extends TestCase
     {
         $emptyProject = new Document();
         $lock = new Lock(
-            $this->redis,
+            $this->withLock(),
             new NoTelemetry(),
             $this->createStub(Database::class),
             $this->authorization,
@@ -265,9 +227,8 @@ final class LockTest extends TestCase
             $emptyProject,
         );
 
-        // Pre-acquire the lock at the 'unknown' projectInternalId path.
         $key = 'lock:platform:unknown:keys:k1';
-        $this->redis->set($key, 'held', ['NX', 'EX' => 30]);
+        $this->heldLocks[$key] = true;
 
         $called = false;
         $lock->run('keys', 'k1', function () use (&$called) {
@@ -275,6 +236,60 @@ final class LockTest extends TestCase
         });
         $this->assertFalse($called, 'Lock without project sequence should hash to the unknown bucket');
 
-        $this->redis->del($key);
+        unset($this->heldLocks[$key]);
+    }
+}
+
+final class MemoryLock implements LockBackend
+{
+    private bool $acquired = false;
+
+    /**
+     * @param array<string, bool> $heldLocks
+     */
+    public function __construct(
+        private readonly string $key,
+        private array &$heldLocks,
+    ) {
+    }
+
+    public function acquire(float $timeout = 0.0): bool
+    {
+        return $this->tryAcquire();
+    }
+
+    public function tryAcquire(): bool
+    {
+        if (isset($this->heldLocks[$this->key])) {
+            return false;
+        }
+
+        $this->heldLocks[$this->key] = true;
+        $this->acquired = true;
+
+        return true;
+    }
+
+    public function release(): void
+    {
+        if (! $this->acquired) {
+            return;
+        }
+
+        unset($this->heldLocks[$this->key]);
+        $this->acquired = false;
+    }
+
+    public function withLock(callable $callback, float $timeout = 0.0): mixed
+    {
+        if (! $this->acquire($timeout)) {
+            return null;
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $this->release();
+        }
     }
 }

--- a/tests/unit/Locking/PlatformLockTest.php
+++ b/tests/unit/Locking/PlatformLockTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Locking;
+
+use Appwrite\Locking\Lock;
+use Appwrite\Locking\PlatformLock;
+use PHPUnit\Framework\TestCase;
+use Utopia\Config\Config;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\Authorization;
+use Utopia\Lock\Lock as UtopiaLock;
+use Utopia\Logger\Log;
+use Utopia\Telemetry\Adapter\None as NoTelemetry;
+
+final class PlatformLockTest extends TestCase
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $heldLocks = [];
+
+    private Document $project;
+
+    private Authorization $authorization;
+
+    private const PROJECT_SEQUENCE = '42';
+
+    private const KEY_PREFIX = 'lock:platform:'.self::PROJECT_SEQUENCE.':';
+
+    protected function setUp(): void
+    {
+        Config::setParam('errors', require __DIR__.'/../../../app/config/errors.php');
+
+        $this->heldLocks = [];
+        $this->project = new Document([
+            '$id' => 'test-project',
+            '$sequence' => self::PROJECT_SEQUENCE,
+        ]);
+        $this->authorization = new Authorization();
+    }
+
+    private function makePlatformLock(?Database $db = null): PlatformLock
+    {
+        return new PlatformLock(
+            new Lock(
+                fn (string $key, int $ttl, \Closure $callback): mixed => $callback(new PlatformMemoryLock($key, $this->heldLocks)),
+                new NoTelemetry(),
+                new Log(),
+                null,
+                $this->project,
+            ),
+            $db ?? $this->createStub(Database::class),
+            $this->authorization,
+        );
+    }
+
+    public function test_set_uses_per_attribute_key_and_auth_skipped_update(): void
+    {
+        $captured = null;
+        $db = $this->createMock(Database::class);
+        $db->expects($this->once())
+            ->method('updateDocument')
+            ->with('projects', 'p1', $this->callback(function (Document $doc) use (&$captured) {
+                $captured = $doc->getArrayCopy();
+
+                return true;
+            }))
+            ->willReturnArgument(2);
+
+        $lock = $this->makePlatformLock($db);
+        $lock->set('projects', 'p1', 'accessedAt', '2024-06-01 12:00:00');
+
+        $this->assertSame(['accessedAt' => '2024-06-01 12:00:00'], $captured);
+        $this->assertArrayNotHasKey(self::KEY_PREFIX.'projects:p1:accessedAt', $this->heldLocks);
+    }
+
+    public function test_set_skips_on_contention(): void
+    {
+        $key = self::KEY_PREFIX.'projects:p1:accessedAt';
+        $this->heldLocks[$key] = true;
+
+        $db = $this->createMock(Database::class);
+        $db->expects($this->never())->method('updateDocument');
+
+        $lock = $this->makePlatformLock($db);
+        $lock->set('projects', 'p1', 'accessedAt', '2024-06-01 12:00:00');
+
+        $this->assertArrayHasKey($key, $this->heldLocks);
+    }
+
+    public function test_set_different_attributes_do_not_compete(): void
+    {
+        $heldKey = self::KEY_PREFIX.'projects:p1:accessedAt';
+        $this->heldLocks[$heldKey] = true;
+
+        $db = $this->createMock(Database::class);
+        $db->expects($this->once())
+            ->method('updateDocument')
+            ->with('projects', 'p1', $this->isInstanceOf(Document::class))
+            ->willReturnArgument(2);
+
+        $lock = $this->makePlatformLock($db);
+        $lock->set('projects', 'p1', 'mcpAccessedAt', '2024-06-01 12:00:00');
+
+        $this->assertArrayHasKey($heldKey, $this->heldLocks);
+    }
+}
+
+final class PlatformMemoryLock implements UtopiaLock
+{
+    private bool $acquired = false;
+
+    /**
+     * @param array<string, bool> $heldLocks
+     */
+    public function __construct(
+        private readonly string $key,
+        private array &$heldLocks,
+    ) {
+    }
+
+    public function acquire(float $timeout = 0.0): bool
+    {
+        return $this->tryAcquire();
+    }
+
+    public function tryAcquire(): bool
+    {
+        if (isset($this->heldLocks[$this->key])) {
+            return false;
+        }
+
+        $this->heldLocks[$this->key] = true;
+        $this->acquired = true;
+
+        return true;
+    }
+
+    public function release(): void
+    {
+        if (! $this->acquired) {
+            return;
+        }
+
+        unset($this->heldLocks[$this->key]);
+        $this->acquired = false;
+    }
+
+    public function withLock(callable $callback, float $timeout = 0.0): mixed
+    {
+        if (! $this->acquire($timeout)) {
+            return null;
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $this->release();
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- Resolve the request-scoped Lock service through the existing `lock` pool instead of the legacy shared `redis` resource.
- Pass Lock a lock-provider callback so the pooled Redis connection stays borrowed while the distributed lock is used.
- Keep existing Redis resource and pool registration behavior unchanged.
- Convert LockTest to a true unit test with an in-memory `Utopia\Lock\Lock` fake instead of connecting to Redis.

## Why
Cloud already configures its `lock` pool through `_APP_CONNECTIONS_LOCKS`. Appwrite CE only needs to consume the existing lock pool; it should not add new env behavior or make unit tests depend on external Redis.

This follows the existing Cloud `main` pattern where a dedicated `lock` pool is registered from `_APP_CONNECTIONS_LOCKS` and consumers use `$pools->get('lock')` rather than creating ad-hoc Redis clients:
https://github.com/appwrite-labs/cloud/blob/f2f3661fde840d0476d2bb945c9f6ac373499804/app/init/registers.php#L161-L162

## Testing
- composer lint
- vendor/bin/phpunit --no-configuration --bootstrap vendor/autoload.php tests/unit/Locking/LockTest.php
- php -l app/init/resources/request.php
- php -l src/Appwrite/Locking/Lock.php
- php -l tests/unit/Locking/LockTest.php
- git diff --check