### PR TITLE
fix(deletes): run execution-limit cleanup sequentially to avoid shared-connection crash

### DIFF
--- a/src/Appwrite/Platform/Workers/Deletes.php
+++ b/src/Appwrite/Platform/Workers/Deletes.php
@@ -1106,7 +1106,7 @@ class Deletes extends Action
             // fast path, no need to list anything!
             $delete($dbForProject, $resourceInternalId, $resourceType);
         } else {
-            $processResource = function (string $type) use ($dbForProject, $delete) {
+            foreach ([RESOURCE_TYPE_SITES, RESOURCE_TYPE_FUNCTIONS] as $type) {
                 $this->listByGroup(
                     collection: $type,
                     queries: [Query::select(['$id', '$sequence'])],
@@ -1115,13 +1115,7 @@ class Deletes extends Action
                         $delete($dbForProject, $resource->getSequence(), $type);
                     }
                 );
-            };
-
-            /* perform processing in parallel */
-            batch([
-                fn () => $processResource(RESOURCE_TYPE_SITES),
-                fn () => $processResource(RESOURCE_TYPE_FUNCTIONS),
-            ]);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The Deletes worker crashes with a fatal, uncaught `PDOException`:

```
SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other
unbuffered queries are active. Consider using PDOStatement::fetchAll().
```

The crash originates in `deleteExecutionsByLimit()` and takes down the whole worker process (followed by `Channel is destroyed` warnings as `batch()` tears down).

## Root cause

`deleteExecutionsByLimit()` fans the two resource types out concurrently:

```php
batch([
    fn () => $processResource(RESOURCE_TYPE_SITES),
    fn () => $processResource(RESOURCE_TYPE_FUNCTIONS),
]);
```

Both closures capture the **same** `$dbForProject`. In the worker, `getProjectDB` caches the `Database` per host, so the two coroutines genuinely share one `Database` → one `Pool` adapter instance.

When the functions coroutine reaches `deleteByGroup → deleteDocuments`, that wraps each batch in `withTransaction()`. On the `Pool` adapter this sets a **process-global** `pinnedAdapter` and routes *all* subsequent `delegate()` calls onto that one pinned connection, bypassing pool/coroutine isolation. Meanwhile the sites coroutine's `findOne('executions', …)` is misrouted onto that same connection — which is mid-delete-transaction with an open result set — producing the `2014` error. It's uncaught in `findOne`, so the worker dies.

## Fix

Process the two resource types sequentially. Only one transaction pins the connection at a time, so there's no concurrent sibling read to collide with. Behaviour is otherwise identical; this just removes the unsafe parallelism (net −6 LoC).

## Note

The underlying `Pool` bug — transaction pinning stored in a process-global field rather than coroutine-local — is unchanged. A follow-up keying `pinnedAdapter` by `Coroutine::getCid()` in `utopia-php/database` would make the adapter safe to share across coroutines mid-transaction and eliminate this class of crash for the other `batch()` call sites too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)