### PR TITLE
Fix builds worker overwriting canceled deployment status

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e922d0ba4d0c7d12cc24cff52b552803",
+    "content-hash": "1842adc3102a8d4af14a013751acd366",
     "packages": [
         {
             "name": "adhocore/jwt",

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -249,19 +249,28 @@ class Builds extends Action
 
         if ($deployment->getAttribute('status') === 'canceled') {
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
-            $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+            $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
             return;
         }
 
         $deploymentId = $deployment->getId();
 
-        $deployment->setAttribute('buildStartedAt', $startTime);
-        $deployment->setAttribute('status', 'processing');
-        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+        $updated = $dbForProject->updateDocuments('deployments', new Document([
             'buildStartedAt' => $startTime,
             'status' => 'processing',
-        ]));
+        ]), [
+            Query::equal('$id', [$deploymentId]),
+            Query::notEqual('status', 'canceled'),
+        ]);
+
+        if ($updated === 0) {
+            $resource = $this->updateLatestDeployment($dbForProject, $resource);
+            $this->finalizeCanceledDeployment($deploymentId, $dbForProject, $queueForRealtime);
+            return;
+        }
+
+        $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
         $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
@@ -389,7 +398,7 @@ class Builds extends Action
                 Console::execute('mkdir -p ' . \escapeshellarg('/tmp/builds/' . $deploymentId), '', $stdout, $stderr);
 
                 if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                    $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                    $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                     return;
                 }
@@ -531,10 +540,19 @@ class Builds extends Action
             }
 
             /** Request the executor to build the code... */
-            $deployment->setAttribute('status', 'building');
-            $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+            $updated = $dbForProject->updateDocuments('deployments', new Document([
                 'status' => 'building',
-            ]));
+            ]), [
+                Query::equal('$id', [$deploymentId]),
+                Query::notEqual('status', 'canceled'),
+            ]);
+
+            if ($updated === 0) {
+                $this->finalizeCanceledDeployment($deploymentId, $dbForProject, $queueForRealtime);
+                return;
+            }
+
+            $deployment = $dbForProject->getDocument('deployments', $deploymentId);
             Span::add('deployment.status', 'building');
 
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
@@ -672,7 +690,7 @@ class Builds extends Action
             $err = null;
 
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
@@ -827,7 +845,7 @@ class Builds extends Action
 
             $latestDeployment = $dbForProject->getDocument('deployments', $deploymentId);
             if ($latestDeployment->getAttribute('status') === 'canceled') {
-                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
@@ -1073,7 +1091,7 @@ class Builds extends Action
                 ->trigger();
 
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
@@ -1105,7 +1123,7 @@ class Builds extends Action
             }
         } catch (\Throwable $th) {
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
-                $this->cancelDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
+                $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
 
                 return;
             }
@@ -1521,7 +1539,7 @@ class Builds extends Action
         );
     }
 
-    private function cancelDeployment(string $deploymentId, Database $dbForProject, Realtime $queueForRealtime)
+    private function finalizeCanceledDeployment(string $deploymentId, Database $dbForProject, Realtime $queueForRealtime)
     {
         Span::add('deployment.status', 'canceled');
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where the builds worker could resurrect a canceled deployment.

The worker checks for a `canceled` status once when it dequeues a job, then unconditionally writes `status: 'processing'` (and later `status: 'building'`). If a cancel request lands between the check and the write, the worker clobbers `canceled` and the build proceeds — it can even reach `ready` and get deployed, which the cancel endpoint's docs explicitly promise can't happen. All of the worker's later cancellation re-checks are blind to this because the `canceled` marker is gone.

This is also the root cause of the flaky `testErrorPages` Sites E2E test: the proxy renders the canceled error page, then the deployment status flips back to `processing`, so the test's status-based expectation no longer matches the body it captured.

Changes:
- The `processing` and `building` status writes are now conditional (`updateDocuments` with `Query::notEqual('status', 'canceled')`), so they can never overwrite a cancellation. When the conditional write matches nothing, the worker takes the same early-exit path as the existing cancellation checks.
- Renamed the private `cancelDeployment` helper to `finalizeCanceledDeployment` — it never cancels anything; it appends the "Build has been canceled" log line and fires the realtime event after a cancellation is detected.

## Test Plan

- `composer lint` and PHPStan pass on the modified file.
- Existing Sites/Functions E2E suites cover the cancel flow (`testErrorPages`, `testCancelDeploymentBuild`); this fix removes the race that made `testErrorPages` flaky in CI.

## Related PRs and Issues

- Flaky failure: https://github.com/appwrite-labs/cloud/actions/runs/27339697746/job/80773360021

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, group, etc.), does it also include updated API specs and example docs?