### PR TITLE
fix: use warning instead of exception on adapter mismatch

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -906,7 +906,7 @@ class Builds extends Action
                     Span::add('build.adapter', $deployment->getAttribute('adapter'));
                     Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
                 } elseif ($adapter === 'ssr' && $detection->getName() === 'static') {
-                    throw new BuildException('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
+                    Console::warning('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Replaces `BuildException` throw with `Console::warning` when post-build rendering detection disagrees with the explicitly set adapter

## Why
Post-build detection can incorrectly flag SSR sites as static when they have prerendered pages. Since the developer has explicitly set the adapter, their setting should take precedence — blocking the build is too aggressive.