### PR TITLE
Complete V24 schema migrations

### DIFF
--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -239,6 +239,8 @@ class V24 extends Migration
                         'startCommand',
                         'buildSpecification',
                         'runtimeSpecification',
+                        'providerBranches',
+                        'providerPaths',
                     ];
                     try {
                         $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
@@ -254,6 +256,8 @@ class V24 extends Migration
                         'deploymentRetention',
                         'buildSpecification',
                         'runtimeSpecification',
+                        'providerBranches',
+                        'providerPaths',
                     ];
                     try {
                         $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);

--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -115,6 +115,12 @@ class V24 extends Migration
                         } catch (Throwable $th) {
                             Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
                         }
+
+                        try {
+                            $this->createIndexFromCollection($this->dbForProject, $id, '_key_teamInternalId');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create index \"_key_teamInternalId\" from {$id}: {$th->getMessage()}");
+                        }
                     }
                     $this->dbForProject->purgeCachedCollection($id);
                     break;
@@ -213,6 +219,15 @@ class V24 extends Migration
                     $this->dbForProject->purgeCachedCollection($id);
                     break;
 
+                case 'memberships':
+                    try {
+                        $this->createIndexFromCollection($this->dbForProject, $id, '_key_team_confirm');
+                    } catch (Throwable $th) {
+                        Console::warning("Failed to create index \"_key_team_confirm\" from {$id}: {$th->getMessage()}");
+                    }
+                    $this->dbForProject->purgeCachedCollection($id);
+                    break;
+
                 case 'tokens':
                     try {
                         $this->createIndexFromCollection($this->dbForProject, $id, '_key_type_expire');
@@ -295,6 +310,32 @@ class V24 extends Migration
                         $this->dbForProject->deleteIndex($id, '_fulltext_name');
                     } catch (Throwable $th) {
                         Console::warning("Failed to delete index \"_fulltext_name\" from {$id}: {$th->getMessage()}");
+                    }
+                    $this->dbForProject->purgeCachedCollection($id);
+                    break;
+
+                case 'platforms':
+                case 'webhooks':
+                    if ($collectionType === 'console') {
+                        try {
+                            $this->createIndexFromCollection($this->dbForProject, $id, '_key_project_id');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create index \"_key_project_id\" from {$id}: {$th->getMessage()}");
+                        }
+                    }
+                    $this->dbForProject->purgeCachedCollection($id);
+                    break;
+
+                case 'reports':
+                case 'insights':
+                    if ($collectionType === 'console') {
+                        try {
+                            $this->createCollection($id);
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create collection \"{$id}\": {$th->getMessage()}");
+
+                            throw $th;
+                        }
                     }
                     $this->dbForProject->purgeCachedCollection($id);
                     break;


### PR DESCRIPTION
## What does this PR do?

Completes missing V24 schema migration steps for upgraded 1.9.x self-hosted instances.

This adds migration coverage for:

- `providerBranches` and `providerPaths` on existing `functions` and `sites` collections
- `reports` and `insights` platform collections used by the Advisor module
- `_key_team_confirm` on `memberships`
- `_key_teamInternalId` on console `projects`
- `_key_project_id` on console `platforms` and `webhooks`

Without the provider trigger attributes, function/site writes can fail on upgraded databases with `Unknown attribute: "providerBranches"`. Without the Advisor collections, upgraded console/platform databases can miss collections used by the registered Advisor routes.

## Test Plan

- `composer lint src/Appwrite/Migration/Version/V24.php`
- `php -l src/Appwrite/Migration/Version/V24.php`
- `git diff --check origin/1.9.x..HEAD -- src/Appwrite/Migration/Version/V24.php`
- Not run: `docker compose exec appwrite test tests/unit/Migration/MigrationVersionsTest.php` because the local `appwrite` service is not running.

## Related PRs and Issues

- Reported issue: upgraded 1.9.x self-hosted instances missing provider trigger attributes on `functions`/`sites` collections.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
