### PR TITLE
Fix project config lost updates from stale cached reads

### DIFF
--- a/src/Appwrite/Platform/Action.php
+++ b/src/Appwrite/Platform/Action.php
@@ -8,6 +8,7 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
+use Utopia\Database\Validator\Authorization;
 use Utopia\Platform\Action as UtopiaAction;
 
 class Action extends UtopiaAction
@@ -103,6 +104,32 @@ class Action extends UtopiaAction
 
             $latestDocument = $results[array_key_last($results)];
         }
+    }
+
+    /**
+     * Update the project document from a locked read of the current row.
+     *
+     * Project configuration lives in map attributes (services, auths, smtp,
+     * apis, oAuthProviders, templates) that endpoints merge a single key into.
+     * Computing that merge from the request-scoped project resource loses
+     * concurrent writes: the resource is a cached read taken at request start,
+     * and writing the merged map back replaces the whole attribute. The
+     * changes callback receives the current row, read under a row lock inside
+     * a transaction, so the merge is atomic with the write.
+     *
+     * @param callable(Document): array<string, mixed> $changes
+     */
+    protected function updateProject(
+        Database $dbForPlatform,
+        Authorization $authorization,
+        Document $project,
+        callable $changes
+    ): Document {
+        return $dbForPlatform->withTransaction(fn () => $authorization->skip(function () use ($dbForPlatform, $project, $changes) {
+            $current = $dbForPlatform->getDocument('projects', $project->getId(), forUpdate: true);
+
+            return $dbForPlatform->updateDocument('projects', $project->getId(), new Document($changes($current)));
+        }));
     }
 
     public function disableSubqueries(array $filters = []): void

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
@@ -76,12 +76,12 @@ class Update extends Action
         $auth = Config::getParam('auth')[$methodId] ?? [];
         $authKey = $auth['key'] ?? '';
 
-        $auths = $project->getAttribute('auths', []);
-        $auths[$authKey] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($authKey, $enabled) {
+            $auths = $current->getAttribute('auths', []);
+            $auths[$authKey] = $enabled;
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-            'auths' => $auths,
-        ])));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents->setParam('methodId', $methodId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Create.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Project\Http\Project\MockPhone;
 use Appwrite\Auth\Validator\Phone;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -13,7 +14,6 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
-use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Validator\Text;
 
@@ -71,20 +71,6 @@ class Create extends Action
         Database $dbForPlatform,
         Authorization $authorization,
     ) {
-        $auths = $project->getAttribute('auths', []);
-
-        $mockNumbers = $auths['mockNumbers'] ?? [];
-
-        if (\count($mockNumbers) >= APP_LIMIT_COUNT) {
-            throw new Exception(Exception::MOCK_NUMBER_LIMIT_EXCEEDED);
-        }
-
-        foreach ($mockNumbers as $mockNumber) {
-            if ($mockNumber['phone'] === $number) {
-                throw new Exception(Exception::MOCK_NUMBER_ALREADY_EXISTS);
-            }
-        }
-
         // Set to now date
         $mockNumber = [
             'phone' => $number,
@@ -93,14 +79,26 @@ class Create extends Action
             '$updatedAt' => DateTime::now(),
         ];
 
-        $mockNumbers[] = $mockNumber;
-        $auths['mockNumbers'] = $mockNumbers;
+        $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($number, $mockNumber) {
+            $auths = $current->getAttribute('auths', []);
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
+            $mockNumbers = $auths['mockNumbers'] ?? [];
 
-        $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            if (\count($mockNumbers) >= APP_LIMIT_COUNT) {
+                throw new Exception(Exception::MOCK_NUMBER_LIMIT_EXCEEDED);
+            }
+
+            foreach ($mockNumbers as $mock) {
+                if ($mock['phone'] === $number) {
+                    throw new Exception(Exception::MOCK_NUMBER_ALREADY_EXISTS);
+                }
+            }
+
+            $mockNumbers[] = $mockNumber;
+            $auths['mockNumbers'] = $mockNumbers;
+
+            return ['auths' => $auths];
+        });
 
         $queueForEvents->setParam('number', $number);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Delete.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Project\Http\Project\MockPhone;
 use Appwrite\Auth\Validator\Phone;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
@@ -13,7 +14,6 @@ use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
-use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 
 class Delete extends Action
@@ -69,32 +69,30 @@ class Delete extends Action
         Database $dbForPlatform,
         Authorization $authorization,
     ) {
-        $auths = $project->getAttribute('auths', []);
+        $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($number) {
+            $auths = $current->getAttribute('auths', []);
 
-        $mockNumbers = $auths['mockNumbers'] ?? [];
+            $mockNumbers = $auths['mockNumbers'] ?? [];
 
-        $mockNumberIndex = null;
-        foreach ($mockNumbers as $index => $mock) {
-            if ($mock['phone'] === $number) {
-                $mockNumberIndex = $index;
-                break;
+            $mockNumberIndex = null;
+            foreach ($mockNumbers as $index => $mock) {
+                if ($mock['phone'] === $number) {
+                    $mockNumberIndex = $index;
+                    break;
+                }
             }
-        }
 
-        if (\is_null($mockNumberIndex)) {
-            throw new Exception(Exception::MOCK_NUMBER_NOT_FOUND);
-        }
+            if (\is_null($mockNumberIndex)) {
+                throw new Exception(Exception::MOCK_NUMBER_NOT_FOUND);
+            }
 
-        unset($mockNumbers[$mockNumberIndex]);
-        $mockNumbers = array_values($mockNumbers);
+            unset($mockNumbers[$mockNumberIndex]);
+            $mockNumbers = array_values($mockNumbers);
 
-        $auths['mockNumbers'] = $mockNumbers;
+            $auths['mockNumbers'] = $mockNumbers;
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents->setParam('number', $number);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Update.php
@@ -5,6 +5,7 @@ namespace Appwrite\Platform\Modules\Project\Http\Project\MockPhone;
 use Appwrite\Auth\Validator\Phone;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -13,7 +14,6 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
-use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Validator\Text;
 
@@ -71,37 +71,38 @@ class Update extends Action
         Database $dbForPlatform,
         Authorization $authorization,
     ) {
-        $auths = $project->getAttribute('auths', []);
+        $mockNumber = [];
 
-        $mockNumbers = $auths['mockNumbers'] ?? [];
+        $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($number, $otp, &$mockNumber) {
+            $auths = $current->getAttribute('auths', []);
 
-        $mockNumberIndex = null;
-        foreach ($mockNumbers as $index => $mock) {
-            if ($mock['phone'] === $number) {
-                $mockNumberIndex = $index;
-                break;
+            $mockNumbers = $auths['mockNumbers'] ?? [];
+
+            $mockNumberIndex = null;
+            foreach ($mockNumbers as $index => $mock) {
+                if ($mock['phone'] === $number) {
+                    $mockNumberIndex = $index;
+                    break;
+                }
             }
-        }
 
-        if (\is_null($mockNumberIndex)) {
-            throw new Exception(Exception::MOCK_NUMBER_NOT_FOUND);
-        }
+            if (\is_null($mockNumberIndex)) {
+                throw new Exception(Exception::MOCK_NUMBER_NOT_FOUND);
+            }
 
-        $mockNumbers[$mockNumberIndex]['otp'] = $otp;
-        $mockNumbers[$mockNumberIndex]['$updatedAt'] = DateTime::now();
+            $mockNumbers[$mockNumberIndex]['otp'] = $otp;
+            $mockNumbers[$mockNumberIndex]['$updatedAt'] = DateTime::now();
 
-        $auths['mockNumbers'] = $mockNumbers;
+            $auths['mockNumbers'] = $mockNumbers;
+            $mockNumber = $mockNumbers[$mockNumberIndex];
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents->setParam('number', $number);
 
         $response
             ->setStatusCode(Response::STATUS_CODE_OK)
-            ->dynamic(new Document($mockNumbers[$mockNumberIndex]), Response::MODEL_MOCK_NUMBER);
+            ->dynamic(new Document($mockNumber), Response::MODEL_MOCK_NUMBER);
     }
 }

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
@@ -381,39 +381,32 @@ abstract class Base extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Provider ' . $providerId . ' is not supported by server configuration.');
         }
 
-        $oAuthProviders = $project->getAttribute('oAuthProviders', []);
-
         $appIdKey = $providerId . 'Appid';
         $appSecretKey = $providerId . 'Secret';
         $enabledKey = $providerId . 'Enabled';
 
-        if (!\is_null($clientId)) {
-            $oAuthProviders[$appIdKey] = $clientId;
-        }
+        // Validate against the merged view (request params over current values)
+        // before taking the row lock: verifyCredentials performs network calls.
+        $oAuthProviders = $project->getAttribute('oAuthProviders', []);
+        $appId = $clientId ?? $oAuthProviders[$appIdKey] ?? '';
+        $appSecret = $clientSecret ?? $oAuthProviders[$appSecretKey] ?? '';
 
-        if (!\is_null($clientSecret)) {
-            $oAuthProviders[$appSecretKey] = $clientSecret;
-        }
-
-        if (!\is_null($enabled)) {
-            $oAuthProviders[$enabledKey] = $enabled;
-        }
-
+        $validatedEnabled = $enabled;
         if ($enabled === true || \is_null($enabled)) {
             try {
-                if (empty($oAuthProviders[$appIdKey]) || empty($oAuthProviders[$appSecretKey])) {
+                if (empty($appId) || empty($appSecret)) {
                     throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Client ID and Client Secret are required when enabling OAuth2 provider.');
                 }
 
                 $providerClass = static::getProviderClass();
-                $providerInstance = new $providerClass(appId: $oAuthProviders[$appIdKey], appSecret: $oAuthProviders[$appSecretKey], callback: '', state: [], scopes: []);
+                $providerInstance = new $providerClass(appId: $appId, appSecret: $appSecret, callback: '', state: [], scopes: []);
 
                 // E2E integration check
                 if (\method_exists($providerInstance, 'verifyCredentials')) {
                     $providerInstance->verifyCredentials();
                 }
 
-                $oAuthProviders[$enabledKey] = true;
+                $validatedEnabled = true;
             } catch (\Throwable $err) {
                 if ($enabled === true) {
                     throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Could not enable OAuth2 provider: ' . $err->getMessage());
@@ -421,11 +414,23 @@ abstract class Base extends Action
             }
         }
 
-        $updates = new Document([
-            'oAuthProviders' => $oAuthProviders
-        ]);
+        return $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($appIdKey, $appSecretKey, $enabledKey, $clientId, $clientSecret, $validatedEnabled) {
+            $oAuthProviders = $current->getAttribute('oAuthProviders', []);
 
-        return $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            if (!\is_null($clientId)) {
+                $oAuthProviders[$appIdKey] = $clientId;
+            }
+
+            if (!\is_null($clientSecret)) {
+                $oAuthProviders[$appSecretKey] = $clientSecret;
+            }
+
+            if (!\is_null($validatedEnabled)) {
+                $oAuthProviders[$enabledKey] = $validatedEnabled;
+            }
+
+            return ['oAuthProviders' => $oAuthProviders];
+        });
     }
 
     public function action(

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
@@ -77,32 +77,30 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($userId, $userEmail, $userPhone, $userName, $userMFA, $userAccessedAt) {
+            $auths = $current->getAttribute('auths', []);
 
-        if ($userId !== null) {
-            $auths['membershipsUserId'] = $userId;
-        }
-        if ($userEmail !== null) {
-            $auths['membershipsUserEmail'] = $userEmail;
-        }
-        if ($userPhone !== null) {
-            $auths['membershipsUserPhone'] = $userPhone;
-        }
-        if ($userName !== null) {
-            $auths['membershipsUserName'] = $userName;
-        }
-        if ($userMFA !== null) {
-            $auths['membershipsMfa'] = $userMFA;
-        }
-        if ($userAccessedAt !== null) {
-            $auths['membershipsUserAccessedAt'] = $userAccessedAt;
-        }
+            if ($userId !== null) {
+                $auths['membershipsUserId'] = $userId;
+            }
+            if ($userEmail !== null) {
+                $auths['membershipsUserEmail'] = $userEmail;
+            }
+            if ($userPhone !== null) {
+                $auths['membershipsUserPhone'] = $userPhone;
+            }
+            if ($userName !== null) {
+                $auths['membershipsUserName'] = $userName;
+            }
+            if ($userMFA !== null) {
+                $auths['membershipsMfa'] = $userMFA;
+            }
+            if ($userAccessedAt !== null) {
+                $auths['membershipsUserAccessedAt'] = $userAccessedAt;
+            }
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
@@ -67,14 +67,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
-        $auths['passwordDictionary'] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($enabled) {
+            $auths = $current->getAttribute('auths', []);
+            $auths['passwordDictionary'] = $enabled;
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
@@ -70,19 +70,17 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($total) {
+            $auths = $current->getAttribute('auths', []);
 
-        if (\is_null($total)) {
-            $auths['passwordHistory'] = 0;
-        } else {
-            $auths['passwordHistory'] = $total;
-        }
+            if (\is_null($total)) {
+                $auths['passwordHistory'] = 0;
+            } else {
+                $auths['passwordHistory'] = $total;
+            }
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
@@ -68,14 +68,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
-        $auths['personalDataCheck'] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($enabled) {
+            $auths = $current->getAttribute('auths', []);
+            $auths['personalDataCheck'] = $enabled;
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
@@ -75,34 +75,36 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($min, $uppercase, $lowercase, $number, $symbols) {
+            $auths = $current->getAttribute('auths', []);
+            $auths['passwordStrength'] = \array_merge([
+                'min' => 8,
+                'uppercase' => false,
+                'lowercase' => false,
+                'number' => false,
+                'symbols' => false,
+            ], $auths['passwordStrength'] ?? []);
+
+            if ($min !== null) {
+                $auths['passwordStrength']['min'] = $min;
+            }
+            if ($uppercase !== null) {
+                $auths['passwordStrength']['uppercase'] = $uppercase;
+            }
+            if ($lowercase !== null) {
+                $auths['passwordStrength']['lowercase'] = $lowercase;
+            }
+            if ($number !== null) {
+                $auths['passwordStrength']['number'] = $number;
+            }
+            if ($symbols !== null) {
+                $auths['passwordStrength']['symbols'] = $symbols;
+            }
+
+            return ['auths' => $auths];
+        });
+
         $auths = $project->getAttribute('auths', []);
-        $auths['passwordStrength'] = \array_merge([
-            'min' => 8,
-            'uppercase' => false,
-            'lowercase' => false,
-            'number' => false,
-            'symbols' => false,
-        ], $auths['passwordStrength'] ?? []);
-
-        if ($min !== null) {
-            $auths['passwordStrength']['min'] = $min;
-        }
-        if ($uppercase !== null) {
-            $auths['passwordStrength']['uppercase'] = $uppercase;
-        }
-        if ($lowercase !== null) {
-            $auths['passwordStrength']['lowercase'] = $lowercase;
-        }
-        if ($number !== null) {
-            $auths['passwordStrength']['number'] = $number;
-        }
-        if ($symbols !== null) {
-            $auths['passwordStrength']['symbols'] = $symbols;
-        }
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-            'auths' => $auths,
-        ])));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
@@ -67,14 +67,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
-        $auths['sessionAlerts'] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($enabled) {
+            $auths = $current->getAttribute('auths', []);
+            $auths['sessionAlerts'] = $enabled;
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
@@ -67,14 +67,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
-        $auths['duration'] = $duration;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($duration) {
+            $auths = $current->getAttribute('auths', []);
+            $auths['duration'] = $duration;
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
@@ -67,14 +67,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
-        $auths['invalidateSessions'] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($enabled) {
+            $auths = $current->getAttribute('auths', []);
+            $auths['invalidateSessions'] = $enabled;
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
@@ -68,19 +68,17 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($total) {
+            $auths = $current->getAttribute('auths', []);
 
-        if (\is_null($total)) {
-            $auths['maxSessions'] = 0;
-        } else {
-            $auths['maxSessions'] = $total;
-        }
+            if (\is_null($total)) {
+                $auths['maxSessions'] = 0;
+            } else {
+                $auths['maxSessions'] = $total;
+            }
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
@@ -68,19 +68,17 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $auths = $project->getAttribute('auths', []);
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($total) {
+            $auths = $current->getAttribute('auths', []);
 
-        if (\is_null($total)) {
-            $auths['limit'] = 0;
-        } else {
-            $auths['limit'] = $total;
-        }
+            if (\is_null($total)) {
+                $auths['limit'] = 0;
+            } else {
+                $auths['limit'] = $total;
+            }
 
-        $updates = new Document([
-            'auths' => $auths,
-        ]);
-
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            return ['auths' => $auths];
+        });
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
@@ -73,12 +73,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents,
     ): void {
-        $protocols = $project->getAttribute('apis', []);
-        $protocols[$protocolId] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($protocolId, $enabled) {
+            $protocols = $current->getAttribute('apis', []);
+            $protocols[$protocolId] = $enabled;
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-            'apis' => $protocols,
-        ])));
+            return ['apis' => $protocols];
+        });
 
         $queueForEvents->setParam('protocolId', $protocolId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
@@ -164,12 +164,27 @@ class Update extends Action
             }
         }
 
-        // Save configuration
-        $updates = new Document([
-            'smtp' => $smtp,
-        ]);
+        $validatedEnabled = $enabled ?? ((($smtp['enabled'] ?? null) === true) ? true : null);
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($host, $port, $username, $password, $senderEmail, $senderName, $replyToEmail, $replyToName, $secure, $validatedEnabled) {
+            // Re-merge onto the locked row: request params and the validated enabled outcome win, untouched keys keep concurrent writes.
+            $smtp = $current->getAttribute('smtp', []);
+
+            $keys = ['host', 'port', 'username', 'password', 'senderEmail', 'senderName', 'replyToEmail', 'replyToName', 'secure'];
+            foreach ($keys as $key) {
+                if (!\is_null(${$key})) {
+                    $smtp[$key] = ${$key};
+                }
+            }
+
+            $smtp['replyToEmail'] = $smtp['replyToEmail'] ?? $smtp['replyTo'] ?? '';
+
+            if (!\is_null($validatedEnabled)) {
+                $smtp['enabled'] = $validatedEnabled;
+            }
+
+            return ['smtp' => $smtp];
+        });
 
         $response->dynamic($project, Response::MODEL_PROJECT);
     }

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
@@ -73,12 +73,12 @@ class Update extends Action
         Authorization $authorization,
         Event $queueForEvents
     ): void {
-        $services = $project->getAttribute('services', []);
-        $services[$serviceId] = $enabled;
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($serviceId, $enabled) {
+            $services = $current->getAttribute('services', []);
+            $services[$serviceId] = $enabled;
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
-            'services' => $services,
-        ])));
+            return ['services' => $services];
+        });
 
         $queueForEvents->setParam('serviceId', $serviceId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Project\Http\Project\Templates\Email;
 
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
@@ -13,7 +14,6 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Emails\Validator\Email;
-use Utopia\Platform\Action;
 use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\System\System;
@@ -96,39 +96,40 @@ class Update extends Action
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'SMTP must be enabled on the project to configure custom email templates.');
         }
 
-        // Fetch current configuration
-        $templates = $project->getAttribute('templates', []);
-        $template = $templates['email.' . $templateId . '-' . $locale] ?? [];
+        $project = $this->updateProject($dbForPlatform, $authorization, $project, function (Document $current) use ($templateId, $locale, $subject, $message, $senderName, $senderEmail, $replyToEmail, $replyToName) {
+            // Fetch current configuration
+            $templates = $current->getAttribute('templates', []);
+            $template = $templates['email.' . $templateId . '-' . $locale] ?? [];
 
-        // Apply changes — null means "not provided, keep existing".
-        // Empty string explicitly clears a previously-set value.
-        $keys = ['senderName', 'senderEmail', 'replyToEmail', 'replyToName', 'message', 'subject'];
-        foreach ($keys as $key) {
-            if (!\is_null(${$key})) {
-                $template[$key] = ${$key};
+            // Apply changes — null means "not provided, keep existing".
+            // Empty string explicitly clears a previously-set value.
+            $keys = ['senderName', 'senderEmail', 'replyToEmail', 'replyToName', 'message', 'subject'];
+            foreach ($keys as $key) {
+                if (!\is_null(${$key})) {
+                    $template[$key] = ${$key};
+                }
             }
-        }
 
-        // Backwards compatibility
-        if (!\is_null($template['replyTo'] ?? null)) {
-            $template['replyToEmail'] = $template['replyToEmail'] ?? $template['replyTo'] ?? '';
-        }
-
-        // Ensure required fields are set
-        $requiredKeys = ['subject', 'message'];
-        foreach ($requiredKeys as $key) {
-            if (empty($template[$key])) {
-                throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Param "' . $key . '" is not optional.');
+            // Backwards compatibility
+            if (!\is_null($template['replyTo'] ?? null)) {
+                $template['replyToEmail'] = $template['replyToEmail'] ?? $template['replyTo'] ?? '';
             }
-        }
 
-        // Save configuration
-        $templates['email.' . $templateId . '-' . $locale] = $template;
-        $updates = new Document([
-            'templates' => $templates,
-        ]);
+            // Ensure required fields are set
+            $requiredKeys = ['subject', 'message'];
+            foreach ($requiredKeys as $key) {
+                if (empty($template[$key])) {
+                    throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Param "' . $key . '" is not optional.');
+                }
+            }
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            // Save configuration
+            $templates['email.' . $templateId . '-' . $locale] = $template;
+
+            return ['templates' => $templates];
+        });
+
+        $template = $project->getAttribute('templates', [])['email.' . $templateId . '-' . $locale] ?? [];
 
         $queueForEvents->setParam('templateId', $templateId);
 


### PR DESCRIPTION
## What does this PR do?

Project configuration endpoints (services, auth methods, auth policies, SMTP, protocols, OAuth2 providers, email templates, mock numbers) merge a single key into a map attribute (`services`, `auths`, `smtp`, `apis`, `oAuthProviders`, `templates`) read from the request-scoped `$project` resource, then write the whole map back.

That resource is a cached read taken at request start. When the document cache holds a stale copy — a concurrent reader (realtime, workers) re-caching the old row in the window around a writer's purge — the merge writes the stale map back and **durably reverts every concurrent update to that map**. This is the root cause of the recurring `ProjectsConsoleClientTest::testGetProject` flake (`Service should be disabled: serviceStatusForUsers`, `Auth method should be disabled: authPhone`, `smtpEnabled` asserting true, `authDuration` reverting to 31536000), currently failing the majority of CI runs in appwrite-labs/cloud.

The fix: a shared `Action::updateProject()` helper runs the merge inside a transaction against a row-locked (`forUpdate`) read of the current project, so the merge is atomic with the write. All 19 read-modify-write call sites now compute their changes from that locked read.

Two endpoints perform network IO as part of validation and keep it **outside** the lock:
- **SMTP** — the PHPMailer connection test still validates against the request-scoped merge; only the validated outcome and the request params are re-merged onto the locked row for the write.
- **OAuth2** — `verifyCredentials()` (live provider check) validates against the merged request/current credentials before the transaction; the enable decision carries into the locked merge.

`Labels` and the console `Projects/Update`/`Team/Update` endpoints are untouched: they replace whole attributes from request input rather than merging current state, so there is no stale-merge to fix.

Pairs with [utopia-php/database#888](https://github.com/utopia-php/database/pull/888), which makes `forUpdate` reads bypass the document cache (without it, the locked read itself can be served from a poisoned cache — that PR carries a deterministic regression test for the lost-update). Between the two, plus the already-merged [utopia-php/database#887](https://github.com/utopia-php/database/pull/887) post-commit purge, the durable-corruption paths are closed.

## Test plan

- `php -l` clean on all 20 changed files; Pint passes.
- Deterministic regression test for the underlying lost-update lives in utopia-php/database#888 (stale cache + unrelated update must not resurrect old attributes).
- `tests/e2e/Services/Projects/ProjectsConsoleClientTest` exercises every converted endpoint (testGetProject PATCHes all 17 services, 7 auth methods, ~10 policies, SMTP, protocols) — the flaky assertions are the regression coverage for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)