### PR TITLE
Update php-retry action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Run Unit Tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
+        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -352,7 +352,7 @@ jobs:
 
       - name: Run General Tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
+        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -442,7 +442,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
+        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -517,7 +517,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
+        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
@@ -583,7 +583,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@d4500b9db3258e2cc8857427980f28e1611eb79c # v3
+        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates the `itznotabug/php-retry` GitHub Action pin in CI from v3 to v4.

The v4 release migrates the action runtime to Node 24 and includes a fix for extracting container names when Docker calls are wrapped in shell logic.

## Test Plan

- [x] Confirmed the v4 tag resolves to `60547503cb2126eddaa082d0999e99cfca2b3856`.
- [x] Ran `actionlint .github/workflows/ci.yml`.
- [x] Ran `git diff --check`.

## Related PRs and Issues

- https://github.com/ItzNotABug/php-retry/releases/tag/v4

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
