### PR TITLE
fix(builds): mask internal errors from user-visible build logs

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/BuildException.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/BuildException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Functions\Workers;
+
+use Appwrite\Extend\Exception;
+
+/**
+ * A build failure whose message is safe to surface in user-visible build logs.
+ *
+ * Every build error the worker raises intentionally is a BuildException, so the
+ * failure handler can show its message to users while masking any other
+ * throwable (e.g. database or executor failures) behind a generic message.
+ */
+class BuildException extends Exception
+{
+    public function __construct(
+        ?string $message = null,
+        string $type = Exception::BUILD_FAILED,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($type, $message, previous: $previous);
+    }
+}

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1151,6 +1151,13 @@ class Builds extends Action
                 ? $th->getMessage()
                 : 'An internal error occurred while building. Please try again, and contact support if the problem persists.';
 
+            // Record user-facing failures on the span here, since they're not
+            // re-raised to the harness (which records internal errors via setError).
+            if ($isUserFacing) {
+                Span::add('build.exception.type', $th->getType());
+                Span::add('build.exception.message', $th->getMessage());
+            }
+
             // Color message red
             if (! \str_contains($message, '')) {
                 $message = '[31m' . $message;

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -195,6 +195,7 @@ class Builds extends Action
 
         $startTime = DateTime::now();
         $durationStart = \microtime(true);
+        $phaseStart = $durationStart;
 
         $resourceKey = match ($resource->getCollection()) {
             'functions' => 'functionId',
@@ -296,6 +297,9 @@ class Builds extends Action
 
             $github->initializeVariables($providerInstallationId, $privateKey, $githubAppId);
         }
+
+        Span::add('timings.setup', \round(\microtime(true) - $phaseStart, 3));
+        $phaseStart = \microtime(true);
 
         try {
             if (! $isVcsEnabled) {
@@ -538,6 +542,9 @@ class Builds extends Action
 
                 $this->runGitAction('processing', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
             }
+
+            Span::add('timings.source', \round(\microtime(true) - $phaseStart, 3));
+            $phaseStart = \microtime(true);
 
             /** Request the executor to build the code... */
             $updated = $dbForProject->updateDocuments('deployments', new Document([
@@ -849,6 +856,9 @@ class Builds extends Action
                 }),
             ]);
 
+            Span::add('timings.build', \round(\microtime(true) - $phaseStart, 3));
+            $phaseStart = \microtime(true);
+
             $latestDeployment = $dbForProject->getDocument('deployments', $deploymentId);
             if ($latestDeployment->getAttribute('status') === 'canceled') {
                 $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
@@ -1127,6 +1137,8 @@ class Builds extends Action
 
                 Span::add('build.screenshot_queued', true);
             }
+
+            Span::add('timings.finalize', \round(\microtime(true) - $phaseStart, 3));
         } catch (\Throwable $th) {
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
                 $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -215,7 +215,7 @@ class Builds extends Action
         }
 
         if ($isResourceBlocked($project, $resource->getCollection() === 'functions' ? RESOURCE_TYPE_FUNCTIONS : RESOURCE_TYPE_SITES, $resource->getId())) {
-            throw new \Exception('Resource is blocked');
+            throw new BuildException('Resource is blocked');
         }
 
         $log->addTag('deploymentId', $deployment->getId());
@@ -226,7 +226,7 @@ class Builds extends Action
         }
 
         if ($resource->getCollection() === 'functions' && empty($deployment->getAttribute('entrypoint', ''))) {
-            throw new \Exception('Entrypoint for your Appwrite Function is missing. Please specify it when making deployment or update the entrypoint under your function\'s "Settings" > "Configuration" > "Entrypoint".');
+            throw new BuildException('Entrypoint for your Appwrite Function is missing. Please specify it when making deployment or update the entrypoint under your function\'s "Settings" > "Configuration" > "Entrypoint".');
         }
 
         $version = $this->getVersion($resource);
@@ -406,7 +406,7 @@ class Builds extends Action
                 $exit = Console::execute($gitCloneCommand, '', $stdout, $stderr);
 
                 if ($exit !== 0) {
-                    throw new \Exception('Unable to clone code repository: ' . $stderr);
+                    throw new BuildException('Unable to clone code repository: ' . $stderr);
                 }
 
                 // Local refactoring for function folder with spaces
@@ -501,7 +501,7 @@ class Builds extends Action
                 }
 
                 if ($directorySize > $sizeLimit && $sizeLimit !== 0) {
-                    throw new \Exception('Repository directory size should be less than ' . number_format($sizeLimit / (1000 * 1000), 2) . ' MBs.');
+                    throw new BuildException('Repository directory size should be less than ' . number_format($sizeLimit / (1000 * 1000), 2) . ' MBs.');
                 }
 
                 Console::execute('find ' . \escapeshellarg($tmpDirectory) . ' -type d -name ".git" -exec rm -rf {} +', '', $stdout, $stderr);
@@ -739,7 +739,7 @@ class Builds extends Action
                         $span?->set('build.runtime.timed_out', true);
                         $span?->set('build.runtime.error_type', $error::class);
                         $span?->set('build.runtime.error_message', $error->getMessage());
-                        $err = new AppwriteException(AppwriteException::BUILD_TIMEOUT, previous: $error);
+                        $err = new BuildException(type: AppwriteException::BUILD_TIMEOUT, previous: $error);
                     } catch (\Throwable $error) {
                         $span?->set('build.runtime.error_type', $error::class);
                         $span?->set('build.runtime.error_message', $error->getMessage());
@@ -865,7 +865,7 @@ class Builds extends Action
                 $buildSizeLimit = $plan['buildSize'] * 1000 * 1000;
             }
             if ($response['size'] > $buildSizeLimit && $buildSizeLimit !== 0) {
-                throw new \Exception('Build size should be less than ' . number_format($buildSizeLimit / (1000 * 1000), 2) . ' MBs.');
+                throw new BuildException('Build size should be less than ' . number_format($buildSizeLimit / (1000 * 1000), 2) . ' MBs.');
             }
 
             $deployment->setAttribute('buildPath', $response['path']);
@@ -896,7 +896,7 @@ class Builds extends Action
                     Span::add('build.adapter', $deployment->getAttribute('adapter'));
                     Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
                 } elseif ($adapter === 'ssr' && $detection->getName() === 'static') {
-                    throw new \Exception('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
+                    throw new BuildException('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
                 }
             }
 
@@ -1134,14 +1134,12 @@ class Builds extends Action
                 return;
             }
 
-            Span::add('build.error.stage', 'deployment');
-            Span::add('build.error.type', $th::class);
-            Span::add('build.error.message', $th->getMessage());
-            Span::add('build.error.file', $th->getFile());
-            Span::add('build.error.line', $th->getLine());
+            $isUserFacing = $th instanceof BuildException;
+            $message = $isUserFacing
+                ? $th->getMessage()
+                : 'An internal error occurred while building. Please try again, and contact support if the problem persists.';
 
             // Color message red
-            $message = $th->getMessage();
             if (! \str_contains($message, '')) {
                 $message = '[31m' . $message;
             }
@@ -1180,6 +1178,11 @@ class Builds extends Action
 
             if ($isVcsEnabled) {
                 $this->runGitAction('failed', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform, true);
+            }
+
+            // Let the worker harness record internal errors via the span and logger.
+            if (! $isUserFacing) {
+                throw $th;
             }
         } finally {
             $queueForRealtime
@@ -1277,7 +1280,7 @@ class Builds extends Action
             default => null
         };
         if (\is_null($runtime)) {
-            throw new \Exception('Runtime "' . $resource->getAttribute('runtime', '') . '" is not supported');
+            throw new BuildException('Runtime "' . $resource->getAttribute('runtime', '') . '" is not supported');
         }
 
         return $runtime;


### PR DESCRIPTION
## What

Two changes to the builds worker:

1. **Stop leaking internal errors into user-visible build logs.** The worker wrote the message of **any** caught throwable straight into `buildLogs`. When a build failed for an internal reason — a `Utopia\Database\Exception`, an executor connection failure, a `TypeError` — its raw message was shown to users as "build logs", and the failure was silently swallowed (never reaching the worker's error logger/Sentry).
2. **Record per-phase build timings** on the span for profiling.

## How

### Masking internal errors

- Added `BuildException`, a typed `Appwrite\Extend\Exception` defaulting to `BUILD_FAILED`, used **only** for build failures that are safe and useful to show the user (missing entrypoint, unsupported runtime, adapter mismatch, size limits, build timeout, user-repo clone failure, blocked resource).
- Genuinely internal/infra faults stay plain `\Exception` (malformed payload, invalid resource type, resource/deployment vanished mid-build, template-repo clone/push, commit-SHA lookup, file/dir moves).
- The failure handler shows the message only when `$th instanceof BuildException`; anything else is replaced with a generic message. Internal errors are then **re-raised** so the worker harness records them via the span (`setError`) and the error logger, and the queue moves the job to its failed list — instead of being hand-rolled onto the span and swallowed.
- Because a `BuildException` is handled (not re-raised), its reason would otherwise be absent from the trace, so the handler records `build.exception.type`/`build.exception.message` on the span. Net: every failed build is observable — user-facing ones via `build.exception.*`, internal ones via the harness `setError` + logger.

Because `BuildException` is the single marker for user-facing errors, the handler stays a stable `instanceof` check — a new user-facing error just throws `BuildException`.

### Per-phase timings

`timings.{setup,source,build,finalize}` are emitted on the span so each distinct phase can be profiled independently of the overall `build.duration`:

| Key | Covers |
|-----|--------|
| `timings.setup` | load resource/deployment/spec, mark `processing` |
| `timings.source` | clone / template / package / upload source |
| `timings.build` | executor `createRuntime` + log streaming |
| `timings.finalize` | size check, framework detection, activation, schedule, screenshot |

`timings.build` is recorded right after the executor returns, so it's captured even when the build then errors.

## Test plan

- [ ] Build failure from a `BuildException` (e.g. missing entrypoint) → user sees the descriptive message.
- [ ] Internal failure (e.g. a database exception mid-build) → user sees the generic message; the real error reaches the span/logger and the job lands in the failed queue.
- [ ] Successful build → `timings.*` present on the span and roughly sum to `build.duration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
