### PR TITLE
Fix #12643: Update project and user accessedAt during GraphQL requests

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1680,10 +1680,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                     $failureRedirect(Exception::USER_EMAIL_DISPOSABLE);
                 }
 
-                if (($plan['supportsCanonicalEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false) && $emailMetadata['emailIsCanonical'] === false) {
-                    $failureRedirect(Exception::USER_EMAIL_NOT_CANONICAL);
-                }
-
+                
                 if (($plan['supportsFreeEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['freeEmails'] ?? false) && $emailMetadata['emailIsFree']) {
                     $failureRedirect(Exception::USER_EMAIL_FREE);
                 }
@@ -1821,10 +1818,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 $failureRedirect(Exception::USER_EMAIL_DISPOSABLE);
             }
 
-            if (($plan['supportsCanonicalEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false) && $emailMetadata['emailIsCanonical'] === false) {
-                $failureRedirect(Exception::USER_EMAIL_NOT_CANONICAL);
-            }
-
+            
             if (($plan['supportsFreeEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['freeEmails'] ?? false) && $emailMetadata['emailIsFree']) {
                 $failureRedirect(Exception::USER_EMAIL_FREE);
             }

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1680,7 +1680,10 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                     $failureRedirect(Exception::USER_EMAIL_DISPOSABLE);
                 }
 
-                
+                if (($plan['supportsCanonicalEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false) && $emailMetadata['emailIsCanonical'] === false) {
+                    $failureRedirect(Exception::USER_EMAIL_NOT_CANONICAL);
+                }
+
                 if (($plan['supportsFreeEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['freeEmails'] ?? false) && $emailMetadata['emailIsFree']) {
                     $failureRedirect(Exception::USER_EMAIL_FREE);
                 }
@@ -1818,7 +1821,10 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 $failureRedirect(Exception::USER_EMAIL_DISPOSABLE);
             }
 
-            
+            if (($plan['supportsCanonicalEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false) && $emailMetadata['emailIsCanonical'] === false) {
+                $failureRedirect(Exception::USER_EMAIL_NOT_CANONICAL);
+            }
+
             if (($plan['supportsFreeEmailValidation'] ?? false) && ($project->getAttribute('auths', [])['freeEmails'] ?? false) && $emailMetadata['emailIsFree']) {
                 $failureRedirect(Exception::USER_EMAIL_FREE);
             }

--- a/app/controllers/api/graphql.php
+++ b/app/controllers/api/graphql.php
@@ -18,6 +18,8 @@ use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use Swoole\Coroutine\WaitGroup;
+use Utopia\Database\Database;
+use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Http\Http;
@@ -32,7 +34,10 @@ Http::init()
     ->inject('request')
     ->inject('response')
     ->inject('authorization')
-    ->action(function (Document $project, User $user, Request $request, Response $response, Authorization $authorization) {
+    ->inject('dbForPlatform')
+    ->inject('dbForProject')
+    ->inject('mode')
+    ->action(function (Document $project, User $user, Request $request, Response $response, Authorization $authorization, Database $dbForPlatform, Database $dbForProject, string $mode) {
         $response->setUser($user);
         $request->setUser($user);
 
@@ -42,6 +47,37 @@ Http::init()
             && !($user->isPrivileged($authorization->getRoles()) || $user->isApp($authorization->getRoles()))
         ) {
             throw new AppwriteException(AppwriteException::GENERAL_API_DISABLED);
+        }
+
+        // Update project last activity
+        if ($project->getId() !== 'console') {
+            $accessedAt = $project->getAttribute('accessedAt', 0);
+            if (DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_PROJECT_ACCESS)) > $accessedAt) {
+                $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
+                    'accessedAt' => DateTime::now()
+                ])));
+            }
+        }
+
+        // Update user last activity
+        if (! empty($user->getId())) {
+            $impersonatorUserId = $user->getAttribute('impersonatorUserId');
+            $accessedAt = $user->getAttribute('accessedAt', 0);
+
+            // Skip updating accessedAt for impersonated requests so we don't attribute activity to the target user.
+            if (! $impersonatorUserId && DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_USER_ACCESS)) > $accessedAt) {
+                $user->setAttribute('accessedAt', DateTime::now());
+
+                if ($project->getId() !== 'console' && $mode !== APP_MODE_ADMIN) {
+                    $dbForProject->updateDocument('users', $user->getId(), new Document([
+                        'accessedAt' => $user->getAttribute('accessedAt')
+                    ]));
+                } else {
+                    $authorization->skip(fn () => $dbForPlatform->updateDocument('users', $user->getId(), new Document([
+                        'accessedAt' => $user->getAttribute('accessedAt')
+                    ])));
+                }
+            }
         }
     });
 


### PR DESCRIPTION
This PR updates the project and user accessedAt timestamps on incoming GraphQL requests. Previously, GraphQL requests did not trigger these updates, causing projects that only use GraphQL to be incorrectly flagged as inactive.