### PR TITLE
Update utopia-php/dns to ^1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",
-        "utopia-php/dns": "1.7.*",
+        "utopia-php/dns": "^1.8",
         "utopia-php/dsn": "0.2.1",
         "utopia-php/http": "^2.0@RC",
         "utopia-php/fetch": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8e8a31556be2ad12d15a25969c4d59f",
+    "content-hash": "fe6368e3d42f385c63d7e5e2e911febd",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3835,16 +3835,16 @@
         },
         {
             "name": "utopia-php/dns",
-            "version": "1.7.3",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/dns.git",
-                "reference": "5ee1c165b381c05fea1ad9dd62263a5a854786f8"
+                "reference": "c09469c396c6f95888789151a3157fd0928e740b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/dns/zipball/5ee1c165b381c05fea1ad9dd62263a5a854786f8",
-                "reference": "5ee1c165b381c05fea1ad9dd62263a5a854786f8",
+                "url": "https://api.github.com/repos/utopia-php/dns/zipball/c09469c396c6f95888789151a3157fd0928e740b",
+                "reference": "c09469c396c6f95888789151a3157fd0928e740b",
                 "shasum": ""
             },
             "require": {
@@ -3886,9 +3886,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/dns/issues",
-                "source": "https://github.com/utopia-php/dns/tree/1.7.3"
+                "source": "https://github.com/utopia-php/dns/tree/1.8.0"
             },
-            "time": "2026-06-07T14:02:16+00:00"
+            "time": "2026-06-12T04:44:06+00:00"
         },
         {
             "name": "utopia-php/domains",


### PR DESCRIPTION
## What does this PR do?

Bumps `utopia-php/dns` from `1.7.*` to `^1.8` ([1.8.0 release notes](https://github.com/utopia-php/dns/releases/tag/1.8.0)).

1.8.0 updates `Validator\Name` to follow RFC owner name rules: wildcard owner names (`*` as the entire leftmost label, RFC 4592) and underscored labels (RFC 8552) are now accepted for all record types except A/AAAA, and the record type constructor argument is optional.

This codebase only uses `Utopia\DNS\Validator\DNS` and `Utopia\DNS\Message\Record`, neither of which changed — the bump is behavior-neutral here. It unblocks Appwrite Cloud, which adopts the updated `Validator\Name` on all DNS record create/update endpoints after a production incident where an invalid record name (containing a space) made a zone file unparseable and SERVFAILed an entire customer domain.

## Test Plan

- `composer update utopia-php/dns` resolves cleanly to 1.8.0 with no security advisories
- Existing CI (the DNS validator and record encoding paths are covered by existing tests)

## Related PRs and Issues

- https://github.com/utopia-php/dns/pull/50
- Internal: CLO-4459