### PR TITLE
Run CI on merged PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ env:
 
 on:
   pull_request:
+  push:
+    branches:
+      - 1.9.x
   workflow_dispatch:
     inputs:
       response_format:
@@ -705,7 +708,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -747,9 +750,11 @@ jobs:
       - name: Prepare benchmark before
         id: benchmark_before_prepare
         continue-on-error: true
+        env:
+          BENCHMARK_BEFORE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
-          git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
-          git worktree add --detach /tmp/appwrite-benchmark-before ${{ github.event.pull_request.base.sha }}
+          git fetch --depth=1 origin "${BENCHMARK_BEFORE_SHA}"
+          git worktree add --detach /tmp/appwrite-benchmark-before "${BENCHMARK_BEFORE_SHA}"
           docker build \
             --cache-from ${{ env.IMAGE }}:after \
             --target development \
@@ -871,8 +876,8 @@ jobs:
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          BENCHMARK_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          BENCHMARK_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BENCHMARK_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.before }}
+          BENCHMARK_HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.sha }}
         with:
           script: |
             const comment = require('./.github/workflows/benchmark-comment.js');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Runs the CI workflow after PRs are merged into the default `1.9.x` branch by adding a `push` trigger for that branch.

This also allows the benchmark job to run on merged push events. For push runs, the benchmark compares `github.event.before` to `github.sha`, while keeping the existing PR comparison behavior and PR comment behavior intact.

## Test Plan

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
- `actionlint .github/workflows/ci.yml`

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
