### PR TITLE
Fix race between rule creation and async orphaned rule cleanup

### DIFF
--- a/mongo-entrypoint.sh
+++ b/mongo-entrypoint.sh
@@ -13,25 +13,5 @@ fi
 chmod 400 "$KEYFILE_PATH"
 chown mongodb:mongodb "$KEYFILE_PATH" 2>/dev/null || chown 999:999 "$KEYFILE_PATH"
 
-# Use MongoDB's standard entrypoint with our command.
-# On first boot, the standard entrypoint's temporary init mongod may not have
-# released port 27017 by the time the real mongod binds it, which makes mongod
-# exit with code 48 (address already in use). Retry only on that exit code.
-child=0
-trap '[ "$child" -ne 0 ] && kill -TERM "$child" 2>/dev/null' TERM INT
-
-for attempt in 1 2 3; do
-  docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH" &
-  child=$!
-  exit_code=0
-  wait "$child" || exit_code=$?
-
-  if [ "$exit_code" -ne 48 ]; then
-    exit "$exit_code"
-  fi
-
-  echo "mongod could not bind port 27017 (exit code 48), retrying ($attempt/3)..."
-  sleep 2
-done
-
-exit 48
+# Use MongoDB's standard entrypoint with our command
+exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH"

--- a/mongo-entrypoint.sh
+++ b/mongo-entrypoint.sh
@@ -13,5 +13,25 @@ fi
 chmod 400 "$KEYFILE_PATH"
 chown mongodb:mongodb "$KEYFILE_PATH" 2>/dev/null || chown 999:999 "$KEYFILE_PATH"
 
-# Use MongoDB's standard entrypoint with our command
-exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH"
+# Use MongoDB's standard entrypoint with our command.
+# On first boot, the standard entrypoint's temporary init mongod may not have
+# released port 27017 by the time the real mongod binds it, which makes mongod
+# exit with code 48 (address already in use). Retry only on that exit code.
+child=0
+trap '[ "$child" -ne 0 ] && kill -TERM "$child" 2>/dev/null' TERM INT
+
+for attempt in 1 2 3; do
+  docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH" &
+  child=$!
+  exit_code=0
+  wait "$child" || exit_code=$?
+
+  if [ "$exit_code" -ne 48 ]; then
+    exit "$exit_code"
+  fi
+
+  echo "mongod could not bind port 27017 (exit code 48), retrying ($attempt/3)..."
+  sleep 2
+done
+
+exit 48

--- a/src/Appwrite/Platform/Modules/Proxy/Action.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Action.php
@@ -54,10 +54,11 @@ class Action extends PlatformAction
             return $dbForPlatform->getDocument('rules', $rule->getId());
         });
 
-        if (
-            $existingRule->isEmpty() ||
-            $existingRule->getAttribute('domain', '') !== $rule->getAttribute('domain', '')
-        ) {
+        if ($existingRule->isEmpty()) {
+            return true;
+        }
+
+        if ($existingRule->getAttribute('domain', '') !== $rule->getAttribute('domain', '')) {
             return false;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in `createRule` that causes the flaky `ProxyConsoleClientTest::testCreateRuleDeletesOrphanedRule` failure (409 instead of 201).

Project deletion removes the project document synchronously, but the project's rules are cleaned up asynchronously by the Deletes worker. When a rule for the same domain is created while that cleanup is in flight, there are three interleavings:

1. Worker already deleted the rule → `createDocument` succeeds → 201
2. Worker hasn't run yet → `Duplicate` is thrown, `deleteOrphanedRule` finds the rule, sees its project is gone, deletes it, and the retry succeeds → 201
3. Worker deletes the rule **between** the `Duplicate` and the orphan lookup → both the domain query and the ID fallback come back empty, `deleteOrphanedRule` returns `false`, and the request fails with 409 — even though the conflicting rule no longer exists and the retry would have succeeded

This PR fixes case 3: when the conflicting rule has already vanished, `deleteOrphanedRule` now reports success so `createRule` proceeds to the retry. A genuine duplicate that reappears is still rejected with 409 by the existing `Duplicate` catch around the retry.

Example failure: https://github.com/appwrite/appwrite/actions/runs/27341804102/job/80780640596

## Test Plan

- Covered by the existing `testCreateRuleDeletesOrphanedRule` E2E test — this change removes its flaky failure mode.
- `composer lint` and PHPStan pass on the modified file.

## Related PRs and Issues

- Flaky failure observed on https://github.com/appwrite/appwrite/pull/12570 CI

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, group, etc.), does it also include updated API specs and example docs?

## Also: fix flaky MongoDB container startup in CI

This PR also fixes the flaky `container appwrite-mongodb is unhealthy` failure that `docker compose up -d --wait` hits before tests run (observed on this PR's CI: https://github.com/appwrite/appwrite/actions/runs/27345809512/job/80794566543).

On a fresh volume, the official `mongo` image's entrypoint starts a temporary init mongod on `127.0.0.1:27017`, runs init scripts, shuts it down, and execs the real mongod. The shutdown wait can return before the temp process fully releases the port, so the real mongod (`--bind_ip_all`) occasionally exits with code 48 (`Address already in use`). The restart policy recovers the container ~0.2s later, but the compose waiter has already counted the death and fails the job.

`mongo-entrypoint.sh` now runs the standard entrypoint in a retry loop instead of a bare `exec`: exit code 48 is retried up to 3 times with a 2s pause, any other exit code is propagated immediately. A `trap` forwards `TERM`/`INT` to the child so container stop semantics are preserved. Verified against a stub that exits 48 twice then runs: both failures retried, third attempt proceeds, and `SIGTERM` forwards correctly (exit 143).
