### PR TITLE
Handle missing resource token collection

### DIFF
--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -1108,7 +1108,11 @@ return function (Container $context): void {
                 return new Document([]);
             }
 
-            $token = $authorization->skip(fn () => $dbForProject->getDocument('resourceTokens', $tokenId));
+            try {
+                $token = $authorization->skip(fn () => $dbForProject->getDocument('resourceTokens', $tokenId));
+            } catch (\Utopia\Database\Exception\NotFound) {
+                return new Document([]);
+            }
 
             if ($token->isEmpty()) {
                 return new Document([]);


### PR DESCRIPTION
## What does this PR do?

This PR prevents the per-request `resourceToken` resolver from turning unrelated request body parameters named `token` into a fatal request bootstrap error when the project database does not have the `resourceTokens` collection.

The immediate failure was seen on Cloud staging when the Appwrite CLI attempted OAuth2 device-flow logout against the built-in `console` project:

```text
POST /v1/oauth2/console/revoke
500 general_unknown
Utopia\Database\Exception\NotFound: Collection not found
```

The revoke endpoint correctly accepts an OAuth2 token in a body parameter named `token`. Before the route handler runs, the shared request resource resolver also reads `$request->getParam('token')` and tries to decode it as a resource-token JWT. CLI OAuth2 refresh tokens are HS256 JWTs signed with the same cluster key and include a `tokenId`, so that resolver can decode the OAuth2 refresh token and then tries to load:

```php
$dbForProject->getDocument('resourceTokens', $tokenId)
```

For project databases that do not contain `resourceTokens`, such as the affected migrated `console` project database in staging, this throws `Utopia\Database\Exception\NotFound` during request bootstrap. That prevents the OAuth2 revoke handler from reaching its own RFC 7009 behavior, where unknown or invalid tokens should be handled without leaking token existence.

This change keeps the fix intentionally narrow: only the optional `resourceTokens` lookup is guarded. If the collection is missing, the resolver now returns an empty `Document`, the same result it already returns for malformed tokens, missing `tokenId`, and unknown resource-token documents. Valid resource-token behavior is otherwise unchanged.

## Test Plan

- Ran PHP syntax validation for the changed file:

```text
php -l app/init/resources/request.php
No syntax errors detected in app/init/resources/request.php
```

- Verified the diff is limited to `app/init/resources/request.php` and only wraps the `resourceTokens` lookup.

- Reproduced the staging failure before the fix in both Cloud staging regions using a synthetic HS256 JWT body parameter named `token` against the OAuth2 revoke route:

```text
do-fra1-cloud-fra1-stg: POST /v1/oauth2/console/revoke -> 500 general_unknown
do-syd1-cloud-syd1-stg: POST /v1/oauth2/console/revoke -> 500 general_unknown
```

- Confirmed both region logs reported the same pre-handler bootstrap failure:

```text
http.path=/v1/oauth2/:project_id/revoke
error.type=Utopia\Database\Exception\NotFound
error.message=Collection not found
error.trace[0].file=/usr/src/code/vendor/appwrite/server-ce/app/init/resources/request.php
error.trace[0].line=1111
```

## Related PRs and Issues

- #XXXX
- Sentry staging issue observed as `CLOUD-STAGING-5DQ` for `oauth2.revoke` / `Collection not found`.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
