### PR TITLE
Add batch execution upserts

### DIFF
--- a/src/Appwrite/Event/Message/Executions.php
+++ b/src/Appwrite/Event/Message/Executions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Appwrite\Event\Message;
+
+use Utopia\Database\Document;
+
+final class Executions extends Base
+{
+    /**
+     * @param array<Document> $executions
+     */
+    public function __construct(
+        public readonly Document $project,
+        public readonly array $executions,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'project' => $this->project->getArrayCopy(),
+            'executions' => \array_map(
+                fn (Document $execution) => $execution->getArrayCopy(),
+                $this->executions
+            ),
+        ];
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new self(
+            project: new Document($data['project'] ?? []),
+            executions: \array_map(
+                fn (array $execution) => new Document($execution),
+                $data['executions'] ?? []
+            ),
+        );
+    }
+}

--- a/src/Appwrite/Event/Publisher/Execution.php
+++ b/src/Appwrite/Event/Publisher/Execution.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Event\Publisher;
 
 use Appwrite\Event\Message\Execution as ExecutionMessage;
+use Appwrite\Event\Message\Executions as ExecutionsMessage;
 use Utopia\Queue\Publisher;
 use Utopia\Queue\Queue;
 
@@ -15,7 +16,7 @@ readonly class Execution extends Base
         parent::__construct($publisher);
     }
 
-    public function enqueue(ExecutionMessage $message): string|bool
+    public function enqueue(ExecutionMessage|ExecutionsMessage $message): string|bool
     {
         return $this->publish($this->queue, $message);
     }

--- a/src/Appwrite/Platform/Workers/Executions.php
+++ b/src/Appwrite/Platform/Workers/Executions.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Platform\Workers;
 
 use Appwrite\Event\Message\Execution;
+use Appwrite\Event\Message\Executions as ExecutionsMessage;
 use Exception;
 use Utopia\Database\Database;
 use Utopia\Platform\Action;
@@ -11,6 +12,8 @@ use Utopia\Span\Span;
 
 class Executions extends Action
 {
+    private const int UPSERT_BATCH_SIZE = 100;
+
     public static function getName(): string
     {
         return 'executions';
@@ -33,19 +36,36 @@ class Executions extends Action
         Message $message,
         Database $dbForProject,
     ): void {
-        $executionMessage = Execution::fromArray($message->getPayload());
-        $execution = $executionMessage->execution;
+        $payload = $message->getPayload();
+        $isBatch = isset($payload['executions']) && \is_array($payload['executions']);
 
-        if ($execution->isEmpty()) {
-            throw new Exception('Missing execution');
+        if ($isBatch) {
+            $executionMessage = ExecutionsMessage::fromArray($payload);
+            $executions = \array_values(\array_filter(
+                $executionMessage->executions,
+                fn ($execution) => !$execution->isEmpty()
+            ));
+        } else {
+            $executionMessage = Execution::fromArray($payload);
+            $executions = [$executionMessage->execution];
+        }
+
+        if (empty($executions)) {
+            throw new Exception($isBatch ? 'Missing executions' : 'Missing execution');
         }
 
         Span::add('project.id', $executionMessage->project->getId());
-        Span::add('function.id', $execution->getAttribute('resourceId', ''));
-        Span::add('execution.id', $execution->getId());
-        Span::add('deployment.id', $execution->getAttribute('deploymentId', ''));
-        Span::add('resource.type', $execution->getAttribute('resourceType', ''));
 
-        $dbForProject->upsertDocument('executions', $execution);
+        if ($isBatch) {
+            Span::add('executions.count', \count($executions));
+            $dbForProject->upsertDocuments('executions', $executions, self::UPSERT_BATCH_SIZE);
+        } else {
+            $execution = $executions[0];
+            Span::add('function.id', $execution->getAttribute('resourceId', ''));
+            Span::add('execution.id', $execution->getId());
+            Span::add('deployment.id', $execution->getAttribute('deploymentId', ''));
+            Span::add('resource.type', $execution->getAttribute('resourceType', ''));
+            $dbForProject->upsertDocument('executions', $execution);
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds support for batched execution queue payloads so the executions worker can persist multiple execution documents with a single `upsertDocuments()` call.

The existing single execution payload remains supported. Producers can continue sending `execution`, while future Cloud/Edge batching can send `executions` without changing the worker name or queue.

## Test Plan

- `composer lint src/Appwrite/Event/Message/Executions.php src/Appwrite/Event/Publisher/Execution.php src/Appwrite/Platform/Workers/Executions.php`
- `composer analyze`

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
