### PR TITLE
feat(messaging): deliver email messages to raw email addresses

### DIFF
--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -3390,6 +3390,7 @@ Http::post('/v1/messaging/messages/email')
     ->param('topics', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'List of Targets IDs.', true, ['dbForProject'])
+    ->param('emails', [], new ArrayList(new Email()), 'List of email addresses to send the message to. Use this to deliver to recipients that are not backed by an Appwrite user, target, or topic.', true)
     ->param('cc', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Array of target IDs to be added as CC.', true, ['dbForProject'])
     ->param('bcc', [], fn (Database $dbForProject) => new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength())), 'Array of target IDs to be added as BCC.', true, ['dbForProject'])
     ->param('attachments', [], new ArrayList(new CompoundUID()), 'Array of compound ID strings of bucket IDs and file IDs to be attached to the email. They should be formatted as <BUCKET_ID>:<FILE_ID>.', true)
@@ -3402,7 +3403,7 @@ Http::post('/v1/messaging/messages/email')
     ->inject('project')
     ->inject('publisherForMessaging')
     ->inject('response')
-    ->action(function (string $messageId, string $subject, string $content, ?array $topics, ?array $users, ?array $targets, ?array $cc, ?array $bcc, ?array $attachments, bool $draft, bool $html, ?string $scheduledAt, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response) {
+    ->action(function (string $messageId, string $subject, string $content, ?array $topics, ?array $users, ?array $targets, ?array $emails, ?array $cc, ?array $bcc, ?array $attachments, bool $draft, bool $html, ?string $scheduledAt, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response) {
         $messageId = $messageId == 'unique()'
             ? ID::unique()
             : $messageId;
@@ -3415,7 +3416,7 @@ Http::post('/v1/messaging/messages/email')
                 : MessageStatus::SCHEDULED;
         }
 
-        if ($status !== MessageStatus::DRAFT && \count($topics) === 0 && \count($users) === 0 && \count($targets) === 0) {
+        if ($status !== MessageStatus::DRAFT && \count($topics) === 0 && \count($users) === 0 && \count($targets) === 0 && \count($emails) === 0) {
             throw new Exception(Exception::MESSAGE_MISSING_TARGET);
         }
 
@@ -3476,6 +3477,7 @@ Http::post('/v1/messaging/messages/email')
                 'cc' => $cc,
                 'bcc' => $bcc,
                 'attachments' => $attachments,
+                'emails' => $emails,
             ],
             'status' => $status,
         ]);
@@ -4190,6 +4192,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
     ->param('topics', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Topic IDs.', true, ['dbForProject'])
     ->param('users', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of User IDs.', true, ['dbForProject'])
     ->param('targets', null, fn (Database $dbForProject) => new Nullable(new ArrayList(new UID($dbForProject->getAdapter()->getMaxUIDLength()))), 'List of Targets IDs.', true, ['dbForProject'])
+    ->param('emails', null, new Nullable(new ArrayList(new Email())), 'List of email addresses to send the message to. Use this to deliver to recipients that are not backed by an Appwrite user, target, or topic.', true)
     ->param('subject', null, new Nullable(new Text(998)), 'Email Subject.', true)
     ->param('content', null, new Nullable(new Text(64230)), 'Email Content.', true)
     ->param('draft', null, new Nullable(new Boolean()), 'Is message a draft', true)
@@ -4204,7 +4207,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
     ->inject('project')
     ->inject('publisherForMessaging')
     ->inject('response')
-    ->action(function (string $messageId, ?array $topics, ?array $users, ?array $targets, ?string $subject, ?string $content, ?bool $draft, ?bool $html, ?array $cc, ?array $bcc, ?string $scheduledAt, ?array $attachments, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response) {
+    ->action(function (string $messageId, ?array $topics, ?array $users, ?array $targets, ?array $emails, ?string $subject, ?string $content, ?bool $draft, ?bool $html, ?array $cc, ?array $bcc, ?string $scheduledAt, ?array $attachments, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response) {
         $message = $dbForProject->getDocument('messages', $messageId);
 
         if ($message->isEmpty()) {
@@ -4228,6 +4231,7 @@ Http::patch('/v1/messaging/messages/email/:messageId')
             && \count($topics ?? $message->getAttribute('topics', [])) === 0
             && \count($users ?? $message->getAttribute('users', [])) === 0
             && \count($targets ?? $message->getAttribute('targets', [])) === 0
+            && \count($emails ?? $message->getAttribute('data', [])['emails'] ?? []) === 0
         ) {
             throw new Exception(Exception::MESSAGE_MISSING_TARGET);
         }
@@ -4349,6 +4353,10 @@ Http::patch('/v1/messaging/messages/email/:messageId')
 
         if (!\is_null($bcc)) {
             $data['bcc'] = $bcc;
+        }
+
+        if (!\is_null($emails)) {
+            $data['emails'] = $emails;
         }
 
         $message->setAttribute('data', $data);

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -466,8 +466,9 @@ class Messaging extends Action
 
         if (\count($emails) > 0) {
             // Raw emails are already delivery identifiers, so they bypass the targets/subscribers lookups
-            // entirely and route straight to the default provider in bounded pages.
-            foreach (\array_chunk($emails, MESSAGE_RECIPIENTS_PAGE_SIZE) as $chunk) {
+            // entirely and route straight to the default provider in bounded pages. Deduplicate up front so a
+            // repeated address spanning two chunks is not delivered to more than once.
+            foreach (\array_chunk(\array_values(\array_unique($emails)), MESSAGE_RECIPIENTS_PAGE_SIZE) as $chunk) {
                 $identifiers = [];
 
                 foreach ($chunk as $email) {

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -150,6 +150,7 @@ class Messaging extends Action
         $topicIds = $message->getAttribute('topics', []);
         $targetIds = $message->getAttribute('targets', []);
         $userIds = $message->getAttribute('users', []);
+        $emails = $message->getAttribute('data', [])['emails'] ?? [];
         $providerType = $message->getAttribute('providerType');
 
         Span::add('message.provider_type', $providerType);
@@ -186,7 +187,7 @@ class Messaging extends Action
         $deliveryErrors = [];
         $hasRecipients = false;
 
-        foreach ($this->streamRecipients($dbForProject, $topicIds, $userIds, $targetIds, $providerType, $default) as $page) {
+        foreach ($this->streamRecipients($dbForProject, $topicIds, $userIds, $targetIds, $emails, $providerType, $default) as $page) {
             /**
              * @var array<callable> $tasks
              */
@@ -337,6 +338,7 @@ class Messaging extends Action
      * @param array<string> $topicIds
      * @param array<string> $userIds
      * @param array<string> $targetIds
+     * @param array<string> $emails Raw email addresses not backed by an Appwrite user, target, or topic.
      * @return \Generator<array<string, array<string, null>>>
      * @throws \Exception
      */
@@ -345,6 +347,7 @@ class Messaging extends Action
         array $topicIds,
         array $userIds,
         array $targetIds,
+        array $emails,
         string $providerType,
         Document $default
     ): \Generator {
@@ -459,6 +462,20 @@ class Messaging extends Action
 
                 yield $this->groupTargetsByProvider($targets, $default);
             } while ($count === MESSAGE_RECIPIENTS_PAGE_SIZE);
+        }
+
+        if (\count($emails) > 0) {
+            // Raw emails are already delivery identifiers, so they bypass the targets/subscribers lookups
+            // entirely and route straight to the default provider in bounded pages.
+            foreach (\array_chunk($emails, MESSAGE_RECIPIENTS_PAGE_SIZE) as $chunk) {
+                $identifiers = [];
+
+                foreach ($chunk as $email) {
+                    $identifiers[$default->getId()][$email] = null;
+                }
+
+                yield $identifiers;
+            }
         }
     }
 

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -1802,6 +1802,125 @@ trait MessagingBase
         $this->assertEquals(MessageStatus::DRAFT, $message['status']);
     }
 
+    public function testCreateEmailToRawEmails(): void
+    {
+        $emails = [uniqid() . '@example.com', uniqid() . '@example.com'];
+
+        // Raw emails alone (no topics/users/targets) must satisfy the recipient requirement.
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'emails' => $emails,
+            'subject' => 'New blog post',
+            'content' => 'Check out the new blog post at http://localhost',
+            'draft' => true,
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $message = $response['body'];
+        $this->assertEquals(MessageStatus::DRAFT, $message['status']);
+        $this->assertEquals($emails, $message['data']['emails']);
+
+        // A non-draft message addressed only to raw emails is accepted for processing.
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'emails' => $emails,
+            'subject' => 'New blog post',
+            'content' => 'Check out the new blog post at http://localhost',
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals($emails, $response['body']['data']['emails']);
+
+        // Malformed email addresses are rejected before the message is created.
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'emails' => ['not-an-email'],
+            'subject' => 'New blog post',
+            'content' => 'Check out the new blog post at http://localhost',
+        ]);
+
+        $this->assertEquals(400, $response['headers']['status-code']);
+    }
+
+    public function testSendEmailToRawEmails(): void
+    {
+        if (empty(System::getEnv('_APP_MESSAGE_EMAIL_TEST_DSN'))) {
+            $this->markTestSkipped('Email DSN not provided');
+        }
+
+        $emailDSN = new DSN(System::getEnv('_APP_MESSAGE_EMAIL_TEST_DSN'));
+        $to = $emailDSN->getParam('to');
+        $fromName = $emailDSN->getParam('fromName');
+        $fromEmail = $emailDSN->getParam('fromEmail');
+        $apiKey = $emailDSN->getPassword();
+
+        if (empty($to) || empty($apiKey)) {
+            $this->markTestSkipped('Email provider not configured');
+        }
+
+        $provider = $this->client->call(Client::METHOD_POST, '/messaging/providers/sendgrid', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'providerId' => ID::unique(),
+            'name' => 'Sendgrid-provider',
+            'apiKey' => $apiKey,
+            'fromName' => $fromName,
+            'fromEmail' => $fromEmail,
+            'enabled' => true,
+        ]);
+
+        $this->assertEquals(201, $provider['headers']['status-code']);
+
+        // Deliver straight to a raw email address with no backing user, target, or topic.
+        $email = $this->client->call(Client::METHOD_POST, '/messaging/messages/email', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'emails' => [$to],
+            'subject' => 'New blog post',
+            'content' => 'Check out the new blog post at http://localhost',
+        ]);
+
+        $this->assertEquals(201, $email['headers']['status-code']);
+
+        $emailMessageId = $email['body']['$id'];
+        $this->assertEventually(function () use ($emailMessageId) {
+            $response = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-key' => $this->getProject()['apiKey'],
+            ]);
+            $this->assertContains($response['body']['status'], ['sent', 'failed']);
+        }, 30000, 500);
+
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $emailMessageId, [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]);
+
+        $this->assertEquals(200, $message['headers']['status-code']);
+        $this->assertEquals(1, $message['body']['deliveredTotal']);
+        $this->assertEquals(0, \count($message['body']['deliveryErrors']));
+    }
+
     public function testCreateDraftPushWithImage(): void
     {
         // Create User 1

--- a/tests/unit/Messaging/MessagingFanoutTest.php
+++ b/tests/unit/Messaging/MessagingFanoutTest.php
@@ -430,6 +430,33 @@ final class MessagingFanoutTest extends TestCase
         );
     }
 
+    public function testStreamDeduplicatesRawEmailsAcrossPages(): void
+    {
+        // A duplicate address at the start and end of a list longer than one page would land in different
+        // array_chunk pages; the per-page key dedup cannot collapse it, so it must be deduplicated up front
+        // or it would be delivered to twice.
+        $emails = [];
+        for ($i = 1; $i <= MESSAGE_RECIPIENTS_PAGE_SIZE; $i++) {
+            $emails[] = "raw{$i}@example.com";
+        }
+        $emails[] = 'raw1@example.com';
+
+        $database = new RecordingDatabase();
+        $pages = $this->collectPages($database, emails: $emails);
+
+        $providerId = $this->provider()->getId();
+        $deliveries = 0;
+        foreach ($pages as $page) {
+            $deliveries += \count($page[$providerId] ?? []);
+        }
+
+        $this->assertSame(
+            MESSAGE_RECIPIENTS_PAGE_SIZE,
+            $deliveries,
+            'A duplicate raw email spanning two pages must be delivered to exactly once'
+        );
+    }
+
     public function testStreamCombinesRawEmailsWithRegisteredRecipients(): void
     {
         // A direct target and a raw email together: both resolve, the target via the database and the raw email

--- a/tests/unit/Messaging/MessagingFanoutTest.php
+++ b/tests/unit/Messaging/MessagingFanoutTest.php
@@ -379,6 +379,73 @@ final class MessagingFanoutTest extends TestCase
         $this->assertCount(2, $identifiers);
     }
 
+    public function testStreamResolvesRawEmailsWithoutDatabaseLookups(): void
+    {
+        // Raw emails are not backed by any user/target/topic, so the stream must not touch the database at all.
+        $database = new RecordingDatabase();
+        $emails = ['raw1@example.com', 'raw2@example.com', 'raw3@example.com'];
+
+        $pages = $this->collectPages($database, emails: $emails);
+
+        $this->assertSame([], $database->findCalls, 'Raw emails must never trigger a database read');
+        $this->assertCount(1, $pages, 'A small raw-email list fits in a single page');
+
+        // Every raw email routes to the default provider as a ready-to-send identifier.
+        $providerId = $this->provider()->getId();
+        $this->assertSame([$providerId], \array_keys($pages[0]));
+        $this->assertSame($emails, \array_keys($pages[0][$providerId]));
+    }
+
+    public function testStreamPaginatesRawEmails(): void
+    {
+        // More raw emails than a single page so the chunking is exercised.
+        $count = MESSAGE_RECIPIENTS_PAGE_SIZE * 2 + 7;
+        $emails = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $emails[] = "raw{$i}@example.com";
+        }
+
+        $database = new RecordingDatabase();
+        $identifiers = $this->collectStream($database, emails: $emails);
+
+        $this->assertSame([], $database->findCalls, 'Raw emails must never trigger a database read');
+        $this->assertCount($count, $identifiers);
+        for ($i = 1; $i <= $count; $i++) {
+            $this->assertArrayHasKey("raw{$i}@example.com", $identifiers);
+        }
+    }
+
+    public function testStreamDeduplicatesRawEmailsWithinPage(): void
+    {
+        $database = new RecordingDatabase();
+        $emails = ['dup@example.com', 'dup@example.com', 'unique@example.com'];
+
+        $pages = $this->collectPages($database, emails: $emails);
+
+        $providerId = $this->provider()->getId();
+        $this->assertSame(
+            ['dup@example.com', 'unique@example.com'],
+            \array_keys($pages[0][$providerId]),
+            'Duplicate raw emails within a page must collapse to one'
+        );
+    }
+
+    public function testStreamCombinesRawEmailsWithRegisteredRecipients(): void
+    {
+        // A direct target and a raw email together: both resolve, the target via the database and the raw email
+        // straight through, so a message can mix Appwrite-backed and pure-email recipients.
+        $directTargets = [
+            new Document(['$id' => 'dtarget1', '$sequence' => '20', 'providerId' => null, 'identifier' => 'registered@example.com', 'providerType' => MESSAGE_TYPE_EMAIL]),
+        ];
+        $database = new RecordingDatabase([], [], [], $directTargets);
+
+        $identifiers = $this->collectStream($database, targetIds: ['target-b'], emails: ['raw@example.com']);
+
+        $this->assertArrayHasKey('registered@example.com', $identifiers);
+        $this->assertArrayHasKey('raw@example.com', $identifiers);
+        $this->assertCount(2, $identifiers);
+    }
+
     /**
      * Build a topic-backed dataset: $count subscribers, each pointing at one email target. A single identifier
      * is duplicated so per-page dedup is exercised when the dataset fits in one page.
@@ -423,11 +490,12 @@ final class MessagingFanoutTest extends TestCase
         RecordingDatabase $database,
         array $topicIds = [],
         array $userIds = [],
-        array $targetIds = []
+        array $targetIds = [],
+        array $emails = []
     ): array {
         $identifiers = [];
 
-        foreach ($this->collectPages($database, $topicIds, $userIds, $targetIds) as $page) {
+        foreach ($this->collectPages($database, $topicIds, $userIds, $targetIds, $emails) as $page) {
             foreach ($page as $perProvider) {
                 foreach ($perProvider as $identifier => $_) {
                     $identifiers[$identifier] = null;
@@ -442,13 +510,15 @@ final class MessagingFanoutTest extends TestCase
      * @param array<string> $topicIds
      * @param array<string> $userIds
      * @param array<string> $targetIds
+     * @param array<string> $emails
      * @return array<array<string, array<string, null>>>
      */
     private function collectPages(
         RecordingDatabase $database,
         array $topicIds = [],
         array $userIds = [],
-        array $targetIds = []
+        array $targetIds = [],
+        array $emails = []
     ): array {
         $method = new \ReflectionMethod(Messaging::class, 'streamRecipients');
         $worker = new TestableMessaging();
@@ -460,6 +530,7 @@ final class MessagingFanoutTest extends TestCase
             $topicIds,
             $userIds,
             $targetIds,
+            $emails,
             MESSAGE_TYPE_EMAIL,
             $this->provider()
         );


### PR DESCRIPTION
## What

Adds an `emails` parameter to the **create** (`POST /v1/messaging/messages/email`) and **update** (`PATCH /v1/messaging/messages/email/:messageId`) email message endpoints. It accepts a list of plain email addresses, letting a message be delivered to recipients that are **not** backed by an Appwrite user, target, or topic.

## Why

Today an email message can only target Appwrite-managed recipients (topics, users, or targets). Sending a one-off email to an arbitrary address required first creating a user/target. The `emails` param removes that requirement.

## How

- **Routes** (`app/controllers/api/messaging.php`): new `emails` param validated with `ArrayList(new Email())`. The addresses are stored alongside the other email-only fields (`cc`, `bcc`, `attachments`) in the message `data`, so **no schema migration is needed**. The "missing recipient" guard now treats a non-empty `emails` list as a valid recipient source on both create and update.
- **Worker** (`src/Appwrite/Platform/Workers/Messaging.php`): `sendExternalMessage` reads `data.emails` and threads it into `streamRecipients`, which yields the raw addresses in bounded pages routed straight to the default email provider. Raw emails are already delivery identifiers, so they skip the target/subscriber lookups entirely. Mixed messages (e.g. a topic plus raw emails) are fully supported.

## Tests

- **Unit** (`tests/unit/Messaging/MessagingFanoutTest.php`): raw emails resolve with zero DB reads, paginate beyond the page size, dedupe within a page, and combine with registered targets.
- **E2E** (`tests/e2e/Services/Messaging/MessagingBase.php`):
  - `testCreateEmailToRawEmails` — raw emails alone satisfy the recipient requirement, are persisted in `data.emails`, and malformed addresses are rejected with `400`.
  - `testSendEmailToRawEmails` — full delivery to a raw address via a real provider (runs when `_APP_MESSAGE_EMAIL_TEST_DSN` is set, skipped otherwise).

### Verification

- `composer lint` — passed (changed files)
- `composer analyze` (PHPStan level 4) — no errors (changed files)
- `composer refactor:check` (Rector) — clean (changed tests)
- `vendor/bin/phpunit tests/unit/Messaging/` — 53 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)