### PR TITLE
Purge project cache after legacy OAuth2 update

### DIFF
--- a/app/controllers/api/projects.php
+++ b/app/controllers/api/projects.php
@@ -64,6 +64,8 @@ Http::patch('/v1/projects/:projectId/oauth2')
             ]));
         });
 
+        $dbForPlatform->purgeCachedDocument('projects', $project->getId());
+
         $response->dynamic($project, Response::MODEL_PROJECT);
     });
 


### PR DESCRIPTION
## What does this PR do?

Adds a project cache purge after the legacy `/v1/projects/:projectId/oauth2` update transaction completes.

This avoids a race where the nested `updateDocument()` cache purge can happen before the outer transaction commits, allowing an immediate OAuth2 request to read a stale project document where the provider still appears disabled.

## Test Plan

- `php -l app/controllers/api/projects.php`
- Verified the focused flaky sequence locally before applying this patch in a Cloud checkout:
  - `testCreateOAuth2AccountSession|testConvertAnonymousAccountOAuth2` reproduced a `412 project_provider_disabled` response before the purge.
  - With the same purge added locally, the focused sequence passed 20/20 iterations.

## Related PRs and Issues

- Related Cloud CI flake investigation: `Tests\\E2E\\Services\\Account\\AccountCustomClientTest::testConvertAnonymousAccountOAuth2`

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
