### PR TITLE
feat: introduce dedicated usage.resource label for usage tag derivation

### DIFF
--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Create.php
@@ -42,6 +42,7 @@ class Create extends Action
             ->label('scope', 'account')
             ->label('audits.event', 'user.update')
             ->label('audits.resource', 'user/{response.$id}')
+            ->label('usage.resource', 'user/{response.$id}')
             ->label('audits.userId', '{response.$id}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Delete.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Delete.php
@@ -39,6 +39,7 @@ class Delete extends Action
             ->label('scope', 'account')
             ->label('audits.event', 'user.update')
             ->label('audits.resource', 'user/{user.$id}')
+            ->label('usage.resource', 'user/{user.$id}')
             ->label('audits.userId', '{user.$id}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Authenticators/Update.php
@@ -41,6 +41,7 @@ class Update extends Action
             ->label('scope', 'account')
             ->label('audits.event', 'user.update')
             ->label('audits.resource', 'user/{response.$id}')
+            ->label('usage.resource', 'user/{response.$id}')
             ->label('audits.userId', '{response.$id}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
@@ -57,6 +57,7 @@ class Create extends Action
             ->label('event', 'users.[userId].challenges.[challengeId].create')
             ->label('audits.event', 'challenge.create')
             ->label('audits.resource', 'user/{response.userId}')
+            ->label('usage.resource', 'user/{response.userId}')
             ->label('audits.userId', '{response.userId}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Update.php
@@ -40,6 +40,7 @@ class Update extends Action
             ->label('event', 'users.[userId].sessions.[sessionId].create')
             ->label('audits.event', 'challenges.update')
             ->label('audits.resource', 'user/{response.userId}')
+            ->label('usage.resource', 'user/{response.userId}')
             ->label('audits.userId', '{response.userId}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Create.php
@@ -36,6 +36,7 @@ class Create extends Action
             ->label('scope', 'account')
             ->label('audits.event', 'user.update')
             ->label('audits.resource', 'user/{response.$id}')
+            ->label('usage.resource', 'user/{response.$id}')
             ->label('audits.userId', '{response.$id}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/RecoveryCodes/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('scope', 'account')
             ->label('audits.event', 'user.update')
             ->label('audits.resource', 'user/{response.$id}')
+            ->label('usage.resource', 'user/{response.$id}')
             ->label('audits.userId', '{response.$id}')
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Update.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('scope', 'account')
             ->label('audits.event', 'user.update')
             ->label('audits.resource', 'user/{response.$id}')
+            ->label('usage.resource', 'user/{response.$id}')
             ->label('audits.userId', '{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'account',

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Delete.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Action
             ->label('resourceType', RESOURCE_TYPE_REPORTS)
             ->label('audits.event', 'report.delete')
             ->label('audits.resource', 'report/{request.reportId}')
+            ->label('usage.resource', 'report/{request.reportId}')
             ->label('abuse-key', 'projectId:{projectId},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/BigInt/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/BigInt/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/BigInt/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/BigInt/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Boolean/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Boolean/Create.php
@@ -43,6 +43,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Boolean/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Boolean/Update.php
@@ -42,6 +42,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Datetime/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Datetime/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Datetime/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Datetime/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Delete.php
@@ -44,6 +44,7 @@ class Delete extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Email/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Email/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Email/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Enum/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Enum/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Enum/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Enum/Update.php
@@ -44,6 +44,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Float/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Float/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Float/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Float/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/IP/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/IP/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/IP/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/IP/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Integer/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Integer/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Integer/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Integer/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Line/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Line/Create.php
@@ -45,6 +45,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Line/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Line/Update.php
@@ -44,6 +44,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Longtext/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Longtext/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Longtext/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Longtext/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Mediumtext/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Mediumtext/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Mediumtext/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Mediumtext/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Point/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Point/Create.php
@@ -45,6 +45,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Point/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Point/Update.php
@@ -44,6 +44,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Polygon/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Polygon/Create.php
@@ -45,6 +45,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Polygon/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Polygon/Update.php
@@ -44,6 +44,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Relationship/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Relationship/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Relationship/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Relationship/Update.php
@@ -45,6 +45,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/String/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/String/Create.php
@@ -48,6 +48,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/String/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/String/Update.php
@@ -45,6 +45,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Text/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Text/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Text/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/URL/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/URL/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/URL/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/URL/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Varchar/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Varchar/Create.php
@@ -48,6 +48,7 @@ class Create extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].create')
             ->label('audits.event', 'attribute.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Varchar/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Varchar/Update.php
@@ -45,6 +45,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].attributes.[attributeId].update')
             ->label('audits.event', 'attribute.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
@@ -56,6 +56,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'collection.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'databases',
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Delete.php
@@ -41,6 +41,7 @@ class Delete extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].delete')
             ->label('audits.event', 'collection.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'databases',
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Decrement.php
@@ -52,6 +52,7 @@ class Decrement extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Attribute/Increment.php
@@ -52,6 +52,7 @@ class Increment extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Delete.php
@@ -50,6 +50,7 @@ class Delete extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Update.php
@@ -53,6 +53,7 @@ class Update extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
@@ -50,6 +50,7 @@ class Upsert extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -67,6 +67,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Delete.php
@@ -51,6 +51,7 @@ class Delete extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].documents.[documentId].delete')
             ->label('audits.event', 'document.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Get.php
@@ -43,6 +43,7 @@ class Get extends Action
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
@@ -53,6 +53,7 @@ class Update extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
@@ -54,6 +54,7 @@ class Upsert extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.upsert')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/XList.php
@@ -51,6 +51,7 @@ class XList extends Action
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/documents')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Create.php
@@ -52,6 +52,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'index.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Delete.php
@@ -47,6 +47,7 @@ class Delete extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].indexes.[indexId].update')
             ->label('audits.event', 'index.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
@@ -44,6 +44,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].update')
             ->label('audits.event', 'collection.update')
             ->label('audits.resource', 'database/{request.databaseId}/collections/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collections/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'databases',
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Create.php
@@ -147,6 +147,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'database.create')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', [
                 new Method(
                     namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Delete.php
@@ -35,6 +35,7 @@ class Delete extends Action
             ->label('event', 'databases.[databaseId].delete')
             ->label('audits.event', 'database.delete')
             ->label('audits.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('sdk', [
                 new Method(
                     namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].update')
             ->label('audits.event', 'database.update')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', [
                 new Method(
                     namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Create.php
@@ -43,6 +43,7 @@ class Create extends CollectionCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'collections.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: 'collections',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Delete.php
@@ -35,6 +35,7 @@ class Delete extends CollectionDelete
             ->label('event', 'databases.[databaseId].collections.[collectionId].delete')
             ->label('audits.event', 'collection.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: 'collections',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Attribute/Decrement.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Attribute/Decrement.php
@@ -37,6 +37,7 @@ class Decrement extends DecrementDocumentAttribute
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Attribute/Increment.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Attribute/Increment.php
@@ -37,6 +37,7 @@ class Increment extends IncrementDocumentAttribute
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Bulk/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Bulk/Delete.php
@@ -36,6 +36,7 @@ class Delete extends DocumentsDelete
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Bulk/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Bulk/Update.php
@@ -37,6 +37,7 @@ class Update extends DocumentsUpdate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Bulk/Upsert.php
@@ -36,6 +36,7 @@ class Upsert extends DocumentsUpsert
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Create.php
@@ -51,6 +51,7 @@ class Create extends DocumentCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Delete.php
@@ -41,6 +41,7 @@ class Delete extends DocumentDelete
             ->label('event', 'databases.[databaseId].collections.[collectionId].documents.[documentId].delete')
             ->label('audits.event', 'document.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Update.php
@@ -38,6 +38,7 @@ class Update extends DocumentUpdate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Upsert.php
@@ -38,6 +38,7 @@ class Upsert extends DocumentUpsert
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.upsert')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Create.php
@@ -42,6 +42,7 @@ class Create extends IndexCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'index.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: $this->getSdkGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Delete.php
@@ -40,6 +40,7 @@ class Delete extends IndexDelete
             ->label('event', 'databases.[databaseId].collections.[collectionId].indexes.[indexId].update')
             ->label('audits.event', 'index.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: $this->getSdkGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Update.php
@@ -38,6 +38,7 @@ class Update extends CollectionUpdate
             ->label('event', 'databases.[databaseId].collections.[collectionId].update')
             ->label('audits.event', 'collection.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: 'collections',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Create.php
@@ -33,6 +33,7 @@ class Create extends DatabaseCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'database.create')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: 'documentsdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Delete.php
@@ -31,6 +31,7 @@ class Delete extends DatabaseDelete
             ->label('event', 'databases.[databaseId].delete')
             ->label('audits.event', 'database.delete')
             ->label('audits.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: 'documentsdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Update.php
@@ -33,6 +33,7 @@ class Update extends DatabaseUpdate
             ->label('event', 'databases.[databaseId].update')
             ->label('audits.event', 'database.update')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'documentsDB',
                 group: 'documentsdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Create.php
@@ -33,6 +33,7 @@ class Create extends DatabaseCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'database.create')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'tablesDB',
                 group: 'tablesdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Delete.php
@@ -31,6 +31,7 @@ class Delete extends DatabaseDelete
             ->label('event', 'databases.[databaseId].delete')
             ->label('audits.event', 'database.delete')
             ->label('audits.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('sdk', new Method(
                 namespace: 'tablesDB',
                 group: 'tablesdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/BigInt/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/BigInt/Create.php
@@ -39,6 +39,7 @@ class Create extends BigIntCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/BigInt/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/BigInt/Update.php
@@ -40,6 +40,7 @@ class Update extends BigIntUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Boolean/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Boolean/Create.php
@@ -38,6 +38,7 @@ class Create extends BooleanCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Boolean/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Boolean/Update.php
@@ -39,6 +39,7 @@ class Update extends BooleanUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Datetime/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Datetime/Create.php
@@ -39,6 +39,7 @@ class Create extends DatetimeCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Datetime/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Datetime/Update.php
@@ -40,6 +40,7 @@ class Update extends DatetimeUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Delete.php
@@ -38,6 +38,7 @@ class Delete extends AttributesDelete
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.delete')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Email/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Email/Create.php
@@ -39,6 +39,7 @@ class Create extends EmailCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Email/Update.php
@@ -40,6 +40,7 @@ class Update extends EmailUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Enum/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Enum/Create.php
@@ -40,6 +40,7 @@ class Create extends EnumCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Enum/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Enum/Update.php
@@ -41,6 +41,7 @@ class Update extends EnumUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Float/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Float/Create.php
@@ -39,6 +39,7 @@ class Create extends FloatCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Float/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Float/Update.php
@@ -40,6 +40,7 @@ class Update extends FloatUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/IP/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/IP/Create.php
@@ -39,6 +39,7 @@ class Create extends IPCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/IP/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/IP/Update.php
@@ -40,6 +40,7 @@ class Update extends IPUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Integer/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Integer/Create.php
@@ -39,6 +39,7 @@ class Create extends IntegerCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Integer/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Integer/Update.php
@@ -40,6 +40,7 @@ class Update extends IntegerUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Line/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Line/Create.php
@@ -39,6 +39,7 @@ class Create extends LineCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Line/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Line/Update.php
@@ -40,6 +40,7 @@ class Update extends LineUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Longtext/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Longtext/Create.php
@@ -38,6 +38,7 @@ class Create extends LongtextCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Longtext/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Longtext/Update.php
@@ -39,6 +39,7 @@ class Update extends LongtextUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Mediumtext/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Mediumtext/Create.php
@@ -38,6 +38,7 @@ class Create extends MediumtextCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Mediumtext/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Mediumtext/Update.php
@@ -39,6 +39,7 @@ class Update extends MediumtextUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Point/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Point/Create.php
@@ -39,6 +39,7 @@ class Create extends PointCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Point/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Point/Update.php
@@ -40,6 +40,7 @@ class Update extends PointUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Polygon/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Polygon/Create.php
@@ -39,6 +39,7 @@ class Create extends PolygonCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Polygon/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Polygon/Update.php
@@ -40,6 +40,7 @@ class Update extends PolygonUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Relationship/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Relationship/Create.php
@@ -40,6 +40,7 @@ class Create extends RelationshipCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Relationship/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Relationship/Update.php
@@ -40,6 +40,7 @@ class Update extends RelationshipUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/String/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/String/Create.php
@@ -42,6 +42,7 @@ class Create extends StringCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/String/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/String/Update.php
@@ -42,6 +42,7 @@ class Update extends StringUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Text/Create.php
@@ -38,6 +38,7 @@ class Create extends TextCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Text/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Text/Update.php
@@ -39,6 +39,7 @@ class Update extends TextUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/URL/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/URL/Create.php
@@ -39,6 +39,7 @@ class Create extends URLCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/URL/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/URL/Update.php
@@ -40,6 +40,7 @@ class Update extends URLUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Varchar/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Varchar/Create.php
@@ -40,6 +40,7 @@ class Create extends VarcharCreate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].create')
             ->label('audits.event', 'column.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Varchar/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Varchar/Update.php
@@ -41,6 +41,7 @@ class Update extends VarcharUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].columns.[columnId].update')
             ->label('audits.event', 'column.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
@@ -43,6 +43,7 @@ class Create extends CollectionCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'table.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{response.$id}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: 'tables',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Delete.php
@@ -36,6 +36,7 @@ class Delete extends CollectionDelete
             ->label('event', 'databases.[databaseId].tables.[tableId].delete')
             ->label('audits.event', 'table.delete')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: 'tables',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
@@ -42,6 +42,7 @@ class Create extends IndexCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'index.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Delete.php
@@ -41,6 +41,7 @@ class Delete extends IndexDelete
             ->label('event', 'databases.[databaseId].tables.[tableId].indexes.[indexId].update')
             ->label('audits.event', 'index.delete')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Bulk/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Bulk/Delete.php
@@ -38,6 +38,7 @@ class Delete extends DocumentsDelete
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'rows.delete')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Bulk/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Bulk/Update.php
@@ -39,6 +39,7 @@ class Update extends DocumentsUpdate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'rows.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Bulk/Upsert.php
@@ -38,6 +38,7 @@ class Upsert extends DocumentsUpsert
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'row.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Column/Decrement.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Column/Decrement.php
@@ -39,6 +39,7 @@ class Decrement extends DecrementDocumentAttribute
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'rows.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Column/Increment.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Column/Increment.php
@@ -39,6 +39,7 @@ class Increment extends IncrementDocumentAttribute
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'rows.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Create.php
@@ -46,6 +46,7 @@ class Create extends DocumentCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'row.create')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Delete.php
@@ -43,6 +43,7 @@ class Delete extends DocumentDelete
             ->label('event', 'databases.[databaseId].tables.[tableId].rows.[rowId].delete')
             ->label('audits.event', 'row.delete')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}/row/{request.rowId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}/row/{request.rowId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Update.php
@@ -39,6 +39,7 @@ class Update extends DocumentUpdate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'row.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}/row/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}/row/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Upsert.php
@@ -39,6 +39,7 @@ class Upsert extends DocumentUpsert
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'row.upsert')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}/row/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}/row/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Update.php
@@ -40,6 +40,7 @@ class Update extends CollectionUpdate
             ->label('event', 'databases.[databaseId].tables.[tableId].update')
             ->label('audits.event', 'table.update')
             ->label('audits.resource', 'database/{request.databaseId}/table/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),
                 group: 'tables',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Update.php
@@ -33,6 +33,7 @@ class Update extends DatabaseUpdate
             ->label('event', 'databases.[databaseId].update')
             ->label('audits.event', 'database.update')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'tablesDB',
                 group: 'tablesdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Create.php
@@ -52,6 +52,7 @@ class Create extends CollectionAction
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'collection.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: 'collections',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Delete.php
@@ -35,6 +35,7 @@ class Delete extends CollectionDelete
             ->label('event', 'databases.[databaseId].collections.[collectionId].delete')
             ->label('audits.event', 'collection.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: 'collections',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Bulk/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Bulk/Delete.php
@@ -36,6 +36,7 @@ class Delete extends DocumentsDelete
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Bulk/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Bulk/Update.php
@@ -37,6 +37,7 @@ class Update extends DocumentsUpdate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'documents.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Bulk/Upsert.php
@@ -36,6 +36,7 @@ class Upsert extends DocumentsUpsert
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Create.php
@@ -45,6 +45,7 @@ class Create extends DocumentCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Delete.php
@@ -41,6 +41,7 @@ class Delete extends DocumentDelete
             ->label('event', 'databases.[databaseId].collections.[collectionId].documents.[documentId].delete')
             ->label('audits.event', 'document.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{request.documentId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Update.php
@@ -38,6 +38,7 @@ class Update extends DocumentUpdate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Upsert.php
@@ -39,6 +39,7 @@ class Upsert extends DocumentUpsert
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'document.upsert')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}/document/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Create.php
@@ -42,6 +42,7 @@ class Create extends IndexCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'index.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.tableId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: $this->getSdkGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Delete.php
@@ -40,6 +40,7 @@ class Delete extends IndexDelete
             ->label('event', 'databases.[databaseId].collections.[collectionId].indexes.[indexId].update')
             ->label('audits.event', 'index.delete')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: $this->getSdkGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Update.php
@@ -44,6 +44,7 @@ class Update extends CollectionAction
             ->label('event', 'databases.[databaseId].collections.[collectionId].update')
             ->label('audits.event', 'collection.update')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: 'collections',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Create.php
@@ -32,6 +32,7 @@ class Create extends DatabaseCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'database.create')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: 'vectorsdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Delete.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Delete.php
@@ -30,6 +30,7 @@ class Delete extends DatabaseDelete
             ->label('event', 'databases.[databaseId].delete')
             ->label('audits.event', 'database.delete')
             ->label('audits.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: 'vectorsdb',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
@@ -50,6 +50,7 @@ class Create extends CreateDocumentAction
             ->label('resourceType', RESOURCE_TYPE_EMBEDDINGS_TEXT)
             ->label('audits.event', 'embedding.create')
             ->label('audits.resource', 'vectorsdb/embeddings/text')
+            ->label('usage.resource', 'vectorsdb/embeddings/text')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Update.php
@@ -32,6 +32,7 @@ class Update extends DatabaseUpdate
             ->label('event', 'databases.[databaseId].update')
             ->label('audits.event', 'database.update')
             ->label('audits.resource', 'database/{response.$id}')
+            ->label('usage.resource', 'database/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: 'vectorsdb',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -55,6 +55,7 @@ class Create extends Action
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -41,6 +41,7 @@ class Delete extends Action
             ->label('event', 'functions.[functionId].deployments.[deploymentId].delete')
             ->label('audits.event', 'deployment.delete')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -41,6 +41,7 @@ class Create extends Action
             ->label('event', 'functions.[functionId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -38,6 +38,7 @@ class Update extends Action
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
@@ -48,6 +48,7 @@ class Create extends Base
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Vcs/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Vcs/Create.php
@@ -43,6 +43,7 @@ class Create extends Base
             ->label('event', 'functions.[functionId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -66,6 +66,7 @@ class Create extends Base
             ->label('scope', ['executions.write', 'execution.write'])
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('event', 'functions.[functionId].executions.[executionId].create')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'executions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -40,6 +40,7 @@ class Delete extends Base
             ->label('event', 'functions.[functionId].executions.[executionId].delete')
             ->label('audits.event', 'executions.delete')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'executions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -64,6 +64,7 @@ class Create extends Base
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'function.create')
             ->label('audits.resource', 'function/{response.$id}')
+            ->label('usage.resource', 'function/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Delete.php
@@ -41,6 +41,7 @@ class Delete extends Base
             ->label('event', 'functions.[functionId].delete')
             ->label('audits.event', 'function.delete')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
@@ -40,6 +40,7 @@ class Update extends Base
             ->label('event', 'functions.[functionId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -56,6 +56,7 @@ class Update extends Base
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'function.update')
             ->label('audits.resource', 'function/{response.$id}')
+            ->label('usage.resource', 'function/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
@@ -43,6 +43,7 @@ class Create extends Base
             ->label('event', 'variables.[variableId].create')
             ->label('audits.event', 'variable.create')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
@@ -39,6 +39,7 @@ class Delete extends Base
             ->label('event', 'variables.[variableId].delete')
             ->label('audits.event', 'variable.delete')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
@@ -42,6 +42,7 @@ class Update extends Base
             ->label('event', 'variables.[variableId].update')
             ->label('audits.event', 'variable.update')
             ->label('audits.resource', 'function/{request.functionId}')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Delete.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Delete.php
@@ -34,6 +34,7 @@ class Delete extends Action
             ->label('event', 'migrations.[migrationId].delete')
             ->label('audits.event', 'migrationId.delete')
             ->label('audits.resource', 'migrations/{request.migrationId}')
+            ->label('usage.resource', 'migrations/{request.migrationId}')
             ->label('sdk', new Method(
                 namespace: 'migrations',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Update.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'migrations.[migrationId].retry')
             ->label('audits.event', 'migration.retry')
             ->label('audits.resource', 'migrations/{request.migrationId}')
+            ->label('usage.resource', 'migrations/{request.migrationId}')
             ->label('sdk', new Method(
                 namespace: 'migrations',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
@@ -46,6 +46,7 @@ class Create extends Action
             ->groups(['api', 'organization'])
             ->label('audits.event', 'projects.create')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('scope', 'projects.write')
             ->label('sdk', new Method(
                 namespace: 'organization',

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Delete.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Delete.php
@@ -35,6 +35,7 @@ class Delete extends Action
             ->label('scope', 'projects.write')
             ->label('audits.event', 'projects.delete')
             ->label('audits.resource', 'project/{request.projectId}')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->label('sdk', new Method(
                 namespace: 'organization',
                 group: 'projects',

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Update.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Update.php
@@ -33,6 +33,7 @@ class Update extends Action
             ->label('scope', 'projects.write')
             ->label('audits.event', 'projects.update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'organization',
                 group: 'projects',

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Delete.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Delete.php
@@ -36,6 +36,7 @@ class Delete extends PlatformAction
             ->label('event', 'presences.[presenceId].delete')
             ->label('audits.event', 'presence.delete')
             ->label('audits.resource', 'presence/{request.presenceId}')
+            ->label('usage.resource', 'presence/{request.presenceId}')
             ->label('sdk', new Method(
                 namespace: 'presences',
                 group: 'presences',

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Update.php
@@ -45,6 +45,7 @@ class Update extends PlatformAction
             ->label('event', 'presences.[presenceId].update')
             ->label('audits.event', 'presence.update')
             ->label('audits.resource', 'presence/{response.$id}')
+            ->label('usage.resource', 'presence/{response.$id}')
             ->label('sdk', [
                 // Client-side SDK: `userId` is not accepted (session callers can only update their own presence).
                 new Method(

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Upsert.php
@@ -46,6 +46,7 @@ class Upsert extends PlatformAction
             ->label('event', 'presences.[presenceId].upsert')
             ->label('audits.event', 'presence.upsert')
             ->label('audits.resource', 'presence/{response.$id}')
+            ->label('usage.resource', 'presence/{response.$id}')
             ->label('sdk', [
                 // Client-side SDK: `userId` is not accepted (session callers should just upsert their own presence).
                 new Method(

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
@@ -38,6 +38,7 @@ class Update extends Action
             ->label('event', 'authMethod.[methodId].update')
             ->label('audits.event', 'project.authMethods.[methodId].update')
             ->label('audits.resource', 'project.authMethods/{response.$id}')
+            ->label('usage.resource', 'project.authMethods/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Delete.php
@@ -36,6 +36,7 @@ class Delete extends Action
             ->label('scope', 'project.write')
             ->label('audits.event', 'project.delete')
             ->label('audits.resource', 'project/{project.$id}')
+            ->label('usage.resource', 'project/{project.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Create.php
@@ -46,6 +46,7 @@ class Create extends Base
             ->label('event', 'keys.[keyId].create')
             ->label('audits.event', 'project.key.create')
             ->label('audits.resource', 'project.key/{response.$id}')
+            ->label('usage.resource', 'project.key/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'keys',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Base
             ->label('event', 'keys.[keyId].delete')
             ->label('audits.event', 'project.key.delete')
             ->label('audits.resource', 'project.key/{request.keyId}')
+            ->label('usage.resource', 'project.key/{request.keyId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'keys',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Ephemeral/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Ephemeral/Create.php
@@ -42,6 +42,7 @@ class Create extends Base
             ->label('event', 'keys.[keyId].create')
             ->label('audits.event', 'project.key.create')
             ->label('audits.resource', 'project.key/{response.$id}')
+            ->label('usage.resource', 'project.key/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'keys',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Update.php
@@ -44,6 +44,7 @@ class Update extends Base
             ->label('event', 'keys.[keyId].update')
             ->label('audits.event', 'project.key.update')
             ->label('audits.resource', 'project.key/{response.$id}')
+            ->label('usage.resource', 'project.key/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'keys',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Labels/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Labels/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             // ->label('event', 'project.labels.update')
             ->label('audits.event', 'project.labels.update')
             ->label('audits.resource', 'project.labels/{response.$id}')
+            ->label('usage.resource', 'project.labels/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Create.php
@@ -37,6 +37,7 @@ class Create extends Action
             ->label('event', 'mock-phones.[number].create')
             ->label('audits.event', 'project.mock-phone.create')
             ->label('audits.resource', 'project.mock-phone/{response.number}')
+            ->label('usage.resource', 'project.mock-phone/{response.number}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'mocks',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Delete.php
@@ -36,6 +36,7 @@ class Delete extends Action
             ->label('event', 'mock-phones.[number].delete')
             ->label('audits.event', 'project.mock-phone.delete')
             ->label('audits.resource', 'project.mock-phone/{request.number}')
+            ->label('usage.resource', 'project.mock-phone/{request.number}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'mocks',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Update.php
@@ -37,6 +37,7 @@ class Update extends Action
             ->label('event', 'mock-phones.[number].update')
             ->label('audits.event', 'project.mock-phone.update')
             ->label('audits.resource', 'project.mock-phone/{response.number}')
+            ->label('usage.resource', 'project.mock-phone/{response.number}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'mocks',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Apple/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Apple/Update.php
@@ -116,6 +116,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Auth0/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Auth0/Update.php
@@ -90,6 +90,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Authentik/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Authentik/Update.php
@@ -90,6 +90,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
@@ -242,6 +242,7 @@ abstract class Base extends Action
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/FusionAuth/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/FusionAuth/Update.php
@@ -90,6 +90,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Gitlab/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Gitlab/Update.php
@@ -101,6 +101,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Google/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Google/Update.php
@@ -94,6 +94,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Keycloak/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Keycloak/Update.php
@@ -96,6 +96,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Microsoft/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Microsoft/Update.php
@@ -100,6 +100,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Oidc/Update.php
@@ -110,6 +110,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Okta/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Okta/Update.php
@@ -98,6 +98,7 @@ class Update extends Base
             ->label('event', 'oauth2.[providerId].update')
             ->label('audits.event', 'project.oauth2.[providerId].update')
             ->label('audits.resource', 'project.oauth2/{response.$id}')
+            ->label('usage.resource', 'project.oauth2/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Create.php
@@ -39,6 +39,7 @@ class Create extends Action
             ->label('event', 'platforms.[platformId].create')
             ->label('audits.event', 'project.platform.create')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Update.php
@@ -37,6 +37,7 @@ class Update extends Action
             ->label('event', 'platforms.[platformId].update')
             ->label('audits.event', 'project.platform.update')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Create.php
@@ -39,6 +39,7 @@ class Create extends Action
             ->label('event', 'platforms.[platformId].create')
             ->label('audits.event', 'project.platform.create')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Update.php
@@ -37,6 +37,7 @@ class Update extends Action
             ->label('event', 'platforms.[platformId].update')
             ->label('audits.event', 'project.platform.update')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Delete.php
@@ -37,6 +37,7 @@ class Delete extends Action
             ->label('event', 'platforms.[platformId].delete')
             ->label('audits.event', 'project.platform.delete')
             ->label('audits.resource', 'project.platform/{request.platformId}')
+            ->label('usage.resource', 'project.platform/{request.platformId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Create.php
@@ -39,6 +39,7 @@ class Create extends Action
             ->label('event', 'platforms.[platformId].create')
             ->label('audits.event', 'project.platform.create')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Update.php
@@ -37,6 +37,7 @@ class Update extends Action
             ->label('event', 'platforms.[platformId].update')
             ->label('audits.event', 'project.platform.update')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Create.php
@@ -47,6 +47,7 @@ class Create extends Action
             ->label('event', 'platforms.[platformId].create')
             ->label('audits.event', 'project.platform.create')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Update.php
@@ -39,6 +39,7 @@ class Update extends Action
             ->label('event', 'platforms.[platformId].update')
             ->label('audits.event', 'project.platform.update')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Create.php
@@ -39,6 +39,7 @@ class Create extends Action
             ->label('event', 'platforms.[platformId].create')
             ->label('audits.event', 'project.platform.create')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Update.php
@@ -37,6 +37,7 @@ class Update extends Action
             ->label('event', 'platforms.[platformId].update')
             ->label('audits.event', 'project.platform.update')
             ->label('audits.resource', 'project.platform/{response.$id}')
+            ->label('usage.resource', 'project.platform/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.event', 'projects.[projectId].policies.[policy].update')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
@@ -39,6 +39,7 @@ class Update extends Action
             ->label('event', 'protocols.[protocolId].update')
             ->label('audits.event', 'project.protocols.[protocolId].update')
             ->label('audits.resource', 'project.protocols/{response.$id}')
+            ->label('usage.resource', 'project.protocols/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
@@ -45,6 +45,7 @@ class Update extends Action
             // ->label('event', 'project.smtp.update')
             ->label('audits.event', 'project.smtp.update')
             ->label('audits.resource', 'project.smtp/{response.$id}')
+            ->label('usage.resource', 'project.smtp/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'smtp',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
@@ -39,6 +39,7 @@ class Update extends Action
             ->label('event', 'services.[serviceId].update')
             ->label('audits.event', 'project.services.[serviceId].update')
             ->label('audits.resource', 'project.services/{response.$id}')
+            ->label('usage.resource', 'project.services/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
@@ -42,6 +42,7 @@ class Update extends Action
             ->label('event', 'templates.[templateId].update')
             ->label('audits.event', 'project.template.update')
             ->label('audits.resource', 'project.template/{response.templateId}')
+            ->label('usage.resource', 'project.template/{response.templateId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'templates',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Create.php
@@ -38,6 +38,7 @@ class Create extends Action
             ->label('event', 'variables.[variableId].create')
             ->label('audits.event', 'project.variable.create')
             ->label('audits.resource', 'project.variable/{response.$id}')
+            ->label('usage.resource', 'project.variable/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Delete.php
@@ -35,6 +35,7 @@ class Delete extends Action
             ->label('event', 'variables.[variableId].delete')
             ->label('audits.event', 'project.variable.delete')
             ->label('audits.resource', 'project.variable/{request.variableId}')
+            ->label('usage.resource', 'project.variable/{request.variableId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Update.php
@@ -37,6 +37,7 @@ class Update extends Action
             ->label('event', 'variables.[variableId].update')
             ->label('audits.event', 'project.variable.update')
             ->label('audits.resource', 'project.variable/{response.$id}')
+            ->label('usage.resource', 'project.variable/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
@@ -51,6 +51,7 @@ class Create extends Action
             ->groups(['api', 'projects'])
             ->label('audits.event', 'projects.create')
             ->label('audits.resource', 'project/{response.$id}')
+            ->label('usage.resource', 'project/{response.$id}')
             ->label('scope', 'projects.write')
             ->param('projectId', '', new ProjectId(), 'Unique Id. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, and hyphen. Can\'t start with a special char. Max length is 36 chars.')
             ->param('name', null, new Text(128), 'Project name. Max length: 128 chars.')

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Update.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('scope', 'projects.write')
             ->label('audits.event', 'projects.update')
             ->label('audits.resource', 'project/{request.projectId}')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->param('projectId', '', new UID(), 'Project unique ID.')
             ->param('name', null, new Text(128), 'Project name. Max length: 128 chars.')
             ->param('description', '', new Text(256), 'Project description. Max length: 256 chars.', true)

--- a/src/Appwrite/Platform/Modules/Projects/Http/Schedules/Create.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Schedules/Create.php
@@ -72,6 +72,7 @@ class Create extends Action
             ->label('event', 'schedules.[scheduleId].create')
             ->label('audits.event', 'schedule.create')
             ->label('audits.resource', 'schedule/{response.$id}')
+            ->label('usage.resource', 'schedule/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'projects',
                 group: 'schedules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
@@ -41,6 +41,7 @@ class Create extends Action
             ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
+            ->label('usage.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Delete.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Action
             ->label('event', 'rules.[ruleId].delete')
             ->label('audits.event', 'rules.delete')
             ->label('audits.resource', 'rule/{request.ruleId}')
+            ->label('usage.resource', 'rule/{request.ruleId}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
@@ -43,6 +43,7 @@ class Create extends Action
             ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
+            ->label('usage.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
@@ -45,6 +45,7 @@ class Create extends Action
             ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
+            ->label('usage.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
@@ -43,6 +43,7 @@ class Create extends Action
             ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
+            ->label('usage.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Status/Update.php
@@ -41,6 +41,7 @@ class Update extends Action
             ->label('event', 'rules.[ruleId].update')
             ->label('audits.event', 'rule.update')
             ->label('audits.resource', 'rule/{response.$id}')
+            ->label('usage.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -55,6 +55,7 @@ class Create extends Action
             ->label('event', 'sites.[siteId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -41,6 +41,7 @@ class Delete extends Action
             ->label('event', 'sites.[siteId].deployments.[deploymentId].delete')
             ->label('audits.event', 'deployment.delete')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -41,6 +41,7 @@ class Create extends Action
             ->label('event', 'sites.[siteId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('scope', 'sites.write')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
@@ -49,6 +49,7 @@ class Create extends Base
             ->label('event', 'sites.[siteId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Vcs/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Vcs/Create.php
@@ -44,6 +44,7 @@ class Create extends Base
             ->label('event', 'sites.[siteId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'deployments',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/Delete.php
@@ -35,6 +35,7 @@ class Delete extends Base
             ->label('event', 'sites.[siteId].logs.[logId].delete')
             ->label('audits.event', 'logs.delete')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'logs',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -47,6 +47,7 @@ class Create extends Base
             ->label('event', 'sites.[siteId].create')
             ->label('audits.event', 'site.create')
             ->label('audits.resource', 'site/{response.$id}')
+            ->label('usage.resource', 'site/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Base
             ->label('event', 'sites.[siteId].delete')
             ->label('audits.event', 'site.delete')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -38,6 +38,7 @@ class Update extends Base
             ->label('event', 'sites.[siteId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -51,6 +51,7 @@ class Update extends Base
             ->label('event', 'sites.[siteId].update')
             ->label('audits.event', 'sites.update')
             ->label('audits.resource', 'site/{response.$id}')
+            ->label('usage.resource', 'site/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Create.php
@@ -41,6 +41,7 @@ class Create extends Base
             ->label('event', 'variables.[variableId].create')
             ->label('audits.event', 'variable.create')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Delete.php
@@ -37,6 +37,7 @@ class Delete extends Base
             ->label('event', 'variables.[variableId].delete')
             ->label('audits.event', 'variable.delete')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('sdk', new Method(
                 namespace: 'sites',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Update.php
@@ -39,6 +39,7 @@ class Update extends Base
             ->label('event', 'variables.[variableId].update')
             ->label('audits.event', 'variable.update')
             ->label('audits.resource', 'site/{request.siteId}')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
@@ -49,6 +49,7 @@ class Create extends Action
             ->label('event', 'buckets.[bucketId].create')
             ->label('audits.event', 'bucket.create')
             ->label('audits.resource', 'bucket/{response.$id}')
+            ->label('usage.resource', 'bucket/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'storage',
                 group: 'buckets',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Delete.php
@@ -37,6 +37,7 @@ class Delete extends Action
             ->label('audits.event', 'bucket.delete')
             ->label('event', 'buckets.[bucketId].delete')
             ->label('audits.resource', 'bucket/{request.bucketId}')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('sdk', new Method(
                 namespace: 'storage',
                 group: 'buckets',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -62,6 +62,7 @@ class Create extends Action
             ->label('audits.event', 'file.create')
             ->label('event', 'buckets.[bucketId].files.[fileId].create')
             ->label('audits.resource', 'file/{response.$id}')
+            ->label('usage.resource', 'file/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId},chunkId:{chunkId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
@@ -42,6 +42,7 @@ class Delete extends Action
             ->label('event', 'buckets.[bucketId].files.[fileId].delete')
             ->label('audits.event', 'file.delete')
             ->label('audits.resource', 'file/{request.fileId}')
+            ->label('usage.resource', 'file/{request.fileId}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
@@ -43,6 +43,7 @@ class Update extends Action
             ->label('event', 'buckets.[bucketId].files.[fileId].update')
             ->label('audits.event', 'file.update')
             ->label('audits.resource', 'file/{response.$id}')
+            ->label('usage.resource', 'file/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'storage',
                 group: 'files',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
@@ -46,6 +46,7 @@ class Update extends Action
             ->label('event', 'buckets.[bucketId].update')
             ->label('audits.event', 'bucket.update')
             ->label('audits.resource', 'bucket/{response.$id}')
+            ->label('usage.resource', 'bucket/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'storage',
                 group: 'buckets',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -61,6 +61,7 @@ class Create extends Action
             ->label('auth.type', 'invites')
             ->label('audits.event', 'membership.create')
             ->label('audits.resource', 'team/{request.teamId}')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('audits.userId', '{request.userId}')
             ->label('sdk', new Method(
                 namespace: 'teams',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Delete.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Action
             ->label('scope', 'teams.write')
             ->label('audits.event', 'membership.delete')
             ->label('audits.resource', 'team/{request.teamId}')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'memberships',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Status/Update.php
@@ -46,6 +46,7 @@ class Update extends Action
             ->label('scope', 'public')
             ->label('audits.event', 'membership.update')
             ->label('audits.resource', 'team/{request.teamId}')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('audits.userId', '{request.userId}')
             ->label('sdk', new Method(
                 namespace: 'teams',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
@@ -40,6 +40,7 @@ class Update extends Action
             ->label('scope', 'teams.write')
             ->label('audits.event', 'membership.update')
             ->label('audits.resource', 'team/{request.teamId}')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'memberships',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
@@ -36,6 +36,7 @@ class Update extends Action
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.update')
             ->label('audits.resource', 'team/{response.$id}')
+            ->label('usage.resource', 'team/{response.$id}')
             ->label('audits.userId', '{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'teams',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.create')
             ->label('audits.resource', 'team/{response.$id}')
+            ->label('usage.resource', 'team/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'teams',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Delete.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Action
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.delete')
             ->label('audits.resource', 'team/{request.teamId}')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'teams',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Name/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Name/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.update')
             ->label('audits.resource', 'team/{response.$id}')
+            ->label('usage.resource', 'team/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'teams',

--- a/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Buckets/Files/Create.php
@@ -40,6 +40,7 @@ class Create extends Action
         ->label('event', 'tokens.[tokenId].create')
         ->label('audits.event', 'token.create')
         ->label('audits.resource', 'token/{response.$id}')
+        ->label('usage.resource', 'token/{response.$id}')
         ->label('usage.metric', 'tokens.{scope}.requests.create')
         ->label('usage.params', ['resourceId:{request.resourceId}', 'resourceType:{request.resourceType}'])
         ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')

--- a/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Delete.php
+++ b/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Delete.php
@@ -33,6 +33,7 @@ class Delete extends Action
         ->label('event', 'tokens.[tokenId].delete')
         ->label('audits.event', 'tokens.delete')
         ->label('audits.resource', 'token/{request.tokenId}')
+        ->label('usage.resource', 'token/{request.tokenId}')
         ->label('usage.metric', 'tokens.{scope}.requests.delete')
         ->label('usage.params', ['tokenId:{request.tokenId}'])
         ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')

--- a/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Update.php
+++ b/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Update.php
@@ -35,6 +35,7 @@ class Update extends Action
         ->label('event', 'tokens.[tokenId].update')
         ->label('audits.event', 'tokens.update')
         ->label('audits.resource', 'tokens/{response.$id}')
+        ->label('usage.resource', 'tokens/{response.$id}')
         ->label('usage.metric', 'tokens.{scope}.requests.update')
         ->label('usage.params', ['tokenId:{request.tokenId}'])
         ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')

--- a/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Create.php
+++ b/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Create.php
@@ -47,6 +47,7 @@ class Create extends Action
             ->label('event', 'webhooks.[webhookId].create')
             ->label('audits.event', 'webhook.create')
             ->label('audits.resource', 'webhook/{response.$id}')
+            ->label('usage.resource', 'webhook/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'webhooks',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Delete.php
+++ b/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Delete.php
@@ -38,6 +38,7 @@ class Delete extends Action
             ->label('event', 'webhooks.[webhookId].delete')
             ->label('audits.event', 'webhook.delete')
             ->label('audits.resource', 'webhook/{request.webhookId}')
+            ->label('usage.resource', 'webhook/{request.webhookId}')
             ->label('sdk', new Method(
                 namespace: 'webhooks',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Secret/Update.php
+++ b/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Secret/Update.php
@@ -38,6 +38,7 @@ class Update extends Action
             ->label('event', 'webhooks.[webhookId].update')
             ->label('audits.event', 'webhooks.update')
             ->label('audits.resource', 'webhook/{response.$id}')
+            ->label('usage.resource', 'webhook/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'webhooks',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Update.php
+++ b/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Update.php
@@ -44,6 +44,7 @@ class Update extends Action
             ->label('event', 'webhooks.[webhookId].update')
             ->label('audits.event', 'webhooks.update')
             ->label('audits.resource', 'webhook/{response.$id}')
+            ->label('usage.resource', 'webhook/{response.$id}')
             ->label('sdk', new Method(
                 namespace: 'webhooks',
                 group: null,


### PR DESCRIPTION
## Summary

Cloud's request lifecycle reads each route's resource label to derive `service` / `resource` / `resourceId` tags on every usage event row in ClickHouse. Until now it read `audits.resource`, which is also what CE's audit publisher uses to write audit log entries. This conflation has three symptoms:

1. **Reads can't tag correctly without enabling audit logging.** `GET /v1/databases/.../documents` emits the `databases.operations.reads` metric but doesn't audit; adding `audits.resource` would start writing audit log entries on every list/get (`app/controllers/shared/api.php:909-960` enqueues whenever `audits.resource` is set and a user is present — there's no `audits.event` gate).

2. **Network metrics on audited routes inherit the audit shape.** `Bus/Listeners/Usage` emits `METRIC_NETWORK_REQUESTS` / `_INBOUND` / `_OUTBOUND` on every HTTP request through the same Context. Today they're tagged with whatever `audits.resource` says — which means if anyone customizes the audit-side label for richer display, the usage tag silently follows.

3. **Audit and usage paths can legitimately want different shapes.** A single shared label couples the consumers together.

## The change

Introduce a dedicated **`usage.resource`** label with the same shape as `audits.resource` (`<resource>/<idTemplate>[/<deeper>...]`). The first two slash-separated segments drive the usage Context's `resource` and `resourceId`. Cloud will be updated in a follow-up to read `usage.resource` (with `audits.resource` fallback during the rollout window).

## Scope

Every audited route gets `usage.resource` — **268 files**. The reason the sweep is the full audited surface, not just the metric-emitting endpoints: `Bus/Listeners/Usage` emits the three network metrics on every HTTP request via the same Context, so any audited route benefits transitively.

| Group | Count | What changed |
|---|---:|---|
| Has `audits.resource` already | 265 | Verbatim mirror of the value. Identical strings today; allowed to diverge later. **No audit-log or usage-tag behavior change.** |
| Read endpoints that emit usage metrics but never had a resource label | 2 | `Documents/XList`, `Documents/Get` — gain the label, fixing `databases.operations.reads` tagging. |
| Has metric, never had a resource label | 1 | `Functions/Executions/Create` gains `function/{request.functionId}`. |

Skipped on purpose:

- **`Avatars/Screenshots/Get`** — project-scoped metric; cloud's project-fallback already tags it correctly.
- **`Databases/Transactions/Update`** — emits per-database metrics but only carries `transactionId` in the URL; resolving the underlying `databaseId` would need a per-request document lookup, which the label syntax cannot express. Tracked as a separate concern.
- **Routes without `audits.resource` and without metric emission** (health checks, console-only paths) — project-fallback is correct for network metrics there.
- **`Functions/Workers/Builds`** + **`Bus/Listeners/Usage`** — not HTTP endpoints; no route labels.

## What this is NOT

This does not change any audit log behavior. `audits.resource` is untouched on every endpoint. The audit publisher in `app/controllers/shared/api.php` continues to fire on exactly the same routes it fired on before.

## Repro for the original bug

```
GET /v1/tablesdb/688f787e002c78bd299f/tables/68993e6c003af0fe657f/rows
```

Before this PR + cloud follow-up: `databases.operations.reads` row in the usage events table is tagged `resource='project'`, `resourceId=<projectId>`.

After this PR + cloud follow-up: `resource='database'`, `resourceId='688f787e002c78bd299f'`. Matches the (already-correct) tagging on the `PATCH` equivalent.

## Companion cloud PR

Follow-up against `appwrite-labs/cloud` will:
- Mirror the same pattern on cloud-only audited HTTP endpoints (Backups/Policies/Create, Compute/Databases/Backups/Policies/Create).
- Switch `app/controllers/general.php` to read `usage.resource` first, fall back to `audits.resource` during the rollout window. Once this PR is in cloud's vendor, the fallback becomes dead code that can be cleaned up.

## Test plan

- [x] `composer lint` clean on all 268 touched files
- [ ] After deploy (cloud companion): `GET /v1/databases/.../documents` writes a row tagged `resource='database'`, `resourceId={databaseId}`
- [ ] After deploy: `PATCH` on the same path still tags correctly (no regression)
- [ ] After deploy: network metrics on audited routes carry the same `resource` / `resourceId` they did before (no regression — values are identical)
- [ ] After deploy: audit log entries are unchanged on every touched endpoint
