### PR TITLE
fix(sites): correct error message for deployment size limit

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -655,6 +655,11 @@ return [
         'description' => 'Site with the requested ID could not be found.',
         'code' => 404,
     ],
+    Exception::SITES_DEPLOYMENT_SIZE_EXCEEDED => [
+        'name' => Exception::SITES_DEPLOYMENT_SIZE_EXCEEDED,
+        'description' => 'The deployment size exceeds the maximum allowed size. Please check the file or the value of the _APP_COMPUTE_SIZE_LIMIT environment variable.',
+        'code' => 400,
+    ],
     Exception::SITE_ALREADY_EXISTS => [
         'name' => Exception::SITE_ALREADY_EXISTS,
         'description' => 'Site with the requested ID already exists. Try again with a different ID or use ID.unique() to generate a unique ID.',


### PR DESCRIPTION
## Summary

This PR fixes an incorrect error message in the Sites deployment endpoint. When a deployment exceeds the size limit, the error message was referencing _APP_STORAGE_LIMIT instead of the correct _APP_COMPUTE_SIZE_LIMIT environment variable.

## Changes

1. Added new exception constant SITES_DEPLOYMENT_SIZE_EXCEEDED in Exception.php
2. Added corresponding error message in errors.php with the correct environment variable reference
3. Updated Sites/Http/Deployments/Create.php to use the new exception

## Impact

- Users will now see the correct environment variable (_APP_COMPUTE_SIZE_LIMIT) in the error message when their deployment exceeds the size limit
- This makes troubleshooting easier for users who need to adjust the deployment size limit

Closes #9904