### PR TITLE
debug: log site rendering detection inputs and result

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -33,6 +33,7 @@ use Utopia\Database\Exception\Restricted;
 use Utopia\Database\Exception\Structure;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
+use Utopia\Detector\Detection\Rendering as RenderingDetection;
 use Utopia\Detector\Detection\Rendering\SSR;
 use Utopia\Detector\Detection\Rendering\XStatic;
 use Utopia\Detector\Detector\Rendering;
@@ -1432,6 +1433,7 @@ class Builds extends Action
             $detector->addInput($file);
         }
 
+        /** @var RenderingDetection $result */
         $result = $detector
             ->addOption(new SSR())
             ->addOption(new XStatic())

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1424,15 +1424,22 @@ class Builds extends Action
         $files = \array_map(\trim(...), $files);
         $files = \array_map(fn ($file) => \str_starts_with($file, './') ? \substr($file, 2) : $file, $files);
 
+        Console::info('[Detection] Framework: ' . $framework);
+        Console::info('[Detection] Files: ' . \implode(', ', $files));
+
         $detector = new Rendering($framework);
         foreach ($files as $file) {
             $detector->addInput($file);
         }
 
-        return $detector
+        $result = $detector
             ->addOption(new SSR())
             ->addOption(new XStatic())
             ->detect();
+
+        Console::info('[Detection] Result: ' . $result->getName());
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Temporary debug logging to trace why post-build rendering detection returns `static` for tanstack-start SSR sites.

Logs framework name, file list passed to the detector, and detection result to worker container logs.

**To use:** trigger a failing vibes build and check `docker logs appwrite-worker-builds` (or cloud worker logs).

> **Note:** This PR should be reverted/replaced once root cause is found.