### PR TITLE
Resolve data-plane database before writing collection metadata

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
@@ -103,6 +103,15 @@ class Create extends Action
         // Map aggregate permissions into the multiple permissions they represent.
         $permissions = Permission::aggregate($permissions) ?? [];
 
+        // Resolve the data-plane database BEFORE writing the metadata row. For a
+        // dedicated product database this throws while provisioning (no DSN yet);
+        // writing the row first would leave an orphaned collection with no backing
+        // collection, which lists fine but fails every document operation.
+        /**
+         * @var Database $dbForDatabases
+         */
+        $dbForDatabases = $getDatabasesDB($database);
+
         try {
             $collection = $dbForProject->createDocument('database_' . $database->getSequence(), new Document([
                 '$id' => $collectionId,
@@ -121,11 +130,6 @@ class Create extends Action
         } catch (NotFoundException) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
-
-        /**
-         * @var Database $dbForDatabases
-         */
-        $dbForDatabases = $getDatabasesDB($database);
 
         $collectionKey = 'database_' . $database->getSequence() . '_collection_' . $collection->getSequence();
         $databaseKey = 'database_' . $database->getSequence();

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
@@ -94,6 +94,13 @@ class Create extends CollectionAction
         // Map aggregate permissions into the multiple permissions they represent.
         $permissions = Permission::aggregate($permissions) ?? [];
 
+        // Resolve the data-plane database BEFORE writing the metadata row. For a
+        // dedicated product database this throws while provisioning (no DSN yet);
+        // writing the row first would leave an orphaned collection with no backing
+        // collection, which lists fine but fails every document operation.
+        /** @var Database $dbForDatabases */
+        $dbForDatabases = $getDatabasesDB($database);
+
         try {
             $collection = $dbForProject->createDocument('database_' . $database->getSequence(), new Document([
                 '$id' => $collectionId,
@@ -114,8 +121,6 @@ class Create extends CollectionAction
         } catch (NotFoundException) {
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
-        /** @var Database $dbForDatabases */
-        $dbForDatabases = $getDatabasesDB($database);
 
         $attributes = [];
         $indexes = [];


### PR DESCRIPTION
## Problem

Found validating the VectorsDB/DocumentsDB dedicated flow on Cloud prod: creating a collection while the product database is still provisioning returns **409 `dedicated_database_not_available`** but still **persists the collection metadata row**.

Both `Databases/Collections/Create` (base for DocumentsDB collections / TablesDB tables) and `VectorsDB/Collections/Create` write the control-plane row in `dbForProject` first and only then call `$getDatabasesDB($database)` — which is what throws for a database whose DSN is not yet published. Nothing rolls the row back on that throw.

The orphaned collection lists fine in the API and console, but every document write/read against it fails with `Invalid document structure: Missing collection attribute $collection` — observed live on Cloud (console-created collections during the provisioning window were permanently broken).

## Fix

Resolve the data-plane database **before** writing the metadata row, in both create paths. A provisioning or unreachable backend now rejects the request before any state is written; retrying after provisioning completes creates a healthy collection.

## Testing

The provisioning-window 409 only exists on Cloud (the dedicated-database resolver), so the regression e2e lands there: asserting that collection creates rejected during provisioning leave zero collections listed. Cloud will pick this change up with the next `appwrite/server-ce` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)