### PR TITLE
fix: purge collection cache after attribute update

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
@@ -689,6 +689,7 @@ abstract class Action extends UtopiaAction
         }
 
         $dbForProject->purgeCachedDocument('database_' . $db->getSequence(), $collection->getId());
+        $dbForProject->purgeCachedCollection('database_' . $db->getSequence() . '_collection_' . $collection->getSequence());
 
         $queueForEvents
             ->setContext('database', $db)


### PR DESCRIPTION
## Changes

When updating an attribute (e.g., removing default value and enabling null), the collection metadata cache was not being purged. This caused new documents to still receive the old default value even after it was removed.

Added \purgeCachedCollection\ call after updating attributes to ensure the cache is cleared and new documents respect the updated attribute settings.

Closes issue related to attribute default value persistence.