### PR TITLE
fix(compose): add missing _APP_DOMAIN* and _APP_OPTIONS_FORCE_HTTPS env vars to appwrite-worker-executions and appwrite-task-scheduler-messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -668,6 +668,10 @@ services:
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_DOMAIN
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
@@ -1162,6 +1166,10 @@ services:
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_DOMAIN
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER


### PR DESCRIPTION
## Summary

The `appwrite-worker-executions` and `appwrite-task-scheduler-messages` service definitions in `docker-compose.yml` are missing `_APP_DOMAIN`, `_APP_DOMAIN_FUNCTIONS`, `_APP_DOMAIN_SITES`, and `_APP_OPTIONS_FORCE_HTTPS` from their `environment:` blocks. Their sibling services (`appwrite-task-scheduler-functions`, `appwrite-task-scheduler-executions`, `appwrite-worker-functions`) all have these vars — this looks like an oversight on the two services touched here.

## Impact

`appwrite-worker-executions` reads `_APP_DOMAIN` (via `app/config/platform.php` → `$platform['apiHostname']`) when computing `APPWRITE_FUNCTION_API_ENDPOINT` for runtime injection (`src/Appwrite/Platform/Workers/Functions.php:480`). Without the env, the worker boots with `apiHostname='localhost'` and every scheduled function execution receives `APPWRITE_FUNCTION_API_ENDPOINT=https://localhost/v1`. The function's SDK calls back to `https://localhost/v1` (nothing listening inside the runtime container) → `fetch failed` errors.

HTTP-triggered functions are unaffected because they go through the `appwrite` container, which has `_APP_DOMAIN`. Scheduled functions break silently — they complete with HTTP 200 but log the fetch failure, so it can take a while to notice in production.

`appwrite-task-scheduler-messages` likely has the same effect on scheduled SMS/email message delivery though I haven't traced that one end-to-end.

## Changes

Add the four env vars to both services' `environment:` blocks. Matches the layout already present on the three other scheduler/function services.

## Tested

Self-hosted Appwrite 1.9.0 instance: applied the same fix via `docker-compose.override.yml`, verified runtime now receives the correct `APPWRITE_FUNCTION_API_ENDPOINT` (matching `_APP_DOMAIN` from `.env`), scheduled function executions complete cleanly.

## Related

- Companion to the `_APP_OPENSSL_KEY_V1` fix on `appwrite-worker-executions` already on `main` — same class of bug (oversight in the env block of this particular worker).
- Detailed root-cause analysis + reproduction: #12622
