### PR TITLE
fix: add CORS headers to GraphQL endpoint

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -987,7 +987,7 @@ Http::init()
  * @see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
  */
 Http::init()
-    ->groups(['api', 'web'])
+    ->groups(['api', 'web', 'graphql'])
     ->inject('request')
     ->inject('response')
     ->inject('cors')


### PR DESCRIPTION
## What problem does this PR solve?

GraphQL endpoint was missing CORS headers because the CORS init hook was not registered for the 'graphql' group.

## Changes

- Added 'graphql' to the CORS init hook groups

Based on #12526 by @deepshekhardas