### PR TITLE
fix: purge project cache after config updates

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
@@ -82,6 +82,7 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'auths' => $auths,
         ])));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents->setParam('methodId', $methodId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
@@ -425,7 +425,10 @@ abstract class Base extends Action
             'oAuthProviders' => $oAuthProviders
         ]);
 
-        return $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
+
+        return $project;
     }
 
     public function action(

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
@@ -103,6 +103,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
@@ -75,6 +75,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
@@ -83,6 +83,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
@@ -76,6 +76,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
@@ -103,6 +103,7 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'auths' => $auths,
         ])));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
@@ -75,6 +75,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
@@ -75,6 +75,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
@@ -75,6 +75,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
@@ -81,6 +81,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
@@ -81,6 +81,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
@@ -79,6 +79,7 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'apis' => $protocols,
         ])));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents->setParam('protocolId', $protocolId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
@@ -170,6 +170,7 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $response->dynamic($project, Response::MODEL_PROJECT);
     }

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
@@ -79,6 +79,7 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'services' => $services,
         ])));
+        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents->setParam('serviceId', $serviceId);
 


### PR DESCRIPTION
## What

Purge the cached `projects` document after a project's **auth / security config** is updated, so the next request reads the fresh config instead of a stale cache hit.

Adds `$authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()))` immediately after the `updateDocument('projects', ...)` call in the following project-config endpoints:

- `AuthMethods/Update.php`
- `OAuth2/Base.php`
- `Policies/{MembershipPrivacy,PasswordDictionary,PasswordHistory,PasswordPersonalData,PasswordStrength,SessionAlert,SessionDuration,SessionInvalidation,SessionLimit,UserLimit}/Update.php`
- `Protocols/Update.php`
- `SMTP/Update.php`
- `Services/Update.php`

## Why

The project document is cached. When these settings are updated, the cached copy was not invalidated, so subsequent requests could serve the old configuration until the cache expired. This mirrors the `purgeCachedDocument` pattern already in place for the `Platforms/*` and `Keys/*` project endpoints.

## History

This is a fresh re-application of a change that was previously reverted (`Revert "Purge project cache after project settings updates"`). This PR re-adds only the config-update endpoints listed above, matching the established purge idiom.

## Changes

- 15 files under `src/Appwrite/Platform/Modules/Project/Http/Project/` — one `purgeCachedDocument` call each (OAuth2 also restructured to capture the updated document before purging).

## Test plan

- `composer lint` on all touched files → passed
- After update of each setting, re-fetch the project and confirm the new value is returned without waiting for cache TTL.
