### PR TITLE
Expose ping in SDK specs

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -14,6 +14,7 @@ use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception as AppwriteException;
 use Appwrite\Network\Cors;
 use Appwrite\Platform\Appwrite;
+use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Transformation\Adapter\Preview;
@@ -1662,11 +1663,10 @@ Http::get('/v1/ping')
         namespace: 'ping',
         group: null,
         name: 'get',
-        hide: true,
         description: <<<EOT
         Send a ping to project as part of onboarding.
         EOT,
-        auth: [],
+        auth: [AuthType::ADMIN, AuthType::KEY, AuthType::JWT, AuthType::SESSION],
         responses: [
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,


### PR DESCRIPTION
## What does this PR do?

Updates the `/v1/ping` SDK metadata so the route is included in generated SDK specs instead of being hidden. The method now declares the auth types that map it to client, server, and console SDK specs.

## Test Plan

- Ran `php -l app/controllers/general.php`
- Ran `php app/cli.php specs --version=1.9.x --git=no`
- Verified `/ping` is present in generated client, server, and console OpenAPI specs with `scope: global`, no `hidden` marker, and all SDK platforms.

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
