### PR TITLE
docs(sdk): add missing docstrings for call method in TS SDKs

### DIFF
--- a/public/sdk-console/client.ts
+++ b/public/sdk-console/client.ts
@@ -358,6 +358,15 @@ class Client {
         }
     }
 
+    /**
+     * Call an API endpoint
+     *
+     * @param {string} method
+     * @param {URL} url
+     * @param {Headers} headers
+     * @param {Payload} params
+     * @returns {Promise<any>}
+     */
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}): Promise<any> {
         method = method.toUpperCase();
 

--- a/public/sdk-project/client.ts
+++ b/public/sdk-project/client.ts
@@ -358,6 +358,15 @@ class Client {
         }
     }
 
+    /**
+     * Call an API endpoint
+     *
+     * @param {string} method
+     * @param {URL} url
+     * @param {Headers} headers
+     * @param {Payload} params
+     * @returns {Promise<any>}
+     */
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}): Promise<any> {
         method = method.toUpperCase();
 

--- a/public/sdk-web/client.ts
+++ b/public/sdk-web/client.ts
@@ -358,6 +358,15 @@ class Client {
         }
     }
 
+    /**
+     * Call an API endpoint
+     *
+     * @param {string} method
+     * @param {URL} url
+     * @param {Headers} headers
+     * @param {Payload} params
+     * @returns {Promise<any>}
+     */
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}): Promise<any> {
         method = method.toUpperCase();
 


### PR DESCRIPTION
### What does this PR do?
This PR adds identical JSDoc comment blocks to the `call` method in all three TypeScript SDK client files (`sdk-console`, `sdk-project`, and `sdk-web`). This fills in the previously missing documentation for its parameters (`method`, `url`, `headers`, `params`) and return type (`Promise<any>`).

This improves developer experience by enabling IDE intellisense and inline documentation when consuming the TypeScript SDK clients.

### Test Plan
This is a purely additive documentation change (JSDoc comments only). The function signatures and runtime logic remain completely untouched. It can be verified by compiling the TypeScript project (`npm run build`) and ensuring no syntax errors exist.

### Related PRs and Issues
N/A

### Checklist
- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? *(N/A - purely internal SDK JSDoc change)*
