### PR TITLE
fix: preserve VCS repository record when providerRepositoryId is omitted in updateFunction/updateSite

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -182,7 +182,7 @@ class Update extends Base
 
         $isConnected = !empty($function->getAttribute('providerRepositoryId', ''));
 
-        // If providerRepositoryId is omitted (null) and function is already connected, preserve existing VCS values
+        // Omitted providerRepositoryId (null) on a connected function — preserve existing VCS values
         if ($isConnected && $providerRepositoryId === null) {
             $providerRepositoryId = $function->getAttribute('providerRepositoryId', '');
             $installationId = $function->getAttribute('installationId', '');

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -190,6 +190,7 @@ class Update extends Base
             $providerRootDirectory = $providerRootDirectory ?: $function->getAttribute('providerRootDirectory', '');
             $repositoryId = $function->getAttribute('repositoryId', '');
             $repositoryInternalId = $function->getAttribute('repositoryInternalId', '');
+            $installation = $dbForPlatform->getDocument('installations', $installationId);
         }
 
         // Git disconnect logic. Disconnecting only when providerRepositoryId is empty, allowing for continue updates without disconnecting git

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -182,6 +182,16 @@ class Update extends Base
 
         $isConnected = !empty($function->getAttribute('providerRepositoryId', ''));
 
+        // If providerRepositoryId is omitted (null) and function is already connected, preserve existing VCS values
+        if ($isConnected && $providerRepositoryId === null) {
+            $providerRepositoryId = $function->getAttribute('providerRepositoryId', '');
+            $installationId = $function->getAttribute('installationId', '');
+            $providerBranch = $providerBranch ?: $function->getAttribute('providerBranch', '');
+            $providerRootDirectory = $providerRootDirectory ?: $function->getAttribute('providerRootDirectory', '');
+            $repositoryId = $function->getAttribute('repositoryId', '');
+            $repositoryInternalId = $function->getAttribute('repositoryInternalId', '');
+        }
+
         // Git disconnect logic. Disconnecting only when providerRepositoryId is empty, allowing for continue updates without disconnecting git
         if ($isConnected && ($providerRepositoryId !== null && empty($providerRepositoryId))) {
             $repositories = $dbForPlatform->find('repositories', [

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -190,6 +190,7 @@ class Update extends Base
             $providerRootDirectory = $providerRootDirectory ?: $site->getAttribute('providerRootDirectory', '');
             $repositoryId = $site->getAttribute('repositoryId', '');
             $repositoryInternalId = $site->getAttribute('repositoryInternalId', '');
+            $installation = $dbForPlatform->getDocument('installations', $installationId);
         }
 
         // Git disconnect logic. Disconnecting only when providerRepositoryId is empty, allowing for continue updates without disconnecting git

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -182,6 +182,16 @@ class Update extends Base
 
         $isConnected = !empty($site->getAttribute('providerRepositoryId', ''));
 
+        // If providerRepositoryId is omitted (null) and site is already connected, preserve existing VCS values
+        if ($isConnected && $providerRepositoryId === null) {
+            $providerRepositoryId = $site->getAttribute('providerRepositoryId', '');
+            $installationId = $site->getAttribute('installationId', '');
+            $providerBranch = $providerBranch ?: $site->getAttribute('providerBranch', '');
+            $providerRootDirectory = $providerRootDirectory ?: $site->getAttribute('providerRootDirectory', '');
+            $repositoryId = $site->getAttribute('repositoryId', '');
+            $repositoryInternalId = $site->getAttribute('repositoryInternalId', '');
+        }
+
         // Git disconnect logic. Disconnecting only when providerRepositoryId is empty, allowing for continue updates without disconnecting git
         if ($isConnected && ($providerRepositoryId !== null && empty($providerRepositoryId))) {
             $repositories = $dbForPlatform->find('repositories', [

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -182,7 +182,7 @@ class Update extends Base
 
         $isConnected = !empty($site->getAttribute('providerRepositoryId', ''));
 
-        // If providerRepositoryId is omitted (null) and site is already connected, preserve existing VCS values
+        // Omitted providerRepositoryId (null) on a connected site — preserve existing VCS values
         if ($isConnected && $providerRepositoryId === null) {
             $providerRepositoryId = $site->getAttribute('providerRepositoryId', '');
             $installationId = $site->getAttribute('installationId', '');

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -3312,45 +3312,4 @@ final class FunctionsCustomServerTest extends Scope
         }
     }
 
-    /**
-     * Regression: omitting providerRepositoryId must not clear VCS fields or leave
-     * the platform repository record orphaned (causing ghost GitHub builds).
-     */
-    public function testUpdateFunctionPreservesVcsOnOmittedProviderRepositoryId(): void
-    {
-        $functionId = $this->setupFunction([
-            'functionId' => ID::unique(),
-            'name' => 'VCS Preserve Test',
-            'runtime' => 'node-22',
-            'entrypoint' => 'index.js',
-            'commands' => '',
-        ]);
-
-        // 1. Update without providerRepositoryId — field should stay empty, no error
-        $response = $this->updateFunction($functionId, [
-            'name' => 'VCS Preserve Test',
-            'runtime' => 'node-22',
-        ]);
-        $this->assertSame(200, $response['headers']['status-code']);
-        $this->assertSame('', $response['body']['providerRepositoryId']);
-        $this->assertSame('', $response['body']['installationId']);
-        $this->assertSame('', $response['body']['providerBranch']);
-
-        // 2. Update with providerRepositoryId="" explicit on non-connected function — no-op, no error
-        $response = $this->updateFunction($functionId, [
-            'name' => 'VCS Preserve Test',
-            'runtime' => 'node-22',
-            'providerRepositoryId' => '',
-        ]);
-        $this->assertSame(200, $response['headers']['status-code']);
-        $this->assertSame('', $response['body']['providerRepositoryId']);
-
-        // 3. Verify GET also reflects the unchanged state
-        $response = $this->getFunction($functionId);
-        $this->assertSame(200, $response['headers']['status-code']);
-        $this->assertSame('', $response['body']['providerRepositoryId']);
-        $this->assertSame('', $response['body']['installationId']);
-
-        $this->cleanupFunction($functionId);
-    }
 }

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -3311,4 +3311,59 @@ final class FunctionsCustomServerTest extends Scope
             $this->cleanupFunction($functionId);
         }
     }
+
+    /**
+     * Regression test for: omitting providerRepositoryId in updateFunction must not silently
+     * clear the VCS connection while leaving the platform repository record intact.
+     *
+     * Before the fix, calling updateFunction without providerRepositoryId on a connected
+     * function would write null/empty to the function document (making it look disconnected
+     * in the console) but would NOT delete the repositories record in the platform DB, so
+     * GitHub webhooks would keep finding the record and keep triggering builds.
+     *
+     * This test covers the API-observable side:
+     *   1. Omitting providerRepositoryId on a non-connected function keeps the field empty.
+     *   2. Passing providerRepositoryId="" (explicit disconnect) on a non-connected function
+     *      is a no-op and does not cause errors.
+     *
+     * The full scenario (connected function + omit providerRepositoryId) requires a live
+     * VCS installation and is validated in VCSCustomServerTest.
+     */
+    public function testUpdateFunctionPreservesVcsOnOmittedProviderRepositoryId(): void
+    {
+        $functionId = $this->setupFunction([
+            'functionId' => ID::unique(),
+            'name' => 'VCS Preserve Test',
+            'runtime' => 'node-22',
+            'entrypoint' => 'index.js',
+            'commands' => '',
+        ]);
+
+        // 1. Update without providerRepositoryId — field should stay empty, no error
+        $response = $this->updateFunction($functionId, [
+            'name' => 'VCS Preserve Test',
+            'runtime' => 'node-22',
+        ]);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['providerRepositoryId']);
+        $this->assertSame('', $response['body']['installationId']);
+        $this->assertSame('', $response['body']['providerBranch']);
+
+        // 2. Update with providerRepositoryId="" explicit on non-connected function — no-op, no error
+        $response = $this->updateFunction($functionId, [
+            'name' => 'VCS Preserve Test',
+            'runtime' => 'node-22',
+            'providerRepositoryId' => '',
+        ]);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['providerRepositoryId']);
+
+        // 3. Verify GET also reflects the unchanged state
+        $response = $this->getFunction($functionId);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['providerRepositoryId']);
+        $this->assertSame('', $response['body']['installationId']);
+
+        $this->cleanupFunction($functionId);
+    }
 }

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -3313,21 +3313,8 @@ final class FunctionsCustomServerTest extends Scope
     }
 
     /**
-     * Regression test for: omitting providerRepositoryId in updateFunction must not silently
-     * clear the VCS connection while leaving the platform repository record intact.
-     *
-     * Before the fix, calling updateFunction without providerRepositoryId on a connected
-     * function would write null/empty to the function document (making it look disconnected
-     * in the console) but would NOT delete the repositories record in the platform DB, so
-     * GitHub webhooks would keep finding the record and keep triggering builds.
-     *
-     * This test covers the API-observable side:
-     *   1. Omitting providerRepositoryId on a non-connected function keeps the field empty.
-     *   2. Passing providerRepositoryId="" (explicit disconnect) on a non-connected function
-     *      is a no-op and does not cause errors.
-     *
-     * The full scenario (connected function + omit providerRepositoryId) requires a live
-     * VCS installation and is validated in VCSCustomServerTest.
+     * Regression: omitting providerRepositoryId must not clear VCS fields or leave
+     * the platform repository record orphaned (causing ghost GitHub builds).
      */
     public function testUpdateFunctionPreservesVcsOnOmittedProviderRepositoryId(): void
     {

--- a/tests/e2e/Services/VCS/VCSConsoleClientTest.php
+++ b/tests/e2e/Services/VCS/VCSConsoleClientTest.php
@@ -653,6 +653,27 @@ final class VCSConsoleClientTest extends Scope
         $this->assertEquals('main', $function['body']['providerBranch']);
     }
 
+    public function testUpdateFunctionOmitProviderRepositoryIdPreservesVcs(): void
+    {
+        $data = $this->setupFunctionUsingVCS();
+
+        // Omit providerRepositoryId entirely — should preserve VCS connection, not clear it
+        $function = $this->client->call(Client::METHOD_PUT, '/functions/' . $data['functionId'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'name' => 'Test',
+            'runtime' => 'php-8.0',
+            'entrypoint' => 'index.php',
+            'timeout' => 10,
+        ]);
+
+        $this->assertEquals(200, $function['headers']['status-code']);
+        $this->assertNotEmpty($function['body']['providerRepositoryId']);
+        $this->assertNotEmpty($function['body']['installationId']);
+        $this->assertNotEmpty($function['body']['providerBranch']);
+    }
+
     public function testCreateRepository(): void
     {
         $installationId = $this->setupInstallation();

--- a/tests/e2e/Services/VCS/VCSConsoleClientTest.php
+++ b/tests/e2e/Services/VCS/VCSConsoleClientTest.php
@@ -674,6 +674,47 @@ final class VCSConsoleClientTest extends Scope
         $this->assertNotEmpty($function['body']['providerBranch']);
     }
 
+    public function testUpdateSiteOmitProviderRepositoryIdPreservesVcs(): void
+    {
+        $installationId = $this->setupInstallation();
+
+        $site = $this->client->call(Client::METHOD_POST, '/sites', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'siteId' => ID::unique(),
+            'name' => 'Test Site VCS',
+            'framework' => 'other',
+            'buildRuntime' => 'node-22',
+            'installationId' => $installationId,
+            'providerRepositoryId' => $this->providerRepositoryId3,
+            'providerBranch' => 'main',
+        ]);
+
+        $this->assertEquals(201, $site['headers']['status-code']);
+        $siteId = $site['body']['$id'];
+
+        // Omit providerRepositoryId — should preserve VCS connection, not clear it
+        $updated = $this->client->call(Client::METHOD_PUT, '/sites/' . $siteId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'name' => 'Test Site VCS',
+            'framework' => 'other',
+            'buildRuntime' => 'node-22',
+        ]);
+
+        $this->assertEquals(200, $updated['headers']['status-code']);
+        $this->assertNotEmpty($updated['body']['providerRepositoryId']);
+        $this->assertNotEmpty($updated['body']['installationId']);
+        $this->assertNotEmpty($updated['body']['providerBranch']);
+
+        $this->client->call(Client::METHOD_DELETE, '/sites/' . $siteId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+    }
+
     public function testCreateRepository(): void
     {
         $installationId = $this->setupInstallation();


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
