### PR TITLE
Fix local installer dev flow

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -270,8 +270,8 @@ function createDatabase(Container $resources, string $resourceKey, string $dbNam
             '$id' => ID::custom($index['$id']),
             'type' => $index['type'],
             'attributes' => $index['attributes'],
-            'lengths' => $index['lengths'],
-            'orders' => $index['orders'],
+            'lengths' => $index['lengths'] ?? [],
+            'orders' => $index['orders'] ?? [],
         ]), $collection['indexes']);
 
         $database->createCollection($key, $attributes, $indexes);
@@ -353,8 +353,8 @@ $http->on(Constant::EVENT_START, function ($http) use ($payloadSize, $totalWorke
                     '$id' => ID::custom($index['$id']),
                     'type' => $index['type'],
                     'attributes' => $index['attributes'],
-                    'lengths' => $index['lengths'],
-                    'orders' => $index['orders'],
+                    'lengths' => $index['lengths'] ?? [],
+                    'orders' => $index['orders'] ?? [],
                 ]), $files['indexes']);
 
                 $dbForPlatform->createCollection('bucket_' . $bucket->getSequence(), $attributes, $indexes);
@@ -399,8 +399,8 @@ $http->on(Constant::EVENT_START, function ($http) use ($payloadSize, $totalWorke
                     '$id' => ID::custom($index['$id']),
                     'type' => $index['type'],
                     'attributes' => $index['attributes'],
-                    'lengths' => $index['lengths'],
-                    'orders' => $index['orders'],
+                    'lengths' => $index['lengths'] ?? [],
+                    'orders' => $index['orders'] ?? [],
                 ]), $files['indexes']);
 
                 $authorization->skip(fn () => $dbForPlatform->createCollection('bucket_' . $bucket->getSequence(), $attributes, $indexes));

--- a/app/views/install/compose.phtml
+++ b/app/views/install/compose.phtml
@@ -12,6 +12,7 @@ $version = $this->getParam('version', '');
 $organization = $this->getParam('organization', '');
 $image = $this->getParam('image', '');
 $enableAssistant = $this->getParam('enableAssistant', false);
+$executorImages = $this->getParam('executorImages', '');
 $dbService = $this->getParam('database', 'mongodb');
 $allowedDbServices = ['mariadb', 'mongodb'];
 if (!\in_array($dbService, $allowedDbServices, true)) {
@@ -991,7 +992,6 @@ $hostPath = rtrim($this->getParam('hostPath', ''), '/');
     image: openruntimes/executor:0.25.1
     networks:
       - appwrite
-      - runtimes
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - appwrite-builds:/storage/builds:rw
@@ -1003,6 +1003,7 @@ $hostPath = rtrim($this->getParam('hostPath', ''), '/');
     environment:
       - OPR_EXECUTOR_CONNECTION_STORAGE=local://localhost
       - OPR_EXECUTOR_CONNECTION_BUILD_CACHE_STORAGE=
+      - OPR_EXECUTOR_IMAGES=<?php echo $executorImages; ?>
       - OPR_EXECUTOR_INACTIVE_TRESHOLD=$_APP_COMPUTE_INACTIVE_THRESHOLD
       - OPR_EXECUTOR_MAINTENANCE_INTERVAL=$_APP_COMPUTE_MAINTENANCE_INTERVAL
       - OPR_EXECUTOR_NETWORK=$_APP_COMPUTE_RUNTIMES_NETWORK

--- a/src/Appwrite/Platform/Installer/Http/Installer/Install.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/Install.php
@@ -42,7 +42,14 @@ class Install extends Action
             ->param('accountPassword', '', new Password(allowEmpty: true), 'Account password', true)
             ->param('database', '', new WhiteList(['mongodb', 'mariadb', 'postgresql']), 'Database adapter', true)
             ->param('installId', '', new Text(64, 0), 'Installation ID', true)
-            ->param('retryStep', null, new Nullable(new WhiteList([Server::STEP_DOCKER_COMPOSE, Server::STEP_ENV_VARS, Server::STEP_DOCKER_CONTAINERS], true)), 'Retry from step', true)
+            ->param('retryStep', null, new Nullable(new WhiteList([
+                Server::STEP_CONFIG_FILES,
+                Server::STEP_DOCKER_COMPOSE,
+                Server::STEP_ENV_VARS,
+                Server::STEP_DOCKER_CONTAINERS,
+                Server::STEP_ACCOUNT_SETUP,
+                Server::STEP_MIGRATION,
+            ], true)), 'Retry from step', true)
             ->param('migrate', false, new \Utopia\Validator\Boolean(true), 'Run database migration after upgrade', true)
             ->inject('request')
             ->inject('response')

--- a/src/Appwrite/Platform/Installer/Http/Installer/Reset.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/Reset.php
@@ -69,17 +69,33 @@ class Reset extends Action
         $isLocal = $config->isLocal();
         $composeFileName = $isLocal ? 'docker-compose.web-installer.yml' : 'docker-compose.yml';
         $envFileName = $isLocal ? '.env.web-installer' : '.env';
-        $path = $isLocal ? '/usr/src/code' : '/usr/src/code/appwrite';
+        $path = $isLocal ? $config->getHostPath() : '/usr/src/code/appwrite';
+
+        if ($path === null || $path === '') {
+            return 'Missing host path for local installer reset';
+        }
 
         $composeFile = $path . '/' . $composeFileName;
+        $envFile = $path . '/' . $envFileName;
 
         if (file_exists($composeFile)) {
-            $command = array_map(escapeshellarg(...), [
+            $command = [
                 'docker', 'compose',
-                '-f', $composeFile,
+            ];
+            if (file_exists($envFile)) {
+                $command[] = '--env-file';
+                $command[] = $envFile;
+            }
+            $command = array_map(escapeshellarg(...), [
+                ...$command,
+                '-f',
+                $composeFile,
                 ...($isLocal ? ['--project-name', 'appwrite'] : []),
-                '--project-directory', $path,
-                'down', '-v', '--remove-orphans',
+                '--project-directory',
+                $path,
+                'down',
+                '-v',
+                '--remove-orphans',
             ]);
 
             $output = [];
@@ -92,7 +108,6 @@ class Reset extends Action
             @unlink($composeFile);
         }
 
-        $envFile = $path . '/' . $envFileName;
         if (file_exists($envFile)) {
             @unlink($envFile);
         }

--- a/src/Appwrite/Platform/Installer/Server.php
+++ b/src/Appwrite/Platform/Installer/Server.php
@@ -114,7 +114,6 @@ class Server
         }
 
         if (isset($opts['docker'])) {
-            $this->printInstallerUrl($host, $port);
             $this->startDockerInstaller($opts);
         }
 
@@ -365,9 +364,13 @@ class Server
             '-i',
             '--rm',
             '--name', $container,
+            '--label', 'com.docker.compose.project=appwrite-installer',
+            '--label', 'com.docker.compose.service=appwrite-installer',
+            '--add-host', 'host.docker.internal:host-gateway',
             '-p', "127.0.0.1:$port:" . self::INSTALLER_WEB_PORT,
             '--volume', '/var/run/docker.sock:/var/run/docker.sock',
             '--volume', "$volumePath:/usr/src/code:rw",
+            '--volume', "$volumePath:$volumePath:rw",
         ];
         $args[] = '-e';
         $args[] = 'APPWRITE_INSTALLER_CONFIG=' . $configJson;

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
@@ -129,8 +129,8 @@ class Create extends Action
                     '$id' => $index['$id'],
                     'type' => $index['type'],
                     'attributes' => $index['attributes'],
-                    'lengths' => $index['lengths'],
-                    'orders' => $index['orders'],
+                    'lengths' => $index['lengths'] ?? [],
+                    'orders' => $index['orders'] ?? [],
                 ]);
             }
 

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -538,6 +538,19 @@ class Install extends Action
 
         $assistantKey = (string) ($input['_APP_ASSISTANT_OPENAI_API_KEY'] ?? '');
         $enableAssistant = trim($assistantKey) !== '';
+        $enabledRuntimes = \array_unique(\array_filter(\array_map(
+            'trim',
+            \explode(',', ($input['_APP_FUNCTIONS_RUNTIMES'] ?? '') . ',' . ($input['_APP_SITES_RUNTIMES'] ?? ''))
+        )));
+        $runtimes = Config::getParam('runtimes', []);
+        $runtimeImages = [];
+        foreach ($enabledRuntimes as $runtime) {
+            $imageName = $runtimes[$runtime]['image'] ?? '';
+            if ($imageName !== '') {
+                $runtimeImages[] = $imageName;
+            }
+        }
+        $executorImages = \implode(',', \array_unique($runtimeImages));
 
         $templateForCompose
             ->setParam('httpPort', $httpPort)
@@ -547,17 +560,24 @@ class Install extends Action
             ->setParam('image', $image)
             ->setParam('database', $database)
             ->setParam('hostPath', $this->hostPath)
-            ->setParam('enableAssistant', $enableAssistant);
+            ->setParam('enableAssistant', $enableAssistant)
+            ->setParam('executorImages', $executorImages);
 
         $templateForEnv->setParam('vars', $input);
 
         $steps = [
             InstallerServer::STEP_DOCKER_COMPOSE,
             InstallerServer::STEP_ENV_VARS,
-            InstallerServer::STEP_DOCKER_CONTAINERS
+            InstallerServer::STEP_DOCKER_CONTAINERS,
+            InstallerServer::STEP_ACCOUNT_SETUP,
+            InstallerServer::STEP_MIGRATION,
         ];
 
         $startIndex = 0;
+        $resumeFromStep = match ($resumeFromStep) {
+            InstallerServer::STEP_CONFIG_FILES => InstallerServer::STEP_DOCKER_COMPOSE,
+            default => $resumeFromStep,
+        };
         if ($resumeFromStep !== null) {
             $resumeIndex = array_search($resumeFromStep, $steps, true);
             if ($resumeIndex !== false) {
@@ -597,37 +617,43 @@ class Install extends Action
                 $this->updateProgress($progress, InstallerServer::STEP_CONFIG_FILES, InstallerServer::STATUS_COMPLETED, $messages);
             }
 
-            if ($database === 'mongodb' && !$useExistingConfig) {
+            if ($database === 'mongodb' && !$useExistingConfig && $startIndex <= 1) {
                 $this->copyMongoEntrypointIfNeeded();
             }
 
             if (!$noStart) {
-                $currentStep = InstallerServer::STEP_DOCKER_CONTAINERS;
-                $this->updateProgress($progress, InstallerServer::STEP_DOCKER_CONTAINERS, InstallerServer::STATUS_IN_PROGRESS, $messages);
-                $this->runDockerCompose($input, $isLocalInstall, $useExistingConfig, $isCLI, $progress, $isUpgrade);
+                $shouldStartContainers = $startIndex <= 2;
+                if ($shouldStartContainers) {
+                    $currentStep = InstallerServer::STEP_DOCKER_CONTAINERS;
+                    $this->updateProgress($progress, InstallerServer::STEP_DOCKER_CONTAINERS, InstallerServer::STATUS_IN_PROGRESS, $messages);
+                    $this->runDockerCompose($input, $isLocalInstall, $useExistingConfig, $isCLI, $progress, $isUpgrade);
 
-                if (!$isUpgrade) {
-                    $this->updateProgress($progress, InstallerServer::STEP_DOCKER_CONTAINERS, InstallerServer::STATUS_COMPLETED, $messages);
-                    $this->updateProgress($progress, InstallerServer::STEP_ACCOUNT_SETUP, InstallerServer::STATUS_IN_PROGRESS, messageOverride: 'Creating Appwrite account...');
+                    if (!$isUpgrade) {
+                        $this->updateProgress($progress, InstallerServer::STEP_DOCKER_CONTAINERS, InstallerServer::STATUS_COMPLETED, $messages);
+                        $this->updateProgress($progress, InstallerServer::STEP_ACCOUNT_SETUP, InstallerServer::STATUS_IN_PROGRESS, messageOverride: 'Creating Appwrite account...');
+                    }
                 }
 
-                if (!$isLocalInstall) {
+                if (!$isLocalInstall || file_exists('/.dockerenv') || file_exists('/run/.containerenv')) {
                     $this->connectInstallerToAppwriteNetwork();
                 }
 
                 $domain = $input['_APP_DOMAIN'] ?? 'localhost';
 
                 $healthStep = $isUpgrade ? InstallerServer::STEP_DOCKER_CONTAINERS : InstallerServer::STEP_ACCOUNT_SETUP;
+                if ($isUpgrade && $startIndex >= 4) {
+                    $healthStep = InstallerServer::STEP_MIGRATION;
+                }
                 if (!$isUpgrade) {
                     $currentStep = InstallerServer::STEP_ACCOUNT_SETUP;
                 }
                 $apiUrl = $this->waitForApiReady($domain, $httpPort, $isLocalInstall, $progress, $healthStep);
 
-                if ($isUpgrade) {
+                if ($isUpgrade && $shouldStartContainers) {
                     $this->updateProgress($progress, InstallerServer::STEP_DOCKER_CONTAINERS, InstallerServer::STATUS_COMPLETED, $messages);
                 }
 
-                if (!$isUpgrade) {
+                if (!$isUpgrade && $startIndex <= 3) {
                     $this->createInitialAdminAccount($account, $progress, $apiUrl, $domain);
                 }
 
@@ -762,13 +788,30 @@ class Install extends Action
         // Allow the SSE chunk to flush before the blocking exec
         usleep(100_000);
 
-        // Static command — no user input involved
-        $command = $isLocalInstall
-            ? 'docker compose exec appwrite migrate 2>&1'
-            : 'docker exec appwrite migrate 2>&1';
+        if ($isLocalInstall) {
+            $composePath = $this->hostPath !== '' ? $this->hostPath : $this->path;
+            $command = [
+                'docker',
+                'compose',
+                '--env-file',
+                $composePath . '/' . $this->getEnvFileName(),
+                '-f',
+                $composePath . '/' . $this->getComposeFileName(),
+                '--project-name',
+                'appwrite',
+                '--project-directory',
+                $composePath,
+                'exec',
+                'appwrite',
+                'migrate',
+            ];
+        } else {
+            $command = ['docker', 'exec', 'appwrite', 'migrate'];
+        }
+        $commandLine = implode(' ', array_map(escapeshellarg(...), $command));
 
         $output = [];
-        \exec($command, $output, $exit);
+        \exec($commandLine . ' 2>&1', $output, $exit);
 
         if ($exit !== 0) {
             $message = trim(implode("\n", $output));
@@ -856,9 +899,9 @@ class Install extends Action
      * the runtime context and returns whichever responds first.
      *
      * Candidates (in order of preference):
-     *  - Docker internal DNS (http://appwrite) — only if on the appwrite network
-     *  - host.docker.internal:{port} — reaches host-published ports from inside a container
+     *  - Docker internal DNS (http://appwrite) — preferred when on the appwrite network
      *  - localhost:{port} — works when running directly on the host (local dev)
+     *  - host.docker.internal:{port} — non-local fallback for host-published ports
      */
     private function waitForApiReady(string $domain, string $httpPort, bool $isLocalInstall, ?callable $progress, string $step = InstallerServer::STEP_ACCOUNT_SETUP): string
     {
@@ -872,6 +915,7 @@ class Install extends Action
 
         if ($isLocalInstall) {
             $candidates = [
+                self::APPWRITE_API_URL . $healthPath,
                 'http://localhost:' . $httpPort . $healthPath,
             ];
         } else {
@@ -1081,12 +1125,18 @@ class Install extends Action
             Console::log("Running \"docker compose up -d --remove-orphans --renew-anon-volumes\"");
         }
 
-        $composeFileName = $this->getComposeFileName();
-        $composeFile = $this->path . '/' . $composeFileName;
+        $composePath = $this->path;
+        if ($isLocalInstall && $this->hostPath !== '') {
+            $composePath = $this->hostPath;
+        }
+        $composeFile = $composePath . '/' . $this->getComposeFileName();
+        $envFile = $composePath . '/' . $this->getEnvFileName();
 
         $command = [
             'docker',
             'compose',
+            '--env-file',
+            $envFile,
             '-f',
             $composeFile,
         ];
@@ -1097,7 +1147,7 @@ class Install extends Action
         }
 
         $command[] = '--project-directory';
-        $command[] = $this->path;
+        $command[] = $composePath;
         $command[] = 'up';
         $command[] = '-d';
         $command[] = '--remove-orphans';


### PR DESCRIPTION
## What does this PR do?

Fixes several issues in the local web installer/dev flow:

- Prevents the Dockerized installer container from inheriting stale Compose labels and removes a duplicate installer URL log.
- Uses host-reachable paths and `.env.web-installer` when running local installer Compose commands.
- Allows the installer health check to reach host-published Appwrite ports from inside the installer container.
- Fixes executor setup by letting executor manage the `runtimes` network and configuring `OPR_EXECUTOR_IMAGES` for valid startup pulls.
- Accepts UI retry step IDs and maps them to resumable backend install phases.
- Avoids undefined index warnings when collection index configs omit optional `lengths` or `orders`.

## Test Plan

- Ran PHP syntax checks on touched PHP files.
- Ran `composer lint` on touched PHP/template files.
- Verified local Appwrite health at `http://localhost:80/v1/health/version`.
- Verified a container can reach `http://host.docker.internal:80/v1/health/version`.
- Recreated `openruntimes-executor` locally and verified `appwrite` can reach `http://exc1/v1/health`.
- Verified executor logs report `[ImagePuller] Pulled 3/3 images.` without the blank image pull failure.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
