### PR TITLE
Fix Composer source fallback in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
           submodules: 'recursive'
 
       - name: Build the Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: false
@@ -116,7 +118,9 @@ jobs:
 
       - name: Install dependencies
         id: install
-        run: composer install --prefer-dist --no-progress --ignore-platform-reqs
+        run: |
+          composer config source-fallback true
+          composer install --prefer-dist --no-progress --ignore-platform-reqs
 
       - name: Install Node dependencies
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
@@ -263,10 +267,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push Appwrite
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /usr/local/src/
 COPY composer.lock /usr/local/src/
 COPY composer.json /usr/local/src/
 
-RUN composer install --ignore-platform-reqs --optimize-autoloader \
+RUN composer config source-fallback true && \
+    composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 


### PR DESCRIPTION
## What does this PR do?

Enables Composer source fallback for CI dependency installs and Docker image builds so transient GitHub dist archive failures can fall back to source installs instead of failing the build.

Also bumps the CI Docker Buildx and build-push actions to the same versions used in the related cloud CI fix, and disables Docker build record uploads for those CI build steps.

## Test Plan

- Parsed `.github/workflows/ci.yml` with Ruby YAML loader.
- Verified the branch diff is limited to CI/Docker build configuration.

## Related PRs and Issues

- Related cloud PR: https://github.com/appwrite-labs/cloud/pull/4523

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
