### PR TITLE
Fix parallel deployment chunk uploads on S3 devices

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -202,8 +202,27 @@ class Create extends Action
         $metadata = ['content_type' => $deviceForLocal->getFileMimeType($fileTmpName)];
         $completed = false;
 
+        $mergeUploadMetadata = function (array $stored, array $current): array {
+            $merged = \array_merge($stored, $current);
+
+            if (isset($stored['parts']) || isset($current['parts'])) {
+                $parts = $stored['parts'] ?? [];
+                foreach (($current['parts'] ?? []) as $part => $value) {
+                    $parts[(int) $part] = $value;
+                }
+                \ksort($parts);
+
+                $merged['parts'] = $parts;
+                $merged['chunks'] = \count($parts);
+            }
+
+            return $merged;
+        };
+
+        $type = $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual';
+
         try {
-            $locks($lockKey, 600, function () use (&$chunks, $dbForProject, $deploymentId, &$metadata, &$completed, $response): void {
+            $locks($lockKey, 600, function () use ($activate, &$chunks, $commands, $contentRange, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, &$metadata, $path, $type, &$completed, $response): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
                 if (!$deployment->isEmpty()) {
@@ -220,6 +239,35 @@ class Create extends Action
                         return;
                     }
                 }
+
+                if ($deployment->isEmpty()) {
+                    $deviceForFunctions->prepareUpload($path, $metadata['content_type'] ?? '', $chunks, $metadata);
+
+                    if (!empty($contentRange)) {
+                        $deployment = $dbForProject->createDocument('deployments', new Document([
+                            '$id' => $deploymentId,
+                            '$permissions' => [
+                                Permission::read(Role::any()),
+                                Permission::update(Role::any()),
+                                Permission::delete(Role::any()),
+                            ],
+                            'resourceInternalId' => $function->getSequence(),
+                            'resourceId' => $function->getId(),
+                            'resourceType' => 'functions',
+                            'entrypoint' => $entrypoint,
+                            'buildCommands' => $commands,
+                            'startCommand' => $function->getAttribute('startCommand', ''),
+                            'sourcePath' => $path,
+                            'sourceSize' => $fileSize,
+                            'totalSize' => $fileSize,
+                            'sourceChunksTotal' => $chunks,
+                            'sourceChunksUploaded' => 0,
+                            'activate' => $activate,
+                            'sourceMetadata' => $metadata,
+                            'type' => $type
+                        ]));
+                    }
+                }
             }, timeout: 120.0);
         } catch (LockContention) {
             $response->addHeader('Retry-After', '5');
@@ -231,23 +279,21 @@ class Create extends Action
             return;
         }
 
-        $chunksUploaded = $deviceForFunctions->upload($fileTmpName, $path, $chunk, $chunks, $metadata);
+        $chunksUploaded = $deviceForFunctions->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
 
         if (empty($chunksUploaded)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
         }
 
-        $type = $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual';
-
         try {
-            $locks($lockKey, 600, function () use ($activate, &$chunks, $chunksUploaded, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, $functionId, $path, &$metadata, $platform, $project, $publisherForBuilds, $queueForEvents, $response, $type): void {
+            $locks($lockKey, 600, function () use ($activate, &$chunks, $chunksUploaded, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, $functionId, $path, &$metadata, $mergeUploadMetadata, $platform, $project, $publisherForBuilds, $queueForEvents, $response, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
                 $uploaded = 0;
 
                 if (!$deployment->isEmpty()) {
                     $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
                     $uploaded = $deployment->getAttribute('sourceChunksUploaded', 0);
-                    $metadata = \array_merge($deployment->getAttribute('sourceMetadata', []), $metadata);
+                    $metadata = $mergeUploadMetadata($deployment->getAttribute('sourceMetadata', []), $metadata);
 
                     if ($uploaded === $chunks) {
                         $queueForEvents->reset();
@@ -259,9 +305,11 @@ class Create extends Action
                     }
                 }
 
-                $chunksUploaded = max($uploaded, $chunksUploaded);
+                $chunksUploaded = max($uploaded, $chunksUploaded, (int) ($metadata['chunks'] ?? 0));
 
                 if ($chunksUploaded === $chunks && $uploaded < $chunks) {
+                    $deviceForFunctions->finalizeUpload($path, $chunks, $metadata);
+
                     if ($activate) {
                         // Remove deploy for all other deployments.
                         $activeDeployments = $dbForProject->find('deployments', [
@@ -320,36 +368,10 @@ class Create extends Action
                         platform: $platform,
                     ));
                 } else {
-                    if ($deployment->isEmpty()) {
-                        $deployment = $dbForProject->createDocument('deployments', new Document([
-                            '$id' => $deploymentId,
-                            '$permissions' => [
-                                Permission::read(Role::any()),
-                                Permission::update(Role::any()),
-                                Permission::delete(Role::any()),
-                            ],
-                            'resourceInternalId' => $function->getSequence(),
-                            'resourceId' => $function->getId(),
-                            'resourceType' => 'functions',
-                            'entrypoint' => $entrypoint,
-                            'buildCommands' => $commands,
-                            'startCommand' => $function->getAttribute('startCommand', ''),
-                            'sourcePath' => $path,
-                            'sourceSize' => $fileSize,
-                            'totalSize' => $fileSize,
-                            'sourceChunksTotal' => $chunks,
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'activate' => $activate,
-                            'sourceMetadata' => $metadata,
-                            'type' => $type
-                        ]));
-
-                    } else {
-                        $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'sourceMetadata' => $metadata,
-                        ]));
-                    }
+                    $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                        'sourceChunksUploaded' => $chunksUploaded,
+                        'sourceMetadata' => $metadata,
+                    ]));
                 }
 
                 $metadata = null;

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -202,8 +202,35 @@ class Create extends Action
         $metadata = ['content_type' => $deviceForLocal->getFileMimeType($fileTmpName)];
         $completed = false;
 
+        $mergeUploadMetadata = function (array $stored, array $current): array {
+            $merged = \array_merge($stored, $current);
+
+            if (isset($stored['parts']) || isset($current['parts'])) {
+                $parts = $stored['parts'] ?? [];
+                foreach (($current['parts'] ?? []) as $part => $value) {
+                    $parts[(int) $part] = $value;
+                }
+                \ksort($parts);
+
+                $merged['parts'] = $parts;
+                $merged['chunks'] = \count($parts);
+            }
+
+            return $merged;
+        };
+
+        $type = $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual';
+
+        $commands = [];
+        if (!empty($installCommand)) {
+            $commands[] = $installCommand;
+        }
+        if (!empty($buildCommand)) {
+            $commands[] = $buildCommand;
+        }
+
         try {
-            $locks($lockKey, 600, function () use (&$chunks, $dbForProject, $deploymentId, &$metadata, &$completed, $response): void {
+            $locks($lockKey, 600, function () use ($activate, $authorization, &$chunks, $commands, $contentRange, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $outputDirectory, $path, $platform, $project, &$site, $type, &$completed, $response): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
 
                 if (!$deployment->isEmpty()) {
@@ -220,6 +247,65 @@ class Create extends Action
                         return;
                     }
                 }
+
+                if ($deployment->isEmpty()) {
+                    $deviceForSites->prepareUpload($path, $metadata['content_type'] ?? '', $chunks, $metadata);
+
+                    if (!empty($contentRange)) {
+                        $deployment = $dbForProject->createDocument('deployments', new Document([
+                            '$id' => $deploymentId,
+                            '$permissions' => [
+                                Permission::read(Role::any()),
+                                Permission::update(Role::any()),
+                                Permission::delete(Role::any()),
+                            ],
+                            'resourceInternalId' => $site->getSequence(),
+                            'resourceId' => $site->getId(),
+                            'resourceType' => 'sites',
+                            'buildCommands' => \implode(' && ', $commands),
+                            'startCommand' => $site->getAttribute('startCommand', ''),
+                            'buildOutput' => $outputDirectory,
+                            'adapter' => $site->getAttribute('adapter', ''),
+                            'fallbackFile' => $site->getAttribute('fallbackFile', ''),
+                            'sourcePath' => $path,
+                            'sourceSize' => $fileSize,
+                            'totalSize' => $fileSize,
+                            'sourceChunksTotal' => $chunks,
+                            'sourceChunksUploaded' => 0,
+                            'activate' => $activate,
+                            'sourceMetadata' => $metadata,
+                            'type' => $type,
+                        ]));
+
+                        $sitesDomain = $platform['sitesDomain'];
+                        $domain = ID::unique() . "." . $sitesDomain;
+
+                        // TODO: (@Meldiron) Remove after 1.7.x migration
+                        $isMd5 = System::getEnv('_APP_RULES_FORMAT') === 'md5';
+                        $ruleId = $isMd5 ? md5($domain) : ID::unique();
+
+                        $authorization->skip(
+                            fn () => $dbForPlatform->createDocument('rules', new Document([
+                                '$id' => $ruleId,
+                                'projectId' => $project->getId(),
+                                'projectInternalId' => $project->getSequence(),
+                                'domain' => $domain,
+                                'type' => 'deployment',
+                                'trigger' => 'deployment',
+                                'deploymentId' => $deployment->isEmpty() ? '' : $deployment->getId(),
+                                'deploymentInternalId' => $deployment->isEmpty() ? '' : $deployment->getSequence(),
+                                'deploymentResourceType' => 'site',
+                                'deploymentResourceId' => $site->getId(),
+                                'deploymentResourceInternalId' => $site->getSequence(),
+                                'status' => 'verified',
+                                'certificateId' => '',
+                                'search' => implode(' ', [$ruleId, $domain]),
+                                'owner' => 'Appwrite',
+                                'region' => $project->getAttribute('region')
+                            ]))
+                        );
+                    }
+                }
             }, timeout: 120.0);
         } catch (LockContention) {
             $response->addHeader('Retry-After', '5');
@@ -231,31 +317,21 @@ class Create extends Action
             return;
         }
 
-        $chunksUploaded = $deviceForSites->upload($fileTmpName, $path, $chunk, $chunks, $metadata);
+        $chunksUploaded = $deviceForSites->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
 
         if (empty($chunksUploaded)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');
         }
 
-        $type = $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual';
-
-        $commands = [];
-        if (!empty($installCommand)) {
-            $commands[] = $installCommand;
-        }
-        if (!empty($buildCommand)) {
-            $commands[] = $buildCommand;
-        }
-
         try {
-            $locks($lockKey, 600, function () use ($activate, $authorization, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $outputDirectory, $path, $platform, $project, $publisherForBuilds, $queueForEvents, $response, &$site, $siteId, $type): void {
+            $locks($lockKey, 600, function () use ($activate, $authorization, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $publisherForBuilds, $queueForEvents, $response, &$site, $siteId, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
                 $uploaded = 0;
 
                 if (!$deployment->isEmpty()) {
                     $chunks = $deployment->getAttribute('sourceChunksTotal', 1);
                     $uploaded = $deployment->getAttribute('sourceChunksUploaded', 0);
-                    $metadata = \array_merge($deployment->getAttribute('sourceMetadata', []), $metadata);
+                    $metadata = $mergeUploadMetadata($deployment->getAttribute('sourceMetadata', []), $metadata);
 
                     if ($uploaded === $chunks) {
                         $queueForEvents->reset();
@@ -267,9 +343,11 @@ class Create extends Action
                     }
                 }
 
-                $chunksUploaded = max($uploaded, $chunksUploaded);
+                $chunksUploaded = max($uploaded, $chunksUploaded, (int) ($metadata['chunks'] ?? 0));
 
                 if ($chunksUploaded === $chunks && $uploaded < $chunks) {
+                    $deviceForSites->finalizeUpload($path, $chunks, $metadata);
+
                     if ($activate) {
                         // Remove deploy for all other deployments.
                         $activeDeployments = $dbForProject->find('deployments', [
@@ -355,61 +433,10 @@ class Create extends Action
                         platform: $platform,
                     ));
                 } else {
-                    if ($deployment->isEmpty()) {
-                        $deployment = $dbForProject->createDocument('deployments', new Document([
-                            '$id' => $deploymentId,
-                            '$permissions' => [
-                                Permission::read(Role::any()),
-                                Permission::update(Role::any()),
-                                Permission::delete(Role::any()),
-                            ],
-                            'resourceInternalId' => $site->getSequence(),
-                            'resourceId' => $site->getId(),
-                            'resourceType' => 'sites',
-                            'buildCommands' => \implode(' && ', $commands),
-                            'startCommand' => $site->getAttribute('startCommand', ''),
-                            'buildOutput' => $outputDirectory,
-                            'adapter' => $site->getAttribute('adapter', ''),
-                            'fallbackFile' => $site->getAttribute('fallbackFile', ''),
-                            'sourcePath' => $path,
-                            'sourceSize' => $fileSize,
-                            'totalSize' => $fileSize,
-                            'sourceChunksTotal' => $chunks,
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'activate' => $activate,
-                            'sourceMetadata' => $metadata,
-                            'type' => $type,
-                        ]));
-
-                        $sitesDomain = $platform['sitesDomain'];
-                        $domain = ID::unique() . "." . $sitesDomain;
-                        $ruleId = md5($domain);
-                        $authorization->skip(
-                            fn () => $dbForPlatform->createDocument('rules', new Document([
-                                '$id' => $ruleId,
-                                'projectId' => $project->getId(),
-                                'projectInternalId' => $project->getSequence(),
-                                'domain' => $domain,
-                                'type' => 'deployment',
-                                'trigger' => 'deployment',
-                                'deploymentId' => $deployment->isEmpty() ? '' : $deployment->getId(),
-                                'deploymentInternalId' => $deployment->isEmpty() ? '' : $deployment->getSequence(),
-                                'deploymentResourceType' => 'site',
-                                'deploymentResourceId' => $site->getId(),
-                                'deploymentResourceInternalId' => $site->getSequence(),
-                                'status' => 'verified',
-                                'certificateId' => '',
-                                'search' => implode(' ', [$ruleId, $domain]),
-                                'owner' => 'Appwrite',
-                                'region' => $project->getAttribute('region')
-                            ]))
-                        );
-                    } else {
-                        $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
-                            'sourceChunksUploaded' => $chunksUploaded,
-                            'sourceMetadata' => $metadata,
-                        ]));
-                    }
+                    $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                        'sourceChunksUploaded' => $chunksUploaded,
+                        'sourceMetadata' => $metadata,
+                    ]));
                 }
 
                 $metadata = null;


### PR DESCRIPTION
## What does this PR do?

Fixes sites and functions deployments getting permanently stuck in `waiting` status when uploaded with CLI 22.0.0 (or any SDK using parallel chunked uploads) on S3-family storage devices.

CLI 22 uploads the first chunk alone, then the remaining chunks with concurrency 8. On S3 devices the chunk count is derived purely from the metadata passed into the device (`S3::uploadChunkData` increments `$metadata['chunks']`), so with concurrent requests:

1. Each parallel request read the same stale `sourceMetadata` from the DB before uploading, so no request ever observed the full chunk count.
2. Each commit overwrote `sourceMetadata.parts` with its own view (plain `array_merge`), permanently losing the S3 part ETags uploaded by concurrent requests.
3. `sourceChunksUploaded` plateaued below `sourceChunksTotal`, the multipart upload was never completed, and the build message was never enqueued — deployment stuck in `waiting` forever, no logs.

Storage uploads were already fixed (#12209); this ports the same pattern to the sites and functions deployment endpoints:

- `prepareUpload()` + deployment document creation moved into the first lock, so exactly one S3 multipart `uploadId` is minted and shared by all concurrent chunk requests.
- `uploadChunk()` instead of `upload()`, so the device never finalizes outside the lock (the internal finalize raced the explicit one, causing `InvalidPart` from `completeMultipartUpload`; this also removes a concurrent `joinChunks` race on the local device).
- Stored and current `parts` maps are unioned (`mergeUploadMetadata`) instead of clobbered, and the completion check is `max($uploaded, $chunksUploaded, count(parts))`.
- Explicit, lock-protected `finalizeUpload()` in the completion branch before `getFileSize()`.

The local device was unaffected because `countChunks()` globs part files on disk — ground truth independent of metadata — which is also why the existing parallel-chunk e2e tests pass in CI (they run on the local device).

## Test Plan

Verified against MinIO (`_APP_STORAGE_DEVICE=s3`, custom endpoint):

- Before the fix, `testCreateDeploymentParallelChunksLargeFile` (sites) fails: deployment stuck at `waiting` until the 120s timeout — exact reproduction of the reported CLI behavior.
- After the fix, sites + functions `testCreateDeploymentParallelChunksLargeFile`, `testCreateDeploymentOutOfOrder`, `testCreateDeploymentWithSingleContentRangeChunk`, and functions `testCreateDeploymentLarge` all pass (parallel tests repeated 3×).
- End-to-end with the published `appwrite-cli@22.0.0` against the patched server on MinIO: 21 MB (5 chunks) and 28 MB (6 chunks) site deployments reach `ready`; assembled objects verified in the bucket. The same payload sizes reproduce the stuck `waiting` state without this patch.
- Full chunk-test matrix re-run on the local device to confirm no regression.

S3-accurate CI coverage (MinIO service) will be added in the cloud repo once this lands.

## Related PRs and Issues

- Storage-side fix this ports: #12209