### PR TITLE
Accept multipart ETag signatures for chunked uploads on S3 devices

### DIFF
--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -25,6 +25,35 @@ trait StorageBase
     private static array $cachedZstdBucket = [];
 
     /**
+     * Valid signatures for a chunk-uploaded file: the content MD5 on local
+     * devices, or the composite multipart ETag (md5 of part MD5s suffixed
+     * with the part count) on S3 devices.
+     */
+    protected function getChunkedFileSignatures(string $path, int $chunkSize = 5 * 1024 * 1024): array
+    {
+        $signatures = [\md5_file($path)];
+
+        $handle = \fopen($path, 'rb');
+        $binary = '';
+        $parts = 0;
+        while (!\feof($handle)) {
+            $chunk = \fread($handle, $chunkSize);
+            if ($chunk === '' || $chunk === false) {
+                break;
+            }
+            $binary .= \md5($chunk, true);
+            $parts++;
+        }
+        \fclose($handle);
+
+        if ($parts > 1) {
+            $signatures[] = \md5($binary) . '-' . $parts;
+        }
+
+        return $signatures;
+    }
+
+    /**
      * Helper method to set up bucket and file data for tests.
      * Uses static caching to avoid recreating resources.
      */
@@ -287,7 +316,7 @@ trait StorageBase
         $this->assertEquals('large-file.mp4', $largeFile['body']['name']);
         $this->assertEquals('video/mp4', $largeFile['body']['mimeType']);
         $this->assertEquals($totalSize, $largeFile['body']['sizeOriginal']);
-        $this->assertEquals(md5_file(realpath(__DIR__ . '/../../../resources/disk-a/large-file.mp4')), $largeFile['body']['signature']); // should validate that the file is not encrypted
+        $this->assertContains($largeFile['body']['signature'], $this->getChunkedFileSignatures(realpath(__DIR__ . '/../../../resources/disk-a/large-file.mp4'))); // should validate that the file is not encrypted
 
         /**
          * Failure

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -34,6 +34,9 @@ trait StorageBase
         $signatures = [\md5_file($path)];
 
         $handle = \fopen($path, 'rb');
+        if ($handle === false) {
+            return $signatures;
+        }
         $binary = '';
         $parts = 0;
         while (!\feof($handle)) {


### PR DESCRIPTION
## What does this PR do?

Fixes the storage e2e suite failing on S3-family devices. `StorageBase` asserted that a chunk-uploaded file's `signature` equals the content MD5, which only holds on the local device. On S3 the signature comes from the object ETag, and multipart objects return the composite form `md5(concat(part MD5s))-N`. The assertion now accepts either value via a `getChunkedFileSignatures` helper that computes both deterministically — it stays exact on both devices (verified the computed ETag matches MinIO byte-for-byte: `124bcf1072133a75cc623f0ef7e3dcf2-5` for `large-file.mp4` at 5 MiB parts).

Single-part assertions are untouched (a single-PUT S3 ETag is the content MD5), as are download-content checks (they hash the downloaded bytes, which is device-agnostic).

## Test Plan

- `StorageCustomServerTest --filter=testCreateBucketFile` passes on the local device.
- Unblocks running the vendored storage suite against MinIO in cloud CI (appwrite-labs/cloud#4342), where this assertion was the only storage failure.

## Related PRs and Issues

- #12574
- appwrite-labs/cloud#4342