### PR TITLE
Pr 12707

### DIFF
--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -191,6 +191,18 @@ class V24 extends Migration
                     break;
 
                 case 'users':
+                    $attributes = [
+                        'emailCanonical',
+                        'emailIsFree',
+                        'emailIsDisposable',
+                        'emailIsCorporate',
+                        'emailIsCanonical',
+                    ];
+                    try {
+                        $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
+                    } catch (Throwable $th) {
+                        Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
+                    }
                     try {
                         $this->createAttributeFromCollection($this->dbForProject, $id, 'impersonator');
                     } catch (Throwable $th) {
@@ -406,6 +418,29 @@ class V24 extends Migration
                     $document->setAttribute('resourceType', 'projects');
                     $document->setAttribute('resourceId', $projectId);
                     $document->setAttribute('resourceInternalId', $projectInternalId);
+                }
+                break;
+            case 'users':
+                $email = $document->getAttribute('email');
+                if (!empty($email) && empty($document->getAttribute('emailCanonical'))) {
+                    try {
+                        $parsedEmail = new \Utopia\Emails\Email($email);
+                        $canonical = $parsedEmail->getCanonical();
+                        $document
+                            ->setAttribute('emailCanonical', $canonical)
+                            ->setAttribute('emailIsCanonical', $parsedEmail->get() === $canonical)
+                            ->setAttribute('emailIsCorporate', $parsedEmail->isCorporate())
+                            ->setAttribute('emailIsDisposable', $parsedEmail->isDisposable())
+                            ->setAttribute('emailIsFree', $parsedEmail->isFree());
+                    } catch (Throwable) {
+                        // In case the email is invalid, set emailCanonical to lowercase email
+                        $document
+                            ->setAttribute('emailCanonical', \strtolower($email))
+                            ->setAttribute('emailIsCanonical', true)
+                            ->setAttribute('emailIsCorporate', false)
+                            ->setAttribute('emailIsDisposable', false)
+                            ->setAttribute('emailIsFree', false);
+                    }
                 }
                 break;
             default:

--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -192,6 +192,7 @@ class V24 extends Migration
 
                 case 'users':
                     $attributes = [
+                        'keys',
                         'emailCanonical',
                         'emailIsFree',
                         'emailIsDisposable',

--- a/src/Appwrite/Migration/Version/V24.php
+++ b/src/Appwrite/Migration/Version/V24.php
@@ -198,21 +198,43 @@ class V24 extends Migration
                         'emailIsCorporate',
                         'emailIsCanonical',
                     ];
-                    try {
-                        $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
-                    } catch (Throwable $th) {
-                        Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
+                    $collectionDoc = $this->dbForProject->getCollection($id);
+                    $existingAttributes = [];
+                    $existingIndexes = [];
+                    if (!$collectionDoc->isEmpty()) {
+                        foreach ($collectionDoc->getAttribute('attributes', []) as $attributeDoc) {
+                            $existingAttributes[] = $attributeDoc->getAttribute('key');
+                        }
+                        foreach ($collectionDoc->getAttribute('indexes', []) as $indexDoc) {
+                            $existingIndexes[] = $indexDoc->getAttribute('key');
+                        }
                     }
-                    try {
-                        $this->createAttributeFromCollection($this->dbForProject, $id, 'impersonator');
-                    } catch (Throwable $th) {
-                        Console::warning("Failed to create attribute \"impersonator\" in collection {$id}: {$th->getMessage()}");
+
+                    $attributesToCreate = \array_diff($attributes, $existingAttributes);
+                    if (!empty($attributesToCreate)) {
+                        try {
+                            $this->createAttributesFromCollection($this->dbForProject, $id, $attributesToCreate);
+                        } catch (Throwable $th) {
+                            Console::warning('Failed to create attributes "' . \implode(', ', $attributesToCreate) . "\" in collection {$id}: {$th->getMessage()}");
+                        }
                     }
-                    try {
-                        $this->createIndexFromCollection($this->dbForProject, $id, 'impersonator');
-                    } catch (Throwable $th) {
-                        Console::warning("Failed to create index \"impersonator\" from {$id}: {$th->getMessage()}");
+
+                    if (!\in_array('impersonator', $existingAttributes)) {
+                        try {
+                            $this->createAttributeFromCollection($this->dbForProject, $id, 'impersonator');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create attribute \"impersonator\" in collection {$id}: {$th->getMessage()}");
+                        }
                     }
+
+                    if (!\in_array('impersonator', $existingIndexes)) {
+                        try {
+                            $this->createIndexFromCollection($this->dbForProject, $id, 'impersonator');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create index \"impersonator\" from {$id}: {$th->getMessage()}");
+                        }
+                    }
+
                     $this->dbForProject->purgeCachedCollection($id);
                     break;
 
@@ -436,7 +458,7 @@ class V24 extends Migration
                         // In case the email is invalid, set emailCanonical to lowercase email
                         $document
                             ->setAttribute('emailCanonical', \strtolower($email))
-                            ->setAttribute('emailIsCanonical', true)
+                            ->setAttribute('emailIsCanonical', $email === \strtolower($email))
                             ->setAttribute('emailIsCorporate', false)
                             ->setAttribute('emailIsDisposable', false)
                             ->setAttribute('emailIsFree', false);


### PR DESCRIPTION
## Summary

This PR complements #12707.

While testing the fix from #12707 on a real upgraded self-hosted instance (1.8.x → 1.9.x), I found that authentication still failed with:

```
Invalid document structure: Unknown attribute: "keys"
```

The new migration correctly creates and backfills the email-related attributes, but the `keys` attribute is still missing from upgraded users collections.

Adding `keys` to the migrated attributes resolves the issue.

## Reproduction

1. Upgrade an existing Appwrite 1.8.x installation to 1.9.x.
2. Apply the changes from #12707.
3. Attempt to log in.

Result:

```
Unknown attribute: "keys"
```

## After this change

* ✅ Login works
* ✅ Create user works
* ✅ Delete user works
* ✅ Authentication succeeds on the upgraded instance

I verified this on a real self-hosted production upgrade.
