### PR TITLE
Fix project inactivity flagging: invalidate cache for key updates

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -249,10 +249,13 @@ Http::init()
 
                     if (! empty($apiKey->getProjectId())) {
                         $dbForPlatform->getAuthorization()->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
-                    } elseif (! empty($apiKey->getUserId())) {
-                        $dbForPlatform->getAuthorization()->skip(fn () => $dbForPlatform->purgeCachedDocument('users', $user->getId()));
-                    } elseif (! empty($apiKey->getTeamId())) {
-                        $dbForPlatform->getAuthorization()->skip(fn () => $dbForPlatform->purgeCachedDocument('teams', $team->getId()));
+                    } else {
+                        $dbForProjectToUse = ($project->getId() !== 'console' && $mode !== APP_MODE_ADMIN) ? $dbForProject : $dbForPlatform;
+                        if (! empty($apiKey->getUserId())) {
+                            $dbForProjectToUse->getAuthorization()->skip(fn () => $dbForProjectToUse->purgeCachedDocument('users', $user->getId()));
+                        } elseif (! empty($apiKey->getTeamId())) {
+                            $dbForProjectToUse->getAuthorization()->skip(fn () => $dbForProjectToUse->purgeCachedDocument('teams', $team->getId()));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #12622

### What does this change?
When an API key is accessed, the `accessedAt` property is updated. To ensure consecutive requests see the updated last-accessed time (and do not keep hitting the stale cache or repeatedly updating database records), the parent document's cache must be invalidated. 

Currently, `app/controllers/shared/api.php` attempts to purge the parent cache by calling `$dbForPlatform->purgeCachedDocument(...)`. However, user and team documents are stored in the project database (`$dbForProject`) for non-console, non-admin requests, meaning purging them from `$dbForPlatform` has no effect.

This PR fixes the issue by resolving the correct database instance (`$dbForProject` or `$dbForPlatform`) for user/team documents and invalidating the cache on that correct instance.