### PR TITLE
Update utopia-php/database to 5.9.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "dev-fix-mongo-transaction-write-conflict-retry as 5.9.0",
+        "utopia-php/database": "5.*",
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "5.*",
+        "utopia-php/database": "dev-fix-mongo-transaction-write-conflict-retry as 5.9.0",
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8e8a31556be2ad12d15a25969c4d59f",
+    "content-hash": "88a81318fcd7a046a15ef118bd9b4a7b",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3682,16 +3682,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "5.9.0",
+            "version": "dev-fix-mongo-transaction-write-conflict-retry",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "477bae83e27631f78c159f45b0441c0c7dc69050"
+                "reference": "298837fcd1c8070983636eaa57ab8fdc30288d84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/477bae83e27631f78c159f45b0441c0c7dc69050",
-                "reference": "477bae83e27631f78c159f45b0441c0c7dc69050",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/298837fcd1c8070983636eaa57ab8fdc30288d84",
+                "reference": "298837fcd1c8070983636eaa57ab8fdc30288d84",
                 "shasum": ""
             },
             "require": {
@@ -3736,9 +3736,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/5.9.0"
+                "source": "https://github.com/utopia-php/database/tree/fix-mongo-transaction-write-conflict-retry"
             },
-            "time": "2026-05-17T15:57:21+00:00"
+            "time": "2026-06-12T05:41:38+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -8359,9 +8359,17 @@
             "time": "2026-05-30T17:09:26+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/database",
+            "version": "dev-fix-mongo-transaction-write-conflict-retry",
+            "alias": "5.9.0",
+            "alias_normalized": "5.9.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "utopia-php/database": 20,
         "utopia-php/http": 5,
         "utopia-php/platform": 5
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a81318fcd7a046a15ef118bd9b4a7b",
+    "content-hash": "c8e8a31556be2ad12d15a25969c4d59f",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3682,16 +3682,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "dev-fix-mongo-transaction-write-conflict-retry",
+            "version": "5.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "298837fcd1c8070983636eaa57ab8fdc30288d84"
+                "reference": "698952455dd645ff41057621c90a4cea977fb1bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/298837fcd1c8070983636eaa57ab8fdc30288d84",
-                "reference": "298837fcd1c8070983636eaa57ab8fdc30288d84",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/698952455dd645ff41057621c90a4cea977fb1bf",
+                "reference": "698952455dd645ff41057621c90a4cea977fb1bf",
                 "shasum": ""
             },
             "require": {
@@ -3736,9 +3736,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/fix-mongo-transaction-write-conflict-retry"
+                "source": "https://github.com/utopia-php/database/tree/5.9.2"
             },
-            "time": "2026-06-12T05:41:38+00:00"
+            "time": "2026-06-12T08:33:14+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -8359,17 +8359,9 @@
             "time": "2026-05-30T17:09:26+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "utopia-php/database",
-            "version": "dev-fix-mongo-transaction-write-conflict-retry",
-            "alias": "5.9.0",
-            "alias_normalized": "5.9.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "utopia-php/database": 20,
         "utopia-php/http": 5,
         "utopia-php/platform": 5
     },

--- a/tests/e2e/Services/Sites/SitesBase.php
+++ b/tests/e2e/Services/Sites/SitesBase.php
@@ -72,8 +72,8 @@ trait SitesBase
                 throw new Critical('Deployment failed: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
             }
 
-            Console::execute("docker inspect openruntimes-executor --format='{{.State.ExitCode}}'", '', $this->stdout, $this->stderr);
-            if (\trim($this->stdout) !== '0') {
+            $code = Console::execute("docker inspect openruntimes-executor --format='{{.State.ExitCode}}'", '', $this->stdout, $this->stderr);
+            if ($code === 0 && \trim($this->stdout) !== '' && \trim($this->stdout) !== '0') {
                 $msg = 'Executor has a problem: ' . $this->stderr . ' (' . $this->stdout . '), current status: ';
 
                 Console::execute("docker compose logs openruntimes-executor", '', $this->stdout, $this->stderr);


### PR DESCRIPTION
## What does this PR do?

Updates `utopia-php/database` to [5.9.2](https://github.com/utopia-php/database/releases/tag/5.9.2).

This release includes utopia-php/database#889, which adds retry-with-backoff to the Mongo adapter's `withTransaction` (the other adapters already inherit this from the base `Adapter`). It fixes the flaky MongoDB E2E failures where `E112 WriteConflict` surfaced as `500 general_unknown` on `DELETE /v1/sites/:siteId` (`testInvalidSSRSource` / Sites cleanup, e.g. [this run](https://github.com/appwrite/appwrite/actions/runs/27395946536/job/80963312794)).

This branch previously pointed at the fix branch (`dev-fix-mongo-transaction-write-conflict-retry`) for CI validation; the MongoDB matrix jobs passed against it, and the constraint is now restored to the tagged release.

## Related PRs and Issues

- utopia-php/database#889
