### PR TITLE
Fix OAuth admin project authorization

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -165,6 +165,13 @@ Http::init()
 
         // Step 4: Get scopes for the role
         $scopes = $roles[$role]['scopes'];
+        $isAdminProjectRequest = ! $user->isEmpty()
+            && $project->getId() !== 'console'
+            && $mode === APP_MODE_ADMIN;
+        $isOAuthAdminProjectRequest = ! empty($apiKey)
+            && $apiKey->getType() === API_KEY_OAUTH2
+            && $apiKey->getRole() === User::ROLE_OWNER
+            && $isAdminProjectRequest;
 
         // Step 5: API Key Authentication
         if (! empty($apiKey)) {
@@ -369,6 +376,10 @@ Http::init()
             $authorization->addRole($authRole);
         }
 
+        if ($isOAuthAdminProjectRequest) {
+            $authorization->setDefaultStatus(false);
+        }
+
         if (!$impersonatorUser->isEmpty() && !$targetUser->isEmpty()) {
             $dbForProject->setMetadata('user', $targetUser->getId());
             $dbForPlatform->setMetadata('user', $targetUser->getId());
@@ -379,7 +390,7 @@ Http::init()
          * But, for actions on resources (sites, functions, etc.) in a non-console project, we explicitly check
          * whether the admin user has necessary permission on the project (sites, functions, etc. don't have permissions associated to them).
          */
-        if (empty($apiKey) && ! $user->isEmpty() && $project->getId() !== 'console' && $mode === APP_MODE_ADMIN) {
+        if ($isAdminProjectRequest && (empty($apiKey) || $isOAuthAdminProjectRequest)) {
             $input = new Input(Database::PERMISSION_READ, $project->getPermissionsByType(Database::PERMISSION_READ));
             $initialStatus = $authorization->getStatus();
             $authorization->enable();

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -372,12 +372,11 @@ Http::init()
         $isAdminProjectRequest = ! $user->isEmpty()
             && $project->getId() !== 'console'
             && $mode === APP_MODE_ADMIN;
-        $isOAuthAdminProjectRequest = ! empty($apiKey)
+        $isOAuthAdminKey = ! empty($apiKey)
             && $apiKey->getType() === API_KEY_OAUTH2
-            && $apiKey->getRole() === User::ROLE_OWNER
-            && $isAdminProjectRequest;
+            && $apiKey->getRole() === User::ROLE_OWNER;
 
-        if ($isOAuthAdminProjectRequest) {
+        if ($isAdminProjectRequest && $isOAuthAdminKey) {
             $authorization->setDefaultStatus(false);
         }
 
@@ -391,7 +390,7 @@ Http::init()
          * But, for actions on resources (sites, functions, etc.) in a non-console project, we explicitly check
          * whether the admin user has necessary permission on the project (sites, functions, etc. don't have permissions associated to them).
          */
-        if ($isAdminProjectRequest && (empty($apiKey) || $isOAuthAdminProjectRequest)) {
+        if ($isAdminProjectRequest && (empty($apiKey) || $isOAuthAdminKey)) {
             $input = new Input(Database::PERMISSION_READ, $project->getPermissionsByType(Database::PERMISSION_READ));
             $initialStatus = $authorization->getStatus();
             $authorization->enable();

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -165,13 +165,6 @@ Http::init()
 
         // Step 4: Get scopes for the role
         $scopes = $roles[$role]['scopes'];
-        $isAdminProjectRequest = ! $user->isEmpty()
-            && $project->getId() !== 'console'
-            && $mode === APP_MODE_ADMIN;
-        $isOAuthAdminProjectRequest = ! empty($apiKey)
-            && $apiKey->getType() === API_KEY_OAUTH2
-            && $apiKey->getRole() === User::ROLE_OWNER
-            && $isAdminProjectRequest;
 
         // Step 5: API Key Authentication
         if (! empty($apiKey)) {
@@ -375,6 +368,14 @@ Http::init()
         foreach ($rolesSource->getRoles($authorization) as $authRole) {
             $authorization->addRole($authRole);
         }
+
+        $isAdminProjectRequest = ! $user->isEmpty()
+            && $project->getId() !== 'console'
+            && $mode === APP_MODE_ADMIN;
+        $isOAuthAdminProjectRequest = ! empty($apiKey)
+            && $apiKey->getType() === API_KEY_OAUTH2
+            && $apiKey->getRole() === User::ROLE_OWNER
+            && $isAdminProjectRequest;
 
         if ($isOAuthAdminProjectRequest) {
             $authorization->setDefaultStatus(false);

--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -288,6 +288,7 @@ const API_KEY_STANDARD = 'standard';
 const API_KEY_EPHEMERAL = 'ephemeral';
 const API_KEY_ORGANIZATION = 'organization';
 const API_KEY_ACCOUNT = 'account';
+const API_KEY_OAUTH2 = 'oauth2';
 
 // Realtime
 const CONSOLE_TAIL_CHANNEL_PREFIX = 'console.tail';


### PR DESCRIPTION
## What does this PR do?

Allows OAuth access tokens that represent admin project requests to use the same project DB authorization behavior as normal admin user requests.

Cloud synthesizes OAuth bearer tokens as API keys so shared API scope checks can validate token scopes. That causes these requests to skip the existing admin-user branch that disables project document authorization for admin-mode project routes. This PR adds an OAuth API key type constant and lets OAuth owner keys in project admin mode reuse the same authorization bypass and explicit project read check.

## Test Plan

- `vendor/bin/pint app/init/constants.php app/controllers/shared/api.php`
- `php -l app/init/constants.php && php -l app/controllers/shared/api.php`
- `vendor/bin/phpstan analyse --memory-limit=2G -c phpstan.neon app/init/constants.php app/controllers/shared/api.php`

## Related PRs and Issues

- Related Cloud PR: appwrite-labs/cloud#4491

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
