### PR TITLE
Surface and report Appwrite migration report failures

### DIFF
--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -9,12 +9,9 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Document;
-use Utopia\Logger\Log;
-use Utopia\Logger\Logger;
 use Utopia\Migration\Sources\Appwrite as AppwriteSource;
 use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Text;
 use Utopia\Validator\URL;
@@ -56,8 +53,6 @@ class Get extends Action
             ->param('key', '', new Text(512), "Source's API Key")
             ->inject('response')
             ->inject('getDatabasesDB')
-            ->inject('log')
-            ->inject('logger')
             ->callback($this->action(...));
     }
 
@@ -67,9 +62,7 @@ class Get extends Action
         string $projectID,
         string $key,
         Response $response,
-        callable $getDatabasesDB,
-        Log $log,
-        ?Logger $logger
+        callable $getDatabasesDB
     ): void {
         try {
             $appwrite = new AppwriteSource($projectID, $endpoint, $key, $getDatabasesDB);
@@ -77,39 +70,17 @@ class Get extends Action
         } catch (\Throwable $e) {
             $code = (int) $e->getCode();
 
-            // Only 401/403 are expected user errors — surface, don't Sentry. Other 4xx may be bugs.
+            // 401/403 are expected user errors (bad key, missing scope): surface them as a 4xx so
+            // they are not published to Sentry.
             if ($code === 401 || $code === 403) {
                 throw new Exception(Exception::MIGRATION_PROVIDER_ERROR, $e->getMessage(), previous: $e);
             }
 
-            // Report to Sentry. The endpoint is stripped of any embedded credentials/tokens, and a
-            // logging outage must not mask the migration error thrown below.
-            if ($logger !== null) {
-                $url = \parse_url($endpoint) ?: [];
-                $safeEndpoint = \sprintf('%s://%s%s%s', $url['scheme'] ?? 'https', $url['host'] ?? '', isset($url['port']) ? ':' . $url['port'] : '', $url['path'] ?? '');
-
-                $log->setNamespace('http');
-                $log->setServer(System::getEnv('_APP_LOGGING_SERVICE_IDENTIFIER', \gethostname()));
-                $log->setVersion(System::getEnv('_APP_VERSION', 'UNKNOWN'));
-                $log->setType(Log::TYPE_ERROR);
-                $log->setAction('getAppwriteReport');
-                $log->setMessage($e->getMessage());
-                $log->addTag('code', (string) $e->getCode());
-                $log->addExtra('sourceEndpoint', $safeEndpoint);
-                $log->addExtra('sourceProjectId', $projectID);
-                $log->addExtra('file', $e->getFile());
-                $log->addExtra('line', (string) $e->getLine());
-                $log->addExtra('trace', $e->getTraceAsString());
-
-                try {
-                    $logger->addLog($log);
-                } catch (\Throwable) {
-                }
-            }
-
+            // Genuine source failure — throw as 5xx so the central error handler publishes it.
             throw new Exception(
                 Exception::MIGRATION_PROVIDER_ERROR,
                 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.',
+                code: 502,
                 previous: $e
             );
         }

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -73,7 +73,7 @@ class Get extends Action
             // 401/403 are expected user errors (bad key, missing scope): surface them as a 4xx so
             // they are not published to Sentry.
             if ($code === 401 || $code === 403) {
-                throw new Exception(Exception::MIGRATION_PROVIDER_ERROR, $e->getMessage(), previous: $e);
+                throw new Exception(Exception::MIGRATION_PROVIDER_ERROR, $e->getMessage());
             }
 
             // Genuine source failure — throw as 5xx so the central error handler publishes it.

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -8,10 +8,14 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\CLI\Console;
 use Utopia\Database\Document;
+use Utopia\Logger\Log;
+use Utopia\Logger\Logger;
 use Utopia\Migration\Sources\Appwrite as AppwriteSource;
 use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Text;
 use Utopia\Validator\URL;
@@ -53,6 +57,8 @@ class Get extends Action
             ->param('key', '', new Text(512), "Source's API Key")
             ->inject('response')
             ->inject('getDatabasesDB')
+            ->inject('log')
+            ->inject('logger')
             ->callback($this->action(...));
     }
 
@@ -62,16 +68,48 @@ class Get extends Action
         string $projectID,
         string $key,
         Response $response,
-        callable $getDatabasesDB
+        callable $getDatabasesDB,
+        Log $log,
+        ?Logger $logger
     ): void {
         try {
             $appwrite = new AppwriteSource($projectID, $endpoint, $key, $getDatabasesDB);
             $report = $appwrite->report($resources);
         } catch (\Throwable $e) {
+            $code = (int) $e->getCode();
+
+            // Only 401/403 are expected user errors — surface, don't Sentry. Other 4xx may be bugs.
+            if ($code === 401 || $code === 403) {
+                throw new Exception(Exception::MIGRATION_PROVIDER_ERROR, $e->getMessage(), previous: $e);
+            }
+
+            // Report to Sentry (key is never logged).
+            if ($logger !== null) {
+                $log->setNamespace('http');
+                $log->setServer(System::getEnv('_APP_LOGGING_SERVICE_IDENTIFIER', \gethostname()));
+                $log->setVersion(System::getEnv('_APP_VERSION', 'UNKNOWN'));
+                $log->setType(Log::TYPE_ERROR);
+                $log->setAction('getAppwriteReport');
+                $log->setMessage($e->getMessage());
+                $log->addTag('code', (string) $e->getCode());
+                $log->addExtra('sourceEndpoint', $endpoint);
+                $log->addExtra('sourceProjectId', $projectID);
+                $log->addExtra('file', $e->getFile());
+                $log->addExtra('line', (string) $e->getLine());
+                $log->addExtra('trace', $e->getTraceAsString());
+                $logger->addLog($log);
+            }
+
             throw new Exception(
                 Exception::MIGRATION_PROVIDER_ERROR,
-                'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.'
+                'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.',
+                previous: $e
             );
+        }
+
+        // Log resource groups skipped during an otherwise successful report.
+        foreach ($appwrite->getErrors() as $error) {
+            Console::warning('Appwrite migration report skipped "' . $error->getResourceGroup() . '" for source "' . $endpoint . '": ' . $error->getMessage() . ' [' . $error->getCode() . ']');
         }
 
         $response

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -8,7 +8,6 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
-use Utopia\Console;
 use Utopia\Database\Document;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
@@ -105,11 +104,6 @@ class Get extends Action
                 'Unable to connect to the migration source. Please verify your credentials and ensure the source is reachable from this server. Check for network restrictions such as firewalls, IP allowlists, or outbound connectivity limits.',
                 previous: $e
             );
-        }
-
-        // Log resource groups skipped during an otherwise successful report.
-        foreach ($appwrite->getErrors() as $error) {
-            Console::warning('Appwrite migration report skipped "' . $error->getResourceGroup() . '" for source "' . $endpoint . '": ' . $error->getMessage() . ' [' . $error->getCode() . ']');
         }
 
         $response

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -86,7 +86,7 @@ class Get extends Action
             // logging outage must not mask the migration error thrown below.
             if ($logger !== null) {
                 $url = \parse_url($endpoint) ?: [];
-                $safeEndpoint = \sprintf('%s://%s%s', $url['scheme'] ?? 'https', $url['host'] ?? '', $url['path'] ?? '');
+                $safeEndpoint = \sprintf('%s://%s%s%s', $url['scheme'] ?? 'https', $url['host'] ?? '', isset($url['port']) ? ':' . $url['port'] : '', $url['path'] ?? '');
 
                 $log->setNamespace('http');
                 $log->setServer(System::getEnv('_APP_LOGGING_SERVICE_IDENTIFIER', \gethostname()));

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -82,8 +82,12 @@ class Get extends Action
                 throw new Exception(Exception::MIGRATION_PROVIDER_ERROR, $e->getMessage(), previous: $e);
             }
 
-            // Report to Sentry (key is never logged).
+            // Report to Sentry. The endpoint is stripped of any embedded credentials/tokens, and a
+            // logging outage must not mask the migration error thrown below.
             if ($logger !== null) {
+                $url = \parse_url($endpoint) ?: [];
+                $safeEndpoint = \sprintf('%s://%s%s', $url['scheme'] ?? 'https', $url['host'] ?? '', $url['path'] ?? '');
+
                 $log->setNamespace('http');
                 $log->setServer(System::getEnv('_APP_LOGGING_SERVICE_IDENTIFIER', \gethostname()));
                 $log->setVersion(System::getEnv('_APP_VERSION', 'UNKNOWN'));
@@ -91,12 +95,16 @@ class Get extends Action
                 $log->setAction('getAppwriteReport');
                 $log->setMessage($e->getMessage());
                 $log->addTag('code', (string) $e->getCode());
-                $log->addExtra('sourceEndpoint', $endpoint);
+                $log->addExtra('sourceEndpoint', $safeEndpoint);
                 $log->addExtra('sourceProjectId', $projectID);
                 $log->addExtra('file', $e->getFile());
                 $log->addExtra('line', (string) $e->getLine());
                 $log->addExtra('trace', $e->getTraceAsString());
-                $logger->addLog($log);
+
+                try {
+                    $logger->addLog($log);
+                } catch (\Throwable) {
+                }
             }
 
             throw new Exception(

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Appwrite/Report/Get.php
@@ -8,7 +8,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
-use Utopia\CLI\Console;
+use Utopia\Console;
 use Utopia\Database\Document;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;


### PR DESCRIPTION
## Problem

`GET /v1/migrations/appwrite/report` caught every failure and rethrew a single generic "unable to connect" error (HTTP 400) regardless of cause, so an invalid key, a missing scope, and an unreachable source were indistinguishable to both the user and support.

## Change

The endpoint now classifies the failure (the migration library raises distinct, intentional errors) and chooses the HTTP status so the platform's standard error logging does the right thing:

- **401 (invalid/expired key)** and **403 (missing scopes)** → surfaced to the user as a 4xx with a clear message; **not** published to Sentry (expected, user-fixable).
- **Any other failure** (unreachable source, 5xx, etc.) → thrown as **502** so the central error handler publishes it reliably (`code >= 500`), giving support the real cause without per-endpoint logging.

No inline logger calls — logging stays centralized in the platform error handler, consistent with every other endpoint.