### PR TITLE
Fix OpenAPI 3 spec generation parity with Swagger 2

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -129,6 +129,7 @@ class OpenAPI3 extends Format
             $specs = new Specs();
             $sdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($routeSecurity);
 
+            $sdkPlatforms = array_values(array_unique($sdkPlatforms));
             $namespace = $sdk->getNamespace();
 
             $descContents = $this->getDescriptionContents($desc);
@@ -323,6 +324,17 @@ class OpenAPI3 extends Format
                             'image/bmp',
                         ]) ? 'Image' : 'File',
                     ];
+
+                    if ($produces !== '') {
+                        $temp['responses'][(string)$response->getCode()]['content'] = [
+                            $produces => [
+                                'schema' => [
+                                    'type' => 'string',
+                                    'format' => 'binary',
+                                ],
+                            ],
+                        ];
+                    }
                 } else {
                     if (\is_array($model)) {
                         $modelDescription = \join(', or ', \array_map(fn ($m) => $m->getName(), $model));
@@ -359,10 +371,27 @@ class OpenAPI3 extends Format
                     }
                 }
 
-                if ($response->getCode() === 204) {
+                if (in_array($response->getCode(), [204, 301, 302, 308], true)) {
                     $temp['responses'][(string)$response->getCode()]['description'] = 'No content';
+                }
+
+                if ($response->getCode() === 204) {
                     unset($temp['responses'][(string)$response->getCode()]['content']);
                 }
+            }
+
+            // No response declares content (e.g. 204 No content): keep the produced
+            // content type available for SDK generation.
+            $hasResponseContent = false;
+            foreach ($temp['responses'] as $responseData) {
+                if (isset($responseData['content'])) {
+                    $hasResponseContent = true;
+                    break;
+                }
+            }
+
+            if (!$hasResponseContent && $produces !== '') {
+                $temp['x-appwrite']['produces'] = [$produces];
             }
 
             if (!empty($scope)) {
@@ -402,7 +431,12 @@ class OpenAPI3 extends Format
 
             $bodyRequired = [];
 
-            foreach ($route->getParams() as $name => $param) { // Set params
+            $parameters = \array_merge(
+                $route->getParams(),
+                $sdk->getAdditionalParameters(),
+            );
+
+            foreach ($parameters as $name => $param) { // Set params
                 if (($param['deprecated'] ?? false) === true) {
                     continue;
                 }
@@ -548,8 +582,8 @@ class OpenAPI3 extends Format
                         break;
                     case \Utopia\Validator\JSON::class:
                     case \Utopia\Validator\Assoc::class:
-                        $param['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];
                         $node['schema']['type'] = 'object';
+                        $node['schema']['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];
                         $node['schema']['x-example'] = ($param['example'] ?? '') ?: '{}';
                         break;
                     case \Utopia\Storage\Validator\File::class:
@@ -679,19 +713,15 @@ class OpenAPI3 extends Format
                                     }
 
                                     $enumKeys = [];
-                                    if (!empty($enum->map)) {
-                                        foreach ($enumValues as $enumValue) {
-                                            $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
-                                        }
+                                    foreach ($enumValues as $enumValue) {
+                                        $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
                                     }
 
                                     $node['schema']['items']['enum'] = $enumValues;
                                     if (!empty($enum->name)) {
                                         $node['schema']['items']['x-enum-name'] = $enum->name;
                                     }
-                                    if (!empty($enumKeys)) {
-                                        $node['schema']['items']['x-enum-keys'] = $enumKeys;
-                                    }
+                                    $node['schema']['items']['x-enum-keys'] = $enumKeys;
                                 }
                             }
                             if ($validator->getType() === 'integer') {
@@ -720,19 +750,15 @@ class OpenAPI3 extends Format
                                     }
 
                                     $enumKeys = [];
-                                    if (!empty($enum->map)) {
-                                        foreach ($enumValues as $enumValue) {
-                                            $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
-                                        }
+                                    foreach ($enumValues as $enumValue) {
+                                        $enumKeys[] = $enum->map[$enumValue] ?? $enumValue;
                                     }
 
                                     $node['schema']['enum'] = $enumValues;
                                     if (!empty($enum->name)) {
                                         $node['schema']['x-enum-name'] = $enum->name;
                                     }
-                                    if (!empty($enumKeys)) {
-                                        $node['schema']['x-enum-keys'] = $enumKeys;
-                                    }
+                                    $node['schema']['x-enum-keys'] = $enumKeys;
                                 }
                             }
                             if ($validator->getType() === 'integer') {
@@ -829,9 +855,7 @@ class OpenAPI3 extends Format
                         /// If the enum flag is Set, add the enum values to the body
                         $body['content'][$consumes[0]]['schema']['properties'][$name]['enum'] = $node['schema']['enum'];
                         $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-name'] = $node['schema']['x-enum-name'] ?? null;
-                        if (isset($node['schema']['x-enum-keys'])) {
-                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-keys'] = $node['schema']['x-enum-keys'];
-                        }
+                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-keys'] = $node['schema']['x-enum-keys'];
                     }
 
                     if ($node['schema']['x-upload-id'] ?? false) {
@@ -930,7 +954,6 @@ class OpenAPI3 extends Format
 
                     case 'json':
                         $type = 'object';
-                        $output['components']['schemas'][$model->getType()]['properties'][$name]['additionalProperties'] = true;
                         break;
 
                     case 'array':
@@ -996,6 +1019,20 @@ class OpenAPI3 extends Format
                 }
 
                 $readOnly = $rule['readOnly'] ?? false;
+                if ($rule['type'] == 'json') {
+                    $output['components']['schemas'][$model->getType()]['properties'][$name] = [
+                        'type' => $type,
+                        'additionalProperties' => true,
+                        'description' => $rule['description'] ?? '',
+                        'x-example' => $rule['example'] ?? null,
+                    ];
+
+                    if ($readOnly) {
+                        $output['components']['schemas'][$model->getType()]['properties'][$name]['readOnly'] = true;
+                    }
+                    continue;
+                }
+
                 if ($rule['array']) {
                     $output['components']['schemas'][$model->getType()]['properties'][$name] = [
                         'type' => 'array',

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\SDK\Specification;
 
+use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\SDK\Specification\Format;
@@ -20,6 +21,7 @@ use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\HealthStatus;
+use Appwrite\Utopia\Response\Model\None as NoneModel;
 use Appwrite\Utopia\Response\Model\PlatformAndroid;
 use Appwrite\Utopia\Response\Model\PlatformApple;
 use Appwrite\Utopia\Response\Model\PlatformLinux;
@@ -27,6 +29,7 @@ use Appwrite\Utopia\Response\Model\PlatformList;
 use Appwrite\Utopia\Response\Model\PlatformWeb;
 use Appwrite\Utopia\Response\Model\PlatformWindows;
 use Appwrite\Utopia\Response\Model\Preferences;
+use Appwrite\Utopia\Response\Model\Provider;
 use Appwrite\Utopia\Response\Model\Team;
 use Appwrite\Utopia\Response\Model\User;
 use Appwrite\Utopia\Response\Model\Webhook;
@@ -35,6 +38,7 @@ use Utopia\Database\Database;
 use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
+use Utopia\Validator\JSON;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\Text;
 
@@ -382,5 +386,144 @@ final class FormatTest extends TestCase
         $this->assertTrue($swaggerProperties['nullablePassword']['x-nullable']);
         $this->assertArrayNotHasKey('format', $swaggerProperties['name']);
         $this->assertSame('password', $swagger['definitions']['webhook']['properties']['authPassword']['format']);
+    }
+
+    public function testNoContentMethodsKeepProducesMetadata(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('DELETE', '/v1/tests/:testId'))
+            ->desc('Delete test')
+            ->label('scope', 'tests.write')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'deleteTest',
+                description: 'Delete test.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 204,
+                        model: Response::MODEL_NONE,
+                    ),
+                ],
+            ))
+            ->param('testId', '', new Text(256), 'Test ID.');
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [new NoneModel()], [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], [new NoneModel()], [], 0, 'console'))->parse();
+
+        $openApiMethod = $openApi['paths']['/tests/{testId}']['delete'];
+
+        $this->assertArrayNotHasKey('content', $openApiMethod['responses']['204']);
+        $this->assertSame(['application/json'], $openApiMethod['x-appwrite']['produces']);
+        $this->assertSame(['application/json'], $swagger['paths']['/tests/{testId}']['delete']['produces']);
+    }
+
+    public function testBinaryResponsesEmitResponseContent(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/icon'))
+            ->desc('Get test icon')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTestIcon',
+                description: 'Get test icon.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_NONE,
+                    ),
+                ],
+                contentType: ContentType::IMAGE_PNG,
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [new NoneModel()], [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], [new NoneModel()], [], 0, 'console'))->parse();
+
+        $openApiMethod = $openApi['paths']['/tests/icon']['get'];
+
+        $this->assertSame(
+            ['type' => 'string', 'format' => 'binary'],
+            $openApiMethod['responses']['200']['content']['image/png']['schema']
+        );
+        $this->assertArrayNotHasKey('produces', $openApiMethod['x-appwrite']);
+        $this->assertSame(['image/png'], $swagger['paths']['/tests/icon']['get']['produces']);
+    }
+
+    public function testAdditionalParametersAreIncludedInRequestBody(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('POST', '/v1/tests/graphql'))
+            ->desc('GraphQL test endpoint')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'queryTest',
+                description: 'GraphQL test endpoint.',
+                auth: [],
+                responses: [],
+                additionalParameters: [
+                    'query' => [
+                        'default' => [],
+                        'validator' => new JSON(),
+                        'description' => 'The query or queries to execute.',
+                        'optional' => false,
+                    ],
+                ],
+            ));
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+
+        $openApiQuery = $openApi['paths']['/tests/graphql']['post']['requestBody']['content']['application/json']['schema']['properties']['query'];
+        $swaggerQuery = $swagger['paths']['/tests/graphql']['post']['parameters'][0]['schema']['properties']['query'];
+
+        $this->assertSame('object', $openApiQuery['type']);
+        $this->assertEquals($swaggerQuery, $openApiQuery);
+    }
+
+    public function testJsonModelRulesKeepAdditionalPropertiesAndSkipNullable(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/provider'))
+            ->desc('Get test provider')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getTestProvider',
+                description: 'Get test provider.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_PROVIDER,
+                    ),
+                ],
+            ));
+
+        $models = [
+            new Provider(),
+            new ErrorModel(),
+        ];
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+        $swagger = (new Swagger2(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+
+        $openApiOptions = $openApi['components']['schemas']['provider']['properties']['options'];
+        $swaggerOptions = $swagger['definitions']['provider']['properties']['options'];
+
+        $this->assertTrue($openApiOptions['additionalProperties']);
+        $this->assertArrayNotHasKey('nullable', $openApiOptions);
+        $this->assertEquals($swaggerOptions, $openApiOptions);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Makes the OpenAPI 3 spec generator emit everything the Swagger 2 generator emits, so SDKs generated from the OpenAPI 3 specs are **byte-identical** to those generated from the Swagger 2 specs. This is the prerequisite for switching the SDK generator from Swagger 2 to OpenAPI 3 spec parsing (appwrite/sdk-generator).

The OpenAPI 3 generator dropped or diverged on several pieces of information:

- **Platforms not deduplicated** — `x-appwrite.platforms` was missing the `array_unique` that Swagger 2 applies.
- **`additionalParameters` ignored** — GraphQL routes lost their `query`/`variables` body parameters entirely.
- **JSON/Assoc parameter defaults** — the `{}` default was set on the wrong node and never reached the schema.
- **`x-enum-keys` only emitted for mapped enums** — Swagger 2 always emits it for string whitelist enums.
- **Binary and redirect responses had no `content`** — the produced content type (e.g. `image/png`, `text/html`) was lost, so generated SDKs were missing `accept` headers. These responses now declare `content` with a `type: string, format: binary` schema, which is also the correct OAS 3 way to describe binary payloads.
- **204-only methods lost their content type** — a 204 response correctly has no `content`, so the produced content type is now preserved in `x-appwrite.produces`. The `No content` description now also covers 301/302/308 like Swagger 2.
- **`json` model rules** — `additionalProperties: true` was overwritten by a later assignment, optional json properties gained a spurious `nullable: true`, and array json rules were typed differently from Swagger 2.

## Test Plan

- 4 new unit tests in `FormatTest` covering produces metadata for no-content methods, response content for binary responses, `additionalParameters` in the request body, and json model rules (all asserting OpenAPI 3 output matches Swagger 2).
- Regenerated all spec files (`specs` task) and ran a structural parity diff of everything the SDK generator consumes from both formats across the console, client, server, and manager platforms: **0 differences** (down from 875).
- Generated **all SDKs** from both spec formats for the console, client, and server platforms with the sdk-generator OpenAPI 3 parser: `diff -r` reports zero differing files.
- `pint`, `phpstan`, and `FormatTest` (14 tests, 81 assertions) all pass.

## Related PRs and Issues

- Upcoming appwrite/sdk-generator PR: switch spec parsing from Swagger 2 to OpenAPI 3 (depends on this PR + republished specs in appwrite/specs).