### PR TITLE
fix(databases): return 404 for a wrong-type database id on product-DB APIs

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Action.php
@@ -21,6 +21,41 @@ class Action extends AppwriteAction
         return $this->context;
     }
 
+    /**
+     * Database types this path may operate on. Single source of truth shared by
+     * the list filter ({@see getDatabaseTypeQueryFilters()}) and the by-id guard
+     * ({@see isDatabaseTypeMismatch()}) so they cannot diverge.
+     *
+     * TablesDB is the compatibility successor to the legacy databases API, so it
+     * also serves legacy-typed databases; the other product APIs are scoped to
+     * their own type. Every database carries a non-null `type` (set on create
+     * and backfilled to 'legacy' by migration V23), so null is not represented.
+     *
+     * @return string[]
+     */
+    protected function getAllowedDatabaseTypes(): array
+    {
+        return match ($this->getDatabaseType()) {
+            DATABASE_TYPE_TABLESDB => [DATABASE_TYPE_TABLESDB, DATABASE_TYPE_LEGACY],
+            default => [$this->getDatabaseType()],
+        };
+    }
+
+    /**
+     * A database resolved by id on a product-DB path must be one of the path's
+     * allowed types; otherwise it is treated as not-found rather than proceeding
+     * to a type-mismatched backend operation that surfaces as an opaque 500. The
+     * legacy /v1/databases API is intentionally not type-guarded.
+     */
+    protected function isDatabaseTypeMismatch(Document $database): bool
+    {
+        if ($this->getDatabaseType() === DATABASE_TYPE_LEGACY) {
+            return false;
+        }
+
+        return !in_array($database->getAttribute('type', ''), $this->getAllowedDatabaseTypes(), true);
+    }
+
     public function setHttpPath(string $path): self
     {
         if (\str_contains($path, '/tablesdb')) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Action.php
@@ -6,6 +6,7 @@ use Appwrite\Event\Event;
 use Appwrite\Event\Message\Database as DatabaseMessage;
 use Appwrite\Event\Publisher\Database as DatabasePublisher;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Action as DatabasesAction;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response as UtopiaResponse;
 use Throwable;
@@ -21,10 +22,9 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Structure;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
-use Utopia\Platform\Action as UtopiaAction;
 use Utopia\Validator\Range;
 
-abstract class Action extends UtopiaAction
+abstract class Action extends DatabasesAction
 {
     /**
      * @var string The current context (either 'column' or 'attribute')
@@ -36,12 +36,14 @@ abstract class Action extends UtopiaAction
      */
     abstract protected function getResponseModel(): string|array;
 
-    public function setHttpPath(string $path): UtopiaAction
+    public function setHttpPath(string $path): DatabasesAction
     {
         if (\str_contains($path, '/tablesdb')) {
             $this->context = COLUMNS;
         }
-        return parent::setHttpPath($path);
+        parent::setHttpPath($path);
+
+        return $this;
     }
 
     /**
@@ -333,7 +335,7 @@ abstract class Action extends UtopiaAction
 
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($db->isEmpty()) {
+        if ($db->isEmpty() || $this->isDatabaseTypeMismatch($db)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 
@@ -495,7 +497,7 @@ abstract class Action extends UtopiaAction
     {
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($db->isEmpty()) {
+        if ($db->isEmpty() || $this->isDatabaseTypeMismatch($db)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Delete.php
@@ -76,7 +76,7 @@ class Delete extends Action
     public function action(string $databaseId, string $collectionId, string $key, UtopiaResponse $response, Database $dbForProject, DatabasePublisher $publisherForDatabase, Event $queueForEvents, Authorization $authorization): void
     {
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($db->isEmpty()) {
+        if ($db->isEmpty() || $this->isDatabaseTypeMismatch($db)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Get.php
@@ -75,7 +75,7 @@ class Get extends Action
     public function action(string $databaseId, string $collectionId, string $key, UtopiaResponse $response, Database $dbForProject, Authorization $authorization): void
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Relationship/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Relationship/Create.php
@@ -99,7 +99,7 @@ class Create extends Action
         $twoWayKey ??= $collectionId;
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/XList.php
@@ -71,7 +71,7 @@ class XList extends Action
     public function action(string $databaseId, string $collectionId, array $queries, bool $includeTotal, UtopiaResponse $response, Database $dbForProject, Authorization $authorization): void
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
@@ -94,7 +94,7 @@ class Create extends Action
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Delete.php
@@ -73,7 +73,7 @@ class Delete extends Action
     public function action(string $databaseId, string $collectionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, DatabasePublisher $publisherForDatabase, Event $queueForEvents, Authorization $authorization): void
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
@@ -97,7 +97,7 @@ class Decrement extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
@@ -97,7 +97,7 @@ class Increment extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Delete.php
@@ -91,7 +91,7 @@ class Delete extends Action
     public function action(string $databaseId, string $collectionId, array $queries, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Context $usage, Event $queueForEvents, Event $queueForRealtime, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, array $plan, EventProcessor $eventProcessor): void
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Update.php
@@ -103,7 +103,7 @@ class Update extends Action
         }
 
         $database = $dbForProject->getDocument('databases', $databaseId);
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
@@ -93,7 +93,7 @@ class Upsert extends Action
     public function action(string $databaseId, string $collectionId, array $documents, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Context $usage, Event $queueForEvents, Event $queueForRealtime, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, array $plan, EventProcessor $eventProcessor): void
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -209,7 +209,7 @@ class Create extends Action
         }
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
@@ -110,7 +110,7 @@ class Delete extends Action
         $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
-        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
@@ -82,7 +82,7 @@ class Get extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Logs/XList.php
@@ -81,7 +81,7 @@ class XList extends Action
     public function action(string $databaseId, string $collectionId, string $documentId, array $queries, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Locale $locale, Reader $geodb, Authorization $authorization, Audit $audit): void
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
@@ -106,7 +106,7 @@ class Update extends Action
         $isAPIKey = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
-        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
@@ -112,7 +112,7 @@ class Upsert extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
@@ -92,7 +92,7 @@ class XList extends Action
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
 
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Get.php
@@ -65,7 +65,7 @@ class Get extends Action
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Action.php
@@ -3,9 +3,9 @@
 namespace Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Indexes;
 
 use Appwrite\Extend\Exception;
-use Utopia\Platform\Action as UtopiaAction;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Action as DatabasesAction;
 
-abstract class Action extends UtopiaAction
+abstract class Action extends DatabasesAction
 {
     /**
      * The current API context (either 'columnIndex' or 'index').
@@ -17,12 +17,14 @@ abstract class Action extends UtopiaAction
      */
     abstract protected function getResponseModel(): string;
 
-    public function setHttpPath(string $path): UtopiaAction
+    public function setHttpPath(string $path): DatabasesAction
     {
         if (\str_contains($path, '/tablesdb')) {
             $this->context = COLUMN_INDEX;
         }
-        return parent::setHttpPath($path);
+        parent::setHttpPath($path);
+
+        return $this;
     }
 
     /**

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Create.php
@@ -90,7 +90,7 @@ class Create extends Action
     {
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($db->isEmpty()) {
+        if ($db->isEmpty() || $this->isDatabaseTypeMismatch($db)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Delete.php
@@ -80,7 +80,7 @@ class Delete extends Action
     {
         $db = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($db->isEmpty()) {
+        if ($db->isEmpty() || $this->isDatabaseTypeMismatch($db)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
         $collection = $dbForProject->getDocument('database_' . $db->getSequence(), $collectionId);

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Get.php
@@ -67,7 +67,7 @@ class Get extends Action
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
         $collection = $dbForProject->getDocument('database_' . $database->getSequence(), $collectionId);

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
@@ -75,7 +75,7 @@ class XList extends Action
         /** @var Document $database */
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Logs/XList.php
@@ -80,7 +80,7 @@ class XList extends Action
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
@@ -80,7 +80,7 @@ class Update extends Action
     public function action(string $databaseId, string $collectionId, ?string $name, ?array $permissions, bool $documentSecurity, bool $enabled, bool $purge, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Event $queueForEvents, Authorization $authorization): void
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/XList.php
@@ -75,7 +75,7 @@ class XList extends Action
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
@@ -15,7 +15,6 @@ use Appwrite\Utopia\Response as UtopiaResponse;
 use Utopia\Database\Database;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
-use Utopia\Platform\Action;
 
 class Delete extends Action
 {
@@ -68,7 +67,7 @@ class Delete extends Action
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Get.php
@@ -12,7 +12,6 @@ use Appwrite\Utopia\Response as UtopiaResponse;
 use Utopia\Database\Database;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
-use Utopia\Platform\Action;
 
 class Get extends Action
 {
@@ -60,7 +59,7 @@ class Get extends Action
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Logs/XList.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Databases\Http\Databases\Logs;
 
 use Appwrite\Detector\Detector;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Deprecated;
@@ -23,7 +24,6 @@ use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
 use Utopia\Locale\Locale;
-use Utopia\Platform\Action;
 
 class XList extends Action
 {
@@ -75,7 +75,7 @@ class XList extends Action
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Operations/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Operations/Create.php
@@ -122,7 +122,7 @@ class Create extends Action
             }
 
             $database = $databases[$operation['databaseId']] ??= $authorization->skip(fn () => $dbForProject->getDocument('databases', $operation['databaseId']));
-            if ($database->isEmpty() || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
+            if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database) || (!$database->getAttribute('enabled', false) && !$isAPIKey && !$isPrivilegedUser)) {
                 throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$operation['databaseId']]);
             }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Update.php
@@ -13,7 +13,6 @@ use Appwrite\Utopia\Response as UtopiaResponse;
 use Utopia\Database\Database;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
-use Utopia\Platform\Action;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Text;
 
@@ -69,7 +68,7 @@ class Update extends Action
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Usage/Get.php
@@ -3,7 +3,7 @@
 namespace Appwrite\Platform\Modules\Databases\Http\Databases\Usage;
 
 use Appwrite\Extend\Exception;
-use Appwrite\Platform\Action;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Action as DatabasesAction;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Deprecated;
@@ -20,7 +20,7 @@ use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
 use Utopia\Platform\Enum;
 use Utopia\Validator\WhiteList;
 
-class Get extends Action
+class Get extends DatabasesAction
 {
     public static function getName(): string
     {
@@ -29,7 +29,7 @@ class Get extends Action
 
     protected $databaseType = DATABASE_TYPE_LEGACY;
 
-    public function setHttpPath(string $path): Action
+    public function setHttpPath(string $path): DatabasesAction
     {
         $this->databaseType = match (true) {
             str_contains($path, '/documentsdb') => DATABASE_TYPE_DOCUMENTSDB,
@@ -114,7 +114,7 @@ class Get extends Action
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/XList.php
@@ -29,7 +29,7 @@ class XList extends Action
 
     protected function getDatabaseTypeQueryFilters(): array
     {
-        return [Query::equal('type', [$this->getDatabaseType()])];
+        return [Query::equal('type', $this->getAllowedDatabaseTypes())];
     }
 
     public function __construct()

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Logs/XList.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Databases\Http\TablesDB\Logs;
 
 use Appwrite\Detector\Detector;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
@@ -22,7 +23,6 @@ use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
 use Utopia\Locale\Locale;
-use Utopia\Platform\Action;
 
 class XList extends Action
 {
@@ -70,7 +70,7 @@ class XList extends Action
     {
         $database = $dbForProject->getDocument('databases', $databaseId);
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND, params: [$databaseId]);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/XList.php
@@ -9,7 +9,6 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\Queries\Databases;
 use Appwrite\Utopia\Response as UtopiaResponse;
-use Utopia\Database\Query;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Text;
@@ -19,16 +18,6 @@ class XList extends DatabaseXList
     public static function getName(): string
     {
         return 'listTablesDatabases';
-    }
-
-    protected function getDatabaseTypeQueryFilters(): array
-    {
-        return [
-            Query::or([
-                Query::equal('type', [DATABASE_TYPE_TABLESDB, DATABASE_TYPE_LEGACY]),
-                Query::isNull('type'),
-            ]),
-        ];
     }
 
     public function __construct()

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
@@ -85,7 +85,7 @@ class Create extends CollectionAction
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
 
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Update.php
@@ -76,7 +76,7 @@ class Update extends CollectionAction
     public function action(string $databaseId, string $collectionId, ?string $name, ?int $dimensions, ?array $permissions, bool $documentSecurity, ?bool $enabled, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Event $queueForEvents, Authorization $authorization): void
     {
         $database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
-        if ($database->isEmpty()) {
+        if ($database->isEmpty() || $this->isDatabaseTypeMismatch($database)) {
             throw new Exception(Exception::DATABASE_NOT_FOUND);
         }
 

--- a/tests/unit/Platform/Modules/Databases/DatabaseTypeMismatchTest.php
+++ b/tests/unit/Platform/Modules/Databases/DatabaseTypeMismatchTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Databases;
+
+use Appwrite\Platform\Modules\Databases\Http\Databases\Action;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Document;
+
+final class DatabaseTypeMismatchTest extends TestCase
+{
+    public function testTablesdbAllowsTablesdbAndLegacyButRejectsOtherProducts(): void
+    {
+        $action = new class () extends Action {
+            public static function getName(): string
+            {
+                return 'testTablesdbTypeGuard';
+            }
+
+            public function exposeMismatch(Document $database): bool
+            {
+                return $this->isDatabaseTypeMismatch($database);
+            }
+
+            /** @return string[] */
+            public function exposeAllowedTypes(): array
+            {
+                return $this->getAllowedDatabaseTypes();
+            }
+        };
+        $action->setHttpPath('/v1/tablesdb/:databaseId/tables');
+
+        // TablesDB is the compatibility successor to the legacy databases API:
+        // the allowed set must equal what listTablesDatabases advertises.
+        $this->assertSame([DATABASE_TYPE_TABLESDB, DATABASE_TYPE_LEGACY], $action->exposeAllowedTypes());
+
+        $this->assertFalse($action->exposeMismatch(new Document(['type' => DATABASE_TYPE_TABLESDB])));
+        $this->assertFalse($action->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
+        $this->assertTrue($action->exposeMismatch(new Document(['type' => DATABASE_TYPE_DOCUMENTSDB])));
+        $this->assertTrue($action->exposeMismatch(new Document(['type' => DATABASE_TYPE_VECTORSDB])));
+        // Databases always carry a non-null type (V23 backfilled old rows to
+        // legacy); an unexpected empty type is excluded by both the list and guard.
+        $this->assertTrue($action->exposeMismatch(new Document([])));
+    }
+
+    public function testDocumentsAndVectorsPathsScopeStrictlyToTheirOwnType(): void
+    {
+        $documents = new class () extends Action {
+            public static function getName(): string
+            {
+                return 'testDocumentsdbTypeGuard';
+            }
+
+            public function exposeMismatch(Document $database): bool
+            {
+                return $this->isDatabaseTypeMismatch($database);
+            }
+        };
+        $documents->setHttpPath('/v1/documentsdb/:databaseId/collections');
+        $this->assertFalse($documents->exposeMismatch(new Document(['type' => DATABASE_TYPE_DOCUMENTSDB])));
+        $this->assertTrue($documents->exposeMismatch(new Document(['type' => DATABASE_TYPE_VECTORSDB])));
+        $this->assertTrue($documents->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
+        $this->assertTrue($documents->exposeMismatch(new Document([])));
+
+        $vectors = new class () extends Action {
+            public static function getName(): string
+            {
+                return 'testVectorsdbTypeGuard';
+            }
+
+            public function exposeMismatch(Document $database): bool
+            {
+                return $this->isDatabaseTypeMismatch($database);
+            }
+        };
+        $vectors->setHttpPath('/v1/vectorsdb/:databaseId/collections');
+        $this->assertFalse($vectors->exposeMismatch(new Document(['type' => DATABASE_TYPE_VECTORSDB])));
+        $this->assertTrue($vectors->exposeMismatch(new Document(['type' => DATABASE_TYPE_DOCUMENTSDB])));
+        $this->assertTrue($vectors->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
+    }
+
+    public function testLegacyDatabasesPathIsNeverTypeGuarded(): void
+    {
+        $legacy = new class () extends Action {
+            public static function getName(): string
+            {
+                return 'testLegacyTypeGuard';
+            }
+
+            public function exposeMismatch(Document $database): bool
+            {
+                return $this->isDatabaseTypeMismatch($database);
+            }
+        };
+        $legacy->setHttpPath('/v1/databases/:databaseId/collections');
+        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
+        $this->assertFalse($legacy->exposeMismatch(new Document([])));
+        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_TABLESDB])));
+        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_DOCUMENTSDB])));
+    }
+}


### PR DESCRIPTION
## Problem
On the product-DB APIs (`/v1/tablesdb`, `/v1/documentsdb`, `/v1/vectorsdb`), listing tables/collections resolves the database by id with only an `isEmpty()` check (`Collections/XList`):
```php
$database = $authorization->skip(fn () => $dbForProject->getDocument('databases', $databaseId));
if ($database->isEmpty()) { throw DATABASE_NOT_FOUND; }
```
A genuinely missing id correctly returns **404**. But a db that **exists with a different type** (e.g. a documentsdb id on the tablesdb path, or a compute-backed db) is *not* empty, so it proceeds to a type-mismatched backend operation that surfaces as an opaque **500 `general_unknown`** instead of a clean 404.

Reproduced on a live project:
- `GET /v1/tablesdb/{tablesdbId}/tables` → 200 ✅
- `GET /v1/tablesdb/{missingId}/tables` → 404 ✅
- `GET /v1/tablesdb/{nonTablesdbId}/tables` → **500** ❌ (should be 404)

## Fix
Add a migration-safe type guard on the Databases base `Action` and apply it where the table/collection list resolves the database:
```php
protected function isDatabaseTypeMismatch(Document $database): bool
{
    $expected = $this->getDatabaseType();
    if ($expected === DATABASE_TYPE_LEGACY) {
        return false; // legacy /v1/databases API is intentionally not type-guarded
    }
    return $database->getAttribute('type', '') !== $expected;
}
```
- Product paths: a db whose `type` ≠ the path's type → treated as not-found (404), same as a missing id.
- **Legacy `/v1/databases` is never type-guarded**, so databases predating the `type` attribute (empty `type`) are unaffected — no behavior change on the legacy API.

## Scope
This targets the **table/collection list** (`Collections/XList`), which is the shared base behind tablesdb tables + documentsdb/vectorsdb collections lists — i.e. the reproduced symptom, fixed for all three in one place. Other db-resolution sites in the module (db-level Get/Update/Delete, sub-resources) have the same `getDocument+isEmpty`-only pattern; note that several extend `Utopia\Platform\Action` rather than the type-aware `Databases\Action`, so guarding them needs per-handler work — tracked as a follow-up rather than bundled here.

## Test plan
- New unit test `tests/unit/Platform/Modules/Databases/DatabaseTypeMismatchTest.php` (3 tests, 12 assertions): product paths reject mismatched/missing type, documents/vectors scope to their own type, legacy path is never guarded.
- Pint + PHPStan (level 4) on changed files: clean.

Context: Appwrite Cloud dedicated-DB testing (DAT-1628).