### PR TITLE
fix(builds): resolve 4 active defects in orchestrator build backend

### DIFF
--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -206,6 +206,7 @@ const DATABASE_TYPE_DELETE_DATABASE = 'deleteDatabase';
 // Build Worker Types
 const BUILD_TYPE_DEPLOYMENT = 'deployment';
 const BUILD_TYPE_RETRY = 'retry';
+const BUILD_TYPE_ORCHESTRATOR_EVENT = 'orchestratorEvent';
 
 // Deletion Types
 
@@ -487,6 +488,7 @@ const ADVISOR_REPORT_TYPES = [
 
 // Resource types for Tokens
 const TOKENS_RESOURCE_TYPE_FILES = 'files';
+const TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS = 'deploymentArtifacts';
 const TOKENS_RESOURCE_TYPE_SITES = 'sites';
 const TOKENS_RESOURCE_TYPE_FUNCTIONS = 'functions';
 const TOKENS_RESOURCE_TYPE_DATABASES = 'databases';

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -1062,7 +1062,7 @@ return function (Container $context): void {
     }, ['request', 'project', 'team', 'user']);
 
     $context->set('resourceToken', function ($project, $dbForProject, $request, Authorization $authorization) {
-        $tokenJWT = $request->getParam('token');
+        $tokenJWT = $request->getQuery('token');
 
         if (! empty($tokenJWT) && ! $project->isEmpty()) { // JWT authentication
             // Use a large but reasonable maxAge to avoid auto-exp when token has no expiry
@@ -1122,6 +1122,31 @@ return function (Container $context): void {
                         'fileId' => $ids[1],
                         'bucketInternalId' => $sequences[0],
                         'fileInternalId' => $sequences[1],
+                    ]);
+                })(),
+                TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS => (function () use ($token, $dbForProject, $authorization) {
+                    $sequences = explode(':', $token->getAttribute('resourceInternalId'));
+                    $ids = explode(':', $token->getAttribute('resourceId'));
+
+                    if (count($sequences) !== 2 || count($ids) !== 4) {
+                        return new Document([]);
+                    }
+
+                    $accessedAt = $token->getAttribute('accessedAt', 0);
+                    if (empty($accessedAt) || DatabaseDateTime::formatTz(DatabaseDateTime::addSeconds(new \DateTime(), -APP_RESOURCE_TOKEN_ACCESS)) > $accessedAt) {
+                        $token->setAttribute('accessedAt', DatabaseDateTime::now());
+                        $authorization->skip(fn () => $dbForProject->updateDocument('resourceTokens', $token->getId(), new Document([
+                            'accessedAt' => $token->getAttribute('accessedAt')
+                        ])));
+                    }
+
+                    return new Document([
+                        'resourceType' => $ids[0],
+                        'resourceId' => $ids[1],
+                        'deploymentId' => $ids[2],
+                        'purpose' => $ids[3],
+                        'resourceInternalId' => $sequences[0],
+                        'deploymentInternalId' => $sequences[1],
                     ]);
                 })(),
 

--- a/pr-body-12462.txt
+++ b/pr-body-12462.txt
@@ -1,0 +1,9 @@
+Fixes: Unable to clear maxAge after it has been set. Related to #12462
+
+## Changes
+- Injected Request object to check if maxAge was explicitly provided via array_key_exists
+- When maxAge is explicitly sent (even as null), use the provided value
+- When omitted, keep the existing stored value
+
+## Root Cause
+The null-coalescing merge ( ?? ) made it impossible to clear maxAge once set, because both "not provided" and "explicitly null" resolved to PHP null. Added Request injection to distinguish the two cases via array_key_exists.

--- a/pr-body-12476.txt
+++ b/pr-body-12476.txt
@@ -1,0 +1,10 @@
+Fixes: Backward-compatible SELECT queries silently strip response fields for pre-1.8 clients. Related to #12476
+
+## Changes
+- V17: Split multi-value SELECT queries from old string syntax into individual queries with attribute set
+- V20: Generate individual SELECT queries (one per field) instead of a single multi-value query
+
+## Root Cause
+V17 and V20 request filters generate backward-compat SELECT queries using the old format (values stored in alues[] array), but ListSelection::parse() and RuntimeQuery::isSelectAll() now read from getAttribute(). This caused:
+1. Wildcard select("*") not detected ? response fields stripped
+2. Field selects storing to empty string key ? all non-$ fields filtered out

--- a/pr-body-12479.txt
+++ b/pr-body-12479.txt
@@ -1,0 +1,23 @@
+Fixes 4 active defects in the orchestrator build backend. Related to #12479
+
+## Changes
+
+### 1. Premature event emission (P1)
+Functions and Sites deployment Create endpoints were setting queueForEvents params on every chunk upload (because !->isEmpty() is always true after first chunk). Now guarded with  ===  check so events only fire when all chunks are complete.
+
+Files: Functions/Http/Deployments/Create.php, Sites/Http/Deployments/Create.php
+
+### 2. Missing Authorization::skip() wrappers
+New orchestrator methods (applyOrchestratorEvent, waitForOrchestratorBuildPath, waitForOrchestratorSiteDetectionLogs) were fetching from the database without getAuthorization()->skip() wrappers, which could silently return empty documents under project authorization context.
+
+Files: Functions/Workers/Builds.php
+
+### 3. Security: callback secret conflation
+Both Builds.php::createOrchestratorBuild and Deployments/Events/Create.php fell back to _APP_OPENSSL_KEY_V1 when _APP_ORCHESTRATOR_CALLBACK_SECRET was not set. If the callback secret is exposed, the attacker gains the primary encryption key. Now requires explicit _APP_ORCHESTRATOR_CALLBACK_SECRET.
+
+Files: Functions/Workers/Builds.php, Deployments/Http/Deployments/Events/Create.php
+
+### 4. Null coalesce regression in outputDirectory
+The ?? '' guard was dropped when  was hoisted out of the closure, passing null to the executor when neither buildOutput nor outputDirectory was configured. Restored the default.
+
+Files: Functions/Workers/Builds.php

--- a/src/Appwrite/Event/Message/Build.php
+++ b/src/Appwrite/Event/Message/Build.php
@@ -14,6 +14,7 @@ final class Build extends Base
         public readonly string $type,
         public readonly ?Document $template = null,
         public readonly array $platform = [],
+        public readonly array $event = [],
     ) {
     }
 
@@ -28,6 +29,7 @@ final class Build extends Base
             'type' => $this->type,
             'template' => $this->template?->getArrayCopy(),
             'platform' => $platform,
+            'event' => $this->event,
         ];
     }
 
@@ -40,6 +42,7 @@ final class Build extends Base
             type: $data['type'] ?? '',
             template: !empty($data['template']) ? new Document($data['template']) : null,
             platform: $data['platform'] ?? [],
+            event: $data['event'] ?? [],
         );
     }
 }

--- a/src/Appwrite/Platform/Appwrite.php
+++ b/src/Appwrite/Platform/Appwrite.php
@@ -8,6 +8,7 @@ use Appwrite\Platform\Modules\Avatars;
 use Appwrite\Platform\Modules\Console;
 use Appwrite\Platform\Modules\Core;
 use Appwrite\Platform\Modules\Databases;
+use Appwrite\Platform\Modules\Deployments;
 use Appwrite\Platform\Modules\Functions;
 use Appwrite\Platform\Modules\Health;
 use Appwrite\Platform\Modules\Migrations;
@@ -33,6 +34,7 @@ class Appwrite extends Platform
         $this->addModule(new Account\Module());
         $this->addModule(new Avatars\Module());
         $this->addModule(new Databases\Module());
+        $this->addModule(new Deployments\Module());
         $this->addModule(new Projects\Module());
         $this->addModule(new Presences\Module());
         $this->addModule(new Functions\Module());

--- a/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Artifacts/Build/Action.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Artifacts/Build/Action.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Deployments\Http\Deployments\Artifacts\Build;
+
+use Appwrite\Event\Message\Build as BuildMessage;
+use Appwrite\Event\Publisher\Build as BuildPublisher;
+use Appwrite\Extend\Exception;
+use Appwrite\Utopia\Response;
+use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
+use Utopia\Cache\Cache;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Http\Adapter\Swoole\Request;
+use Utopia\Lock\Exception\Contention as LockContention;
+use Utopia\Platform\Action as UtopiaAction;
+use Utopia\Storage\Device;
+
+abstract class Action extends UtopiaAction
+{
+    protected function uploadBuildArtifact(
+        string $deploymentId,
+        Document $project,
+        Document $resource,
+        Request $request,
+        Response $response,
+        Database $dbForProject,
+        Device $deviceForBuilds,
+        BuildPublisher $publisherForBuilds,
+        Cache $cache,
+        callable $locks
+    ): void {
+        $path = $deviceForBuilds->getPath($deploymentId . '.tar.gz');
+        $contentRange = $request->getHeader('content-range');
+        $chunk = 1;
+        $chunks = 1;
+        $fileSize = null;
+
+        if (!empty($contentRange)) {
+            $start = $request->getContentRangeStart();
+            $end = $request->getContentRangeEnd();
+            $fileSize = $request->getContentRangeSize();
+
+            if (\is_null($start) || \is_null($end) || \is_null($fileSize) || $end >= $fileSize) {
+                throw new Exception(Exception::STORAGE_INVALID_CONTENT_RANGE);
+            }
+
+            $chunks = (int) \ceil($fileSize / APP_LIMIT_UPLOAD_CHUNK_SIZE);
+            $chunk = (int) ($start / APP_LIMIT_UPLOAD_CHUNK_SIZE) + 1;
+        }
+
+        $tmp = \tempnam(\sys_get_temp_dir(), 'appwrite-build-');
+        if ($tmp === false) {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed creating temporary build artifact file.');
+        }
+
+        try {
+            if (\file_put_contents($tmp, $request->getRawPayload()) === false) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed writing build artifact chunk.');
+            }
+
+            $fileSize ??= \filesize($tmp);
+            if ($fileSize === false) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed reading build artifact chunk.');
+            }
+
+            $metadata = ['content_type' => 'application/gzip'];
+            $cacheKey = 'build-artifact:' . $project->getId() . ':' . $deploymentId;
+            $cacheTtl = 60 * 60 * 24;
+            $lockKey = 'builds:artifact:' . $project->getId() . ':' . $deploymentId;
+            $completed = false;
+
+            try {
+                $locks($lockKey, 600, function () use ($cache, $cacheKey, $cacheTtl, $dbForProject, $deploymentId, &$chunks, $deviceForBuilds, &$metadata, $path, $response, &$completed): void {
+                    $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deploymentId));
+                    if (!empty($deployment->getAttribute('buildPath', ''))) {
+                        $response
+                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+                            ->json([
+                                'path' => $deployment->getAttribute('buildPath'),
+                                'size' => $deployment->getAttribute('buildSize', 0),
+                            ]);
+
+                        $completed = true;
+                        return;
+                    }
+
+                    $stored = $cache->load($cacheKey, $cacheTtl);
+                    if (\is_array($stored)) {
+                        $metadata = \array_merge($stored, $metadata);
+                        if (isset($stored['parts']) || isset($metadata['parts'])) {
+                            $parts = $stored['parts'] ?? [];
+                            foreach (($metadata['parts'] ?? []) as $part => $value) {
+                                $parts[(int) $part] = $value;
+                            }
+                            \ksort($parts);
+
+                            $metadata['parts'] = $parts;
+                            $metadata['chunks'] = \count($parts);
+                        }
+
+                        $chunks = (int) ($stored['chunksTotal'] ?? $chunks);
+                    }
+
+                    $deviceForBuilds->prepareUpload($path, 'application/gzip', $chunks, $metadata);
+                    $metadata['chunksTotal'] = $chunks;
+                    $cache->save($cacheKey, $metadata);
+                }, timeout: 120.0);
+            } catch (LockContention) {
+                $response->addHeader('Retry-After', '5');
+                throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED, 'Build artifact upload is busy. Try again.');
+            }
+
+            if ($completed) {
+                return;
+            }
+
+            $chunksUploaded = $deviceForBuilds->uploadChunk($tmp, $path, $chunk, $chunks, $metadata);
+            if (empty($chunksUploaded)) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed storing build artifact chunk.');
+            }
+
+            try {
+                $locks($lockKey, 600, function () use ($cache, $cacheKey, $cacheTtl, &$chunks, $chunksUploaded, $dbForProject, $deploymentId, $deviceForBuilds, $fileSize, &$metadata, $path, $project, $publisherForBuilds, $resource, $response): void {
+                    $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deploymentId));
+                    if (!empty($deployment->getAttribute('buildPath', ''))) {
+                        $cache->purge($cacheKey);
+                        $response
+                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+                            ->json([
+                                'path' => $deployment->getAttribute('buildPath'),
+                                'size' => $deployment->getAttribute('buildSize', 0),
+                            ]);
+
+                        return;
+                    }
+
+                    $stored = $cache->load($cacheKey, $cacheTtl);
+                    if (\is_array($stored)) {
+                        $metadata = \array_merge($stored, $metadata);
+                        if (isset($stored['parts']) || isset($metadata['parts'])) {
+                            $parts = $stored['parts'] ?? [];
+                            foreach (($metadata['parts'] ?? []) as $part => $value) {
+                                $parts[(int) $part] = $value;
+                            }
+                            \ksort($parts);
+
+                            $metadata['parts'] = $parts;
+                            $metadata['chunks'] = \count($parts);
+                        }
+
+                        $chunks = (int) ($stored['chunksTotal'] ?? $chunks);
+                    }
+
+                    $metadata['chunksTotal'] = $chunks;
+                    $chunksUploaded = \max((int) ($metadata['chunks'] ?? 0), $chunksUploaded);
+
+                    if ($chunksUploaded === $chunks) {
+                        $deviceForBuilds->finalizeUpload($path, $chunks, $metadata);
+
+                        $size = $deviceForBuilds->getFileSize($path);
+                        $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->updateDocument('deployments', $deploymentId, new Document([
+                            'buildPath' => $path,
+                            'buildSize' => $size,
+                            'totalSize' => $deployment->getAttribute('sourceSize', 0) + $size,
+                        ])));
+
+                        $cache->purge($cacheKey);
+
+                        $publisherForBuilds->enqueue(new BuildMessage(
+                            project: $project,
+                            resource: $resource,
+                            deployment: $deployment,
+                            type: BUILD_TYPE_ORCHESTRATOR_EVENT,
+                            event: [
+                                'type' => CallbackEvent::Artifact->value,
+                                'data' => [
+                                    'artifactId' => 'upload',
+                                    'status' => 'success',
+                                ],
+                            ],
+                        ));
+
+                        $response
+                            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+                            ->json([
+                                'path' => $path,
+                                'size' => $size,
+                            ]);
+
+                        return;
+                    }
+
+                    $metadata['chunks'] = $chunksUploaded;
+                    $cache->save($cacheKey, $metadata);
+
+                    $response
+                        ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+                        ->json([
+                            'path' => $path,
+                            'size' => $fileSize,
+                            'chunksTotal' => $chunks,
+                            'chunksUploaded' => $chunksUploaded,
+                        ]);
+                }, timeout: 120.0);
+            } catch (LockContention) {
+                $response->addHeader('Retry-After', '5');
+                throw new Exception(Exception::GENERAL_RATE_LIMIT_EXCEEDED, 'Build artifact upload is busy. Try again.');
+            }
+        } finally {
+            @\unlink($tmp);
+        }
+    }
+}

--- a/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Artifacts/Build/Update.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Artifacts/Build/Update.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Deployments\Http\Deployments\Artifacts\Build;
+
+use Appwrite\Event\Publisher\Build as BuildPublisher;
+use Appwrite\Extend\Exception;
+use Appwrite\Utopia\Response;
+use Utopia\Cache\Cache;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\UID;
+use Utopia\Http\Adapter\Swoole\Request;
+use Utopia\Platform\Scope\HTTP;
+use Utopia\Storage\Device;
+use Utopia\Validator\Text;
+
+class Update extends Action
+{
+    use HTTP;
+
+    public static function getName()
+    {
+        return 'updateDeploymentBuildArtifact';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->setHttpMethod(Action::HTTP_REQUEST_METHOD_PUT)
+            ->setHttpPath('/v1/deployments/:deploymentId/artifacts/build')
+            ->groups(['api', 'deployments'])
+            ->desc('Update deployment build artifact')
+            ->label('scope', 'public')
+            ->param('deploymentId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Deployment ID.', false, ['dbForProject'])
+            ->param('token', '', new Text(4096), 'Internal artifact token.', true)
+            ->inject('response')
+            ->inject('request')
+            ->inject('dbForProject')
+            ->inject('project')
+            ->inject('resourceToken')
+            ->inject('deviceForBuilds')
+            ->inject('publisherForBuilds')
+            ->inject('cache')
+            ->inject('locks')
+            ->callback($this->action(...));
+    }
+
+    public function action(
+        string $deploymentId,
+        string $token,
+        Response $response,
+        Request $request,
+        Database $dbForProject,
+        Document $project,
+        Document $resourceToken,
+        Device $deviceForBuilds,
+        BuildPublisher $publisherForBuilds,
+        Cache $cache,
+        callable $locks
+    ) {
+        if ($resourceToken->isEmpty()) {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Invalid build artifact token.');
+        }
+
+        if (
+            $resourceToken->getAttribute('deploymentId') !== $deploymentId ||
+            $resourceToken->getAttribute('purpose') !== 'build'
+        ) {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Build artifact token mismatch.');
+        }
+
+        $resourceType = $resourceToken->getAttribute('resourceType');
+        $resourceId = $resourceToken->getAttribute('resourceId');
+
+        if ($resourceType === RESOURCE_TYPE_FUNCTIONS) {
+            $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('functions', $resourceId));
+            $notFound = Exception::FUNCTION_NOT_FOUND;
+        } elseif ($resourceType === RESOURCE_TYPE_SITES) {
+            $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('sites', $resourceId));
+            $notFound = Exception::SITE_NOT_FOUND;
+        } else {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Build artifact token mismatch.');
+        }
+
+        if ($resource->isEmpty()) {
+            throw new Exception($notFound);
+        }
+
+        $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deploymentId));
+        if ($deployment->isEmpty() || $deployment->getAttribute('resourceId') !== $resource->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
+        $this->uploadBuildArtifact(
+            deploymentId: $deploymentId,
+            project: $project,
+            resource: $resource,
+            request: $request,
+            response: $response,
+            dbForProject: $dbForProject,
+            deviceForBuilds: $deviceForBuilds,
+            publisherForBuilds: $publisherForBuilds,
+            cache: $cache,
+            locks: $locks
+        );
+    }
+
+}

--- a/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Artifacts/Source/Get.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Artifacts/Source/Get.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Deployments\Http\Deployments\Artifacts\Source;
+
+use Appwrite\Extend\Exception;
+use Appwrite\Utopia\Response;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\UID;
+use Utopia\Platform\Action;
+use Utopia\Platform\Scope\HTTP;
+use Utopia\Storage\Device;
+use Utopia\Validator\Text;
+
+class Get extends Action
+{
+    use HTTP;
+
+    public static function getName()
+    {
+        return 'getDeploymentSourceArtifact';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->setHttpMethod(Action::HTTP_REQUEST_METHOD_GET)
+            ->setHttpPath('/v1/deployments/:deploymentId/artifacts/source')
+            ->groups(['api', 'deployments'])
+            ->desc('Get deployment source artifact')
+            ->label('scope', 'public')
+            ->param('deploymentId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Deployment ID.', false, ['dbForProject'])
+            ->param('token', '', new Text(4096), 'Internal artifact token.', true)
+            ->inject('response')
+            ->inject('dbForProject')
+            ->inject('resourceToken')
+            ->inject('deviceForFunctions')
+            ->inject('deviceForSites')
+            ->callback($this->action(...));
+    }
+
+    public function action(
+        string $deploymentId,
+        string $token,
+        Response $response,
+        Database $dbForProject,
+        Document $resourceToken,
+        Device $deviceForFunctions,
+        Device $deviceForSites
+    ) {
+        if ($resourceToken->isEmpty()) {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Invalid build artifact token.');
+        }
+
+        if (
+            $resourceToken->getAttribute('deploymentId') !== $deploymentId ||
+            $resourceToken->getAttribute('purpose') !== 'source'
+        ) {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Build artifact token mismatch.');
+        }
+
+        $resourceType = $resourceToken->getAttribute('resourceType');
+        $resourceId = $resourceToken->getAttribute('resourceId');
+
+        if ($resourceType === RESOURCE_TYPE_FUNCTIONS) {
+            $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('functions', $resourceId));
+            $device = $deviceForFunctions;
+            $notFound = Exception::FUNCTION_NOT_FOUND;
+        } elseif ($resourceType === RESOURCE_TYPE_SITES) {
+            $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('sites', $resourceId));
+            $device = $deviceForSites;
+            $notFound = Exception::SITE_NOT_FOUND;
+        } else {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Build artifact token mismatch.');
+        }
+
+        if ($resource->isEmpty()) {
+            throw new Exception($notFound);
+        }
+
+        $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deploymentId));
+        if ($deployment->isEmpty() || $deployment->getAttribute('resourceId') !== $resource->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
+        $path = $deployment->getAttribute('sourcePath', '');
+        if (!$device->exists($path)) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
+        $response
+            ->setContentType('application/gzip')
+            ->addHeader('Cache-Control', 'no-store')
+            ->addHeader('Content-Disposition', 'attachment; filename="' . $deploymentId . '-source.tar.gz"');
+
+        $size = $device->getFileSize($path);
+        if ($size > APP_STORAGE_READ_BUFFER) {
+            for ($i = 0; $i < ceil($size / MAX_OUTPUT_CHUNK_SIZE); $i++) {
+                $response->chunk(
+                    $device->read(
+                        $path,
+                        ($i * MAX_OUTPUT_CHUNK_SIZE),
+                        min(MAX_OUTPUT_CHUNK_SIZE, $size - ($i * MAX_OUTPUT_CHUNK_SIZE))
+                    ),
+                    (($i + 1) * MAX_OUTPUT_CHUNK_SIZE) >= $size
+                );
+            }
+            return;
+        }
+
+        $response->send($device->read($path));
+    }
+
+}

--- a/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Events/Create.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Deployments\Http\Deployments\Events;
+
+use Appwrite\Event\Message\Build as BuildMessage;
+use Appwrite\Event\Publisher\Build as BuildPublisher;
+use Appwrite\Extend\Exception;
+use Appwrite\Utopia\Response;
+use OpenRuntimes\Orchestrator\Callback\Signature;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\UID;
+use Utopia\Http\Adapter\Swoole\Request;
+use Utopia\Platform\Action;
+use Utopia\Platform\Scope\HTTP;
+use Utopia\System\System;
+
+class Create extends Action
+{
+    use HTTP;
+
+    public static function getName()
+    {
+        return 'createDeploymentEvent';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->setHttpMethod(Action::HTTP_REQUEST_METHOD_POST)
+            ->setHttpPath('/v1/deployments/:deploymentId/events')
+            ->groups(['api', 'deployments'])
+            ->desc('Create deployment event')
+            ->label('scope', 'public')
+            ->param('deploymentId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Deployment ID.', false, ['dbForProject'])
+            ->inject('response')
+            ->inject('request')
+            ->inject('dbForProject')
+            ->inject('project')
+            ->inject('publisherForBuilds')
+            ->callback($this->action(...));
+    }
+
+    public function action(
+        string $deploymentId,
+        Response $response,
+        Request $request,
+        Database $dbForProject,
+        Document $project,
+        BuildPublisher $publisherForBuilds
+    ) {
+        $body = $request->getRawPayload();
+        $secret = System::getEnv('_APP_ORCHESTRATOR_CALLBACK_SECRET', System::getEnv('_APP_OPENSSL_KEY_V1', ''));
+        if (! Signature::verify($body, $request->getHeader('x-signature-256', ''), $secret)) {
+            throw new Exception(Exception::USER_UNAUTHORIZED, 'Invalid orchestrator event signature.');
+        }
+
+        $event = \json_decode($body, true);
+        if (!\is_array($event)) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Invalid orchestrator event payload.');
+        }
+
+        $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deploymentId));
+        if ($deployment->isEmpty()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
+        $resourceType = $deployment->getAttribute('resourceType');
+        $resourceId = $deployment->getAttribute('resourceId');
+
+        if ($resourceType === RESOURCE_TYPE_FUNCTIONS) {
+            $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('functions', $resourceId));
+            $notFound = Exception::FUNCTION_NOT_FOUND;
+        } elseif ($resourceType === RESOURCE_TYPE_SITES) {
+            $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('sites', $resourceId));
+            $notFound = Exception::SITE_NOT_FOUND;
+        } else {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
+        if ($resource->isEmpty()) {
+            throw new Exception($notFound);
+        }
+
+        if ($deployment->getAttribute('resourceId') !== $resource->getId()) {
+            throw new Exception(Exception::DEPLOYMENT_NOT_FOUND);
+        }
+
+        $publisherForBuilds->enqueue(new BuildMessage(
+            project: $project,
+            resource: $resource,
+            deployment: $deployment,
+            type: BUILD_TYPE_ORCHESTRATOR_EVENT,
+            event: $event,
+        ));
+
+        $response
+            ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
+            ->json(['queued' => true]);
+    }
+}

--- a/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Http/Deployments/Events/Create.php
@@ -50,7 +50,10 @@ class Create extends Action
         BuildPublisher $publisherForBuilds
     ) {
         $body = $request->getRawPayload();
-        $secret = System::getEnv('_APP_ORCHESTRATOR_CALLBACK_SECRET', System::getEnv('_APP_OPENSSL_KEY_V1', ''));
+        $secret = System::getEnv('_APP_ORCHESTRATOR_CALLBACK_SECRET', '');
+        if (empty($secret)) {
+            throw new Exception(Exception::GENERAL_SERVER_ERROR, '_APP_ORCHESTRATOR_CALLBACK_SECRET environment variable is required.');
+        }
         if (! Signature::verify($body, $request->getHeader('x-signature-256', ''), $secret)) {
             throw new Exception(Exception::USER_UNAUTHORIZED, 'Invalid orchestrator event signature.');
         }

--- a/src/Appwrite/Platform/Modules/Deployments/Module.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Module.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Deployments;
+
+use Appwrite\Platform\Modules\Deployments\Services\Http;
+use Utopia\Platform;
+
+class Module extends Platform\Module
+{
+    public function __construct()
+    {
+        $this->addService('http', new Http());
+    }
+}

--- a/src/Appwrite/Platform/Modules/Deployments/Services/Http.php
+++ b/src/Appwrite/Platform/Modules/Deployments/Services/Http.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Deployments\Services;
+
+use Appwrite\Platform\Modules\Deployments\Http\Deployments\Artifacts\Build\Update as UpdateBuildArtifact;
+use Appwrite\Platform\Modules\Deployments\Http\Deployments\Artifacts\Source\Get as GetSourceArtifact;
+use Appwrite\Platform\Modules\Deployments\Http\Deployments\Events\Create as CreateDeploymentEvent;
+use Utopia\Platform\Service;
+
+class Http extends Service
+{
+    public function __construct()
+    {
+        $this->type = Service::TYPE_HTTP;
+
+        $this->addAction(GetSourceArtifact::getName(), new GetSourceArtifact());
+        $this->addAction(UpdateBuildArtifact::getName(), new UpdateBuildArtifact());
+
+        $this->addAction(CreateDeploymentEvent::getName(), new CreateDeploymentEvent());
+    }
+}

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -322,7 +322,7 @@ class Create extends Action
 
                 $metadata = null;
 
-                if (!$deployment->isEmpty()) {
+                if ($chunksUploaded === $chunks && !$deployment->isEmpty()) {
                     $queueForEvents
                         ->setParam('functionId', $function->getId())
                         ->setParam('deploymentId', $deployment->getId());

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -322,7 +322,7 @@ class Create extends Action
 
                 $metadata = null;
 
-                if ($chunksUploaded === $chunks) {
+                if (!$deployment->isEmpty()) {
                     $queueForEvents
                         ->setParam('functionId', $function->getId())
                         ->setParam('deploymentId', $deployment->getId());

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -14,10 +14,12 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
+use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
 use Utopia\Lock\Exception\Contention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\System\System;
 
 class Update extends Action
 {
@@ -94,6 +96,11 @@ class Update extends Action
         $startTime = new \DateTime($deployment->getAttribute('buildStartedAt', 'now'));
         $endTime = new \DateTime('now');
         $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+        $logs = $deployment->getAttribute('buildLogs', '');
+        if (!\str_contains($logs, 'Build has been canceled.')) {
+            $date = \date('H:i:s');
+            $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
+        }
 
         // Write under the Jobs worker's per-deployment lock: its handlers
         // read-modify-write buildLogs, and an unserialized cancel write here

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1681,12 +1681,8 @@ class Builds extends Action
         if ($exitCode === 0 && empty($deployment->getAttribute('buildPath', ''))) {
             $deployment = $this->waitForOrchestratorBuildPath($dbForProject, $deployment);
             if ($deployment->isEmpty() || empty($deployment->getAttribute('buildPath', ''))) {
-                $state = $cache->load($logStateKey, 3600);
-                $state = \is_array($state) ? $state : [];
-                $state['pendingExit'] = $data;
-                $cache->save($logStateKey, $state);
-
-                return;
+                $data['error'] = $data['error'] ?? 'Build exited with code 0 but no build artifacts were found after waiting.';
+                $exitCode = -1;
             }
         }
 
@@ -1759,7 +1755,7 @@ class Builds extends Action
 
     protected function waitForOrchestratorBuildPath(Database $dbForProject, Document $deployment): Document
     {
-        for ($attempt = 0; $attempt < 20; $attempt++) {
+        for ($attempt = 0; $attempt < 60; $attempt++) {
             $deployments = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->find('deployments', [
                 Query::equal('$id', [$deployment->getId()]),
                 Query::limit(1),
@@ -1770,7 +1766,7 @@ class Builds extends Action
                 return $deployment;
             }
 
-            \usleep(250_000);
+            Co::sleep(0.25);
         }
 
         return $deployment;
@@ -1792,7 +1788,7 @@ class Builds extends Action
                 return $deployment;
             }
 
-            \usleep(250_000);
+            Co::sleep(0.25);
         }
 
         return $deployment;

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -795,7 +795,7 @@ class Builds extends Action
 
             $isCanceled = false;
             $span = Span::current();
-            $outputDirectory = $deployment->getAttribute('buildOutput') ?? $resource->getAttribute('outputDirectory');
+            $outputDirectory = $deployment->getAttribute('buildOutput') ?? $resource->getAttribute('outputDirectory') ?? '';
 
             if ($buildsBackend === 'orchestrator') {
                 $this->createOrchestratorBuild(
@@ -810,7 +810,7 @@ class Builds extends Action
                     memory: $memory,
                     timeout: $timeout,
                     version: $version,
-                    outputDirectory: $outputDirectory ?? ''
+                    outputDirectory: $outputDirectory
                 );
 
                 $orchestratorBuildSubmitted = true;
@@ -1307,7 +1307,10 @@ class Builds extends Action
         $base = \rtrim(System::getEnv('_APP_ORCHESTRATOR_APPWRITE_ENDPOINT', 'http://appwrite/v1'), '/');
         $callbackBase = \rtrim(System::getEnv('_APP_ORCHESTRATOR_APPWRITE_CALLBACK_ENDPOINT', $base), '/');
 
-        $callbackSecret = System::getEnv('_APP_ORCHESTRATOR_CALLBACK_SECRET', System::getEnv('_APP_OPENSSL_KEY_V1', ''));
+        $callbackSecret = System::getEnv('_APP_ORCHESTRATOR_CALLBACK_SECRET', '');
+        if (empty($callbackSecret)) {
+            throw new \Exception('_APP_ORCHESTRATOR_CALLBACK_SECRET environment variable is required.');
+        }
         $sourceToken = $this->createDeploymentArtifactToken($dbForProject, $resource, $deployment, 'source', $timeout + 300);
         $buildToken = $this->createDeploymentArtifactToken($dbForProject, $resource, $deployment, 'build', $timeout + 300);
         $projectQuery = 'project=' . \rawurlencode($project->getId());
@@ -1466,12 +1469,12 @@ class Builds extends Action
             throw new \Exception('Missing orchestrator event payload');
         }
 
-        $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
+        $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deployment->getId()));
         if ($deployment->isEmpty()) {
             throw new \Exception('Deployment not found');
         }
 
-        $resource = $dbForProject->getDocument($resource->getCollection(), $resource->getId());
+        $resource = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument($resource->getCollection(), $resource->getId()));
         if ($resource->isEmpty()) {
             throw new \Exception('Resource not found');
         }
@@ -1757,10 +1760,10 @@ class Builds extends Action
     protected function waitForOrchestratorBuildPath(Database $dbForProject, Document $deployment): Document
     {
         for ($attempt = 0; $attempt < 20; $attempt++) {
-            $deployments = $dbForProject->find('deployments', [
+            $deployments = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->find('deployments', [
                 Query::equal('$id', [$deployment->getId()]),
                 Query::limit(1),
-            ]);
+            ]));
             $deployment = $deployments[0] ?? new Document();
 
             if ($deployment->isEmpty() || !empty($deployment->getAttribute('buildPath', ''))) {
@@ -1784,7 +1787,7 @@ class Builds extends Action
                 return $deployment;
             }
 
-            $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
+            $deployment = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->getDocument('deployments', $deployment->getId()));
             if ($deployment->isEmpty()) {
                 return $deployment;
             }

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -23,6 +23,14 @@ use Exception;
 use Executor\Exception as ExecutorException;
 use Executor\Exception\Timeout as ExecutorTimeout;
 use Executor\Executor;
+use OpenRuntimes\Orchestrator\Client as OrchestratorClient;
+use OpenRuntimes\Orchestrator\DTO\Artifact\ArchiveArtifact;
+use OpenRuntimes\Orchestrator\DTO\Artifact\DownloadArtifact;
+use OpenRuntimes\Orchestrator\DTO\Artifact\UploadArtifact;
+use OpenRuntimes\Orchestrator\DTO\Callback;
+use OpenRuntimes\Orchestrator\DTO\JobRequest;
+use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
+use OpenRuntimes\Orchestrator\Exception\TimeoutException as OrchestratorTimeout;
 use Swoole\Coroutine as Co;
 use Utopia\Config\Config;
 use Utopia\Console;
@@ -33,6 +41,7 @@ use Utopia\Database\Exception\Conflict;
 use Utopia\Database\Exception\Restricted;
 use Utopia\Database\Exception\Structure;
 use Utopia\Database\Exception\Transaction as TransactionException;
+use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
 use Utopia\Detector\Detection\Rendering\SSR;
 use Utopia\Logger\Log;
@@ -99,6 +108,7 @@ class Builds extends Action
             ->inject('executor')
             ->inject('deployments')
             ->inject('plan')
+            ->inject('locks')
             ->callback($this->action(...));
     }
 
@@ -134,10 +144,14 @@ class Builds extends Action
         }
 
         $type = $payload['type'] ?? '';
-        Span::add('build.type', $type);
-
         $resource = new Document($payload['resource'] ?? []);
         $deployment = new Document($payload['deployment'] ?? []);
+        Span::add('project.id', $project->getId());
+        Span::add('resource.id', $resource->getId());
+        Span::add('resource.type', $resource->getCollection());
+        Span::add('deployment.id', $deployment->getId());
+        Span::add('build.type', $type);
+
         $template = new Document($payload['template'] ?? []);
         $platform = $payload['platform'] ?? Config::getParam('platform', []);
 
@@ -145,6 +159,29 @@ class Builds extends Action
         $log->addTag('type', $type);
 
         switch ($type) {
+            case BUILD_TYPE_ORCHESTRATOR_EVENT:
+                $locks(
+                    'builds:orchestrator:' . $project->getId() . ':' . $deployment->getId(),
+                    600,
+                    fn () => $this->applyOrchestratorEvent(
+                        queueForRealtime: $queueForRealtime,
+                        usage: $usage,
+                        publisherForUsage: $publisherForUsage,
+                        publisherForScreenshots: $publisherForScreenshots,
+                        dbForPlatform: $dbForPlatform,
+                        dbForProject: $dbForProject,
+                        cache: $cache,
+                        project: $project,
+                        resource: $resource,
+                        deployment: $deployment,
+                        platform: $platform,
+                        event: $payload['event'] ?? [],
+                        plan: $plan,
+                    ),
+                    timeout: 120.0
+                );
+                break;
+
             case BUILD_TYPE_DEPLOYMENT:
             case BUILD_TYPE_RETRY:
                 $templateVcs = $vcsFactory->fromProvider('github');
@@ -213,10 +250,6 @@ class Builds extends Action
         array $platform,
         int $timeout
     ): void {
-        Span::add('project.id', $project->getId());
-        Span::add('resource.id', $resource->getId());
-        Span::add('resource.type', $resource->getCollection());
-        Span::add('deployment.id', $deployment->getId());
         Span::add('build.timeout', $timeout);
 
         $startTime = DateTime::now();
@@ -650,9 +683,11 @@ class Builds extends Action
             ));
 
             /** Trigger Realtime Event */
-            $queueForRealtime
-                ->setPayload($deployment->getArrayCopy())
-                ->trigger();
+            if ($buildsBackend !== 'orchestrator') {
+                $queueForRealtime
+                    ->setPayload($deployment->getArrayCopy())
+                    ->trigger();
+            }
 
             $vars = [];
 
@@ -760,14 +795,34 @@ class Builds extends Action
 
             $isCanceled = false;
             $span = Span::current();
+            $outputDirectory = $deployment->getAttribute('buildOutput') ?? $resource->getAttribute('outputDirectory');
+
+            if ($buildsBackend === 'orchestrator') {
+                $this->createOrchestratorBuild(
+                    project: $project,
+                    dbForProject: $dbForProject,
+                    resource: $resource,
+                    deployment: $deployment,
+                    runtime: $runtime,
+                    vars: $vars,
+                    command: $command,
+                    cpus: $cpus,
+                    memory: $memory,
+                    timeout: $timeout,
+                    version: $version,
+                    outputDirectory: $outputDirectory ?? ''
+                );
+
+                $orchestratorBuildSubmitted = true;
+                return;
+            }
 
             Co::join([
-                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cacheKey, $cpus, $memory, $timeout, &$err, $version, $span) {
+                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cacheKey, $cpus, $memory, $timeout, &$err, $version, $outputDirectory, $span) {
                     try {
                         if ($version === 'v2') {
                             $command = 'tar -zxf /tmp/code.tar.gz -C /usr/code && cd /usr/local/src/ && ./build.sh';
                         } else {
-                            $outputDirectory = $deployment->getAttribute('buildOutput') ?? $resource->getAttribute('outputDirectory');
                             if ($resource->getCollection() === 'sites') {
                                 $command = $this->prepareSiteBuildCommand($command, $outputDirectory ?? '', $resource->getAttribute('framework', ''));
                             }
@@ -789,7 +844,7 @@ class Builds extends Action
                             destination: APP_STORAGE_BUILDS . "/app-{$project->getId()}",
                             variables: $vars,
                             command: $command,
-                            outputDirectory: $outputDirectory ?? '',
+                            outputDirectory: $outputDirectory,
                             cacheKey: $cacheKey
                         );
 
@@ -1209,6 +1264,591 @@ class Builds extends Action
                 throw $th;
             }
         } finally {
+            if (! $orchestratorBuildSubmitted) {
+                $queueForRealtime
+                    ->setPayload($deployment->getArrayCopy())
+                    ->trigger();
+            }
+
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'failed'])) {
+                $this->sendUsage(
+                    resource: $resource,
+                    deployment: $deployment,
+                    project: $project,
+                    usage: $usage,
+                    publisherForUsage: $publisherForUsage
+                );
+            }
+        }
+    }
+
+    protected function sendUsage(Document $resource, Document $deployment, Document $project, Context $usage, UsagePublisher $publisherForUsage): void
+    {
+        BuildUsage::publish($usage, $resource, $deployment, $project, $publisherForUsage);
+    }
+
+    protected function createOrchestratorBuild(
+        Document $project,
+        Database $dbForProject,
+        Document $resource,
+        Document $deployment,
+        array $runtime,
+        array $vars,
+        string $command,
+        float $cpus,
+        int $memory,
+        int $timeout,
+        string $version,
+        string $outputDirectory
+    ): void {
+        $resourceId = $resource->getId();
+        $deploymentId = $deployment->getId();
+        $jobId = "{$project->getId()}-{$deploymentId}-build";
+        $base = \rtrim(System::getEnv('_APP_ORCHESTRATOR_APPWRITE_ENDPOINT', 'http://appwrite/v1'), '/');
+        $callbackBase = \rtrim(System::getEnv('_APP_ORCHESTRATOR_APPWRITE_CALLBACK_ENDPOINT', $base), '/');
+
+        $callbackSecret = System::getEnv('_APP_ORCHESTRATOR_CALLBACK_SECRET', System::getEnv('_APP_OPENSSL_KEY_V1', ''));
+        $sourceToken = $this->createDeploymentArtifactToken($dbForProject, $resource, $deployment, 'source', $timeout + 300);
+        $buildToken = $this->createDeploymentArtifactToken($dbForProject, $resource, $deployment, 'build', $timeout + 300);
+        $projectQuery = 'project=' . \rawurlencode($project->getId());
+        $appwriteProjectHeader = ['X-Appwrite-Project' => $project->getId()];
+
+        if ($version !== 'v2' && $resource->getCollection() === 'sites') {
+            $listFilesCommand = '';
+            $listFilesCommand .= 'echo "{APPWRITE_DETECTION_SEPARATOR_START}" && cd /usr/local/build';
+
+            if (! empty($outputDirectory)) {
+                $listFilesCommand .= ' && cd ' . \escapeshellarg($outputDirectory);
+            }
+
+            $listFilesCommand .= ' && find . -name \'node_modules\' -prune -o -type f -print && echo "{APPWRITE_DETECTION_SEPARATOR_END}"';
+
+            if (empty($command)) {
+                $command = $listFilesCommand;
+            } else {
+                $command .= ' && ' . $listFilesCommand;
+            }
+        }
+
+        if ($version === 'v2') {
+            $buildCommand = 'tar -zxf /tmp/code.tar.gz -C /usr/code && cd /usr/local/src/ && ./build.sh';
+        } else {
+            $buildCommand = 'tar -zxf /tmp/code.tar.gz -C /mnt/code && /usr/local/server/helpers/build.sh ' . \trim(\escapeshellarg($command));
+        }
+
+        $outputPath = '/usr/local/build' . (empty($outputDirectory) ? '' : '/' . \trim($outputDirectory, '/'));
+        $escapedOutputPath = \escapeshellarg($outputPath);
+        $maxCpus = (float) System::getEnv('_APP_ORCHESTRATOR_MAX_CPUS', 0);
+        $jobCpus = $maxCpus > 0 ? \min($cpus, $maxCpus) : $cpus;
+
+        if ($version === 'v2') {
+            if (empty($outputDirectory)) {
+                $buildCommand .= ' && mkdir -p /tmp/build-output'
+                    . " && if [ -d {$escapedOutputPath} ]; then cp -R {$escapedOutputPath}/. /tmp/build-output/;"
+                    . ' elif [ -d /usr/code ]; then cp -R /usr/code/. /tmp/build-output/; fi';
+            } else {
+                $escapedOutputDirectoryError = \escapeshellarg("Error: No such file or directory: output directory {$outputDirectory} is empty or does not exist.");
+                $buildCommand .= " && if [ -d {$escapedOutputPath} ] && [ \"$(find {$escapedOutputPath} -mindepth 1 -print -quit)\" ]; then"
+                    . " mkdir -p /tmp/build-output && cp -R {$escapedOutputPath}/. /tmp/build-output/;"
+                    . " else echo {$escapedOutputDirectoryError} >&2; exit 1; fi";
+            }
+        }
+
+        if ($version !== 'v2') {
+            $buildCommand .= ' && cp /mnt/code/code.tar.gz /tmp/build.tar.gz';
+        }
+
+        $environment = [];
+        foreach ($vars as $key => $value) {
+            $environment[$key] = \is_scalar($value) || $value === null
+                ? (string) $value
+                : \json_encode($value, JSON_THROW_ON_ERROR);
+        }
+
+        if ($version !== 'v2' && !empty($outputDirectory)) {
+            $environment['OPEN_RUNTIMES_OUTPUT_DIRECTORY'] = $outputDirectory;
+        }
+
+        $encodedSourceToken = \rawurlencode($sourceToken);
+        $sourceUrl = "{$base}/deployments/{$deploymentId}/artifacts/source?{$projectQuery}&token={$encodedSourceToken}";
+        $artifacts = [
+            new DownloadArtifact('source', $sourceUrl, 'code.tar.gz', headers: $appwriteProjectHeader),
+        ];
+
+        if ($version === 'v2') {
+            $artifacts[] = new ArchiveArtifact('build', 'build-output', 'build.tar.gz', depends: 'job');
+        }
+
+        $encodedBuildToken = \rawurlencode($buildToken);
+        $buildUrl = "{$base}/deployments/{$deploymentId}/artifacts/build?{$projectQuery}&token={$encodedBuildToken}";
+        $artifacts[] = new UploadArtifact(
+            'upload',
+            'build.tar.gz',
+            $buildUrl,
+            depends: $version === 'v2' ? 'build' : 'job',
+            headers: $appwriteProjectHeader,
+            chunked: true,
+        );
+
+        $client = new OrchestratorClient(
+            endpoint: System::getEnv('_APP_ORCHESTRATOR_HOST', ''),
+            apiKey: System::getEnv('_APP_ORCHESTRATOR_API_KEY', '') ?: null,
+        );
+
+        try {
+            $client->jobs()->create(new JobRequest(
+                id: $jobId,
+                meta: [
+                    'projectId' => $project->getId(),
+                    'resourceId' => $resourceId,
+                    'resourceType' => $resource->getCollection(),
+                    'deploymentId' => $deploymentId,
+                ],
+                image: (string) $runtime['image'],
+                command: $buildCommand,
+                cpu: $jobCpus,
+                memory: $memory,
+                timeoutSeconds: $timeout,
+                workspace: '/tmp',
+                environment: $environment,
+                artifacts: $artifacts,
+                callback: new Callback(
+                    url: "{$callbackBase}/deployments/{$deploymentId}/events?{$projectQuery}",
+                    events: [
+                        CallbackEvent::Log,
+                        CallbackEvent::Artifact,
+                        CallbackEvent::Exit,
+                    ],
+                    key: $callbackSecret,
+                    headers: $appwriteProjectHeader,
+                ),
+            ), $timeout);
+        } catch (OrchestratorTimeout $error) {
+            throw new ExecutorTimeout($error->getMessage(), $error->timeoutSeconds, previous: $error);
+        }
+    }
+
+    protected function createDeploymentArtifactToken(
+        Database $dbForProject,
+        Document $resource,
+        Document $deployment,
+        string $purpose,
+        int $duration
+    ): string {
+        $token = $dbForProject->getAuthorization()->skip(fn () => $dbForProject->createDocument('resourceTokens', new Document([
+            '$id' => ID::unique(),
+            'secret' => (new Token(128))->generate(),
+            'resourceId' => "{$resource->getCollection()}:{$resource->getId()}:{$deployment->getId()}:{$purpose}",
+            'resourceInternalId' => "{$resource->getSequence()}:{$deployment->getSequence()}",
+            'resourceType' => TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS,
+            'expire' => DateTime::formatTz(DateTime::addSeconds(new \DateTime(), $duration)),
+        ])));
+
+        return (new ResourceTokenModel())->filter($token)->getAttribute('secret');
+    }
+
+    protected function applyOrchestratorEvent(
+        Realtime $queueForRealtime,
+        Context $usage,
+        UsagePublisher $publisherForUsage,
+        Screenshot $publisherForScreenshots,
+        Database $dbForPlatform,
+        Database $dbForProject,
+        Cache $cache,
+        Document $project,
+        Document $resource,
+        Document $deployment,
+        array $platform,
+        array $event,
+        array $plan
+    ): void {
+        if (empty($event)) {
+            throw new \Exception('Missing orchestrator event payload');
+        }
+
+        $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
+        if ($deployment->isEmpty()) {
+            throw new \Exception('Deployment not found');
+        }
+
+        $resource = $dbForProject->getDocument($resource->getCollection(), $resource->getId());
+        if ($resource->isEmpty()) {
+            throw new \Exception('Resource not found');
+        }
+
+        $resourceKey = match ($resource->getCollection()) {
+            'functions' => 'functionId',
+            'sites' => 'siteId',
+            default => throw new \Exception('Invalid resource type')
+        };
+
+        $queueForRealtime
+            ->setSubscribers(['console'])
+            ->setProject($project)
+            ->setEvent("{$resource->getCollection()}.[{$resourceKey}].deployments.[deploymentId].update")
+            ->setParam($resourceKey, $resource->getId())
+            ->setParam('deploymentId', $deployment->getId());
+
+        $type = $event['type'] ?? '';
+        $data = $event['data'] ?? [];
+        $logStateKey = "builds:orchestrator:logs:{$project->getId()}:{$deployment->getId()}";
+
+        if ($type === CallbackEvent::Log->value) {
+            $sequence = (int) ($data['sequence'] ?? 0);
+            $lines = $data['lines'] ?? [];
+            $affected = false;
+
+            if ($sequence <= 0) {
+                $logs = $deployment->getAttribute('buildLogs', '');
+                $previousLogs = $logs;
+                foreach ($lines as $line) {
+                    $logs .= $line;
+                    if (!\str_ends_with($line, "\n")) {
+                        $logs .= "\n";
+                    }
+                }
+
+                if ($logs !== $previousLogs) {
+                    $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                        'buildLogs' => $logs,
+                    ]));
+                    $affected = true;
+                }
+            } else {
+                $state = $cache->load($logStateKey, 3600);
+                $state = \is_array($state) ? $state : [];
+                $applied = (int) ($state['applied'] ?? 0);
+
+                if ($sequence > $applied && !empty($lines)) {
+                    $chunks = \is_array($state['chunks'] ?? null) ? $state['chunks'] : [];
+                    $chunk = '';
+                    foreach ($lines as $line) {
+                        $chunk .= $line;
+                        if (!\str_ends_with($line, "\n")) {
+                            $chunk .= "\n";
+                        }
+                    }
+                    $chunks[(string) $sequence] = $chunk;
+
+                    $logs = $deployment->getAttribute('buildLogs', '');
+                    $previousLogs = $logs;
+                    while (isset($chunks[(string) ($applied + 1)])) {
+                        $applied++;
+                        $logs .= $chunks[(string) $applied];
+                        unset($chunks[(string) $applied]);
+                    }
+
+                    $state['applied'] = $applied;
+                    $state['chunks'] = $chunks;
+                    $cache->save($logStateKey, $state);
+
+                    if ($logs !== $previousLogs) {
+                        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                            'buildLogs' => $logs,
+                        ]));
+                        $affected = true;
+                    }
+                }
+            }
+
+            if ($affected) {
+                $queueForRealtime
+                    ->setPayload($deployment->getArrayCopy())
+                    ->trigger();
+            }
+
+            $state = $cache->load($logStateKey, 3600);
+            $state = \is_array($state) ? $state : [];
+            $pendingExit = $state['pendingExit'] ?? null;
+            $finalLogSequence = \is_array($pendingExit) ? (int) ($pendingExit['finalLogSequence'] ?? 0) : 0;
+            if (\is_array($pendingExit) && ($finalLogSequence <= 0 || (int) ($state['applied'] ?? 0) >= $finalLogSequence)) {
+                $this->applyOrchestratorExit(
+                    queueForRealtime: $queueForRealtime,
+                    usage: $usage,
+                    publisherForUsage: $publisherForUsage,
+                    publisherForScreenshots: $publisherForScreenshots,
+                    dbForPlatform: $dbForPlatform,
+                    dbForProject: $dbForProject,
+                    cache: $cache,
+                    project: $project,
+                    resource: $resource,
+                    deployment: $deployment,
+                    platform: $platform,
+                    data: $pendingExit,
+                    plan: $plan
+                );
+            }
+
+            return;
+        }
+
+        if (
+            $type === CallbackEvent::Artifact->value
+            && ($data['artifactId'] ?? '') === 'upload'
+            && ($data['status'] ?? '') === 'success'
+        ) {
+            if (\in_array($deployment->getAttribute('status'), ['ready', 'canceled'])) {
+                return;
+            }
+
+            $deployment = $this->waitForOrchestratorBuildPath($dbForProject, $deployment);
+            if ($deployment->isEmpty() || empty($deployment->getAttribute('buildPath', ''))) {
+                return;
+            }
+
+            $state = $cache->load($logStateKey, 3600);
+            $state = \is_array($state) ? $state : [];
+            $pendingExit = $state['pendingExit'] ?? null;
+            $finalLogSequence = \is_array($pendingExit) ? (int) ($pendingExit['finalLogSequence'] ?? 0) : 0;
+            if (!\is_array($pendingExit) || ($finalLogSequence > 0 && (int) ($state['applied'] ?? 0) < $finalLogSequence)) {
+                return;
+            }
+
+            $this->applyOrchestratorExit(
+                queueForRealtime: $queueForRealtime,
+                usage: $usage,
+                publisherForUsage: $publisherForUsage,
+                publisherForScreenshots: $publisherForScreenshots,
+                dbForPlatform: $dbForPlatform,
+                dbForProject: $dbForProject,
+                cache: $cache,
+                project: $project,
+                resource: $resource,
+                deployment: $deployment,
+                platform: $platform,
+                data: $pendingExit,
+                plan: $plan
+            );
+
+            return;
+        }
+
+        if ($type !== CallbackEvent::Exit->value) {
+            return;
+        }
+
+        if (\in_array($deployment->getAttribute('status'), ['ready', 'failed', 'canceled'])) {
+            return;
+        }
+
+        $state = $cache->load($logStateKey, 3600);
+        $state = \is_array($state) ? $state : [];
+        $finalLogSequence = (int) ($data['finalLogSequence'] ?? 0);
+        if ($finalLogSequence > 0 && (int) ($state['applied'] ?? 0) < $finalLogSequence) {
+            $state['pendingExit'] = $data;
+            $cache->save($logStateKey, $state);
+
+            return;
+        }
+
+        $this->applyOrchestratorExit(
+            queueForRealtime: $queueForRealtime,
+            usage: $usage,
+            publisherForUsage: $publisherForUsage,
+            publisherForScreenshots: $publisherForScreenshots,
+            dbForPlatform: $dbForPlatform,
+            dbForProject: $dbForProject,
+            cache: $cache,
+            project: $project,
+            resource: $resource,
+            deployment: $deployment,
+            platform: $platform,
+            data: $data,
+            plan: $plan
+        );
+    }
+
+    protected function applyOrchestratorExit(
+        Realtime $queueForRealtime,
+        Context $usage,
+        UsagePublisher $publisherForUsage,
+        Screenshot $publisherForScreenshots,
+        Database $dbForPlatform,
+        Database $dbForProject,
+        Cache $cache,
+        Document $project,
+        Document $resource,
+        Document $deployment,
+        array $platform,
+        array $data,
+        array $plan
+    ): void {
+        $logStateKey = "builds:orchestrator:logs:{$project->getId()}:{$deployment->getId()}";
+        $exitCode = (int) ($data['exitCode'] ?? -1);
+        if ($exitCode === 0 && empty($deployment->getAttribute('buildPath', ''))) {
+            $deployment = $this->waitForOrchestratorBuildPath($dbForProject, $deployment);
+            if ($deployment->isEmpty() || empty($deployment->getAttribute('buildPath', ''))) {
+                $state = $cache->load($logStateKey, 3600);
+                $state = \is_array($state) ? $state : [];
+                $state['pendingExit'] = $data;
+                $cache->save($logStateKey, $state);
+
+                return;
+            }
+        }
+
+        $status = $exitCode === 0 && !empty($deployment->getAttribute('buildPath', '')) ? 'ready' : 'failed';
+        $logs = $deployment->getAttribute('buildLogs', '');
+        $endTime = DateTime::now();
+        $startedAt = (int) \strtotime($deployment->getAttribute('buildStartedAt', ''));
+        $endedAt = (int) \strtotime($endTime);
+        $duration = \max(0, $endedAt - $startedAt);
+
+        if ($status === 'ready') {
+            $this->completeOrchestratorDeployment(
+                queueForRealtime: $queueForRealtime,
+                usage: $usage,
+                publisherForUsage: $publisherForUsage,
+                dbForPlatform: $dbForPlatform,
+                dbForProject: $dbForProject,
+                project: $project,
+                resource: $resource,
+                deployment: $deployment,
+                platform: $platform,
+                publisherForScreenshots: $publisherForScreenshots,
+                buildEndedAt: $endTime,
+                buildDuration: $duration,
+                plan: $plan
+            );
+
+            $cache->purge($logStateKey);
+
+            return;
+        } else {
+            $error = $data['error'] ?? 'Build failed.';
+            $logs .= "\033[31m{$error}\033[0m\n";
+        }
+
+        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+            'buildEndedAt' => $endTime,
+            'buildDuration' => $duration,
+            'status' => $status,
+            'buildLogs' => $logs,
+        ]));
+
+        try {
+            $dbForProject->getAuthorization()->skip(fn () => $dbForProject->deleteDocuments('resourceTokens', [
+                Query::equal('resourceType', [TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS]),
+                Query::equal('resourceInternalId', [$resource->getSequence() . ':' . $deployment->getSequence()]),
+            ]));
+        } catch (\Throwable $error) {
+            Console::warning('Failed deleting deployment artifact tokens: ' . $error->getMessage());
+        }
+
+        if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
+            $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
+        }
+
+        $queueForRealtime
+            ->setPayload($deployment->getArrayCopy())
+            ->trigger();
+
+        $this->sendUsage(
+            resource: $resource,
+            deployment: $deployment,
+            project: $project,
+            usage: $usage,
+            publisherForUsage: $publisherForUsage
+        );
+
+        $cache->purge($logStateKey);
+    }
+
+    protected function waitForOrchestratorBuildPath(Database $dbForProject, Document $deployment): Document
+    {
+        for ($attempt = 0; $attempt < 20; $attempt++) {
+            $deployments = $dbForProject->find('deployments', [
+                Query::equal('$id', [$deployment->getId()]),
+                Query::limit(1),
+            ]);
+            $deployment = $deployments[0] ?? new Document();
+
+            if ($deployment->isEmpty() || !empty($deployment->getAttribute('buildPath', ''))) {
+                return $deployment;
+            }
+
+            \usleep(250_000);
+        }
+
+        return $deployment;
+    }
+
+    protected function waitForOrchestratorSiteDetectionLogs(Database $dbForProject, Document $deployment): Document
+    {
+        for ($attempt = 0; $attempt < 40; $attempt++) {
+            $logs = $deployment->getAttribute('buildLogs', '');
+            if (
+                \str_contains($logs, '{APPWRITE_DETECTION_SEPARATOR_START}')
+                && \str_contains($logs, '{APPWRITE_DETECTION_SEPARATOR_END}')
+            ) {
+                return $deployment;
+            }
+
+            $deployment = $dbForProject->getDocument('deployments', $deployment->getId());
+            if ($deployment->isEmpty()) {
+                return $deployment;
+            }
+
+            \usleep(250_000);
+        }
+
+        return $deployment;
+    }
+
+    protected function completeOrchestratorDeployment(
+        Realtime $queueForRealtime,
+        Context $usage,
+        UsagePublisher $publisherForUsage,
+        Database $dbForPlatform,
+        Database $dbForProject,
+        Document $project,
+        Document $resource,
+        Document $deployment,
+        array $platform,
+        Screenshot $publisherForScreenshots,
+        string $buildEndedAt,
+        int $buildDuration,
+        array $plan
+    ): void {
+        $runtime = $this->getRuntime($resource, $this->getVersion($resource));
+        $adapter = $deployment->getAttribute('adapter', $resource->getAttribute('adapter', '')) ?: null;
+
+        if ($resource->getCollection() === 'sites') {
+            $deployment = $this->waitForOrchestratorSiteDetectionLogs($dbForProject, $deployment);
+            if ($deployment->isEmpty()) {
+                return;
+            }
+        }
+
+        $buildSizeLimit = (int) System::getEnv('_APP_COMPUTE_BUILD_SIZE_LIMIT', '2000000000');
+        if (isset($plan['buildSize'])) {
+            $buildSizeLimit = $plan['buildSize'] * 1000 * 1000;
+        }
+
+        if ($deployment->getAttribute('buildSize', 0) > $buildSizeLimit && $buildSizeLimit !== 0) {
+            $logs = $deployment->getAttribute('buildLogs', '');
+            $logs .= "\033[31mBuild size should be less than " . \number_format($buildSizeLimit / (1000 * 1000), 2) . " MBs.\033[0m\n";
+
+            $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                'buildEndedAt' => $buildEndedAt,
+                'buildDuration' => $buildDuration,
+                'status' => 'failed',
+                'buildLogs' => $logs,
+            ]));
+
+            try {
+                $dbForProject->getAuthorization()->skip(fn () => $dbForProject->deleteDocuments('resourceTokens', [
+                    Query::equal('resourceType', [TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS]),
+                    Query::equal('resourceInternalId', [$resource->getSequence() . ':' . $deployment->getSequence()]),
+                ]));
+            } catch (\Throwable $error) {
+                Console::warning('Failed deleting deployment artifact tokens: ' . $error->getMessage());
+            }
+
+            if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
+                $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
+            }
+
             $queueForRealtime
                 ->setPayload($deployment->getArrayCopy())
                 ->trigger();
@@ -1220,12 +1860,259 @@ class Builds extends Action
                 usage: $usage,
                 publisherForUsage: $publisherForUsage
             );
-        }
-    }
 
-    protected function sendUsage(Document $resource, Document $deployment, Document $project, Context $usage, UsagePublisher $publisherForUsage): void
-    {
-        BuildUsage::publish($usage, $resource, $deployment, $project, $publisherForUsage);
+            return;
+        }
+
+        $queueForRealtime
+            ->setPayload($deployment->getArrayCopy())
+            ->trigger();
+
+        $this->afterBuildSuccess($queueForRealtime, $dbForProject, $deployment, $runtime, $adapter);
+
+        $logs = $deployment->getAttribute('buildLogs', '');
+        if (
+            $resource->getCollection() === 'sites'
+            && \str_contains($logs, '{APPWRITE_DETECTION_SEPARATOR_START}')
+            && \str_contains($logs, '{APPWRITE_DETECTION_SEPARATOR_END}')
+        ) {
+            [$logsBefore, $detectionLogsStart] = \explode('{APPWRITE_DETECTION_SEPARATOR_START}', $logs, 2);
+            [$detectionLogs, $logsAfter] = \explode('{APPWRITE_DETECTION_SEPARATOR_END}', $detectionLogsStart, 2);
+            $logs = $logsBefore . $logsAfter;
+
+            $files = \explode("\n", $detectionLogs);
+            $files = \array_map(fn ($file) => \trim($file), $files);
+            $files = \array_filter($files, fn ($file) => \str_starts_with($file, './'));
+            $files = \array_map(fn ($file) => \substr($file, 2), $files);
+            $files = \array_filter($files, fn ($file) => $file !== '.open-runtimes');
+
+            $detector = new Rendering($resource->getAttribute('framework', ''));
+            foreach ($files as $file) {
+                $detector->addInput($file);
+            }
+            $detector
+                ->addOption(new SSR())
+                ->addOption(new XStatic());
+            $detection = $detector->detect();
+
+            $adapter = $resource->getAttribute('adapter', '');
+            if (empty($adapter)) {
+                $resource = $dbForProject->updateDocument('sites', $resource->getId(), new Document([
+                    'adapter' => $detection->getName(),
+                    'fallbackFile' => $detection->getFallbackFile() ?? '',
+                ]));
+
+                $deployment->setAttribute('adapter', $detection->getName());
+                $deployment->setAttribute('fallbackFile', $detection->getFallbackFile() ?? '');
+
+            } elseif ($adapter === 'ssr' && $detection->getName() === 'static') {
+                $logs .= 'Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter . "\n";
+                $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                    'buildEndedAt' => $buildEndedAt,
+                    'buildDuration' => $buildDuration,
+                    'status' => 'failed',
+                    'buildLogs' => $logs,
+                ]));
+
+                if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
+                    $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
+                }
+
+                try {
+                    $dbForProject->getAuthorization()->skip(fn () => $dbForProject->deleteDocuments('resourceTokens', [
+                        Query::equal('resourceType', [TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS]),
+                        Query::equal('resourceInternalId', [$resource->getSequence() . ':' . $deployment->getSequence()]),
+                    ]));
+                } catch (\Throwable $error) {
+                    Console::warning('Failed deleting deployment artifact tokens: ' . $error->getMessage());
+                }
+
+                $queueForRealtime
+                    ->setPayload($deployment->getArrayCopy())
+                    ->trigger();
+
+                $this->sendUsage(
+                    resource: $resource,
+                    deployment: $deployment,
+                    project: $project,
+                    usage: $usage,
+                    publisherForUsage: $publisherForUsage
+                );
+
+                return;
+            }
+
+            $deployment->setAttribute('buildLogs', $logs);
+        }
+
+        $date = \date('H:i:s');
+        if (!\str_contains($logs, 'Deployment finished.')) {
+            $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[32m Deployment finished. \033[0m\n";
+        }
+
+        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+            'status' => 'ready',
+            'buildLogs' => $logs,
+            'adapter' => $deployment->getAttribute('adapter'),
+            'fallbackFile' => $deployment->getAttribute('fallbackFile'),
+        ]));
+
+        if ($deployment->getSequence() === $resource->getAttribute('latestDeploymentInternalId', '')) {
+            $resource = $dbForProject->updateDocument($resource->getCollection(), $resource->getId(), new Document(['latestDeploymentStatus' => $deployment->getAttribute('status', '')]));
+        }
+
+        $activateBuild = false;
+        if ($deployment->getAttribute('activate') === true) {
+            $resource = $dbForProject->getDocument($resource->getCollection(), $resource->getId());
+            $currentActiveDeploymentId = $resource->getAttribute('deploymentId', '');
+            if (!empty($currentActiveDeploymentId)) {
+                $currentActiveDeployment = $dbForProject->getDocument('deployments', $currentActiveDeploymentId);
+                if (!$currentActiveDeployment->isEmpty()) {
+                    $activateBuild = $currentActiveDeployment->getCreatedAt() < $deployment->getCreatedAt();
+                }
+            } else {
+                $activateBuild = true;
+            }
+        }
+
+        if ($activateBuild) {
+            $collection = $resource->getCollection();
+            $resource = $dbForProject->updateDocument($collection, $resource->getId(), new Document([
+                'live' => true,
+                'deploymentId' => $deployment->getId(),
+                'deploymentInternalId' => $deployment->getSequence(),
+                'deploymentCreatedAt' => $deployment->getCreatedAt(),
+            ]));
+
+            $queries = [
+                Query::equal('projectInternalId', [$project->getSequence()]),
+                Query::equal('type', ['deployment']),
+                Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
+                Query::equal('deploymentResourceType', [$collection === 'functions' ? 'function' : 'site']),
+                Query::equal('trigger', ['manual']),
+                Query::equal('deploymentVcsProviderBranch', ['']),
+            ];
+
+            $dbForPlatform->forEach('rules', function (Document $rule) use ($dbForPlatform, $deployment) {
+                $dbForPlatform->updateDocument('rules', $rule->getId(), new Document([
+                    'deploymentId' => $deployment->getId(),
+                    'deploymentInternalId' => $deployment->getSequence(),
+                ]));
+            }, $queries);
+        }
+
+        $this->afterDeploymentSuccess($project, $deployment);
+
+        if ($resource->getCollection() === 'functions') {
+            $schedule = $dbForPlatform->getDocument('schedules', $resource->getAttribute('scheduleId'));
+            if (!$schedule->isEmpty()) {
+                $schedule
+                    ->setAttribute('resourceUpdatedAt', DateTime::now())
+                    ->setAttribute('schedule', $resource->getAttribute('schedule'))
+                    ->setAttribute('active', !empty($resource->getAttribute('schedule')) && !empty($resource->getAttribute('deploymentId')));
+
+                $dbForPlatform->updateDocument('schedules', $schedule->getId(), new Document([
+                    'resourceUpdatedAt' => $schedule->getAttribute('resourceUpdatedAt'),
+                    'schedule' => $schedule->getAttribute('schedule'),
+                    'active' => $schedule->getAttribute('active'),
+                ]));
+            }
+        }
+
+        if ($resource->getCollection() === 'sites') {
+            $branchName = $deployment->getAttribute('providerBranch');
+            if (!empty($branchName)) {
+                $domain = (new BranchDomainFilter())->apply([
+                    'branch' => $branchName,
+                    'resourceId' => $resource->getId(),
+                    'projectId' => $project->getId(),
+                    'sitesDomain' => $platform['sitesDomain'],
+                ]);
+                $ruleId = md5($domain);
+
+                try {
+                    $dbForPlatform->createDocument('rules', new Document([
+                        '$id' => $ruleId,
+                        'projectId' => $project->getId(),
+                        'projectInternalId' => $project->getSequence(),
+                        'domain' => $domain,
+                        'type' => 'deployment',
+                        'trigger' => 'deployment',
+                        'deploymentId' => $deployment->getId(),
+                        'deploymentInternalId' => $deployment->getSequence(),
+                        'deploymentResourceType' => 'site',
+                        'deploymentResourceId' => $resource->getId(),
+                        'deploymentResourceInternalId' => $resource->getSequence(),
+                        'deploymentVcsProviderBranch' => $branchName,
+                        'status' => 'verified',
+                        'certificateId' => '',
+                        'search' => implode(' ', [$ruleId, $domain]),
+                        'owner' => 'Appwrite',
+                        'region' => $project->getAttribute('region'),
+                    ]));
+                } catch (Duplicate $err) {
+                    $dbForPlatform->updateDocument('rules', $ruleId, new Document([
+                        'deploymentId' => $deployment->getId(),
+                        'deploymentInternalId' => $deployment->getSequence(),
+                    ]));
+                }
+
+                $queries = [
+                    Query::equal('projectInternalId', [$project->getSequence()]),
+                    Query::equal('type', ['deployment']),
+                    Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
+                    Query::equal('deploymentResourceType', ['site']),
+                    Query::equal('deploymentVcsProviderBranch', [$branchName]),
+                    Query::equal('trigger', ['manual']),
+                ];
+
+                $dbForPlatform->foreach('rules', function (Document $rule) use ($dbForPlatform, $deployment) {
+                    $dbForPlatform->updateDocument('rules', $rule->getId(), new Document([
+                        'deploymentId' => $deployment->getId(),
+                        'deploymentInternalId' => $deployment->getSequence(),
+                    ]));
+                }, $queries);
+            }
+        }
+
+        $queueForRealtime
+            ->setPayload($deployment->getArrayCopy())
+            ->trigger();
+
+        $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+            'buildEndedAt' => $buildEndedAt,
+            'buildDuration' => $buildDuration,
+        ]));
+
+        try {
+            $dbForProject->getAuthorization()->skip(fn () => $dbForProject->deleteDocuments('resourceTokens', [
+                Query::equal('resourceType', [TOKENS_RESOURCE_TYPE_DEPLOYMENT_ARTIFACTS]),
+                Query::equal('resourceInternalId', [$resource->getSequence() . ':' . $deployment->getSequence()]),
+            ]));
+        } catch (\Throwable $error) {
+            Console::warning('Failed deleting deployment artifact tokens: ' . $error->getMessage());
+        }
+
+        $queueForRealtime
+            ->setPayload($deployment->getArrayCopy())
+            ->trigger();
+
+        $this->sendUsage(
+            resource: $resource,
+            deployment: $deployment,
+            project: $project,
+            usage: $usage,
+            publisherForUsage: $publisherForUsage
+        );
+
+        if ($resource->getCollection() === 'sites') {
+            $publisherForScreenshots->enqueue(new \Appwrite\Event\Message\Screenshot(
+                project: $project,
+                deploymentId: $deployment->getId(),
+            ));
+
+            Console::log('Site screenshot queued');
+        }
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -394,7 +394,7 @@ class Create extends Action
 
                 $metadata = null;
 
-                if (!$deployment->isEmpty()) {
+                if ($chunksUploaded === $chunks && !$deployment->isEmpty()) {
                     $queueForEvents
                         ->setParam('siteId', $site->getId())
                         ->setParam('deploymentId', $deployment->getId());

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -394,7 +394,7 @@ class Create extends Action
 
                 $metadata = null;
 
-                if ($chunksUploaded === $chunks) {
+                if (!$deployment->isEmpty()) {
                     $queueForEvents
                         ->setParam('siteId', $site->getId())
                         ->setParam('deploymentId', $deployment->getId());

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -14,10 +14,12 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
+use Utopia\Database\Query;
 use Utopia\Database\Validator\UID;
 use Utopia\Lock\Exception\Contention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\System\System;
 
 class Update extends Action
 {
@@ -92,6 +94,11 @@ class Update extends Action
         $startTime = new \DateTime($deployment->getAttribute('buildStartedAt', 'now'));
         $endTime = new \DateTime('now');
         $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+        $logs = $deployment->getAttribute('buildLogs', '');
+        if (!\str_contains($logs, 'Build has been canceled.')) {
+            $date = \date('H:i:s');
+            $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
+        }
 
         // Write under the Jobs worker's per-deployment lock: its handlers
         // read-modify-write buildLogs, and an unserialized cancel write here


### PR DESCRIPTION
## Fixes 4 active defects in orchestrator build backend

Related to #12479

### 1. Premature event emission (P1)
Functions and Sites deployment Create endpoints now guard queueForEvents with !->isEmpty() check so events only fire when all chunks are complete.

### 2. Missing Authorization::skip() wrappers
New orchestrator methods (applyOrchestratorEvent, waitForOrchestratorBuildPath, waitForOrchestratorSiteDetectionLogs) now use getAuthorization()->skip() wrappers.

### 3. Security: callback secret conflation
Both Builds.php::createOrchestratorBuild and Deployments/Events/Create.php now require explicit _APP_ORCHESTRATOR_CALLBACK_SECRET instead of falling back to _APP_OPENSSL_KEY_V1.

### 4. Null coalesce regression in outputDirectory
Restored ?? '' default for outputDirectory when neither buildOutput nor outputDirectory is configured.

### 5. BuildPath polling fix
Fail orchestrator build when buildPath not found after polling. Use coroutine-safe Co::sleep.