### PR TITLE
fix(audits): use span attributes instead of per-message Console logging

### DIFF
--- a/src/Appwrite/Platform/Workers/Audits.php
+++ b/src/Appwrite/Platform/Workers/Audits.php
@@ -5,11 +5,11 @@ namespace Appwrite\Platform\Workers;
 use Appwrite\Event\Message\Audit;
 use Exception;
 use Throwable;
-use Utopia\Console;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Structure;
 use Utopia\Platform\Action;
 use Utopia\Queue\Message;
+use Utopia\Span\Span;
 use Utopia\System\System;
 
 class Audits extends Action
@@ -62,8 +62,6 @@ class Audits extends Action
         }
 
         $auditMessage = Audit::fromArray($payload);
-
-        Console::info('Aggregating audit logs');
 
         $event = $auditMessage->event;
 
@@ -123,10 +121,11 @@ class Audits extends Action
                 ];
         }
 
-        if (isset($this->logs[$auditMessage->project->getSequence()])) {
-            $this->logs[$auditMessage->project->getSequence()]['logs'][] = $eventData;
+        $projectSequence = (string) $auditMessage->project->getSequence();
+        if (isset($this->logs[$projectSequence])) {
+            $this->logs[$projectSequence]['logs'][] = $eventData;
         } else {
-            $this->logs[$auditMessage->project->getSequence()] = [
+            $this->logs[$projectSequence] = [
                 'project' => new Document([
                     '$id' => $auditMessage->project->getId(),
                     '$sequence' => $auditMessage->project->getSequence(),
@@ -148,21 +147,24 @@ class Audits extends Action
             return;
         }
 
+        $projects = 0;
+        $events = 0;
         foreach ($this->logs as $sequence => $projectLogs) {
             try {
-                Console::log('Processing Project "' . $sequence . '" batch with ' . count($projectLogs['logs']) . ' events');
-
-                $projectDocument = $projectLogs['project'];
-                $audit = $getAudit($projectDocument);
+                $audit = $getAudit($projectLogs['project']);
                 $audit->logBatch($projectLogs['logs']);
 
-                Console::success('Audit logs processed successfully');
+                $projects++;
+                $events += count($projectLogs['logs']);
             } catch (Throwable $e) {
-                Console::error('Error processing audit logs for Project "' . $sequence . '": ' . $e->getMessage());
+                Span::add('audits.error', $e->getMessage());
             } finally {
                 unset($this->logs[$sequence]);
             }
         }
+
+        Span::add('audits.projects', $projects);
+        Span::add('audits.count', $events);
 
         $this->lastTriggeredTime = time();
     }


### PR DESCRIPTION
## What

Replace the Audits worker's per-message `Console` logging with span telemetry, and fix a PHP 8.x deprecation.

**Logging → spans.** The worker logged on every message (`Console::info`/`log`/`success`/`error`), flooding worker logs in a hot path (thousands/s) with almost no signal:
- Removed `Console::info('Aggregating audit logs')` — it fired on *every* message, before the batch check, even when only buffering.
- On the batch flush, add `audits.projects` and `audits.count` (total events) to the span instead of per-project `Console::log`/`success`.
- On a per-project failure, add `audits.error` to the span instead of `Console::error` (per-project isolation preserved — the loop still continues + unsets).
- Dropped the now-unused `Utopia\Console` import; added `Utopia\Span\Span` (matches the Executions worker's `Span::add('executions.count', …)` style).

**Deprecation.** The project sequence was used directly as an array key (`$this->logs[$auditMessage->project->getSequence()]`); a `null` sequence triggers `Using null as an array offset is deprecated`. Cast to string once (`null` → `""`, matching the prior silent coercion) and reuse it.

## Why

Pure observability cleanup in a hot path — the Console lines are noise (one fixed string per message), spans give structured, sampled, per-trace counts instead. No behavior change beyond logging; the null key was already coerced to `""`.

Observed in production logs:
```
Aggregating audit logs
Deprecated: Using null as an array offset is deprecated, use an empty string instead in .../Workers/Audits.php:126
```