### PR TITLE
fix: restrict CodeQL workflow permissions on 1.4.x

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,8 +13,13 @@ on:
   schedule:
     - cron: '0 16 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      security-events: write
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The codeql-analysis.yml workflow on 1.4.x had no permissions block, causing it to inherit the default repository token with excessive permissions.

This adds:
- `permissions: contents: read` at the workflow level
- `permissions: security-events: write` at the job level

This matches the fix already applied on the default branch in f8b89b2.