### PR TITLE
Fix web installer template paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,12 @@ COPY ./dev /usr/src/code/dev
 COPY ./mongo-init.js /usr/src/code/mongo-init.js
 COPY ./mongo-entrypoint.sh /usr/src/code/mongo-entrypoint.sh
 
+# Add Installer Templates
+COPY ./app/views/install /usr/local/share/appwrite/app/views/install
+COPY ./docker-compose.yml /usr/local/share/appwrite/docker-compose.yml
+COPY ./mongo-init.js /usr/local/share/appwrite/mongo-init.js
+COPY ./mongo-entrypoint.sh /usr/local/share/appwrite/mongo-entrypoint.sh
+
 # Set Volumes
 RUN mkdir -p /storage/uploads && \
     mkdir -p /storage/imports && \

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -1393,7 +1393,20 @@ class Install extends Action
         if ($suffix !== '' && $suffix[0] !== '/') {
             $suffix = '/' . $suffix;
         }
-        return dirname(__DIR__, 4) . $suffix;
+
+        $roots = [
+            dirname(__DIR__, 4),
+            '/usr/local/share/appwrite',
+        ];
+
+        foreach ($roots as $root) {
+            $path = $root . $suffix;
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return $roots[0] . $suffix;
     }
 
     protected function applyLocalPaths(bool $isLocalInstall, bool $force = false): void


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Applies the web installer template packaging fix from the 1.9.x release branch to `main`.

The installer now resolves source templates from the normal project root first, then falls back to packaged installer templates under `/usr/local/share/appwrite`. The Docker image also includes the installer compose/env support files in that fallback location so the web installer can generate compose and MongoDB support files when `/usr/src/code` does not contain the source templates.

## Test Plan

- Ran `composer lint src/Appwrite/Platform/Tasks/Install.php`
- Verified the branch diff only changes installer template resolution and Docker image packaging

## Related PRs and Issues

- #12737

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
