### PR TITLE
Fix email template E2E test isolation

### DIFF
--- a/tests/e2e/Services/Project/TemplatesBase.php
+++ b/tests/e2e/Services/Project/TemplatesBase.php
@@ -221,27 +221,33 @@ trait TemplatesBase
     {
         $this->ensureSMTPEnabled();
 
+        $runId = \uniqid();
+        $firstSubject = "First subject {$runId}";
+        $firstBody = "First body {$runId}";
+        $secondSubject = "Second subject {$runId}";
+        $secondBody = "Second body {$runId}";
+
         $first = $this->updateEmailTemplate(
             templateId: 'otpSession',
             locale: 'en',
-            subject: 'First subject',
-            message: 'First body',
+            subject: $firstSubject,
+            message: $firstBody,
         );
         $this->assertSame(200, $first['headers']['status-code']);
 
         $second = $this->updateEmailTemplate(
             templateId: 'otpSession',
             locale: 'en',
-            subject: 'Second subject',
-            message: 'Second body',
+            subject: $secondSubject,
+            message: $secondBody,
         );
         $this->assertSame(200, $second['headers']['status-code']);
-        $this->assertSame('Second subject', $second['body']['subject']);
-        $this->assertSame('Second body', $second['body']['message']);
+        $this->assertSame($secondSubject, $second['body']['subject']);
+        $this->assertSame($secondBody, $second['body']['message']);
 
         $get = $this->getEmailTemplate('otpSession', 'en');
-        $this->assertSame('Second subject', $get['body']['subject']);
-        $this->assertSame('Second body', $get['body']['message']);
+        $this->assertSame($secondSubject, $get['body']['subject']);
+        $this->assertSame($secondBody, $get['body']['message']);
     }
 
     public function testUpdateEmailTemplatePartialAfterSeed(): void
@@ -281,32 +287,36 @@ trait TemplatesBase
     {
         $this->ensureSMTPEnabled();
 
+        $runId = \uniqid();
+        $enSubject = "English subject {$runId}";
+        $frSubject = "Sujet francais {$runId}";
+
         $enUpdate = $this->updateEmailTemplate(
             templateId: 'invitation',
             locale: 'en',
-            subject: 'English subject',
+            subject: $enSubject,
             message: 'English body',
         );
         $this->assertSame(200, $enUpdate['headers']['status-code']);
         $this->assertSame('en', $enUpdate['body']['locale']);
-        $this->assertSame('English subject', $enUpdate['body']['subject']);
+        $this->assertSame($enSubject, $enUpdate['body']['subject']);
 
         $frUpdate = $this->updateEmailTemplate(
             templateId: 'invitation',
             locale: 'fr',
-            subject: 'Sujet francais',
+            subject: $frSubject,
             message: 'Corps francais',
         );
         $this->assertSame(200, $frUpdate['headers']['status-code']);
         $this->assertSame('fr', $frUpdate['body']['locale']);
-        $this->assertSame('Sujet francais', $frUpdate['body']['subject']);
+        $this->assertSame($frSubject, $frUpdate['body']['subject']);
 
         // Locales remain independent.
         $enGet = $this->getEmailTemplate('invitation', 'en');
-        $this->assertSame('English subject', $enGet['body']['subject']);
+        $this->assertSame($enSubject, $enGet['body']['subject']);
 
         $frGet = $this->getEmailTemplate('invitation', 'fr');
-        $this->assertSame('Sujet francais', $frGet['body']['subject']);
+        $this->assertSame($frSubject, $frGet['body']['subject']);
     }
 
     public function testUpdateEmailTemplateResponseModel(): void
@@ -729,19 +739,21 @@ trait TemplatesBase
         $response = $this->listEmailTemplates();
         $this->assertSame(200, $response['headers']['status-code']);
 
-        $foundEn = false;
-        $foundFr = false;
-        foreach ($response['body']['templates'] as $template) {
-            if ($template['templateId'] === 'recovery' && $template['locale'] === 'en' && $template['subject'] === $enSubject) {
-                $foundEn = true;
-            }
-            if ($template['templateId'] === 'recovery' && $template['locale'] === 'fr' && $template['subject'] === $frSubject) {
-                $foundFr = true;
-            }
-        }
+        $foundEn = \array_filter(
+            $response['body']['templates'],
+            fn ($template) => $template['templateId'] === 'recovery'
+                && $template['locale'] === 'en'
+                && $template['subject'] === $enSubject
+        );
+        $foundFr = \array_filter(
+            $response['body']['templates'],
+            fn ($template) => $template['templateId'] === 'recovery'
+                && $template['locale'] === 'fr'
+                && $template['subject'] === $frSubject
+        );
 
-        $this->assertTrue($foundEn, 'recovery/en must appear in the list');
-        $this->assertTrue($foundFr, 'recovery/fr must appear in the list');
+        $this->assertNotEmpty($foundEn, 'recovery/en must appear in the list');
+        $this->assertNotEmpty($foundFr, 'recovery/fr must appear in the list');
     }
 
     public function testListEmailTemplatesUpdateDoesNotDuplicate(): void


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Stabilizes a small set of email template E2E tests by making their test data unique per run and by matching list results with explicit filters instead of mutable booleans.

Why this is needed:

Cloud runs the server-ce E2E suites as part of its CI. On pull requests those tests run through `php-retry`, but on `main` merge-commit push runs they only get one attempt. That makes latent test isolation issues show up as noisy merge-commit failures.

Recent Cloud `main` runs showed failures in:

- `Tests\E2E\Services\Project\TemplatesConsoleClientTest::testUpdateEmailTemplateOverwritesPrevious`
- `Tests\E2E\Services\Project\TemplatesConsoleClientTest::testUpdateEmailTemplateDifferentLocales`
- `Tests\E2E\Services\Project\TemplatesConsoleClientTest::testListEmailTemplatesSeparatesLocales`

These tests all write shared project email-template records using fixed template IDs and previously fixed subjects/bodies. If state from another run, retry, or neighboring test is visible, a direct GET or list assertion can observe a valid template record that does not contain the exact static string the test expected.

This PR keeps the API behavior expectations unchanged. It only changes the tests to:

- generate unique subjects and bodies for overwrite assertions;
- generate unique EN/FR subjects for locale-isolation assertions;
- locate list entries by exact `(templateId, locale, subject)` markers.

That makes each assertion verify the record written by the current test invocation instead of relying on globally stable template text.

## Test Plan

- `php -l tests/e2e/Services/Project/TemplatesBase.php`
- `vendor/bin/pint --test tests/e2e/Services/Project/TemplatesBase.php`
- Attempted targeted PHPUnit:
  - `php vendor/bin/phpunit tests/e2e/Services/Project/TemplatesConsoleClientTest.php --filter 'testUpdateEmailTemplateOverwritesPrevious|testUpdateEmailTemplateDifferentLocales|testListEmailTemplatesSeparatesLocales'`
  - Local run could not reach the E2E service host and failed before assertions with `Could not resolve host: appwrite`.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? Not applicable; this PR changes tests only.
