### PR TITLE
fix: use target user for admin membership lookup 

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -299,7 +299,8 @@ Http::init()
         elseif (($project->getId() === 'console' && ! $team->isEmpty() && ! $user->isEmpty()) || ($project->getId() !== 'console' && ! $user->isEmpty() && $mode === APP_MODE_ADMIN)) {
             $teamId = $team->getId();
             $adminRoles = [];
-            $memberships = $user->getAttribute('memberships', []);
+            $membershipSource = !$impersonatorUser->isEmpty() ? $targetUser : $user;
+            $memberships = $membershipSource->getAttribute('memberships', []);
             foreach ($memberships as $membership) {
                 if ($membership->getAttribute('confirm', false) === true && $membership->getAttribute('teamId') === $teamId) {
                     $adminRoles = $membership->getAttribute('roles', []);
@@ -474,7 +475,8 @@ Http::init()
         $minimumFactors = ($mfaEnabled && $hasMoreFactors) ? 2 : 1;
 
         // Step 13: Handle Multi-Factor Authentication
-        if (! in_array('mfa', $route->getGroups())) {
+        // Skip MFA check when impersonating — the actor already satisfied their own MFA during login.
+        if (! in_array('mfa', $route->getGroups()) && $impersonatorUser->isEmpty()) {
             if ($session && \count($session->getAttribute('factors', [])) < $minimumFactors) {
                 throw new Exception(Exception::USER_MORE_FACTORS_REQUIRED);
             }

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -475,8 +475,7 @@ Http::init()
         $minimumFactors = ($mfaEnabled && $hasMoreFactors) ? 2 : 1;
 
         // Step 13: Handle Multi-Factor Authentication
-        // Skip MFA check when impersonating — the actor already satisfied their own MFA during login.
-        if (! in_array('mfa', $route->getGroups()) && $impersonatorUser->isEmpty()) {
+        if (! in_array('mfa', $route->getGroups())) {
             if ($session && \count($session->getAttribute('factors', [])) < $minimumFactors) {
                 throw new Exception(Exception::USER_MORE_FACTORS_REQUIRED);
             }


### PR DESCRIPTION
## Summary

When impersonating, the admin block membership lookup was using `$user` (the operator/actor) instead of `$targetUser` (the impersonated user) to find team roles. Since the operator is not a member of the target user's organization, `$adminRoles` was always empty → `USER_UNAUTHORIZED` thrown on every impersonated console request.

## Root cause

`app/controllers/shared/api.php` line 302:
```php
// before
$memberships = $user->getAttribute('memberships', []);

// after
$membershipSource = !$impersonatorUser->isEmpty() ? $targetUser : $user;
$memberships = $membershipSource->getAttribute('memberships', []);
```

## Test plan

- [ ] Impersonate a user in the console — project page loads without Access Denied
- [ ] Normal (non-impersonation) console access still works