### PR TITLE
ci: run CI on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - 1.9.x
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What

Adds `main` to the `push.branches` trigger in `ci.yml` so that merge commits landing on `main` run CI — previously CI only ran on PRs, pushes to `1.9.x`, and manual dispatch, leaving merge commits to `main` untested.

## Why

The commit that actually lands on `main` is the *merge result*, which can differ from the PR head that CI tested (base moved, parallel merges, semantic conflicts). Running CI on push to `main` catches breakage that slips through green PRs.

## Behavior notes for `main` pushes

These jobs already branch on event type, so on merge to `main`:

- `dependencies` / `security` stay skipped (`if: github.event_name == 'pull_request'`).
- `matrix` runs the **full** DB matrix (3 DBs × 2 modes) — the MongoDB-only narrowing only applies when a PR payload is present.
- `benchmark` runs, using `github.event.before` as the baseline.
- Test retries drop to `max_attempts: 1` (the `pull_request && 2 || 1` guards), so flakes fail the run with no retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)