### PR TITLE
Fix flaky MongoDB container startup in CI

### DIFF
--- a/mongo-entrypoint.sh
+++ b/mongo-entrypoint.sh
@@ -13,5 +13,25 @@ fi
 chmod 400 "$KEYFILE_PATH"
 chown mongodb:mongodb "$KEYFILE_PATH" 2>/dev/null || chown 999:999 "$KEYFILE_PATH"
 
-# Use MongoDB's standard entrypoint with our command
-exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH"
+# Use MongoDB's standard entrypoint with our command.
+# On first boot, the standard entrypoint's temporary init mongod may not have
+# released port 27017 by the time the real mongod binds it, which makes mongod
+# exit with code 48 (address already in use). Retry only on that exit code.
+child=0
+trap '[ "$child" -ne 0 ] && kill -TERM "$child" 2>/dev/null' TERM INT
+
+for attempt in 1 2 3; do
+  docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH" &
+  child=$!
+  exit_code=0
+  wait "$child" || exit_code=$?
+
+  if [ "$exit_code" -ne 48 ]; then
+    exit "$exit_code"
+  fi
+
+  echo "mongod could not bind port 27017 (exit code 48), retrying ($attempt/3)..."
+  sleep 2
+done
+
+exit 48


### PR DESCRIPTION
## What does this PR do?

Fixes flaky CI failures where `docker compose up -d --wait` aborts with `container appwrite-mongodb is unhealthy` before any test runs.

On a fresh volume, the official `mongo` image's `docker-entrypoint.sh` starts a temporary init mongod on `127.0.0.1:27017`, runs init scripts, shuts it down, and execs the real mongod. The shutdown wait returns before the temp process has fully released the port, so the real mongod (`--bind_ip_all`) occasionally fails to bind `0.0.0.0:27017` and exits with code 48 (`Address already in use`). The `restart: on-failure` policy recovers the container ~0.2s later, but the compose waiter has already counted the death and fails the job.

Since `mongo-entrypoint.sh` is ours, it now runs the standard entrypoint in a small retry loop instead of a bare `exec`: exit code 48 is retried up to 3 times with a 2s pause, any other exit code is propagated immediately. A `trap` forwards `TERM`/`INT` to the child so container stop semantics are preserved despite losing `exec`/PID 1 passthrough.

Example failure: https://github.com/appwrite/appwrite/actions/runs/27345809512/job/80794566543 — the mongod log shows `Error setting up transport layer ... 0.0.0.0:27017 :: Address already in use` followed by `Shutting down {exitCode: 48}` about 1s after the temp init mongod began its WiredTiger shutdown.

## Test Plan

- `bash -n` passes.
- Simulated the entrypoint against a stub that exits 48 twice and then runs: both failures are retried, the third attempt proceeds, and `SIGTERM` to the wrapper is forwarded to the child (exits 143).

## Related PRs and Issues

- Flaky failure observed on https://github.com/appwrite/appwrite/pull/12571 CI

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, group, etc.), does it also include updated API specs and example docs?