### PR TITLE
fix: disable build cache

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -704,7 +704,7 @@ class Builds extends Action
             $span = Span::current();
 
             Co::join([
-                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cacheKey, $cpus, $memory, $timeout, &$err, $version, $span) {
+                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cpus, $memory, $timeout, &$err, $version, $span) {
                     try {
                         if ($version === 'v2') {
                             $command = 'tar -zxf /tmp/code.tar.gz -C /usr/code && cd /usr/local/src/ && ./build.sh';

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -732,7 +732,8 @@ class Builds extends Action
                             variables: $vars,
                             command: $command,
                             outputDirectory: $outputDirectory ?? '',
-                            cacheKey: $cacheKey
+                            // temporarily disable build cache
+                            // cacheKey: $cacheKey
                         );
 
                     } catch (ExecutorTimeout $error) {


### PR DESCRIPTION
## What
- Temporarily disables passing the build cache key to executor builds.

## Tests
- composer lint src/Appwrite/Platform/Modules/Functions/Workers/Builds.php