### PR TITLE
chore: switch utopia-php/database to dev-main for testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "6.0.*",
+        "utopia-php/database": "dev-main as 6.0.0",
+>>>>>>> 916c5a050d (chore: switch utopia-php/database to dev-main and tune PostgreSQL CI durability flags)
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "508b3e633843d61eb24f864fd8832db0",
+    "content-hash": "67347c15f27f014d7f465a7a742f7290",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -69,16 +69,16 @@
         },
         {
             "name": "appwrite/appwrite",
-            "version": "26.1.0",
+            "version": "24.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-for-php.git",
-                "reference": "533865f24f306cf6ac6f1737965553a5c54672e0"
+                "reference": "d3217b6524b9d174ab91fb7ffc555c68bfa1da97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-for-php/zipball/533865f24f306cf6ac6f1737965553a5c54672e0",
-                "reference": "533865f24f306cf6ac6f1737965553a5c54672e0",
+                "url": "https://api.github.com/repos/appwrite/sdk-for-php/zipball/d3217b6524b9d174ab91fb7ffc555c68bfa1da97",
+                "reference": "d3217b6524b9d174ab91fb7ffc555c68bfa1da97",
                 "shasum": ""
             },
             "require": {
@@ -88,7 +88,7 @@
             },
             "require-dev": {
                 "mockery/mockery": "1.6.12",
-                "phpunit/phpunit": "^12"
+                "phpunit/phpunit": "^10"
             },
             "type": "library",
             "autoload": {
@@ -104,10 +104,10 @@
             "support": {
                 "email": "team@appwrite.io",
                 "issues": "https://github.com/appwrite/sdk-for-php/issues",
-                "source": "https://github.com/appwrite/sdk-for-php/tree/26.1.0",
+                "source": "https://github.com/appwrite/sdk-for-php/tree/24.2.0",
                 "url": "https://appwrite.io/support"
             },
-            "time": "2026-06-19T08:16:32+00:00"
+            "time": "2026-05-21T18:56:51+00:00"
         },
         {
             "name": "appwrite/php-clamav",
@@ -3118,25 +3118,25 @@
         },
         {
             "name": "utopia-php/abuse",
-            "version": "1.4.1",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/abuse.git",
-                "reference": "8f5df0274869cf9022eea7d8030ca1a0d458b3b2"
+                "reference": "00e59c89a1ac5f4ad771695e5dbee020b3c7ac44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/abuse/zipball/8f5df0274869cf9022eea7d8030ca1a0d458b3b2",
-                "reference": "8f5df0274869cf9022eea7d8030ca1a0d458b3b2",
+                "url": "https://api.github.com/repos/utopia-php/abuse/zipball/00e59c89a1ac5f4ad771695e5dbee020b3c7ac44",
+                "reference": "00e59c89a1ac5f4ad771695e5dbee020b3c7ac44",
                 "shasum": ""
             },
             "require": {
-                "appwrite/appwrite": "^26.0",
+                "appwrite/appwrite": "24.*",
                 "ext-curl": "*",
                 "ext-pdo": "*",
                 "ext-redis": "*",
                 "php": ">=8.2",
-                "utopia-php/database": "^6.0.0"
+                "utopia-php/database": "5.*"
             },
             "require-dev": {
                 "laravel/pint": "1.*",
@@ -3164,9 +3164,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/abuse/issues",
-                "source": "https://github.com/utopia-php/abuse/tree/1.4.1"
+                "source": "https://github.com/utopia-php/abuse/tree/1.3.1"
             },
-            "time": "2026-06-18T11:18:52+00:00"
+            "time": "2026-06-03T07:30:05+00:00"
         },
         {
             "name": "utopia-php/agents",
@@ -3269,21 +3269,21 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "2.6.0",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "f5bb07841e335e9ea7d4bd5860da1f580447014a"
+                "reference": "6f15caaac5455c98cec06e02fe8da3af9477ff38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/f5bb07841e335e9ea7d4bd5860da1f580447014a",
-                "reference": "f5bb07841e335e9ea7d4bd5860da1f580447014a",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/6f15caaac5455c98cec06e02fe8da3af9477ff38",
+                "reference": "6f15caaac5455c98cec06e02fe8da3af9477ff38",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "utopia-php/database": "^6.0.0",
+                "utopia-php/database": "5.*",
                 "utopia-php/fetch": "^1.1",
                 "utopia-php/query": "0.1.*",
                 "utopia-php/validators": "0.2.*"
@@ -3313,22 +3313,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/2.6.0"
+                "source": "https://github.com/utopia-php/audit/tree/2.4.2"
             },
-            "time": "2026-06-22T03:33:28+00:00"
+            "time": "2026-06-03T03:42:22+00:00"
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.7.0",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "22a2cf6ca604e5cc6bf10f0f8240195f0baa063a"
+                "reference": "9245a6342ed94f00425aef6963a32b8af9b0dc9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/22a2cf6ca604e5cc6bf10f0f8240195f0baa063a",
-                "reference": "22a2cf6ca604e5cc6bf10f0f8240195f0baa063a",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/9245a6342ed94f00425aef6963a32b8af9b0dc9d",
+                "reference": "9245a6342ed94f00425aef6963a32b8af9b0dc9d",
                 "shasum": ""
             },
             "require": {
@@ -3336,7 +3336,13 @@
                 "ext-openssl": "*",
                 "ext-scrypt": "*",
                 "ext-sodium": "*",
-                "php": ">=8.1"
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "1.2.*",
+                "phpstan/phpstan": "1.9.x-dev",
+                "phpunit/phpunit": "^9.3",
+                "vimeo/psalm": "4.0.1"
             },
             "type": "library",
             "autoload": {
@@ -3363,9 +3369,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/auth/issues",
-                "source": "https://github.com/utopia-php/auth/tree/0.7.0"
+                "source": "https://github.com/utopia-php/auth/tree/0.5.1"
             },
-            "time": "2026-06-22T11:58:24+00:00"
+            "time": "2026-05-30T12:21:17+00:00"
         },
         {
             "name": "utopia-php/cache",
@@ -3676,16 +3682,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "6.0.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "fff9f0effbd40359ff925741ff9424856d8b4fde"
+                "reference": "567901977c0128a3bd1cb9917553ebb4c1055582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/fff9f0effbd40359ff925741ff9424856d8b4fde",
-                "reference": "fff9f0effbd40359ff925741ff9424856d8b4fde",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/567901977c0128a3bd1cb9917553ebb4c1055582",
+                "reference": "567901977c0128a3bd1cb9917553ebb4c1055582",
                 "shasum": ""
             },
             "require": {
@@ -3710,6 +3716,7 @@
                 "swoole/ide-helper": "5.1.3",
                 "utopia-php/cli": "0.22.*"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -3730,9 +3737,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/6.0.0"
+                "source": "https://github.com/utopia-php/database/tree/main"
             },
-            "time": "2026-06-18T10:37:40+00:00"
+            "time": "2026-05-19T02:54:27+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -3829,16 +3836,16 @@
         },
         {
             "name": "utopia-php/dns",
-            "version": "1.8.0",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/dns.git",
-                "reference": "c09469c396c6f95888789151a3157fd0928e740b"
+                "reference": "5ee1c165b381c05fea1ad9dd62263a5a854786f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/dns/zipball/c09469c396c6f95888789151a3157fd0928e740b",
-                "reference": "c09469c396c6f95888789151a3157fd0928e740b",
+                "url": "https://api.github.com/repos/utopia-php/dns/zipball/5ee1c165b381c05fea1ad9dd62263a5a854786f8",
+                "reference": "5ee1c165b381c05fea1ad9dd62263a5a854786f8",
                 "shasum": ""
             },
             "require": {
@@ -3880,9 +3887,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/dns/issues",
-                "source": "https://github.com/utopia-php/dns/tree/1.8.0"
+                "source": "https://github.com/utopia-php/dns/tree/1.7.3"
             },
-            "time": "2026-06-12T04:44:06+00:00"
+            "time": "2026-06-07T14:02:16+00:00"
         },
         {
             "name": "utopia-php/domains",
@@ -4348,16 +4355,16 @@
         },
         {
             "name": "utopia-php/messaging",
-            "version": "1.2.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/messaging.git",
-                "reference": "3419ffbbeb242b3232b588430bd465024959720c"
+                "reference": "1aca8968c3bf3c78c428a399dfe97cbe9b366ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/3419ffbbeb242b3232b588430bd465024959720c",
-                "reference": "3419ffbbeb242b3232b588430bd465024959720c",
+                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/1aca8968c3bf3c78c428a399dfe97cbe9b366ec4",
+                "reference": "1aca8968c3bf3c78c428a399dfe97cbe9b366ec4",
                 "shasum": ""
             },
             "require": {
@@ -4365,8 +4372,7 @@
                 "ext-openssl": "*",
                 "giggsey/libphonenumber-for-php-lite": "9.0.23",
                 "php": ">=8.1.0",
-                "phpmailer/phpmailer": "6.9.1",
-                "utopia-php/telemetry": "^0.4"
+                "phpmailer/phpmailer": "6.9.1"
             },
             "require-dev": {
                 "laravel/pint": "1.*",
@@ -4394,31 +4400,31 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/messaging/issues",
-                "source": "https://github.com/utopia-php/messaging/tree/1.2.0"
+                "source": "https://github.com/utopia-php/messaging/tree/1.0.0"
             },
-            "time": "2026-06-23T04:24:43+00:00"
+            "time": "2026-06-02T14:54:22+00:00"
         },
         {
             "name": "utopia-php/migration",
-            "version": "1.14.0",
+            "version": "1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "f70dba326f1499d1ff4dd18b218b26a858aff1dd"
+                "reference": "50526e121efcf73e11309446f194623a431d7e32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/f70dba326f1499d1ff4dd18b218b26a858aff1dd",
-                "reference": "f70dba326f1499d1ff4dd18b218b26a858aff1dd",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/50526e121efcf73e11309446f194623a431d7e32",
+                "reference": "50526e121efcf73e11309446f194623a431d7e32",
                 "shasum": ""
             },
             "require": {
-                "appwrite/appwrite": "^26.0",
+                "appwrite/appwrite": "24.*",
                 "ext-curl": "*",
                 "ext-openssl": "*",
                 "halaxa/json-machine": "^1.2",
                 "php": ">=8.2",
-                "utopia-php/database": "^6.0.0",
+                "utopia-php/database": "5.*",
                 "utopia-php/dsn": "0.2.*",
                 "utopia-php/storage": "2.*"
             },
@@ -4449,9 +4455,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/1.14.0"
+                "source": "https://github.com/utopia-php/migration/tree/1.13.2"
             },
-            "time": "2026-06-18T11:19:06+00:00"
+            "time": "2026-06-04T05:09:07+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -5124,16 +5130,16 @@
         },
         {
             "name": "utopia-php/vcs",
-            "version": "4.2.3",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/vcs.git",
-                "reference": "598cbd2793a5a6394493f1046743e75ec6544a57"
+                "reference": "bb42584d3efb95ff4eb241605bb15165c56974de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/598cbd2793a5a6394493f1046743e75ec6544a57",
-                "reference": "598cbd2793a5a6394493f1046743e75ec6544a57",
+                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/bb42584d3efb95ff4eb241605bb15165c56974de",
+                "reference": "bb42584d3efb95ff4eb241605bb15165c56974de",
                 "shasum": ""
             },
             "require": {
@@ -5167,9 +5173,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/vcs/issues",
-                "source": "https://github.com/utopia-php/vcs/tree/4.2.3"
+                "source": "https://github.com/utopia-php/vcs/tree/4.2.2"
             },
-            "time": "2026-06-16T12:14:08+00:00"
+            "time": "2026-06-10T08:08:48+00:00"
         },
         {
             "name": "utopia-php/websocket",
@@ -8354,9 +8360,17 @@
             "time": "2026-05-30T17:09:26+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/database",
+            "version": "dev-main",
+            "alias": "5.9.0",
+            "alias_normalized": "5.9.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "utopia-php/database": 20,
         "utopia-php/http": 5,
         "utopia-php/platform": 5
     },


### PR DESCRIPTION
Updates `utopia-php/database` to `dev-main` to pull in the latest database features and fixes.

Also applies PostgreSQL-only CI settings for the E2E matrix (already merged via #12469):
- `fsync=off` — faster writes, risk of corruption on crash (acceptable for CI)
- `synchronous_commit=off` — improved throughput, risk of lost transactions on crash
- `full_page_writes=off` — reduced WAL volume, risk of corruption after crash

Replaces PR #12467.
