### PR TITLE
Revert disable build cache

### DIFF
--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -988,7 +988,7 @@ $hostPath = rtrim($this->getParam('hostPath', ''), '/');
     <<: *x-logging
     restart: unless-stopped
     stop_signal: SIGINT
-    image: openruntimes/executor:0.24.1
+    image: openruntimes/executor:0.25.1
     networks:
       - appwrite
       - runtimes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1249,7 +1249,7 @@ services:
     hostname: exc1
     <<: *x-logging
     stop_signal: SIGINT
-    image: openruntimes/executor:0.24.1
+    image: openruntimes/executor:0.25.1
     restart: unless-stopped
     networks:
       - appwrite

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -732,8 +732,7 @@ class Builds extends Action
                             variables: $vars,
                             command: $command,
                             outputDirectory: $outputDirectory ?? '',
-                            // temporarily disable build cache
-                            // cacheKey: $cacheKey
+                            cacheKey: $cacheKey
                         );
 
                     } catch (ExecutorTimeout $error) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -704,7 +704,7 @@ class Builds extends Action
             $span = Span::current();
 
             Co::join([
-                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cpus, $memory, $timeout, &$err, $version, $span) {
+                Co\go(function () use ($executor, &$response, $project, $deployment, $source, $resource, $runtime, $vars, $command, $cacheKey, $cpus, $memory, $timeout, &$err, $version, $span) {
                     try {
                         if ($version === 'v2') {
                             $command = 'tar -zxf /tmp/code.tar.gz -C /usr/code && cd /usr/local/src/ && ./build.sh';


### PR DESCRIPTION
## Summary
- Reverts #12602 to restore build cache usage during function builds
- Restores passing the cache key to the executor build request

## Tests
- composer lint src/Appwrite/Platform/Modules/Functions/Workers/Builds.php