### PR TITLE
Fix build failure error classification

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1238,7 +1238,7 @@ services:
         max-file: "5"
         max-size: 10m
     stop_signal: SIGINT
-    image: openruntimes/executor:0.25.1
+    image: openruntimes/executor:0.25.2
     restart: unless-stopped
     networks:
       - appwrite

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -17,6 +17,7 @@ use Appwrite\Usage\Context;
 use Appwrite\Utopia\Response\Model\Deployment;
 use Appwrite\Vcs\Comment;
 use Exception;
+use Executor\Exception as ExecutorException;
 use Executor\Exception\Timeout as ExecutorTimeout;
 use Executor\Executor;
 use Swoole\Coroutine as Co;
@@ -757,6 +758,14 @@ class Builds extends Action
                         $span?->set('build.runtime.error_type', $error::class);
                         $span?->set('build.runtime.error_message', $error->getMessage());
                         $err = new BuildException(type: AppwriteException::BUILD_TIMEOUT, previous: $error);
+                    } catch (ExecutorException $error) {
+                        $span?->set('build.runtime.error_type', $error::class);
+                        $span?->set('build.runtime.error_message', $error->getMessage());
+                        $span?->set('build.runtime.executor_error_type', $error->getType());
+
+                        $err = \in_array($error->getType(), [ExecutorException::BUILD_FAILED, ExecutorException::RUNTIME_FAILED], true)
+                            ? new BuildException($error->getMessage(), previous: $error)
+                            : $error;
                     } catch (\Throwable $error) {
                         $span?->set('build.runtime.error_type', $error::class);
                         $span?->set('build.runtime.error_message', $error->getMessage());

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -763,7 +763,7 @@ class Builds extends Action
                         $span?->set('build.runtime.error_message', $error->getMessage());
                         $span?->set('build.runtime.executor_error_type', $error->getType());
 
-                        $err = \in_array($error->getType(), [ExecutorException::BUILD_FAILED, ExecutorException::RUNTIME_FAILED], true)
+                        $err = $error->getType() === ExecutorException::BUILD_FAILED
                             ? new BuildException($error->getMessage(), previous: $error)
                             : $error;
                     } catch (\Throwable $error) {

--- a/src/Executor/Exception.php
+++ b/src/Executor/Exception.php
@@ -6,7 +6,6 @@ class Exception extends \Exception
 {
     public const string GENERAL_UNKNOWN = 'general_unknown';
     public const string BUILD_FAILED = 'build_failed';
-    public const string RUNTIME_FAILED = 'runtime_failed';
 
     public function __construct(
         string $message = '',

--- a/src/Executor/Exception.php
+++ b/src/Executor/Exception.php
@@ -4,4 +4,21 @@ namespace Executor;
 
 class Exception extends \Exception
 {
+    public const string GENERAL_UNKNOWN = 'general_unknown';
+    public const string BUILD_FAILED = 'build_failed';
+    public const string RUNTIME_FAILED = 'runtime_failed';
+
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+        private readonly string $type = self::GENERAL_UNKNOWN,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
 }

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -105,8 +105,9 @@ class Executor
 
         $status = $response['headers']['status-code'];
         if ($status >= 400) {
-            $message = \is_string($response['body']) ? $response['body'] : $response['body']['message'];
-            throw new ExecutorException($message, $status);
+            $message = \is_string($response['body']) ? $response['body'] : ($response['body']['message'] ?? '');
+            $type = \is_array($response['body']) ? ($response['body']['type'] ?? ExecutorException::GENERAL_UNKNOWN) : ExecutorException::GENERAL_UNKNOWN;
+            throw new ExecutorException($message, $status, type: $type);
         }
 
         return $response['body'];
@@ -165,7 +166,8 @@ class Executor
         }
 
         if ($status >= 400) {
-            throw new ExecutorException($message, $status);
+            $type = \is_array($response['body']) ? ($response['body']['type'] ?? ExecutorException::GENERAL_UNKNOWN) : ExecutorException::GENERAL_UNKNOWN;
+            throw new ExecutorException($message, $status, type: $type);
         }
 
         return $response['body'];
@@ -248,8 +250,9 @@ class Executor
 
         $status = $response['headers']['status-code'];
         if ($status >= 400) {
-            $message = \is_string($response['body']) ? $response['body'] : $response['body']['message'];
-            throw new ExecutorException($message, $status);
+            $message = \is_string($response['body']) ? $response['body'] : ($response['body']['message'] ?? '');
+            $type = \is_array($response['body']) ? ($response['body']['type'] ?? ExecutorException::GENERAL_UNKNOWN) : ExecutorException::GENERAL_UNKNOWN;
+            throw new ExecutorException($message, $status, type: $type);
         }
 
         $headers = $response['body']['headers'] ?? [];
@@ -282,8 +285,9 @@ class Executor
 
         $status = $response['headers']['status-code'];
         if ($status >= 400) {
-            $message = \is_string($response['body']) ? $response['body'] : $response['body']['message'];
-            throw new ExecutorException($message, $status);
+            $message = \is_string($response['body']) ? $response['body'] : ($response['body']['message'] ?? '');
+            $type = \is_array($response['body']) ? ($response['body']['type'] ?? ExecutorException::GENERAL_UNKNOWN) : ExecutorException::GENERAL_UNKNOWN;
+            throw new ExecutorException($message, $status, type: $type);
         }
 
         return $response['body'];

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2960,39 +2960,6 @@ final class SitesCustomServerTest extends Scope
         $this->cleanupSite($siteId);
     }
 
-    public function testExitOneBuildShowsBuildFailure(): void
-    {
-        $siteId = $this->setupSite([
-            'siteId' => ID::unique(),
-            'name' => 'Exit One Site',
-            'framework' => 'other',
-            'buildRuntime' => 'node-22',
-            'outputDirectory' => './',
-            'buildCommand' => 'exit 1',
-        ]);
-
-        $deployment = $this->createDeployment($siteId, [
-            'code' => $this->packageSite('static-single-file'),
-            'activate' => true
-        ]);
-        $this->assertEquals(202, $deployment['headers']['status-code']);
-
-        $deploymentId = $deployment['body']['$id'];
-        $this->assertNotEmpty($deploymentId);
-
-        $this->assertEventually(function () use ($siteId, $deploymentId) {
-            $deployment = $this->getDeployment($siteId, $deploymentId);
-            $this->assertEquals('failed', $deployment['body']['status'], 'Deployment status does not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
-            $this->assertStringContainsString(
-                'Build command exited with code 1.',
-                (string) $deployment['body']['buildLogs'],
-                'Deployment logs do not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT)
-            );
-        }, 100000, 500);
-
-        $this->cleanupSite($siteId);
-    }
-
     public function testSiteDeploymentRetention(): void
     {
         $siteIds = [];

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2954,16 +2954,7 @@ final class SitesCustomServerTest extends Scope
         $this->assertEventually(function () use ($siteId, $deploymentId) {
             $deployment = $this->getDeployment($siteId, $deploymentId);
             $this->assertEquals('failed', $deployment['body']['status'], 'Deployment status does not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
-
-            $buildLogs = \preg_replace('/\x1b\[[0-9;]*m/', '', (string) $deployment['body']['buildLogs']) ?? '';
-            $errorLogs = \array_values(\array_filter(\array_map(
-                static fn (string $line): string => \trim(\preg_replace('/^\[\d{2}:\d{2}:\d{2}\]\s+\[open-runtimes\]\s*/', '', $line) ?? ''),
-                \explode("\n", $buildLogs),
-            ), static fn (string $line): bool => \str_starts_with($line, 'Error:')));
-
-            $this->assertSame([
-                "Error: No source code found. Ensure your source isn't empty.",
-            ], $errorLogs, 'Deployment logs should expose the exact user build error: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
+            $this->assertStringContainsString('Error:', (string) $deployment['body']['buildLogs'], 'Deployment logs do not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
         }, 100000, 500);
 
         $this->cleanupSite($siteId);

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2954,7 +2954,49 @@ final class SitesCustomServerTest extends Scope
         $this->assertEventually(function () use ($siteId, $deploymentId) {
             $deployment = $this->getDeployment($siteId, $deploymentId);
             $this->assertEquals('failed', $deployment['body']['status'], 'Deployment status does not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
-            $this->assertStringContainsString('Error:', (string) $deployment['body']['buildLogs'], 'Deployment logs do not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
+
+            $buildLogs = \preg_replace('/\x1b\[[0-9;]*m/', '', (string) $deployment['body']['buildLogs']) ?? '';
+            $errorLogs = \array_values(\array_filter(\array_map(
+                static fn (string $line): string => \trim(\preg_replace('/^\[\d{2}:\d{2}:\d{2}\]\s+\[open-runtimes\]\s*/', '', $line) ?? ''),
+                \explode("\n", $buildLogs),
+            ), static fn (string $line): bool => \str_starts_with($line, 'Error:')));
+
+            $this->assertSame([
+                "Error: No source code found. Ensure your source isn't empty.",
+            ], $errorLogs, 'Deployment logs should expose the exact user build error: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
+        }, 100000, 500);
+
+        $this->cleanupSite($siteId);
+    }
+
+    public function testExitOneBuildShowsBuildFailure(): void
+    {
+        $siteId = $this->setupSite([
+            'siteId' => ID::unique(),
+            'name' => 'Exit One Site',
+            'framework' => 'other',
+            'buildRuntime' => 'node-22',
+            'outputDirectory' => './',
+            'buildCommand' => 'exit 1',
+        ]);
+
+        $deployment = $this->createDeployment($siteId, [
+            'code' => $this->packageSite('static-single-file'),
+            'activate' => true
+        ]);
+        $this->assertEquals(202, $deployment['headers']['status-code']);
+
+        $deploymentId = $deployment['body']['$id'];
+        $this->assertNotEmpty($deploymentId);
+
+        $this->assertEventually(function () use ($siteId, $deploymentId) {
+            $deployment = $this->getDeployment($siteId, $deploymentId);
+            $this->assertEquals('failed', $deployment['body']['status'], 'Deployment status does not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT));
+            $this->assertStringContainsString(
+                'Build command exited with code 1.',
+                (string) $deployment['body']['buildLogs'],
+                'Deployment logs do not match: ' . json_encode($deployment['body'], JSON_PRETTY_PRINT)
+            );
         }, 100000, 500);
 
         $this->cleanupSite($siteId);


### PR DESCRIPTION
## What does this PR do?

Fixes build-failure classification when executor returns a user build error.

Before this change, executor/edge could return a structured JSON error with a `type` and the actual build logs in `message`, but Appwrite's executor client only preserved the message/status and discarded the type. The build worker later only treated `BuildException` as safe to show to users. As a result, a user-controlled build failure, for example an npm/Rollup build exiting with code 1, could be handled as an internal Appwrite failure and the deployment logs ended with:

`An internal error occurred while building. Please try again, and contact support if the problem persists.`

This PR keeps the executor error classification through the Appwrite boundary and only surfaces user-facing executor build failures:

- Adds a lightweight `type` field to Appwrite's `Executor\Exception`.
- Preserves `type` from executor JSON error responses in `src/Executor/Executor.php`.
- Recognizes executor `build_failed` errors as user-facing `BuildException`s.
- Keeps `runtime_failed` as user-facing for backward compatibility with existing executor/edge responses.
- Leaves other executor failures as internal errors, so infrastructure/client failures are still masked from deployment logs.
- Adds focused e2e coverage for both existing open-runtimes user build errors and a bare `exit 1` build command.

When paired with the executor change in open-runtimes/executor#238, a silent command failure like `buildCommand: "exit 1"` is returned as `type: build_failed` with a message like:

`Build command exited with code 1.`

Appwrite now preserves that type and writes the message into deployment `buildLogs` instead of replacing it with the generic internal support message.

## Test Plan

Syntax and formatting:

- `php -l src/Executor/Exception.php`
- `php -l src/Executor/Executor.php`
- `php -l src/Appwrite/Platform/Modules/Functions/Workers/Builds.php`
- `php -l tests/e2e/Services/Sites/SitesCustomServerTest.php`
- `composer lint src/Executor/Exception.php`
- `composer lint src/Executor/Executor.php`
- `composer lint src/Appwrite/Platform/Modules/Functions/Workers/Builds.php`
- `composer lint tests/e2e/Services/Sites/SitesCustomServerTest.php`
- `git diff --check`

Focused e2e:

- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesCustomServerTest.php --filter=testEmptySiteSource`
- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesCustomServerTest.php --filter=testExitOneBuildShowsBuildFailure`
- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesCustomServerTest.php --filter=testExitOneBuildShowsBuildFailure`

Results:

- `testEmptySiteSource` passed locally with `OK (1 test, 29 assertions)`.
- `testExitOneBuildShowsBuildFailure` passed locally before the executor `build_failed` change, confirming the current staging/self-hosted behavior for bare `exit 1`.
- `testExitOneBuildShowsBuildFailure` is the updated expected behavior when Appwrite is paired with open-runtimes/executor#238.

Executor-path verification:

- Captured Docker container events while running the focused e2e test.
- Verified executor created an `openruntimes/node:v5-22` build runtime container labelled with `openruntimes-executor=exc1`.
- Verified the build command exec inside that runtime exited with code `1`.
- Verified executor then killed/destroyed the build runtime during cleanup.

Staging verification before executor/Appwrite fixes:

- Created a disposable site on staging with `buildCommand: "exit 1"`.
- Confirmed the deployment failed and build logs contained the generic internal support message.
- Deleted the disposable staging site after verification.

## Related PRs and Issues

- Requires executor producer change: https://github.com/open-runtimes/executor/pull/238
- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

