### PR TITLE
Fix: improve branch selector with infinite scroll and server-side search

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Branches/XList.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Branches/XList.php
@@ -96,7 +96,12 @@ class XList extends Action
             throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
         }
 
-        $branches = $github->listBranches($owner, $repositoryName, search: $search);
+        $branches = [];
+        $page = 1;
+        do {
+            $pageBranches = $github->listBranches($owner, $repositoryName, 100, $page++, $search);
+            $branches = array_merge($branches, $pageBranches);
+        } while (\count($pageBranches) === 100);
 
         $total = \count($branches);
         [


### PR DESCRIPTION
## What problem does this PR solve?

The branch selector in VCS repositories was limited to a single page of branches from GitHub API. When repositories had more than 100 branches, pages beyond the first were not fetched.

## Changes

- Fetch branches in a loop, requesting 100 at a time until the response has fewer than 100
- Merge all pages into a single result set

Based on #12572 by @HarshMN2345