### PR TITLE
fix: allow clearing OIDC maxAge via explicit null in update

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Oidc.php
+++ b/src/Appwrite/Auth/OAuth2/Oidc.php
@@ -43,13 +43,25 @@ class Oidc extends OAuth2
      */
     public function getLoginURL(): string
     {
-        return $this->getAuthorizationEndpoint() . '?' . \http_build_query([
+        $params = [
             'client_id' => $this->appID,
             'redirect_uri' => $this->callback,
             'state' => \json_encode($this->state),
             'scope' => \implode(' ', $this->getScopes()),
             'response_type' => 'code',
-        ]);
+        ];
+
+        $prompt = $this->getPrompt();
+        if (!empty($prompt)) {
+            $params['prompt'] = $prompt;
+        }
+
+        $maxAge = $this->getMaxAge();
+        if ($maxAge !== null) {
+            $params['max_age'] = $maxAge;
+        }
+
+        return $this->getAuthorizationEndpoint() . '?' . \http_build_query($params);
     }
 
     /**
@@ -194,6 +206,40 @@ class Oidc extends OAuth2
         $secret = $this->getAppSecret();
 
         return $secret['clientSecret'] ?? '';
+    }
+
+    /**
+     * Extracts the prompt values from the JSON stored in appSecret.
+     *
+     * @return string
+     */
+    protected function getPrompt(): string
+    {
+        $secret = $this->getAppSecret();
+        $prompt = $secret['prompt'] ?? [];
+
+        if (!\is_array($prompt)) {
+            $prompt = [$prompt];
+        }
+
+        return \implode(' ', $prompt);
+    }
+
+    /**
+     * Extracts the max_age value from the JSON stored in appSecret.
+     *
+     * @return int|null
+     */
+    protected function getMaxAge(): ?int
+    {
+        $secret = $this->getAppSecret();
+        $maxAge = $secret['maxAge'] ?? null;
+
+        if ($maxAge === null || $maxAge === '') {
+            return null;
+        }
+
+        return (int) $maxAge;
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
@@ -10,14 +10,19 @@ use Appwrite\Platform\Modules\Project\Http\Project\OAuth2\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
+use Utopia\Platform\Enum;
+use Utopia\Validator\ArrayList;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Nullable;
+use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\URL;
+use Utopia\Validator\WhiteList;
 
 class Update extends Base
 {
@@ -93,6 +98,18 @@ class Update extends Base
                 'example' => 'https://myoauth.com/oauth2/userinfo',
                 'hint' => '',
             ],
+            [
+                '$id' => 'prompt',
+                'name' => 'Prompt',
+                'example' => '["consent"]',
+                'hint' => '',
+            ],
+            [
+                '$id' => 'maxAge',
+                'name' => 'Max Age',
+                'example' => '3600',
+                'hint' => '',
+            ],
         ]);
     }
 
@@ -129,11 +146,14 @@ class Update extends Base
             ->param('authorizationURL', null, new Nullable(new URL(allowEmpty: true)), 'OpenID Connect authorization endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/authorize', optional: true)
             ->param('tokenURL', null, new Nullable(new URL(allowEmpty: true)), 'OpenID Connect token endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/token', optional: true, aliases: ['tokenUrl'])
             ->param('userInfoURL', null, new Nullable(new URL(allowEmpty: true)), 'OpenID Connect user info endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/userinfo', optional: true, aliases: ['userInfoUrl'])
+            ->param('prompt', null, new Nullable(new ArrayList(new WhiteList(['none', 'login', 'consent', 'select_account'], true), 4)), 'Array of OpenID Connect prompt values controlling the authentication and consent screens. If "none" is included, it must be the only element. "none" means: don\'t display any authentication or consent screens. "login" means: prompt the user to re-authenticate. "consent" means: prompt the user for consent. "select_account" means: prompt the user to select an account.', optional: true, enum: new Enum(name: 'ProjectOAuth2OidcPrompt'))
+            ->param('maxAge', null, new Nullable(new Range(0, PHP_INT_MAX, Range::TYPE_INTEGER)), 'Maximum authentication age in seconds. When set, the user must have authenticated within this many seconds, otherwise they are prompted to re-authenticate. Set to null or omit to leave unspecified.', optional: true)
             ->param('enabled', null, new Nullable(new Boolean()), 'OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid.', true)
             ->inject('response')
             ->inject('dbForPlatform')
             ->inject('project')
             ->inject('authorization')
+            ->inject('request')
             ->inject('queueForEvents')
             ->callback($this->handle(...));
     }
@@ -153,6 +173,8 @@ class Update extends Base
             'authorizationURL' => $decoded['authorizationEndpoint'] ?? '',
             'tokenURL' => $decoded['tokenEndpoint'] ?? '',
             'userInfoURL' => $decoded['userInfoEndpoint'] ?? '',
+            'prompt' => $decoded['prompt'] ?? [],
+            'maxAge' => $decoded['maxAge'] ?? null,
         ]);
     }
 
@@ -176,18 +198,25 @@ class Update extends Base
         ?string $authorizationURL,
         ?string $tokenURL,
         ?string $userInfoURL,
+        ?array $prompt,
+        ?int $maxAge,
         ?bool $enabled,
         Response $response,
         Database $dbForPlatform,
         Document $project,
         Authorization $authorization,
+        Request $request,
         QueueEvent $queueForEvents
     ): void {
         $providerId = static::getProviderId();
         $queueForEvents->setParam('providerId', $providerId);
 
+        if ($prompt !== null && \in_array('none', $prompt) && \count($prompt) > 1) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'When "none" is used as a prompt value, it must be the only element in the array.');
+        }
+
         // The secret is stored as JSON
-        // `{"clientSecret": "...", "wellKnownEndpoint": "...", "authorizationEndpoint": "...", "tokenEndpoint": "...", "userInfoEndpoint": "..."}`
+        // `{"clientSecret": "...", "wellKnownEndpoint": "...", "authorizationEndpoint": "...", "tokenEndpoint": "...", "userInfoEndpoint": "...", "prompt": [...], "maxAge": ...}`
         // so that the OIDC OAuth2 adapter can extract each endpoint individually.
         // Merge new values with what's already stored so that submitting only a
         // subset of fields leaves the others untouched.
@@ -203,6 +232,8 @@ class Update extends Base
             'authorizationEndpoint' => $authorizationURL ?? ($existing['authorizationEndpoint'] ?? ''),
             'tokenEndpoint' => $tokenURL ?? ($existing['tokenEndpoint'] ?? ''),
             'userInfoEndpoint' => $userInfoURL ?? ($existing['userInfoEndpoint'] ?? ''),
+            'prompt' => \array_key_exists('prompt', $request->getParams()) ? ($prompt ?? []) : ($existing['prompt'] ?? []),
+            'maxAge' => \array_key_exists('maxAge', $request->getParams()) ? $maxAge : ($existing['maxAge'] ?? null),
         ];
 
         // When enabling, require either wellKnownEndpoint alone, or all three

--- a/src/Appwrite/Utopia/Response/Model/OAuth2Oidc.php
+++ b/src/Appwrite/Utopia/Response/Model/OAuth2Oidc.php
@@ -53,6 +53,21 @@ class OAuth2Oidc extends OAuth2Base
                 'description' => 'OpenID Connect user info endpoint URL.',
                 'default' => '',
                 'example' => 'https://myoauth.com/oauth2/userinfo',
+            ])
+            ->addRule('prompt', [
+                'type' => self::TYPE_ENUM,
+                'description' => 'OpenID Connect prompt values controlling the authentication and consent screens.',
+                'default' => [],
+                'example' => ['consent'],
+                'array' => true,
+                'enum' => ['none', 'login', 'consent', 'select_account'],
+            ])
+            ->addRule('maxAge', [
+                'type' => self::TYPE_INTEGER,
+                'description' => 'Maximum authentication age in seconds. When set, the user must have authenticated within this many seconds.',
+                'default' => null,
+                'example' => 3600,
+                'required' => false,
             ]);
     }
 

--- a/tests/e2e/Services/Project/OAuth2Base.php
+++ b/tests/e2e/Services/Project/OAuth2Base.php
@@ -279,6 +279,148 @@ trait OAuth2Base
         $this->assertSame('general_argument_invalid', $response['body']['type']);
     }
 
+    public function testUpdateOAuth2OidcPromptAndMaxAge(): void
+    {
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-prompt-client',
+            'clientSecret' => 'oidc-prompt-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'prompt' => ['login', 'consent'],
+            'maxAge' => 3600,
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame(['login', 'consent'], $response['body']['prompt']);
+        $this->assertSame(3600, $response['body']['maxAge']);
+
+        $get = $this->client->call(Client::METHOD_GET, '/project/oauth2/oidc', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            ...$this->getHeaders(),
+        ]);
+
+        $this->assertSame(200, $get['headers']['status-code']);
+        $this->assertSame(['login', 'consent'], $get['body']['prompt']);
+        $this->assertSame(3600, $get['body']['maxAge']);
+        $this->assertSame('', $get['body']['clientSecret']);
+
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPartialPreservesPromptAndMaxAge(): void
+    {
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-seed-client',
+            'clientSecret' => 'oidc-seed-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'prompt' => ['select_account'],
+            'maxAge' => 120,
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-rotated-client',
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('oidc-rotated-client', $response['body']['clientId']);
+        $this->assertSame(['select_account'], $response['body']['prompt']);
+        $this->assertSame(120, $response['body']['maxAge']);
+
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPromptNoneAloneRejected(): void
+    {
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-prompt-none',
+            'clientSecret' => 'oidc-prompt-none-secret',
+            'prompt' => ['none', 'consent'],
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(400, $response['headers']['status-code']);
+        $this->assertSame('general_argument_invalid', $response['body']['type']);
+    }
+
+    public function testUpdateOAuth2OidcMaxAgeNegativeRejected(): void
+    {
+        $response = $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-maxage-negative',
+            'clientSecret' => 'oidc-maxage-negative-secret',
+            'maxAge' => -1,
+            'enabled' => false,
+        ]);
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testUpdateOAuth2OidcMaxAgeClearViaNull(): void
+    {
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-maxage-clear',
+            'clientSecret' => 'oidc-maxage-clear-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'maxAge' => 3600,
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'maxAge' => null,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertNull($response['body']['maxAge']);
+
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'maxAge' => null,
+            'enabled' => false,
+        ]);
+    }
+
+    public function testUpdateOAuth2OidcPromptClearViaNull(): void
+    {
+        $this->updateOAuth2('oidc', [
+            'clientId' => 'oidc-prompt-clear',
+            'clientSecret' => 'oidc-prompt-clear-secret',
+            'wellKnownURL' => 'https://idp.example.com/.well-known/openid-configuration',
+            'prompt' => ['login', 'consent'],
+            'enabled' => false,
+        ]);
+
+        $response = $this->updateOAuth2('oidc', [
+            'prompt' => null,
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame([], $response['body']['prompt']);
+
+        $this->updateOAuth2('oidc', [
+            'clientId' => '',
+            'clientSecret' => '',
+            'wellKnownURL' => '',
+            'prompt' => [],
+            'enabled' => false,
+        ]);
+    }
+
     public function testUpdateOAuth2OktaRoundTrip(): void
     {
         $update = $this->updateOAuth2('okta', [


### PR DESCRIPTION
Fixes PR #12462 by Meldiron.

Bug: OIDC maxAge could not be cleared once set because PHP's null-coalescing operator (\??\) cannot distinguish between 'parameter not sent' and 'parameter explicitly set to null'.

Fix: Use \rray_key_exists()\ to check whether the parameter was actually provided in the request body before applying the merge logic. This also applies the same fix to the \prompt\ field for consistency.

Changes:
- Inject Request into the OIDC update handler
- Fix maxAge and prompt merge logic to allow explicit null clearing
- Add tests for maxAge/prompt clear via null, partial preservation, and validation