### PR TITLE
Handle duplicate conflicts in account and teams routes

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -2968,27 +2968,42 @@ Http::post('/v1/account/tokens/phone')
             ]);
 
             $user->removeAttribute('$sequence');
-            $user = $authorization->skip(fn () => $dbForProject->createDocument('users', $user));
+            $created = true;
             try {
-                $target = $authorization->skip(fn () => $dbForProject->createDocument('targets', new Document([
-                    '$permissions' => [
-                        Permission::read(Role::user($user->getId())),
-                        Permission::update(Role::user($user->getId())),
-                        Permission::delete(Role::user($user->getId())),
-                    ],
-                    'userId' => $user->getId(),
-                    'userInternalId' => $user->getSequence(),
-                    'providerType' => MESSAGE_TYPE_SMS,
-                    'identifier' => $phone,
-                ])));
-                $user->setAttribute('targets', [...$user->getAttribute('targets', []), $target]);
+                $user = $authorization->skip(fn () => $dbForProject->createDocument('users', $user));
             } catch (Duplicate) {
-                $existingTarget = $dbForProject->findOne('targets', [
-                    Query::equal('identifier', [$phone]),
+                $created = false;
+                $user = $dbForProject->findOne('users', [
+                    Query::equal('phone', [$phone]),
                 ]);
-                $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget->isEmpty() ? false : $existingTarget]);
+
+                if ($user->isEmpty()) {
+                    throw new Exception(Exception::USER_ALREADY_EXISTS);
+                }
             }
-            $dbForProject->purgeCachedDocument('users', $user->getId());
+
+            if ($created) {
+                try {
+                    $target = $authorization->skip(fn () => $dbForProject->createDocument('targets', new Document([
+                        '$permissions' => [
+                            Permission::read(Role::user($user->getId())),
+                            Permission::update(Role::user($user->getId())),
+                            Permission::delete(Role::user($user->getId())),
+                        ],
+                        'userId' => $user->getId(),
+                        'userInternalId' => $user->getSequence(),
+                        'providerType' => MESSAGE_TYPE_SMS,
+                        'identifier' => $phone,
+                    ])));
+                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $target]);
+                } catch (Duplicate) {
+                    $existingTarget = $dbForProject->findOne('targets', [
+                        Query::equal('identifier', [$phone]),
+                    ]);
+                    $user->setAttribute('targets', [...$user->getAttribute('targets', []), $existingTarget->isEmpty() ? false : $existingTarget]);
+                }
+                $dbForProject->purgeCachedDocument('users', $user->getId());
+            }
         }
 
         $secret = null;
@@ -4683,11 +4698,15 @@ Http::put('/v1/account/targets/:targetId/push')
 
         $target->setAttribute('name', "{$device['deviceBrand']} {$device['deviceModel']}");
 
-        $target = $dbForProject->updateDocument('targets', $target->getId(), new Document([
-            'identifier' => $target->getAttribute('identifier'),
-            'expired' => $target->getAttribute('expired'),
-            'name' => $target->getAttribute('name'),
-        ]));
+        try {
+            $target = $dbForProject->updateDocument('targets', $target->getId(), new Document([
+                'identifier' => $target->getAttribute('identifier'),
+                'expired' => $target->getAttribute('expired'),
+                'name' => $target->getAttribute('name'),
+            ]));
+        } catch (Duplicate) {
+            throw new Exception(Exception::USER_TARGET_ALREADY_EXISTS);
+        }
 
         $dbForProject->purgeCachedDocument('users', $user->getId());
 

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -262,12 +262,30 @@ class Create extends Action
             throw new Exception(Exception::USER_UNAUTHORIZED, 'User is not allowed to send invitations for this team');
         }
 
-        $membership = $dbForProject->findOne('memberships', [
+        $queries = [
             Query::equal('userInternalId', [$invitee->getSequence()]),
             Query::equal('teamInternalId', [$team->getSequence()]),
-        ]);
+        ];
+
+        $membership = $dbForProject->findOne('memberships', $queries);
 
         $secret = $proofForToken->generate();
+        $refresh = function (Document $membership) use ($authorization, $dbForProject, $isAppUser, $isPrivilegedUser, $proofForToken, $secret): Document {
+            $attributes = [
+                'secret' => $proofForToken->hash($secret),
+                'invited' => DateTime::now(),
+            ];
+
+            if ($isPrivilegedUser || $isAppUser) {
+                $attributes['joined'] = DateTime::now();
+                $attributes['confirm'] = true;
+            }
+
+            return ($isPrivilegedUser || $isAppUser) ?
+                $authorization->skip(fn () => $dbForProject->updateDocument('memberships', $membership->getId(), new Document($attributes))) :
+                $dbForProject->updateDocument('memberships', $membership->getId(), new Document($attributes));
+        };
+
         if ($membership->isEmpty()) {
             $membershipId = ID::unique();
             $membership = new Document([
@@ -291,30 +309,31 @@ class Create extends Action
                 'search' => implode(' ', [$membershipId, $invitee->getId()]),
             ]);
 
-            $membership = ($isPrivilegedUser || $isAppUser) ?
-                $authorization->skip(fn () => $dbForProject->createDocument('memberships', $membership)) :
-                $dbForProject->createDocument('memberships', $membership);
+            $created = false;
+            try {
+                $membership = ($isPrivilegedUser || $isAppUser) ?
+                    $authorization->skip(fn () => $dbForProject->createDocument('memberships', $membership)) :
+                    $dbForProject->createDocument('memberships', $membership);
+                $created = true;
+            } catch (Duplicate) {
+                $membership = $dbForProject->findOne('memberships', $queries);
 
-            if ($isPrivilegedUser || $isAppUser) {
+                if ($membership->isEmpty()) {
+                    throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
+                }
+
+                if ($membership->getAttribute('confirm') === false) {
+                    $membership = $refresh($membership);
+                } else {
+                    throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
+                }
+            }
+
+            if (($isPrivilegedUser || $isAppUser) && $created) {
                 $authorization->skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
             }
         } elseif ($membership->getAttribute('confirm') === false) {
-            $secretHash = $proofForToken->hash($secret);
-            $invitedTime = DateTime::now();
-
-            if ($isPrivilegedUser || $isAppUser) {
-                $membership = $authorization->skip(fn () => $dbForProject->updateDocument('memberships', $membership->getId(), new Document([
-                    'secret' => $secretHash,
-                    'invited' => $invitedTime,
-                    'joined' => DateTime::now(),
-                    'confirm' => true
-                ])));
-            } else {
-                $membership = $dbForProject->updateDocument('memberships', $membership->getId(), new Document([
-                    'secret' => $secretHash,
-                    'invited' => $invitedTime
-                ]));
-            }
+            $membership = $refresh($membership);
         } else {
             throw new Exception(Exception::MEMBERSHIP_ALREADY_CONFIRMED);
         }

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -3374,7 +3374,7 @@ final class AccountCustomClientTest extends Scope
             ID::unique(),
             ID::unique(),
         ]);
-        $success = false;
+        $successfulUserIds = [];
 
         foreach ($responses as $response) {
             $body = (string) (\is_array($response['body']) ? \json_encode($response['body']) : $response['body']);
@@ -3384,7 +3384,9 @@ final class AccountCustomClientTest extends Scope
             $this->assertStringNotContainsString('Document with the requested unique attributes already exists', $body);
 
             if ($response['status'] === 201) {
-                $success = true;
+                $this->assertIsArray($response['body']);
+                $this->assertArrayHasKey('userId', $response['body']);
+                $successfulUserIds[] = $response['body']['userId'];
                 continue;
             }
 
@@ -3393,7 +3395,8 @@ final class AccountCustomClientTest extends Scope
             $this->assertSame('user_already_exists', $response['body']['type']);
         }
 
-        $this->assertTrue($success);
+        $this->assertGreaterThan(1, \count($successfulUserIds));
+        $this->assertCount(1, \array_unique($successfulUserIds));
 
         $response = $this->client->call(Client::METHOD_GET, '/users', [
             'content-type' => 'application/json',
@@ -3407,6 +3410,7 @@ final class AccountCustomClientTest extends Scope
 
         $this->assertSame(200, $response['headers']['status-code']);
         $this->assertCount(1, $response['body']['users']);
+        $this->assertSame($successfulUserIds[0], $response['body']['users'][0]['$id']);
 
         /**
          * Test for FAILURE
@@ -4145,6 +4149,11 @@ final class AccountCustomClientTest extends Scope
         $this->assertEquals('test-identifier-updated', $response['body']['identifier']);
         $this->assertEquals(false, $response['body']['expired']);
 
+        $targetId = $response['body']['$id'];
+        $targetUserId = $response['body']['userId'];
+        $expectedIdentifier = $response['body']['identifier'];
+        $expectedExpired = $response['body']['expired'];
+
         $duplicateIdentifier = 'test-identifier-' . ID::unique();
         $duplicate = $this->client->call(Client::METHOD_POST, '/account/targets/push', \array_merge([
             'content-type' => 'application/json',
@@ -4165,6 +4174,17 @@ final class AccountCustomClientTest extends Scope
 
         $this->assertSame(409, $response['headers']['status-code']);
         $this->assertSame('user_target_already_exists', $response['body']['type']);
+
+        $target = $this->client->call(Client::METHOD_GET, '/users/' . $targetUserId . '/targets/' . $targetId, [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]);
+
+        $this->assertSame(200, $target['headers']['status-code']);
+        $this->assertSame($targetId, $target['body']['$id']);
+        $this->assertSame($expectedIdentifier, $target['body']['identifier']);
+        $this->assertSame($expectedExpired, $target['body']['expired']);
     }
 
     /**

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -3343,6 +3343,71 @@ final class AccountCustomClientTest extends Scope
             }
         );
 
+        $response = $this->client->call(Client::METHOD_POST, '/account/tokens/phone', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'userId' => ID::unique(),
+            'phone' => $number,
+        ]);
+
+        $this->assertSame(201, $response['headers']['status-code']);
+        $this->assertSame($userId, $response['body']['userId']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/account/tokens/phone', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'userId' => $userId,
+            'phone' => '+1' . \random_int(1000000000, 9999999999),
+        ]);
+
+        $this->assertSame(409, $response['headers']['status-code']);
+        $this->assertSame('user_already_exists', $response['body']['type']);
+
+        $phone = '+1' . \random_int(1000000000, 9999999999);
+        $responses = $this->createPhoneTokensConcurrently($phone, [
+            ID::unique(),
+            ID::unique(),
+            ID::unique(),
+            ID::unique(),
+        ]);
+        $success = false;
+
+        foreach ($responses as $response) {
+            $body = (string) (\is_array($response['body']) ? \json_encode($response['body']) : $response['body']);
+
+            $this->assertNotSame(500, $response['status']);
+            $this->assertStringNotContainsString('Duplicate', $body);
+            $this->assertStringNotContainsString('Document with the requested unique attributes already exists', $body);
+
+            if ($response['status'] === 201) {
+                $success = true;
+                continue;
+            }
+
+            $this->assertSame(409, $response['status']);
+            $this->assertIsArray($response['body']);
+            $this->assertSame('user_already_exists', $response['body']['type']);
+        }
+
+        $this->assertTrue($success);
+
+        $response = $this->client->call(Client::METHOD_GET, '/users', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'queries' => [
+                Query::equal('phone', [$phone])->toString(),
+            ],
+        ]);
+
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertCount(1, $response['body']['users']);
+
         /**
          * Test for FAILURE
          */
@@ -4079,6 +4144,90 @@ final class AccountCustomClientTest extends Scope
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('test-identifier-updated', $response['body']['identifier']);
         $this->assertEquals(false, $response['body']['expired']);
+
+        $duplicateIdentifier = 'test-identifier-' . ID::unique();
+        $duplicate = $this->client->call(Client::METHOD_POST, '/account/targets/push', \array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'targetId' => ID::unique(),
+            'identifier' => $duplicateIdentifier,
+        ]);
+
+        $this->assertSame(201, $duplicate['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_PUT, '/account/targets/'. $response['body']['$id'] .'/push', \array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'identifier' => $duplicateIdentifier,
+        ]);
+
+        $this->assertSame(409, $response['headers']['status-code']);
+        $this->assertSame('user_target_already_exists', $response['body']['type']);
+    }
+
+    /**
+     * @param list<string> $userIds
+     * @return list<array{status: int, body: array|string}>
+     */
+    private function createPhoneTokensConcurrently(string $phone, array $userIds): array
+    {
+        $multi = \curl_multi_init();
+        $this->assertNotFalse($multi);
+
+        $handles = [];
+        $headers = [
+            'origin: http://localhost',
+            'content-type: application/json',
+            'x-appwrite-project: ' . $this->getProject()['$id'],
+            'x-sdk-version: appwrite:php:v1.0.7',
+        ];
+
+        foreach ($userIds as $userId) {
+            $handle = \curl_init($this->client->getEndpoint() . '/account/tokens/phone');
+            $this->assertNotFalse($handle);
+
+            \curl_setopt($handle, CURLOPT_CUSTOMREQUEST, Client::METHOD_POST);
+            \curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
+            \curl_setopt($handle, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36');
+            \curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+            \curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 0);
+            \curl_setopt($handle, CURLOPT_TIMEOUT, 15);
+            \curl_setopt($handle, CURLOPT_POSTFIELDS, \json_encode([
+                'userId' => $userId,
+                'phone' => $phone,
+            ]));
+
+            \curl_multi_add_handle($multi, $handle);
+            $handles[] = $handle;
+        }
+
+        do {
+            $status = \curl_multi_exec($multi, $running);
+
+            if ($running > 0 && \curl_multi_select($multi, 1.0) === -1) {
+                \usleep(1000);
+            }
+        } while ($running > 0 && $status === CURLM_OK);
+
+        $responses = [];
+        foreach ($handles as $handle) {
+            $body = \curl_multi_getcontent($handle);
+            $decoded = \json_decode($body, true);
+
+            $responses[] = [
+                'status' => \curl_getinfo($handle, CURLINFO_HTTP_CODE),
+                'body' => \is_array($decoded) ? $decoded : $body,
+            ];
+
+            \curl_multi_remove_handle($multi, $handle);
+            \curl_close($handle);
+        }
+
+        \curl_multi_close($multi);
+
+        return $responses;
     }
 
     public function testMFARecoveryCodeChallenge(): void

--- a/tests/e2e/Services/Teams/TeamsBaseServer.php
+++ b/tests/e2e/Services/Teams/TeamsBaseServer.php
@@ -3,6 +3,8 @@
 namespace Tests\E2E\Services\Teams;
 
 use Tests\E2E\Client;
+use Utopia\Database\Helpers\ID;
+use Utopia\Database\Query;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
 
 trait TeamsBaseServer
@@ -246,6 +248,157 @@ trait TeamsBaseServer
         ]);
 
         $this->assertEquals(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateTeamMembershipConcurrentDuplicate(): void
+    {
+        $team = $this->client->call(Client::METHOD_POST, '/teams', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'teamId' => ID::unique(),
+            'name' => 'Concurrent Membership Team',
+        ]);
+
+        $this->assertSame(201, $team['headers']['status-code']);
+
+        $userId = ID::unique();
+        $user = $this->client->call(Client::METHOD_POST, '/users', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'userId' => $userId,
+            'email' => uniqid() . 'parallel@localhost.test',
+            'password' => 'password',
+            'name' => 'Parallel User',
+        ]);
+
+        $this->assertSame(201, $user['headers']['status-code']);
+
+        $requests = 8;
+        $responses = $this->createMembershipsConcurrently($team['body']['$id'], $userId, $requests);
+        $statuses = array_map(fn (array $response): int => $response['headers']['status-code'], $responses);
+
+        foreach ($responses as $response) {
+            $status = $response['headers']['status-code'];
+            $body = is_string($response['body'])
+                ? $response['body']
+                : json_encode($response['body'], JSON_THROW_ON_ERROR);
+
+            $this->assertNotSame(500, $status);
+            $this->assertContains($status, [201, 409]);
+            $this->assertStringNotContainsString('Duplicate', $body);
+            $this->assertStringNotContainsString('Document with the requested unique attributes already exists', $body);
+
+            if ($status === 409) {
+                $this->assertIsArray($response['body']);
+                $this->assertSame('membership_already_confirmed', $response['body']['type'] ?? null);
+            }
+        }
+
+        sort($statuses);
+
+        $this->assertSame(array_merge([201], array_fill(0, $requests - 1, 409)), $statuses);
+
+        $memberships = $this->client->call(Client::METHOD_GET, '/teams/' . $team['body']['$id'] . '/memberships', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [
+                Query::equal('userId', [$userId])->toString(),
+            ],
+        ]);
+
+        $this->assertSame(200, $memberships['headers']['status-code']);
+        $this->assertSame(1, $memberships['body']['total']);
+        $this->assertCount(1, $memberships['body']['memberships']);
+
+        $team = $this->client->call(Client::METHOD_GET, '/teams/' . $team['body']['$id'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertSame(200, $team['headers']['status-code']);
+        $this->assertSame(1, $team['body']['total']);
+    }
+
+    private function createMembershipsConcurrently(string $teamId, string $userId, int $requests): array
+    {
+        $multi = curl_multi_init();
+        $handles = [];
+        $headers = [];
+        $responses = [];
+        $payload = json_encode([
+            'userId' => $userId,
+            'roles' => ['admin', 'editor'],
+            'url' => 'http://localhost:5000/join-us#title',
+        ], JSON_THROW_ON_ERROR);
+        $requestHeaders = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders());
+        $formattedHeaders = [];
+
+        foreach ($requestHeaders as $key => $value) {
+            $formattedHeaders[] = $key . ': ' . $value;
+        }
+
+        for ($index = 0; $index < $requests; $index++) {
+            $handle = curl_init($this->client->getEndpoint() . '/teams/' . $teamId . '/memberships');
+
+            curl_setopt($handle, CURLOPT_CUSTOMREQUEST, Client::METHOD_POST);
+            curl_setopt($handle, CURLOPT_HEADERFUNCTION, function (\CurlHandle $handle, string $header) use (&$headers, $index): int {
+                $length = strlen($header);
+                $parts = explode(':', $header, 2);
+
+                if (count($parts) === 2) {
+                    $headers[$index][strtolower(trim($parts[0]))] = trim($parts[1]);
+                }
+
+                return $length;
+            });
+            curl_setopt($handle, CURLOPT_HTTPHEADER, $formattedHeaders);
+            curl_setopt($handle, CURLOPT_POSTFIELDS, $payload);
+            curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($handle, CURLOPT_TIMEOUT, 15);
+
+            curl_multi_add_handle($multi, $handle);
+            $handles[$index] = $handle;
+        }
+
+        do {
+            $status = curl_multi_exec($multi, $running);
+
+            if ($running > 0) {
+                curl_multi_select($multi);
+            }
+        } while ($running > 0 && $status === CURLM_OK);
+
+        foreach ($handles as $index => $handle) {
+            $body = curl_multi_getcontent($handle);
+            $headers[$index]['status-code'] = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+
+            if (is_string($body) && str_contains($headers[$index]['content-type'] ?? '', 'application/json')) {
+                $decoded = json_decode($body, true);
+
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $body = $decoded;
+                }
+            }
+
+            $responses[$index] = [
+                'headers' => $headers[$index],
+                'body' => $body,
+            ];
+
+            curl_multi_remove_handle($multi, $handle);
+            curl_close($handle);
+        }
+
+        curl_multi_close($multi);
+        ksort($responses);
+
+        return array_values($responses);
     }
 
     public function testUpdateMembershipRoles(): void


### PR DESCRIPTION
## Summary

- Catch duplicate user creation in `account.createPhoneToken`, re-read by phone, and continue token creation for the existing user when the DB unique constraint wins the race.
- Map duplicate push target identifier updates in `account.updatePushTarget` to `user_target_already_exists`.
- Map duplicate team membership creation in `teams.createMembership` to the existing semantic membership conflict path, including the 1.9.x Teams module route.
- Add E2E regression coverage for concurrent phone token creation, duplicate push target updates, and concurrent team membership creation.

## Validation

- `php -l app/controllers/api/account.php`
- `php -l src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php`
- `php -l tests/e2e/Services/Account/AccountCustomClientTest.php`
- `php -l tests/e2e/Services/Teams/TeamsBaseServer.php`
- `vendor/bin/pint --test --config pint.json app/controllers/api/account.php src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php tests/e2e/Services/Account/AccountCustomClientTest.php tests/e2e/Services/Teams/TeamsBaseServer.php`
- `git diff --check origin/1.9.x..HEAD`

Targeted E2E/PHPUnit was not run locally because the Appwrite API was not reachable: `appwrite.test` and `localhost` both refused `/v1/health`, and `docker compose ps` showed no running services.