### PR TITLE
(ci): bump php-retry to node24 runtime commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
 
       - name: Run Unit Tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -418,7 +418,7 @@ jobs:
 
       - name: Run General Tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -508,7 +508,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -583,7 +583,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -649,7 +649,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60


### PR DESCRIPTION
## What

Pin `itznotabug/php-retry` to commit `d4500b9` (node24 runtime) across all 5 usages in `ci.yml`.

```diff
- uses: itznotabug/php-retry@d6bef45a8bff490babfb613e33b00d133e4062f0 # v3
+ uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
```

## Why

CI was printing:

> Node 20 is being deprecated. This workflow is running with Node 24 by default…

The action declared `using: 'node20'` at every ref. [itznotabug/php-retry#15](https://github.com/itznotabug/php-retry/pull/15) (merged) migrates the runtime to `node24`. The `v3` tag has **not** been re-pointed to the new commit yet (it still resolves to the old `d6bef45` / node20), so this pins the merged commit SHA directly to get the fix now.

Verified `action.yml` at `d4500b9` declares `using: 'node24'`.

## Follow-up

Once upstream re-tags `v3` onto `d4500b9`, the `# v3` comment becomes exact; no further change needed (the SHA is already correct).