### PR TITLE
fix(users): rebuild search index on partial user updates

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3262,10 +3262,9 @@ Http::patch('/v1/account/name')
     ->inject('queueForEvents')
     ->action(function (string $name, Response $response, Document $user, Database $dbForProject, Event $queueForEvents) {
 
-        $user->setAttribute('name', $name);
-
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
-            'name' => $user->getAttribute('name'),
+            'name' => $name,
+            'search' => '', // rebuilt by the `userSearch` filter.
         ]));
 
         $queueForEvents->setParam('userId', $user->getId());

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1284,7 +1284,10 @@ Http::put('/v1/users/:userId/labels')
 
         $user->setAttribute('labels', (array) \array_values(\array_unique($labels)));
 
-        $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['labels' => $user->getAttribute('labels')]));
+        $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
+            'labels' => $user->getAttribute('labels'),
+            'search' => '', // rebuilt by the `userSearch` filter.
+        ]));
 
         $queueForEvents
             ->setParam('userId', $user->getId());
@@ -1408,9 +1411,10 @@ Http::patch('/v1/users/:userId/name')
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
-        $user->setAttribute('name', $name);
-
-        $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['name' => $user->getAttribute('name')]));
+        $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
+            'name' => $name,
+            'search' => '', // rebuilt by the `userSearch` filter.
+        ]));
 
         $queueForEvents->setParam('userId', $user->getId());
 
@@ -1640,6 +1644,7 @@ Http::patch('/v1/users/:userId/email')
                 'emailIsCorporate' => $user->getAttribute('emailIsCorporate'),
                 'emailIsDisposable' => $user->getAttribute('emailIsDisposable'),
                 'emailIsFree' => $user->getAttribute('emailIsFree'),
+                'search' => '', // rebuilt by the `userSearch` filter.
             ]));
             $oldTarget = $user->find('identifier', $oldEmail, 'targets');
 
@@ -1733,6 +1738,7 @@ Http::patch('/v1/users/:userId/phone')
             $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
                 'phone' => $phoneValue,
                 'phoneVerification' => $user->getAttribute('phoneVerification'),
+                'search' => '', // rebuilt by the `userSearch` filter.
             ]));
             $oldTarget = $user->find('identifier', $oldPhone, 'targets');
 

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -215,15 +215,58 @@ class Mails extends Action
         );
         $emailMessage->setOrigin(MESSAGE_SEND_TYPE_INTERNAL);
 
-        try {
-            $adapter->send($emailMessage);
-        } catch (\Throwable $error) {
-            Span::add('mail.status', 'failure');
-
-            if ($type === 'smtp') {
-                throw new Exception('Error sending mail: ' . $error->getMessage(), 401);
+        $sendAndCheck = function (EmailAdapter $adapter) use ($emailMessage): void {
+            $response = $adapter->send($emailMessage);
+            $failed = array_filter($response['results'] ?? [], fn($r) => ($r['status'] ?? '') !== 'success');
+            if (!empty($failed)) {
+                $error = array_values($failed)[0]['error'] ?? 'Unknown error';
+                throw new Exception($error);
             }
-            throw new Exception('Error sending mail: ' . $error->getMessage(), 500);
+        };
+
+        try {
+            $sendAndCheck($adapter);
+        } catch (\Throwable $error) {
+            $msg = $error->getMessage();
+            $is421Timeout = str_contains($msg, '421') && str_contains($msg, 'Timeout');
+
+            if ($is421Timeout) {
+                $fresh = empty($smtp)
+                    ? new SMTP(
+                        host: System::getEnv('_APP_SMTP_HOST', 'smtp'),
+                        port: (int) System::getEnv('_APP_SMTP_PORT', 25),
+                        username: System::getEnv('_APP_SMTP_USERNAME', ''),
+                        password: System::getEnv('_APP_SMTP_PASSWORD', ''),
+                        smtpSecure: System::getEnv('_APP_SMTP_SECURE', ''),
+                        smtpAutoTLS: false,
+                        xMailer: 'Appwrite Mailer',
+                        timeout: 10,
+                        keepAlive: false,
+                        timelimit: 30,
+                    )
+                    : new SMTP(
+                        host: $smtp['host'],
+                        port: (int) $smtp['port'],
+                        username: $smtp['username'] ?? '',
+                        password: $smtp['password'] ?? '',
+                        smtpSecure: $smtp['secure'] ?? '',
+                        smtpAutoTLS: false,
+                        xMailer: 'Appwrite Mailer',
+                        timeout: 10,
+                        keepAlive: false,
+                        timelimit: 30,
+                    );
+
+                try {
+                    $sendAndCheck($fresh);
+                } catch (\Throwable $retryError) {
+                    $code = ($type === 'smtp') ? 401 : 500;
+                    throw new Exception('Error sending mail: ' . $retryError->getMessage(), $code);
+                }
+            } else {
+                $code = ($type === 'smtp') ? 401 : 500;
+                throw new Exception('Error sending mail: ' . $msg, $code);
+            }
         }
 
         Span::add('mail.status', 'success');

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -215,58 +215,15 @@ class Mails extends Action
         );
         $emailMessage->setOrigin(MESSAGE_SEND_TYPE_INTERNAL);
 
-        $sendAndCheck = function (EmailAdapter $adapter) use ($emailMessage): void {
-            $response = $adapter->send($emailMessage);
-            $failed = array_filter($response['results'] ?? [], fn($r) => ($r['status'] ?? '') !== 'success');
-            if (!empty($failed)) {
-                $error = array_values($failed)[0]['error'] ?? 'Unknown error';
-                throw new Exception($error);
-            }
-        };
-
         try {
-            $sendAndCheck($adapter);
+            $adapter->send($emailMessage);
         } catch (\Throwable $error) {
-            $msg = $error->getMessage();
-            $is421Timeout = str_contains($msg, '421') && str_contains($msg, 'Timeout');
+            Span::add('mail.status', 'failure');
 
-            if ($is421Timeout) {
-                $fresh = empty($smtp)
-                    ? new SMTP(
-                        host: System::getEnv('_APP_SMTP_HOST', 'smtp'),
-                        port: (int) System::getEnv('_APP_SMTP_PORT', 25),
-                        username: System::getEnv('_APP_SMTP_USERNAME', ''),
-                        password: System::getEnv('_APP_SMTP_PASSWORD', ''),
-                        smtpSecure: System::getEnv('_APP_SMTP_SECURE', ''),
-                        smtpAutoTLS: false,
-                        xMailer: 'Appwrite Mailer',
-                        timeout: 10,
-                        keepAlive: false,
-                        timelimit: 30,
-                    )
-                    : new SMTP(
-                        host: $smtp['host'],
-                        port: (int) $smtp['port'],
-                        username: $smtp['username'] ?? '',
-                        password: $smtp['password'] ?? '',
-                        smtpSecure: $smtp['secure'] ?? '',
-                        smtpAutoTLS: false,
-                        xMailer: 'Appwrite Mailer',
-                        timeout: 10,
-                        keepAlive: false,
-                        timelimit: 30,
-                    );
-
-                try {
-                    $sendAndCheck($fresh);
-                } catch (\Throwable $retryError) {
-                    $code = ($type === 'smtp') ? 401 : 500;
-                    throw new Exception('Error sending mail: ' . $retryError->getMessage(), $code);
-                }
-            } else {
-                $code = ($type === 'smtp') ? 401 : 500;
-                throw new Exception('Error sending mail: ' . $msg, $code);
+            if ($type === 'smtp') {
+                throw new Exception('Error sending mail: ' . $error->getMessage(), 401);
             }
+            throw new Exception('Error sending mail: ' . $error->getMessage(), 500);
         }
 
         Span::add('mail.status', 'success');


### PR DESCRIPTION
When updating user attributes (name, email, phone, labels), include \search\ in the update document to trigger the \userSearch\ filter, which rebuilds the search index from current values.\n\n(cherry picked from the original fix in #12650, retargeted to \1.9.x\)