### PR TITLE
Fix unit test warnings and deprecations

### DIFF
--- a/src/Appwrite/Functions/Validator/Headers.php
+++ b/src/Appwrite/Functions/Validator/Headers.php
@@ -50,13 +50,17 @@ class Headers extends Validator
 
         $size = 0;
         foreach ($value as $key => $val) {
-            $length = \strlen($key);
             // Reject non-string keys
-            if (!\is_string($key) || $length === 0) {
+            if (!\is_string($key)) {
                 return false;
             }
 
-            $size += $length + \strlen($val);
+            $length = \strlen($key);
+            if ($length === 0) {
+                return false;
+            }
+
+            $size += $length + \strlen($val ?? '');
             if ($size >= $this->maxSize) {
                 return false;
             }

--- a/src/Appwrite/Task/Validator/Cron.php
+++ b/src/Appwrite/Task/Validator/Cron.php
@@ -39,10 +39,19 @@ class Cron extends Validator
         }
 
         try {
+            \set_error_handler(static function (int $severity, string $message): bool {
+                if (($severity & E_WARNING) === E_WARNING) {
+                    throw new \RuntimeException($message);
+                }
+
+                return false;
+            });
             (new CronExpression($value))->getNextRunDate();
             return true;
         } catch (\RuntimeException) {
             return false;
+        } finally {
+            \restore_error_handler();
         }
     }
 

--- a/tests/extensions/SwooleCleanupSubscriber.php
+++ b/tests/extensions/SwooleCleanupSubscriber.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Appwrite\Tests;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+use Swoole\Event;
+use Swoole\Timer;
+
+class SwooleCleanupSubscriber implements ExecutionFinishedSubscriber
+{
+    public function notify(ExecutionFinished $event): void
+    {
+        Timer::clearAll();
+        Event::wait();
+    }
+}

--- a/tests/extensions/TestHook.php
+++ b/tests/extensions/TestHook.php
@@ -16,5 +16,6 @@ class TestHook implements Extension
         $facade->registerSubscriber(new TestPreparationStartedSubscriber());
         $facade->registerSubscriber(new TestFinishedSubscriber(self::MAX_SECONDS_ALLOWED));
         $facade->registerSubscriber(new RetrySubscriber());
+        $facade->registerSubscriber(new SwooleCleanupSubscriber());
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes unit test warning/deprecation noise by handling null function header values without deprecated string coercion, treating cron parser warnings as invalid cron expressions, and explicitly draining Swoole test event state before PHPUnit exits.

## Test Plan

- `./vendor/bin/phpunit tests/unit/Functions/Validator/HeadersTest.php tests/unit/Task/Validator/CronTest.php tests/unit/Vcs/CommentTest.php --display-deprecations --display-warnings`
- `composer lint src/Appwrite/Functions/Validator/Headers.php src/Appwrite/Task/Validator/Cron.php tests/extensions/SwooleCleanupSubscriber.php tests/extensions/TestHook.php`

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
