### PR TITLE
Bump utopia-php/auth to ^0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "utopia-php/agents": "2.*",
         "utopia-php/analytics": "0.15.*",
         "utopia-php/audit": "2.6.*",
-        "utopia-php/auth": "^0.6",
+        "utopia-php/auth": "^0.7",
         "utopia-php/cache": "^3.0",
         "utopia-php/cli": "^0.24",
         "utopia-php/compression": "0.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf0c07c029c54b225566c1a731fccae0",
+    "content-hash": "2c365042d311895a9cddaceca7623b1e",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3319,16 +3319,16 @@
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "8323a51314f6988c62926117ed642588ca8e8c4a"
+                "reference": "22a2cf6ca604e5cc6bf10f0f8240195f0baa063a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/8323a51314f6988c62926117ed642588ca8e8c4a",
-                "reference": "8323a51314f6988c62926117ed642588ca8e8c4a",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/22a2cf6ca604e5cc6bf10f0f8240195f0baa063a",
+                "reference": "22a2cf6ca604e5cc6bf10f0f8240195f0baa063a",
                 "shasum": ""
             },
             "require": {
@@ -3336,7 +3336,7 @@
                 "ext-openssl": "*",
                 "ext-scrypt": "*",
                 "ext-sodium": "*",
-                "php": ">=8.0"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -3363,9 +3363,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/auth/issues",
-                "source": "https://github.com/utopia-php/auth/tree/0.6.1"
+                "source": "https://github.com/utopia-php/auth/tree/0.7.0"
             },
-            "time": "2026-06-20T09:45:06+00:00"
+            "time": "2026-06-22T11:58:24+00:00"
         },
         {
             "name": "utopia-php/cache",


### PR DESCRIPTION
## What

Bumps `utopia-php/auth` from `^0.6` to `^0.7` (resolves `0.7.0`).

`auth/0.7.0` adds a generic JWS verifier layer (RS256/HS256) plus `Claim`/`Header` enums, and raises its own PHP floor to `>= 8.1`. Appwrite already requires `>= 8.3.0`, so the constraint is compatible.

## Compatibility

This is a non-breaking bump for Appwrite. Appwrite uses only the auth library's `Proofs\*` (Token/Password/Code), `Hashes\*`, `Store`, and the base `Hash`/`Proof` — none of whose public APIs changed in 0.7.0. The new verifiers/enums are additive, and the only behavior tweaks (Proof's optional-hash constructor default, Password keeping its active hash aligned with its registry) are backward-compatible. No source changes were required.

## Testing

- `composer update utopia-php/auth` resolves `0.6.1 => 0.7.0` with no other lock changes; `composer validate` passes.
- `phpstan analyse src/Appwrite/Auth` — **No errors**.