### PR TITLE
Refocus benchmark on database load, not password hashing

### DIFF
--- a/tests/benchmarks/http.js
+++ b/tests/benchmarks/http.js
@@ -209,6 +209,10 @@ function setupUsers(projectId, count) {
         }, headers, [201], 'setup.account.session');
 
         users.push({ sessionHeaders: { ...headers, Cookie: cookieHeader(session) } });
+
+        // Drop the auto-stored session cookie so the next user can sign in;
+        // setup() runs in a single iteration, so the jar is not reset for us.
+        http.cookieJar().clear(ENDPOINT);
     }
 
     return users;

--- a/tests/benchmarks/http.js
+++ b/tests/benchmarks/http.js
@@ -20,6 +20,7 @@ const PASSWORD = __ENV.APPWRITE_BENCHMARK_PASSWORD || 'Password123!';
 const WORKER_TIMEOUT_MS = Number(__ENV.APPWRITE_WORKER_TIMEOUT_MS || 120000);
 const VUS = Number(__ENV.APPWRITE_BENCHMARK_VUS || 1);
 const DURATION = __ENV.APPWRITE_BENCHMARK_DURATION || '1m';
+const ROWS_PER_FLOW = Number(__ENV.APPWRITE_BENCHMARK_ROWS || 5);
 const SUMMARY_PATH = __ENV.APPWRITE_BENCHMARK_SUMMARY_PATH || '/tmp/appwrite-k6-summary.json';
 const PREVIOUS_SUMMARY_PATH = __ENV.APPWRITE_BENCHMARK_PREVIOUS_SUMMARY_PATH || '';
 const PREVIOUS_SUMMARY = PREVIOUS_SUMMARY_PATH ? loadPreviousSummary(PREVIOUS_SUMMARY_PATH) : null;
@@ -172,6 +173,7 @@ export function setup() {
     }, apiHeaders, [201, 409], 'setup.project.platforms.web.create');
 
     const tablesDb = setupTablesDb(apiHeaders);
+    const users = setupUsers(projectId, VUS);
 
     return {
         runId,
@@ -181,8 +183,35 @@ export function setup() {
         tableId: tablesDb.tableId,
         consoleSessionHeaders,
         apiHeaders,
+        users,
         platformStatus: platform.status,
     };
+}
+
+// Pre-create one signed-in user per VU so password hashing happens once
+// during setup (excluded from metrics) instead of in every iteration.
+function setupUsers(projectId, count) {
+    const headers = projectHeaders(projectId);
+    const users = [];
+
+    for (let index = 0; index < count; index++) {
+        const email = `bench-user-${unique('mail')}@example.com`;
+        setupApi('POST', '/account', {
+            userId: unique('user'),
+            email,
+            password: PASSWORD,
+            name: 'Benchmark User',
+        }, headers, [201], 'setup.account.create');
+
+        const session = setupApi('POST', '/account/sessions/email', {
+            email,
+            password: PASSWORD,
+        }, headers, [201], 'setup.account.session');
+
+        users.push({ sessionHeaders: { ...headers, Cookie: cookieHeader(session) } });
+    }
+
+    return users;
 }
 
 function setupTablesDb(apiHeaders) {
@@ -218,7 +247,8 @@ function setupTablesDb(apiHeaders) {
 }
 
 export function curatedFlows(data) {
-    const ctx = { ...data };
+    const user = data.users[(__VU - 1) % data.users.length];
+    const ctx = { ...data, sessionHeaders: user.sessionHeaders };
 
     try {
         group('account flow', () => accountFlow(ctx));
@@ -242,62 +272,42 @@ export function teardown(data) {
 }
 
 function accountFlow(ctx) {
-    const userId = unique('user');
-    const email = `bench-user-${unique('mail')}@example.com`;
-    const headers = projectHeaders(ctx.projectId);
+    requireSession(ctx, 'accountFlow');
 
-    api('POST', '/account', {
-        userId,
-        email,
-        password: PASSWORD,
-        name: 'Benchmark User',
-    }, headers, [201], 'account.create');
-
-    const session = api('POST', '/account/sessions/email', {
-        email,
-        password: PASSWORD,
-    }, headers, [201], 'account.sessions.email.create');
-
-    const sessionHeaders = {
-        ...headers,
-        Cookie: cookieHeader(session),
-    };
-
-    ctx.userId = userId;
-    ctx.userEmail = email;
-    ctx.sessionHeaders = sessionHeaders;
-
-    api('GET', '/account', null, sessionHeaders, [200], 'account.get');
-    api('GET', '/account/logs', null, sessionHeaders, [200], 'account.logs.list');
-    api('PATCH', '/account/prefs', { prefs: { benchmark: true, runId: ctx.runId } }, sessionHeaders, [200], 'account.prefs.update');
-    api('PATCH', '/account/name', { name: 'Benchmark User Updated' }, sessionHeaders, [200], 'account.name.update');
-    api('PATCH', '/account/password', { password: `${PASSWORD}2`, oldPassword: PASSWORD }, sessionHeaders, [200], 'account.password.update');
+    api('GET', '/account', null, ctx.sessionHeaders, [200], 'account.get');
+    api('GET', '/account/logs', null, ctx.sessionHeaders, [200], 'account.logs.list');
+    api('PATCH', '/account/prefs', { prefs: { benchmark: true, runId: ctx.runId } }, ctx.sessionHeaders, [200], 'account.prefs.update');
+    api('PATCH', '/account/name', { name: 'Benchmark User Updated' }, ctx.sessionHeaders, [200], 'account.name.update');
 }
 
 function tablesDbFlow(ctx) {
     requireSession(ctx, 'tablesDbFlow');
 
-    const databaseId = ctx.databaseId;
-    const tableId = ctx.tableId;
-    const rowId = unique('row');
+    const { databaseId, tableId, sessionHeaders } = ctx;
+    const base = `/tablesdb/${databaseId}/tables/${tableId}/rows`;
+    const rowIds = [];
 
-    api('POST', `/tablesdb/${databaseId}/tables/${tableId}/rows`, {
-        rowId,
-        data: tablePayload(),
-        permissions: ITEM_PERMISSIONS,
-    }, ctx.sessionHeaders, [201], 'tablesdb.rows.create');
-    api('GET', `/tablesdb/${databaseId}/tables/${tableId}/rows`, null, ctx.sessionHeaders, [200], 'tablesdb.rows.list');
-    api('GET', `/tablesdb/${databaseId}/tables/${tableId}/rows/${rowId}`, null, ctx.sessionHeaders, [200], 'tablesdb.rows.get');
-    api('PATCH', `/tablesdb/${databaseId}/tables/${tableId}/rows/${rowId}`, {
-        data: { title: 'Benchmark Row Updated' },
-    }, ctx.sessionHeaders, [200], 'tablesdb.rows.update');
-    api('PATCH', `/tablesdb/${databaseId}/tables/${tableId}/rows/${rowId}/quantity/increment`, {
-        value: 1,
-    }, ctx.sessionHeaders, [200], 'tablesdb.rows.increment');
-    api('PATCH', `/tablesdb/${databaseId}/tables/${tableId}/rows/${rowId}/quantity/decrement`, {
-        value: 1,
-    }, ctx.sessionHeaders, [200], 'tablesdb.rows.decrement');
-    api('DELETE', `/tablesdb/${databaseId}/tables/${tableId}/rows/${rowId}`, null, ctx.sessionHeaders, [204], 'tablesdb.rows.delete');
+    for (let index = 0; index < ROWS_PER_FLOW; index++) {
+        const rowId = unique('row');
+        rowIds.push(rowId);
+        api('POST', base, {
+            rowId,
+            data: tablePayload(),
+            permissions: ITEM_PERMISSIONS,
+        }, sessionHeaders, [201], 'tablesdb.rows.create');
+    }
+
+    api('GET', base, null, sessionHeaders, [200], 'tablesdb.rows.list');
+
+    for (const rowId of rowIds) {
+        api('GET', `${base}/${rowId}`, null, sessionHeaders, [200], 'tablesdb.rows.get');
+        api('PATCH', `${base}/${rowId}`, {
+            data: { title: 'Benchmark Row Updated' },
+        }, sessionHeaders, [200], 'tablesdb.rows.update');
+        api('PATCH', `${base}/${rowId}/quantity/increment`, { value: 1 }, sessionHeaders, [200], 'tablesdb.rows.increment');
+        api('PATCH', `${base}/${rowId}/quantity/decrement`, { value: 1 }, sessionHeaders, [200], 'tablesdb.rows.decrement');
+        api('DELETE', `${base}/${rowId}`, null, sessionHeaders, [204], 'tablesdb.rows.delete');
+    }
 }
 
 function storageFlow(ctx) {


### PR DESCRIPTION
## Problem

The benchmark's per-iteration **account flow** ran three CPU-bound password-hashing operations on *every* iteration:

- `account.create` → Argon2 hash
- `account.sessions.email.create` → hash verify
- `account.password.update` → verify + rehash

Under concurrent VUs this saturates CPU on the hashing, so the benchmark mostly measures Argon2 throughput and **masks regressions in the database layer** — which is what we actually want to track PR-over-PR. The session minted here also gated every other flow.

## Change

- **Move authentication into `setup()`** — pre-create one signed-in user per VU once, via `setupApi` (which is *not* recorded in `appwrite_api_duration`). Hashing now happens ~VUS times during setup instead of on every iteration, and is excluded from the measured metrics.
- **Each VU reuses its own session** across iterations (indexed by `__VU`), so per-VU writes stay sequential — no cross-VU document contention.
- **Slim the account flow** to pure DB-bound account reads/writes (`account.get`, `logs.list`, `prefs.update`, `name.update`) — no create/session/password.
- **Amplify the rows flow** — create a configurable batch of rows (`APPWRITE_BENCHMARK_ROWS`, default `5`) then read/update/increment/decrement/delete each, so database requests dominate the request mix.

Net effect: the hot loop is now overwhelmingly database I/O, so the before/after comparison surfaces DB performance changes instead of being dominated by password hashing.

## Test plan
- [x] `node --check` passes on the module.
- [ ] CI benchmark job runs green and the PR comment shows the DB-weighted mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)