### PR TITLE
fix(audit): record API key internal id as audit actor

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -226,7 +226,7 @@ Http::init()
                     default => ACTOR_TYPE_KEY_ORGANIZATION,
                 });
 
-                if ($apiKey->getType() === API_KEY_STANDARD) {
+                if ($apiKey->getType() === API_KEY_STANDARD || $apiKey->getType() === API_KEY_ORGANIZATION) {
                     $userClone
                         ->setAttribute('$id', $dbKey->getId())
                         ->setAttribute('$sequence', $dbKey->getSequence());

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -225,6 +225,13 @@ Http::init()
                     API_KEY_ACCOUNT => ACTOR_TYPE_KEY_ACCOUNT,
                     default => ACTOR_TYPE_KEY_ORGANIZATION,
                 });
+
+                if ($apiKey->getType() === API_KEY_STANDARD) {
+                    $userClone
+                        ->setAttribute('$id', $dbKey->getId())
+                        ->setAttribute('$sequence', $dbKey->getSequence());
+                }
+
                 $auditContext->user = $userClone;
             }
 


### PR DESCRIPTION
## What

Audit log entries for requests authenticated with a **standard** or **organization** API key were saved with an empty actor id and empty actor internal id, so it was impossible to tell which key performed an action.

## Why

When a request authenticates with a project (standard) or organization API key, the key role builds a synthetic user document with no `$id`/`$sequence`. That synthetic user is then cloned and used as the audit actor. As a result the audit worker reads an empty `getId()`/`getSequence()` and records an empty actor.

The real key document (`$dbKey`) is already loaded a few lines earlier (it has a real id and sequence), but its identity was never copied onto the audit actor.

## Fix

For standard and organization API keys, enrich the audit actor (`$userClone`) with the key document's `$id` and `$sequence` before it is assigned as the audit context user. This makes audit entries correctly attribute the acting key.

The change is scoped to the audit-bound clone only; the original synthetic user (used for permissions and request/response) is left untouched. Account keys are intentionally unchanged: their role keeps the real account user as the audit actor, which already carries a valid id and sequence.

## Test plan

- `php -l app/controllers/shared/api.php` — no syntax errors
- `vendor/bin/pint --test app/controllers/shared/api.php` — passed
- `vendor/bin/phpstan analyse app/controllers/shared/api.php` — no errors
