### PR TITLE
Fix project OAuth provider sparse update

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -38,27 +38,31 @@ Http::patch('/v1/projects/:projectId/oauth2')
     ->inject('dbForPlatform')
     ->action(function (string $projectId, string $provider, ?string $appId, ?string $secret, ?bool $enabled, Response $response, Database $dbForPlatform) {
 
-        $project = $dbForPlatform->getDocument('projects', $projectId);
+        $project = $dbForPlatform->withTransaction(function () use ($dbForPlatform, $projectId, $provider, $appId, $secret, $enabled) {
+            $project = $dbForPlatform->getDocument('projects', $projectId, forUpdate: true);
 
-        if ($project->isEmpty()) {
-            throw new Exception(Exception::PROJECT_NOT_FOUND);
-        }
+            if ($project->isEmpty()) {
+                throw new Exception(Exception::PROJECT_NOT_FOUND);
+            }
 
-        $providers = $project->getAttribute('oAuthProviders', []);
+            $providers = $project->getAttribute('oAuthProviders', []);
 
-        if ($appId !== null) {
-            $providers[$provider . 'Appid'] = $appId;
-        }
+            if ($appId !== null) {
+                $providers[$provider . 'Appid'] = $appId;
+            }
 
-        if ($secret !== null) {
-            $providers[$provider . 'Secret'] = $secret;
-        }
+            if ($secret !== null) {
+                $providers[$provider . 'Secret'] = $secret;
+            }
 
-        if ($enabled !== null) {
-            $providers[$provider . 'Enabled'] = $enabled;
-        }
+            if ($enabled !== null) {
+                $providers[$provider . 'Enabled'] = $enabled;
+            }
 
-        $project = $dbForPlatform->updateDocument('projects', $project->getId(), $project->setAttribute('oAuthProviders', $providers));
+            return $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
+                'oAuthProviders' => $providers,
+            ]));
+        });
 
         $response->dynamic($project, Response::MODEL_PROJECT);
     });


### PR DESCRIPTION
## What does this PR do?

Updates the legacy project OAuth provider endpoint to persist `oAuthProviders` as a sparse document update. This prevents a stale fetched project document from clobbering previously written OAuth provider credentials during repeated `/projects/{projectId}/oauth2` updates.

## Test Plan

- `php -l app/controllers/api/projects.php`
- `vendor/bin/pint --test app/controllers/api/projects.php`

## Related PRs and Issues

- Supports appwrite-labs/cloud#4408

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
