### PR TITLE
fix: migrate missing user email canonical attributes in V24

### DIFF
--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -204,21 +204,43 @@ class V24 extends Migration
                         'emailIsCorporate',
                         'emailIsCanonical',
                     ];
-                    try {
-                        $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
-                    } catch (Throwable $th) {
-                        Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
+                    $collectionDoc = $this->dbForProject->getCollection($id);
+                    $existingAttributes = [];
+                    $existingIndexes = [];
+                    if (!$collectionDoc->isEmpty()) {
+                        foreach ($collectionDoc->getAttribute('attributes', []) as $attributeDoc) {
+                            $existingAttributes[] = $attributeDoc->getAttribute('key');
+                        }
+                        foreach ($collectionDoc->getAttribute('indexes', []) as $indexDoc) {
+                            $existingIndexes[] = $indexDoc->getAttribute('key');
+                        }
                     }
-                    try {
-                        $this->createAttributeFromCollection($this->dbForProject, $id, 'impersonator');
-                    } catch (Throwable $th) {
-                        Console::warning("Failed to create attribute \"impersonator\" in collection {$id}: {$th->getMessage()}");
+
+                    $attributesToCreate = \array_diff($attributes, $existingAttributes);
+                    if (!empty($attributesToCreate)) {
+                        try {
+                            $this->createAttributesFromCollection($this->dbForProject, $id, $attributesToCreate);
+                        } catch (Throwable $th) {
+                            Console::warning('Failed to create attributes "' . \implode(', ', $attributesToCreate) . "\" in collection {$id}: {$th->getMessage()}");
+                        }
                     }
-                    try {
-                        $this->createIndexFromCollection($this->dbForProject, $id, 'impersonator');
-                    } catch (Throwable $th) {
-                        Console::warning("Failed to create index \"impersonator\" from {$id}: {$th->getMessage()}");
+
+                    if (!\in_array('impersonator', $existingAttributes)) {
+                        try {
+                            $this->createAttributeFromCollection($this->dbForProject, $id, 'impersonator');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create attribute \"impersonator\" in collection {$id}: {$th->getMessage()}");
+                        }
                     }
+
+                    if (!\in_array('impersonator', $existingIndexes)) {
+                        try {
+                            $this->createIndexFromCollection($this->dbForProject, $id, 'impersonator');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create index \"impersonator\" from {$id}: {$th->getMessage()}");
+                        }
+                    }
+
                     $this->dbForProject->purgeCachedCollection($id);
                     break;
 
@@ -481,7 +503,7 @@ class V24 extends Migration
                         // In case the email is invalid, set emailCanonical to lowercase email
                         $document
                             ->setAttribute('emailCanonical', \strtolower($email))
-                            ->setAttribute('emailIsCanonical', true)
+                            ->setAttribute('emailIsCanonical', $email === \strtolower($email))
                             ->setAttribute('emailIsCorporate', false)
                             ->setAttribute('emailIsDisposable', false)
                             ->setAttribute('emailIsFree', false);

--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -197,6 +197,18 @@ class V24 extends Migration
                     break;
 
                 case 'users':
+                    $attributes = [
+                        'emailCanonical',
+                        'emailIsFree',
+                        'emailIsDisposable',
+                        'emailIsCorporate',
+                        'emailIsCanonical',
+                    ];
+                    try {
+                        $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
+                    } catch (Throwable $th) {
+                        Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
+                    }
                     try {
                         $this->createAttributeFromCollection($this->dbForProject, $id, 'impersonator');
                     } catch (Throwable $th) {
@@ -451,6 +463,29 @@ class V24 extends Migration
                     $document->setAttribute('resourceType', 'projects');
                     $document->setAttribute('resourceId', $projectId);
                     $document->setAttribute('resourceInternalId', $projectInternalId);
+                }
+                break;
+            case 'users':
+                $email = $document->getAttribute('email');
+                if (!empty($email) && empty($document->getAttribute('emailCanonical'))) {
+                    try {
+                        $parsedEmail = new \Utopia\Emails\Email($email);
+                        $canonical = $parsedEmail->getCanonical();
+                        $document
+                            ->setAttribute('emailCanonical', $canonical)
+                            ->setAttribute('emailIsCanonical', $parsedEmail->get() === $canonical)
+                            ->setAttribute('emailIsCorporate', $parsedEmail->isCorporate())
+                            ->setAttribute('emailIsDisposable', $parsedEmail->isDisposable())
+                            ->setAttribute('emailIsFree', $parsedEmail->isFree());
+                    } catch (Throwable) {
+                        // In case the email is invalid, set emailCanonical to lowercase email
+                        $document
+                            ->setAttribute('emailCanonical', \strtolower($email))
+                            ->setAttribute('emailIsCanonical', true)
+                            ->setAttribute('emailIsCorporate', false)
+                            ->setAttribute('emailIsDisposable', false)
+                            ->setAttribute('emailIsFree', false);
+                    }
                 }
                 break;
             default:


### PR DESCRIPTION
Fixes #12705

## What does this PR do?
This PR ensures that missing user email canonical attributes (`emailCanonical`) are properly migrated in the V24 migration script.

## Test Plan
No tests run

## Related Issues
Closes #12705