### PR TITLE
Fix flaky email template and usage tests

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php
@@ -91,45 +91,63 @@ class Update extends Action
     ) {
         $locale = $locale ?: System::getEnv('_APP_LOCALE', 'en');
 
-        // Prevent template update if custom SMTP is not configured
-        $smtp = $project->getAttribute('smtp', []);
-        if (($smtp['enabled'] ?? false) !== true) {
-            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'SMTP must be enabled on the project to configure custom email templates.');
-        }
+        $templateKey = "email.{$templateId}-{$locale}";
+        $changes = [
+            'senderName' => $senderName,
+            'senderEmail' => $senderEmail,
+            'replyToEmail' => $replyToEmail,
+            'replyToName' => $replyToName,
+            'message' => $message,
+            'subject' => $subject,
+        ];
 
-        // Fetch current configuration
-        $templates = $project->getAttribute('templates', []);
-        $template = $templates['email.' . $templateId . '-' . $locale] ?? [];
+        $project = $dbForPlatform->withTransaction(function () use ($dbForPlatform, $authorization, $project, $templateKey, $changes) {
+            $project = $authorization->skip(fn () => $dbForPlatform->getDocument('projects', $project->getId(), forUpdate: true));
 
-        // Apply changes — null means "not provided, keep existing".
-        // Empty string explicitly clears a previously-set value.
-        $keys = ['senderName', 'senderEmail', 'replyToEmail', 'replyToName', 'message', 'subject'];
-        foreach ($keys as $key) {
-            if (!\is_null(${$key})) {
-                $template[$key] = ${$key};
+            if ($project->isEmpty()) {
+                throw new Exception(Exception::PROJECT_NOT_FOUND);
             }
-        }
 
-        // Backwards compatibility
-        if (!\is_null($template['replyTo'] ?? null)) {
-            $template['replyToEmail'] = $template['replyToEmail'] ?? $template['replyTo'] ?? '';
-        }
-
-        // Ensure required fields are set
-        $requiredKeys = ['subject', 'message'];
-        foreach ($requiredKeys as $key) {
-            if (empty($template[$key])) {
-                throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Param "' . $key . '" is not optional.');
+            // Prevent template update if custom SMTP is not configured
+            $smtp = $project->getAttribute('smtp', []);
+            if (($smtp['enabled'] ?? false) !== true) {
+                throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'SMTP must be enabled on the project to configure custom email templates.');
             }
-        }
 
-        // Save configuration
-        $templates['email.' . $templateId . '-' . $locale] = $template;
-        $updates = new Document([
-            'templates' => $templates,
-        ]);
+            // Fetch current configuration from the locked row so concurrent updates
+            // to other locale/template entries are preserved.
+            $templates = $project->getAttribute('templates', []);
+            $template = $templates[$templateKey] ?? [];
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
+            // Apply changes: null means "not provided, keep existing".
+            // Empty string explicitly clears a previously-set value.
+            foreach ($changes as $key => $value) {
+                if ($value !== null) {
+                    $template[$key] = $value;
+                }
+            }
+
+            // Backwards compatibility
+            if (($template['replyTo'] ?? null) !== null) {
+                $template['replyToEmail'] ??= $template['replyTo'] ?? '';
+            }
+
+            // Ensure required fields are set
+            $requiredKeys = ['subject', 'message'];
+            foreach ($requiredKeys as $key) {
+                if (empty($template[$key])) {
+                    throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Param "' . $key . '" is not optional.');
+                }
+            }
+
+            $templates[$templateKey] = $template;
+
+            return $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
+                'templates' => $templates,
+            ])));
+        });
+
+        $template = $project->getAttribute('templates', [])[$templateKey] ?? [];
 
         $queueForEvents->setParam('templateId', $templateId);
 

--- a/tests/e2e/General/UsageTest.php
+++ b/tests/e2e/General/UsageTest.php
@@ -1869,7 +1869,7 @@ final class UsageTest extends Scope
             $this->validateDates($response['body']['executions']);
             $this->assertEquals($executionTime, $response['body']['executionsTime'][array_key_last($response['body']['executionsTime'])]['value']);
             $this->validateDates($response['body']['executionsTime']);
-        });
+        }, 60000, 500);
 
         $this->assertEventually(function () use ($executions, $executionTime) {
             $response = $this->client->call(
@@ -1901,7 +1901,7 @@ final class UsageTest extends Scope
             $this->validateDates($response['body']['executionsTime']);
             $this->assertGreaterThan(0, $response['body']['buildsTime'][array_key_last($response['body']['buildsTime'])]['value']);
             $this->validateDates($response['body']['buildsTime']);
-        });
+        }, 60000, 500);
     }
 
     public function testCustomDomainsFunctionStats(): void


### PR DESCRIPTION
## What does this PR do?

Fixes two sources of flakiness:

1. Project email template updates now re-read the project row with `forUpdate` inside the update transaction before merging the target template entry. This prevents a stale request-injected project snapshot from overwriting sibling locale/template entries in the `templates` map.

2. `UsageTest::testSitesStats` now gives the Sites usage assertions an explicit 60s polling window. Deployment readiness and usage-stat persistence are handled by separate async workers, so the previous default 10s window could expire under CI load even when the stats were eventually written correctly.

## Test Plan

- `composer lint src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php`
- `php -l src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php`
- `composer analyze -- --no-progress src/Appwrite/Platform/Modules/Project/Http/Project/Templates/Email/Update.php`
- `composer lint tests/e2e/General/UsageTest.php`
- `php -l tests/e2e/General/UsageTest.php`
- `composer analyze -- --no-progress tests/e2e/General/UsageTest.php`
- `git diff --check`

Focused local e2e could not be run because the local `appwrite` container was restarting with `Class "Utopia\\Http\\Adapter\\Swoole\\Mode" not found in /usr/src/code/app/http.php:69`.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
