### PR TITLE
fix: ignore literal 'null' search string in list endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/XList.php
@@ -85,7 +85,7 @@ class XList extends Action
             throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
-        if (!empty($search)) {
+        if (!empty($search) && $search !== 'null') {
             $queries[] = Query::search('search', $search);
         }
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/XList.php
@@ -73,7 +73,7 @@ class XList extends Action
     {
         $queries = Query::parseQueries($queries);
 
-        if (!empty($search)) {
+        if (!empty($search) && $search !== 'null') {
             $queries[] = Query::search('search', $search);
         }
 


### PR DESCRIPTION
## Description

When JavaScript clients serialize 
ull search values via URLSearchParams, the literal string "null" is sent as the search parameter. The existing guard !empty() passes because "null" is a non-empty string, causing Query::search('search', 'null') to search for the literal term � returning zero results.

This is the root cause of the reported issue where relation attribute collection selection shows 0 available collections.

## Changes

- Databases/Http/Collections/XList.php: Added $search !== 'null' guard
- Databases/Http/Databases/XList.php: Added $search !== 'null' guard

## Related Issues
- Fixes #10351
