### PR TITLE
feat: add usage.resource to resource-scoped Get and XList endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Advisor/Http/Insights/Get.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Insights/Get.php
@@ -30,6 +30,7 @@ class Get extends Action
             ->desc('Get insight')
             ->groups(['api', 'advisor'])
             ->label('scope', 'insights.read')
+            ->label('usage.resource', 'report/{request.reportId}')
             ->label('resourceType', RESOURCE_TYPE_INSIGHTS)
             ->label('sdk', new Method(
                 namespace: 'advisor',

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Insights/XList.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Insights/XList.php
@@ -36,6 +36,7 @@ class XList extends Action
             ->desc('List insights')
             ->groups(['api', 'advisor'])
             ->label('scope', 'insights.read')
+            ->label('usage.resource', 'report/{request.reportId}')
             ->label('resourceType', RESOURCE_TYPE_INSIGHTS)
             ->label('sdk', new Method(
                 namespace: 'advisor',

--- a/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Get.php
+++ b/src/Appwrite/Platform/Modules/Advisor/Http/Reports/Get.php
@@ -31,6 +31,7 @@ class Get extends Action
             ->desc('Get report')
             ->groups(['api', 'advisor'])
             ->label('scope', 'reports.read')
+            ->label('usage.resource', 'report/{request.reportId}')
             ->label('resourceType', RESOURCE_TYPE_REPORTS)
             ->label('sdk', new Method(
                 namespace: 'advisor',

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Browsers/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Browsers/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get browser icon')
             ->groups(['api', 'avatars'])
             ->label('scope', 'avatars.read')
+            ->label('usage.resource', 'browser/{request.code}')
             ->label('cache', true)
             ->label('cache.resource', 'avatar/browser')
             ->label('sdk', new Method(

--- a/src/Appwrite/Platform/Modules/Avatars/Http/CreditCards/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/CreditCards/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get credit card icon')
             ->groups(['api', 'avatars'])
             ->label('scope', 'avatars.read')
+            ->label('usage.resource', 'credit-card/{request.code}')
             ->label('cache', true)
             ->label('cache.resource', 'avatar/credit-card')
             ->label('sdk', new Method(

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Flags/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Flags/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get country flag')
             ->groups(['api', 'avatars'])
             ->label('scope', 'avatars.read')
+            ->label('usage.resource', 'flag/{request.code}')
             ->label('cache', true)
             ->label('cache.resource', 'avatar/flag')
             ->label('sdk', new Method(

--- a/src/Appwrite/Platform/Modules/Console/Http/Templates/Email/Get.php
+++ b/src/Appwrite/Platform/Modules/Console/Http/Templates/Email/Get.php
@@ -32,6 +32,7 @@ class Get extends Action
             ->desc('Get email template')
             ->groups(['api'])
             ->label('scope', 'public')
+            ->label('usage.resource', 'email/{request.templateId}')
             ->label('sdk', new Method(
                 namespace: 'console',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Get.php
@@ -45,6 +45,7 @@ class Get extends Action
             ->desc('Get attribute')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/XList.php
@@ -40,6 +40,7 @@ class XList extends Action
             ->desc('List attributes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Logs/XList.php
@@ -45,6 +45,7 @@ class XList extends Action
             ->desc('List document logs')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Get.php
@@ -34,6 +34,7 @@ class Get extends Action
             ->desc('Get collection')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Get.php
@@ -35,6 +35,7 @@ class Get extends Action
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
@@ -41,6 +41,7 @@ class XList extends Action
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Logs/XList.php
@@ -45,6 +45,7 @@ class XList extends Action
             ->desc('List collection logs')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Usage/Get.php
@@ -45,6 +45,7 @@ class Get extends Action
             ->desc('Get collection usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/XList.php
@@ -42,6 +42,7 @@ class XList extends Action
             ->desc('List collections')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Get.php
@@ -28,6 +28,7 @@ class Get extends Action
             ->desc('Get database')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Logs/XList.php
@@ -40,6 +40,7 @@ class XList extends Action
             ->desc('List database logs')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get transaction')
             ->groups(['api', 'database', 'transactions'])
             ->label('scope', 'rows.read')
+            ->label('usage.resource', 'transaction/{request.transactionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Usage/Get.php
@@ -74,6 +74,7 @@ class Get extends DatabasesAction
             ->desc('Get database usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Get.php
@@ -33,6 +33,7 @@ class Get extends DocumentGet
             ->desc('Get document')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/XList.php
@@ -35,6 +35,7 @@ class XList extends DocumentXList
             ->desc('List documents')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Get.php
@@ -31,6 +31,7 @@ class Get extends CollectionGet
             ->desc('Get collection')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Get.php
@@ -32,6 +32,7 @@ class Get extends IndexGet
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/XList.php
@@ -33,6 +33,7 @@ class XList extends IndexXList
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Usage/Get.php
@@ -39,6 +39,7 @@ class Get extends CollectionUsageGet
             ->desc('Get collection usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/XList.php
@@ -34,6 +34,7 @@ class XList extends CollectionXList
             ->desc('List collections')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Get.php
@@ -27,6 +27,7 @@ class Get extends DatabaseGet
             ->desc('Get database')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Logs/XList.php
@@ -30,6 +30,7 @@ class XList extends DatabaseLogs
             ->desc('List database logs')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Transactions/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Transactions/Get.php
@@ -31,6 +31,7 @@ class Get extends TransactionsGet
             ->desc('Get transaction')
             ->groups(['api', 'database', 'transactions'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'transaction/{request.transactionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Usage/Get.php
@@ -34,6 +34,7 @@ class Get extends DatabaseUsageGet
             ->desc('Get DocumentsDB usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Get.php
@@ -27,6 +27,7 @@ class Get extends DatabaseGet
             ->desc('Get database')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Logs/XList.php
@@ -39,6 +39,7 @@ class XList extends Action
             ->desc('List database logs')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Get.php
@@ -43,6 +43,7 @@ class Get extends AttributesGet
             ->desc('Get column')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'columns.read', 'attributes.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/XList.php
@@ -34,6 +34,7 @@ class XList extends AttributesXList
             ->desc('List columns')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'columns.read', 'attributes.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Get.php
@@ -32,6 +32,7 @@ class Get extends CollectionGet
             ->desc('Get table')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Get.php
@@ -33,6 +33,7 @@ class Get extends IndexGet
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'indexes.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/XList.php
@@ -34,6 +34,7 @@ class XList extends IndexXList
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'indexes.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Logs/XList.php
@@ -29,6 +29,7 @@ class XList extends CollectionLogXList
             ->desc('List table logs')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Get.php
@@ -35,6 +35,7 @@ class Get extends DocumentGet
             ->desc('Get row')
             ->groups(['api', 'database'])
             ->label('scope', ['rows.read', 'documents.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Logs/XList.php
@@ -29,6 +29,7 @@ class XList extends DocumentLogXList
             ->desc('List row logs')
             ->groups(['api', 'database'])
             ->label('scope', ['rows.read', 'documents.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/XList.php
@@ -37,6 +37,7 @@ class XList extends DocumentXList
             ->desc('List rows')
             ->groups(['api', 'database'])
             ->label('scope', ['rows.read', 'documents.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Usage/Get.php
@@ -34,6 +34,7 @@ class Get extends CollectionUsageGet
             ->desc('Get table usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', ['tables.read', 'collections.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/XList.php
@@ -35,6 +35,7 @@ class XList extends CollectionXList
             ->desc('List tables')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Transactions/Get.php
@@ -32,6 +32,7 @@ class Get extends TransactionsGet
             ->desc('Get transaction')
             ->groups(['api', 'database', 'transactions'])
             ->label('scope', ['documents.read', 'rows.read'])
+            ->label('usage.resource', 'transaction/{request.transactionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'tablesDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Usage/Get.php
@@ -29,6 +29,7 @@ class Get extends DatabaseUsageGet
             ->desc('Get TablesDB usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', ['tables.read', 'collections.read'])
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Get.php
@@ -33,6 +33,7 @@ class Get extends DocumentGet
             ->desc('Get document')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/XList.php
@@ -35,6 +35,7 @@ class XList extends DocumentXList
             ->desc('List documents')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Get.php
@@ -31,6 +31,7 @@ class Get extends CollectionGet
             ->desc('Get collection')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Get.php
@@ -32,6 +32,7 @@ class Get extends IndexGet
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/XList.php
@@ -33,6 +33,7 @@ class XList extends IndexXList
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Usage/Get.php
@@ -38,6 +38,7 @@ class Get extends CollectionUsageGet
             ->desc('Get collection usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/XList.php
@@ -34,6 +34,7 @@ class XList extends CollectionXList
             ->desc('List collections')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
@@ -50,7 +50,7 @@ class Create extends CreateDocumentAction
             ->label('resourceType', RESOURCE_TYPE_EMBEDDINGS_TEXT)
             ->label('audits.event', 'embedding.create')
             ->label('audits.resource', 'vectorsdb/embeddings/text')
-            ->label('usage.resource', 'vectorsdb/embeddings/text')
+            ->label('usage.resource', 'database/embeddings/text')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId}')
             ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
             ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Get.php
@@ -26,6 +26,7 @@ class Get extends DatabaseGet
             ->desc('Get database')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Logs/XList.php
@@ -29,6 +29,7 @@ class XList extends DatabaseLogs
             ->desc('List database logs')
             ->groups(['api', 'database'])
             ->label('scope', 'databases.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Transactions/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Transactions/Get.php
@@ -31,6 +31,7 @@ class Get extends TransactionsGet
             ->desc('Get transaction')
             ->groups(['api', 'database', 'transactions'])
             ->label('scope', 'documents.read')
+            ->label('usage.resource', 'transaction/{request.transactionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Usage/Get.php
@@ -33,6 +33,7 @@ class Get extends DatabaseUsageGet
             ->desc('Get VectorsDB usage stats')
             ->groups(['api', 'database', 'usage'])
             ->label('scope', 'collections.read')
+            ->label('usage.resource', 'database/{request.databaseId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', [
                 new Method(

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Download/Get.php
@@ -36,6 +36,7 @@ class Get extends Action
             ->groups(['api', 'functions'])
             ->desc('Get deployment download')
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get deployment')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/XList.php
@@ -40,6 +40,7 @@ class XList extends Base
             ->desc('List deployments')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Get.php
@@ -32,6 +32,7 @@ class Get extends Base
             ->desc('Get execution')
             ->groups(['api', 'functions'])
             ->label('scope', ['executions.read', 'execution.read'])
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/XList.php
@@ -40,6 +40,7 @@ class XList extends Base
             ->desc('List executions')
             ->groups(['api', 'functions'])
             ->label('scope', ['executions.read', 'execution.read'])
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Get.php
@@ -30,6 +30,7 @@ class Get extends Base
             ->desc('Get function')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Templates/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Templates/Get.php
@@ -31,6 +31,7 @@ class Get extends Base
             ->desc('Get function template')
             ->groups(['api', 'functions'])
             ->label('scope', 'public')
+            ->label('usage.resource', 'template/{request.templateId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Usage/Get.php
@@ -36,6 +36,7 @@ class Get extends Base
             ->desc('Get function usage')
             ->groups(['api', 'functions', 'usage'])
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('sdk', new Method(
                 namespace: 'functions',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Get.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Get.php
@@ -30,6 +30,7 @@ class Get extends Base
             ->desc('Get variable')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label(
                 'sdk',

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/XList.php
@@ -37,6 +37,7 @@ class XList extends Base
             ->desc('List variables')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.read')
+            ->label('usage.resource', 'function/{request.functionId}')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label(
                 'sdk',

--- a/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Get.php
+++ b/src/Appwrite/Platform/Modules/Migrations/Http/Migrations/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get migration')
             ->groups(['api', 'migrations'])
             ->label('scope', 'migrations.read')
+            ->label('usage.resource', 'migration/{request.migrationId}')
             ->label('sdk', new Method(
                 namespace: 'migrations',
                 group: null,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Get.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Get.php
@@ -30,6 +30,7 @@ class Get extends Action
             ->desc('Get organization project')
             ->groups(['api', 'organization'])
             ->label('scope', 'projects.read')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->label('sdk', new Method(
                 namespace: 'organization',
                 group: 'projects',

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Get.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Get.php
@@ -31,6 +31,7 @@ class Get extends PlatformAction
             ->desc('Get presence')
             ->groups(['api', 'presences'])
             ->label('scope', 'presences.read')
+            ->label('usage.resource', 'presence/{request.presenceId}')
             ->label('sdk', new Method(
                 namespace: 'presences',
                 group: 'presences',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Get.php
@@ -33,6 +33,7 @@ class Get extends Base
             ->desc('Get project key')
             ->groups(['api', 'project'])
             ->label('scope', 'keys.read')
+            ->label('usage.resource', 'key/{request.keyId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'keys',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/MockPhone/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get project mock phone')
             ->groups(['api', 'project'])
             ->label('scope', 'mocks.read')
+            ->label('usage.resource', 'mock-phone/{request.number}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'mocks',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Get.php
@@ -31,6 +31,7 @@ class Get extends Action
             ->desc('Get project OAuth2 provider')
             ->groups(['api', 'project'])
             ->label('scope', 'oauth2.read')
+            ->label('usage.resource', 'oauth2/{request.provider}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'oauth2',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get project platform')
             ->groups(['api', 'project'])
             ->label('scope', 'platforms.read')
+            ->label('usage.resource', 'platform/{request.platformId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'platforms',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/Get.php
@@ -32,6 +32,7 @@ class Get extends Action
             ->desc('Get project policy')
             ->groups(['api', 'project'])
             ->label('scope', ['policies.read', 'project.policies.read'])
+            ->label('usage.resource', 'policy/{request.policyId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'policies',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get project email template')
             ->groups(['api', 'project'])
             ->label('scope', 'templates.read')
+            ->label('usage.resource', 'email/{request.templateId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'templates',

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Get.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Variables/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get project variable')
             ->groups(['api', 'project'])
             ->label('scope', 'project.read')
+            ->label('usage.resource', 'variable/{request.variableId}')
             ->label('sdk', new Method(
                 namespace: 'project',
                 group: 'variables',

--- a/src/Appwrite/Platform/Modules/Projects/Http/DevKeys/Get.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/DevKeys/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get dev key')
             ->groups(['api', 'projects'])
             ->label('scope', 'devKeys.read')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->label('sdk', new Method(
                 namespace: 'projects',
                 group: 'devKeys',

--- a/src/Appwrite/Platform/Modules/Projects/Http/DevKeys/XList.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/DevKeys/XList.php
@@ -33,6 +33,7 @@ class XList extends Action
             ->desc('List dev keys')
             ->groups(['api', 'projects'])
             ->label('scope', 'devKeys.read')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->label('sdk', new Method(
                 namespace: 'projects',
                 group: 'devKeys',

--- a/src/Appwrite/Platform/Modules/Projects/Http/Schedules/Get.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Schedules/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get schedule')
             ->groups(['api', 'projects'])
             ->label('scope', 'schedules.read')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->label('sdk', new Method(
                 namespace: 'projects',
                 group: 'schedules',

--- a/src/Appwrite/Platform/Modules/Projects/Http/Schedules/XList.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Schedules/XList.php
@@ -36,6 +36,7 @@ class XList extends Action
             ->desc('List schedules')
             ->groups(['api', 'projects'])
             ->label('scope', 'schedules.read')
+            ->label('usage.resource', 'project/{request.projectId}')
             ->label('sdk', new Method(
                 namespace: 'projects',
                 group: 'schedules',

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Get.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get rule')
             ->groups(['api', 'proxy'])
             ->label('scope', 'rules.read')
+            ->label('usage.resource', 'rule/{request.ruleId}')
             ->label('sdk', new Method(
                 namespace: 'proxy',
                 group: 'rules',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Download/Get.php
@@ -35,6 +35,7 @@ class Get extends Action
             ->desc('Get deployment download')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get deployment')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/XList.php
@@ -40,6 +40,7 @@ class XList extends Base
             ->desc('List deployments')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/Get.php
@@ -30,6 +30,7 @@ class Get extends Base
             ->desc('Get log')
             ->groups(['api', 'sites'])
             ->label('scope', 'log.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/XList.php
@@ -39,6 +39,7 @@ class XList extends Base
             ->desc('List logs')
             ->groups(['api', 'sites'])
             ->label('scope', 'log.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Get.php
@@ -30,6 +30,7 @@ class Get extends Base
             ->desc('Get site')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Templates/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Templates/Get.php
@@ -31,6 +31,7 @@ class Get extends Base
             ->desc('Get site template')
             ->groups(['api'])
             ->label('scope', 'public')
+            ->label('usage.resource', 'template/{request.templateId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Usage/Get.php
@@ -36,6 +36,7 @@ class Get extends Base
             ->desc('Get site usage')
             ->groups(['api', 'sites', 'usage'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label('sdk', new Method(
                 namespace: 'sites',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Get.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Get.php
@@ -30,6 +30,7 @@ class Get extends Base
             ->desc('Get variable')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label(
                 'sdk',

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/XList.php
@@ -37,6 +37,7 @@ class XList extends Base
             ->desc('List variables')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.read')
+            ->label('usage.resource', 'site/{request.siteId}')
             ->label('resourceType', RESOURCE_TYPE_SITES)
             ->label(
                 'sdk',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Download/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Download/Get.php
@@ -43,6 +43,7 @@ class Get extends Action
             ->desc('Get file for download')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('sdk', new Method(
                 namespace: 'storage',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Get.php
@@ -32,6 +32,7 @@ class Get extends Action
             ->desc('Get file')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('sdk', new Method(
                 namespace: 'storage',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -53,6 +53,7 @@ class Get extends Action
             ->desc('Get file preview')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('cache', true)
             ->label('cache.resourceType', 'bucket/{request.bucketId}')

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Push/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Push/Get.php
@@ -40,6 +40,7 @@ class Get extends Action
             ->desc('Get file for push notification')
             ->groups(['api', 'storage'])
             ->label('scope', 'public')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->param('bucketId', '', new UID(), 'Storage bucket unique ID. You can create a new storage bucket using the Storage service [server integration](https://appwrite.io/docs/server/storage#createBucket).')
             ->param('fileId', '', new UID(), 'File ID.')

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/View/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/View/Get.php
@@ -44,6 +44,7 @@ class Get extends Action
             ->desc('Get file for view')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('sdk', new Method(
                 namespace: 'storage',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/XList.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/XList.php
@@ -41,6 +41,7 @@ class XList extends Action
             ->desc('List files')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('sdk', new Method(
                 namespace: 'storage',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Get.php
@@ -32,6 +32,7 @@ class Get extends Action
             ->desc('Get bucket')
             ->groups(['api', 'storage'])
             ->label('scope', 'buckets.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('sdk', new Method(
                 namespace: 'storage',

--- a/src/Appwrite/Platform/Modules/Storage/Http/Usage/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Usage/Get.php
@@ -35,6 +35,7 @@ class Get extends Action
             ->desc('Get bucket usage stats')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('sdk', new Method(
                 namespace: 'storage',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Logs/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Logs/XList.php
@@ -40,6 +40,7 @@ class XList extends Action
             ->desc('List team logs')
             ->groups(['api', 'teams'])
             ->label('scope', 'teams.read')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'logs',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get team membership')
             ->groups(['api', 'teams'])
             ->label('scope', 'teams.read')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'memberships',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/XList.php
@@ -40,6 +40,7 @@ class XList extends Action
             ->desc('List team memberships')
             ->groups(['api', 'teams'])
             ->label('scope', 'teams.read')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'memberships',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Get.php
@@ -31,6 +31,7 @@ class Get extends Action
             ->desc('Get team preferences')
             ->groups(['api', 'teams'])
             ->label('scope', 'teams.read')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'teams',

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Get.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
             ->desc('Get team')
             ->groups(['api', 'teams'])
             ->label('scope', 'teams.read')
+            ->label('usage.resource', 'team/{request.teamId}')
             ->label('sdk', new Method(
                 namespace: 'teams',
                 group: 'teams',

--- a/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Buckets/Files/XList.php
+++ b/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Buckets/Files/XList.php
@@ -36,6 +36,7 @@ class XList extends Action
             ->desc('List tokens')
             ->groups(['api', 'tokens'])
             ->label('scope', 'tokens.read')
+            ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('usage.metric', 'tokens.requests.read')
             ->label('sdk', new Method(
                 namespace: 'tokens',

--- a/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Get.php
+++ b/src/Appwrite/Platform/Modules/Tokens/Http/Tokens/Get.php
@@ -29,6 +29,7 @@ class Get extends Action
         ->desc('Get token')
         ->groups(['api', 'tokens'])
         ->label('scope', 'tokens.read')
+        ->label('usage.resource', 'token/{request.tokenId}')
         ->label('usage.metric', 'tokens.{scope}.requests.read')
         ->label('usage.params', ['tokenId:{request.tokenId}'])
         ->label('sdk', new Method(

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Get.php
@@ -30,6 +30,7 @@ class Get extends Action
             ->desc('Get installation')
             ->groups(['api', 'vcs'])
             ->label('scope', 'vcs.read')
+            ->label('usage.resource', 'installation/{request.installationId}')
             ->label('resourceType', RESOURCE_TYPE_VCS)
             ->label('sdk', new Method(
                 namespace: 'vcs',

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Branches/XList.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Branches/XList.php
@@ -36,6 +36,7 @@ class XList extends Action
             ->desc('List repository branches')
             ->groups(['api', 'vcs'])
             ->label('scope', 'vcs.read')
+            ->label('usage.resource', 'installation/{request.installationId}')
             ->label('resourceType', RESOURCE_TYPE_VCS)
             ->label('sdk', new Method(
                 namespace: 'vcs',

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Contents/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Contents/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get files and directories of a VCS repository')
             ->groups(['api', 'vcs'])
             ->label('scope', 'vcs.read')
+            ->label('usage.resource', 'installation/{request.installationId}')
             ->label('resourceType', RESOURCE_TYPE_VCS)
             ->label('sdk', new Method(
                 namespace: 'vcs',

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get repository')
             ->groups(['api', 'vcs'])
             ->label('scope', 'vcs.read')
+            ->label('usage.resource', 'installation/{request.installationId}')
             ->label('resourceType', RESOURCE_TYPE_VCS)
             ->label('sdk', new Method(
                 namespace: 'vcs',

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/XList.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/XList.php
@@ -77,6 +77,7 @@ class XList extends Action
             ->desc('List repositories')
             ->groups(['api', 'vcs'])
             ->label('scope', 'vcs.read')
+            ->label('usage.resource', 'installation/{request.installationId}')
             ->label('resourceType', RESOURCE_TYPE_VCS)
             ->label('sdk', new Method(
                 namespace: 'vcs',

--- a/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Get.php
+++ b/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Get.php
@@ -33,6 +33,7 @@ class Get extends Action
             ->desc('Get webhook')
             ->groups(['api', 'webhooks'])
             ->label('scope', 'webhooks.read')
+            ->label('usage.resource', 'webhook/{request.webhookId}')
             ->label('sdk', new Method(
                 namespace: 'webhooks',
                 group: null,


### PR DESCRIPTION
## Summary

Pairs with #12663 (which introduced `usage.resource` and applied it to audited write endpoints + the two reads that emit metrics directly). This PR fills the remaining gap: `Bus/Listeners/Usage` emits `METRIC_NETWORK_REQUESTS` / `_INBOUND` / `_OUTBOUND` on **every** HTTP request through the route's Context, so read endpoints without `usage.resource` have their network metrics fall back to `resource='project'` / `resourceId=<projectId>` — even when the URL targets a specific database, function, bucket, etc.

## Derivation rule

For every `Get.php` / `XList.php` with a path param that doesn't already carry `audits.resource` or `usage.resource`: take the first `:param`, look at the segment immediately before it, singularize, and use the param as resourceId.

| URL | Generated `usage.resource` |
|---|---|
| `/v1/databases/:databaseId/...` | `database/{request.databaseId}` |
| `/v1/storage/buckets/:bucketId/files/...` | `bucket/{request.bucketId}` |
| `/v1/functions/:functionId/executions/...` | `function/{request.functionId}` |
| `/v1/teams/:teamId/memberships/...` | `team/{request.teamId}` |

## Manual normalizations

Two cases where the derivation pulled the wrong stem:

- **`/v1/tablesdb/:databaseId/...`, `/v1/vectorsdb/:databaseId/...`, `/v1/documentsdb/:databaseId/...`** → `database/{request.databaseId}` (not `tablesdb`/`vectorsdb`/`documentsdb`), matching the resource shape on the existing write endpoints (their `usage.resource` is `database/{response.$id}`).
- **`/v1/storage/:bucketId/usage`** → `bucket/{request.bucketId}` (not `storage`), same consistency reason.

## Skipped on purpose

- Routes that already carry `audits.resource` or `usage.resource` — untouched.
- **`Health/Http/Queue/...`** — internal ops/probe surface, no customer-facing resource shape; project-fallback is fine.
- Routes with no path param (project-scoped XLists like `/v1/databases`, `/v1/storage/buckets`) — already correctly tagged via project-fallback.

## What this is NOT

This does not change any audit log behavior. `audits.resource` is untouched on every endpoint.

## Test plan

- [x] `composer format` clean on all 114 touched files
- [ ] After deploy + cloud vendor bump: `GET /v1/databases/.../documents/X` writes a `network.requests` row tagged `resource='database'`, `resourceId={databaseId}` (was `'project'` / projectId)
- [ ] After deploy: project-scoped GETs like `/v1/databases` still tag as `project` via fallback (no regression)
- [ ] After deploy: audit log entries are unchanged on every touched endpoint