### PR TITLE
fix(databases): tag document read operations with database resource

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
@@ -43,6 +43,7 @@ class Get extends Action
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
@@ -51,6 +51,7 @@ class XList extends Action
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/documents')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),


### PR DESCRIPTION
## Summary

Document list and document get endpoints did not set the `audits.resource` label that the request lifecycle reads when populating `service` / `resource` / `resourceId` tags on usage event rows.

Without the label the shutdown hook hits its fallback (see `app/controllers/general.php`) and tags every read with `resource='project'`, `resourceId=<projectId>` — even though the metric itself (`databases.operations.reads`) is scoped to a specific database. Write endpoints (Update / Upsert / Create / Delete) already carry the label and therefore tag correctly with `resource='database'`, `resourceId={request.databaseId}`.

## Repro

```
GET /v1/tablesdb/688f787e002c78bd299f/tables/68993e6c003af0fe657f/rows
```

→ `databases.operations.reads` row in the usage events table is tagged `resource='project'`, `resourceId=<projectId>` instead of `resource='database'`, `resourceId='688f787e002c78bd299f'`. A `PATCH` on the same path tags correctly.

## Fix

Add the missing label on the read endpoints so reads match writes:

- `Documents/XList.php` → `database/{request.databaseId}/collection/{request.collectionId}/documents`
- `Documents/Get.php` → `database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}`

The first two slash-separated segments drive `resource` (`'database'`) and `resourceId` (`{request.databaseId}`) in the usage tag — the controller only consumes `parts[0]` and `parts[1]`. The deeper segments are informational for downstream audit log display and don't change tag behavior.

## What this is NOT

This does not enable audit logging on read endpoints. The audit log path is gated on the `audits.event` label, which these read routes do not set.

## Out of scope (follow-ups)

Other read endpoints in the databases module have the same gap (`Collections/Get`, `Collections/XList`, `Databases/Get`, `Databases/XList`, plus the `tablesdb` / `documentsdb` / `vectorsdb` mirror paths). They're parked here because they emit different metrics — happy to extend the scope of this PR or open a follow-up.

## Test plan

- [x] Both files pass `composer lint`
- [ ] After deploy: `GET /v1/databases/.../documents` writes a row to the usage events table with `resource='database'`, `resourceId={databaseId}`
- [ ] After deploy: `GET /v1/databases/.../documents/{documentId}` writes a row with the same `resource='database'`, `resourceId={databaseId}`
- [ ] Audit log entries are unchanged for these routes (label-only, no `audits.event`)