### PR TITLE
Bump utopia auth to 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "utopia-php/agents": "2.*",
         "utopia-php/analytics": "0.15.*",
         "utopia-php/audit": "2.6.*",
-        "utopia-php/auth": "0.5.*",
+        "utopia-php/auth": "^0.6",
         "utopia-php/cache": "^3.0",
         "utopia-php/cli": "^0.24",
         "utopia-php/compression": "0.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da448b447a61b122c0c454f2b7c86b0d",
+    "content-hash": "bf0c07c029c54b225566c1a731fccae0",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3319,16 +3319,16 @@
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.5.1",
+            "version": "0.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "9245a6342ed94f00425aef6963a32b8af9b0dc9d"
+                "reference": "8323a51314f6988c62926117ed642588ca8e8c4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/9245a6342ed94f00425aef6963a32b8af9b0dc9d",
-                "reference": "9245a6342ed94f00425aef6963a32b8af9b0dc9d",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/8323a51314f6988c62926117ed642588ca8e8c4a",
+                "reference": "8323a51314f6988c62926117ed642588ca8e8c4a",
                 "shasum": ""
             },
             "require": {
@@ -3337,12 +3337,6 @@
                 "ext-scrypt": "*",
                 "ext-sodium": "*",
                 "php": ">=8.0"
-            },
-            "require-dev": {
-                "laravel/pint": "1.2.*",
-                "phpstan/phpstan": "1.9.x-dev",
-                "phpunit/phpunit": "^9.3",
-                "vimeo/psalm": "4.0.1"
             },
             "type": "library",
             "autoload": {
@@ -3369,9 +3363,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/auth/issues",
-                "source": "https://github.com/utopia-php/auth/tree/0.5.1"
+                "source": "https://github.com/utopia-php/auth/tree/0.6.1"
             },
-            "time": "2026-05-30T12:21:17+00:00"
+            "time": "2026-06-20T09:45:06+00:00"
         },
         {
             "name": "utopia-php/cache",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Bumps `utopia-php/auth` from `0.5.*` to `^0.6` and updates the lockfile to `0.6.1`.

This is needed so downstream Cloud changes can use the OAuth2 resource indicator helpers now provided by `utopia-php/auth`.

## Test Plan

- Ran `composer require utopia-php/auth:^0.6 --with-dependencies --ignore-platform-reqs`
- Ran `composer validate --strict`
- Ran `git diff --check`
- Verified `Utopia\Auth\OAuth2\ResourceIndicators::from()` is available through Composer autoload

## Related PRs and Issues

- Supports Cloud OAuth2 resource indicator follow-up work

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
