### PR TITLE
feat(messaging): attach project ID to internal SMS for provider attribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "utopia-php/locale": "0.8.*",
         "utopia-php/lock": "0.2.*",
         "utopia-php/logger": "0.8.*",
-        "utopia-php/messaging": "^1.1",
+        "utopia-php/messaging": "^1.2",
         "utopia-php/migration": "1.14.*",
         "utopia-php/platform": "^1.0@RC",
         "utopia-php/pools": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4348,16 +4348,16 @@
         },
         {
             "name": "utopia-php/messaging",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/messaging.git",
-                "reference": "2a8e82cda89b373833e10923ae959f56466300a3"
+                "reference": "3419ffbbeb242b3232b588430bd465024959720c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/2a8e82cda89b373833e10923ae959f56466300a3",
-                "reference": "2a8e82cda89b373833e10923ae959f56466300a3",
+                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/3419ffbbeb242b3232b588430bd465024959720c",
+                "reference": "3419ffbbeb242b3232b588430bd465024959720c",
                 "shasum": ""
             },
             "require": {
@@ -4394,9 +4394,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/messaging/issues",
-                "source": "https://github.com/utopia-php/messaging/tree/1.1.0"
+                "source": "https://github.com/utopia-php/messaging/tree/1.2.0"
             },
-            "time": "2026-06-16T03:44:58+00:00"
+            "time": "2026-06-23T04:24:43+00:00"
         },
         {
             "name": "utopia-php/migration",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c365042d311895a9cddaceca7623b1e",
+    "content-hash": "508b3e633843d61eb24f864fd8832db0",
     "packages": [
         {
             "name": "adhocore/jwt",

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -33,6 +33,7 @@ use Utopia\Messaging\Adapter\SMS\GEOSMS;
 use Utopia\Messaging\Adapter\SMS\Inforu;
 use Utopia\Messaging\Adapter\SMS\Mock;
 use Utopia\Messaging\Adapter\SMS\Msg91;
+use Utopia\Messaging\Adapter\SMS\Msg91\MetadataParameter;
 use Utopia\Messaging\Adapter\SMS\Telesign;
 use Utopia\Messaging\Adapter\SMS\TextMagic;
 use Utopia\Messaging\Adapter\SMS\Twilio;
@@ -823,6 +824,10 @@ class Messaging extends Action
             $from
         );
         $sms->setOrigin(MESSAGE_SEND_TYPE_INTERNAL);
+
+        // Attach the project ID so the SMS provider's delivery logs and
+        // webhooks can be attributed back to the originating project.
+        $sms->setMetadata([MetadataParameter::UUID->value => $project->getId()]);
 
         $this->adapter->send($sms);
     }


### PR DESCRIPTION
## What

Attaches the originating **project ID** to internal (auth) SMS as the MSG91 `UUID` tracking field, so the SMS provider's delivery logs and webhooks can be reconciled back to a project.

```php
$sms->setMetadata([MetadataParameter::UUID->value => $project->getId()]);
```

Applied at the **internal** send path in `Workers/Messaging.php` (`MESSAGE_SEND_TYPE_INTERNAL`) — i.e. phone OTP, MFA challenges, and team invites sent through Appwrite's own provider. The external/customer messaging path (`buildSmsMessage`, customer's own provider) is intentionally left unchanged.

## Why

Provider-side reports (e.g. MSG91 analytics exports) currently expose `UUID`/`CRQID` columns but we never populate them, so there's no way to trace a sent SMS back to the project that triggered it. This blocks per-project reconciliation of SMS spend vs. billing. The project ID (≤36 chars, `[A-Za-z0-9._-]`) fits MSG91's `UUID` constraint (≤80 chars, `[A-Za-z0-9_.-]`).

## Dependency

Bumps `utopia-php/messaging` `1.1.0` → `1.2.0` (adds `SMS::setMetadata()` and the `Msg91\MetadataParameter` enum via utopia-php/messaging#135).

## Notes

- Metadata is ignored by adapters that don't consume it (Twilio, Fast2SMS, Inforu), so it's safe for all internal providers and routes through GEOSMS.
- Targets `1.9.x` so Appwrite Cloud picks it up via its `appwrite/server-ce: 1.9.x-dev` constraint.

## Test plan

- [x] `php -l` + Pint pass on the changed file
- [x] `composer update utopia-php/messaging` resolves to 1.2.0; `MetadataParameter::UUID->value` autoloads
- [ ] Send a phone OTP and confirm `UUID` = project ID appears in the MSG91 delivery report