### PR TITLE
Fix local installer bind mount paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -876,6 +876,7 @@ services:
       - _APP_MIGRATION_HOST
   appwrite-task-maintenance:
     entrypoint: maintenance
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -922,6 +923,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-interval:
     entrypoint: interval
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -963,6 +965,7 @@ services:
   appwrite-task-stats-resources:
     container_name: appwrite-task-stats-resources
     entrypoint: stats-resources
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -1066,6 +1069,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-functions:
     entrypoint: schedule-functions
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -1104,6 +1108,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-executions:
     entrypoint: schedule-executions
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -1142,6 +1147,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-messages:
     entrypoint: schedule-messages
+    restart: on-failure:3
     logging:
       driver: json-file
       options:

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -106,6 +106,7 @@ class Generator
             }
 
             $this->rewriteDependencies($service);
+            $this->rewriteRelativeBindMounts($service);
             $this->rewriteLocalVolumes($name, $service);
         }
         unset($service);
@@ -242,6 +243,25 @@ class Generator
                 $service['depends_on'][$selected] = $selector['condition'];
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $service
+     */
+    private function rewriteRelativeBindMounts(array &$service): void
+    {
+        if ($this->params['version'] !== 'local' || empty($this->params['hostPath']) || empty($service['volumes'])) {
+            return;
+        }
+
+        foreach ($service['volumes'] as &$volume) {
+            if (!\is_string($volume) || !\str_starts_with($volume, './')) {
+                continue;
+            }
+
+            $volume = $this->params['hostPath'] . '/' . \substr($volume, 2);
+        }
+        unset($volume);
     }
 
     /**

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -222,8 +222,9 @@ class Generator
                     }
                 ));
 
-                if ($hasSelectedDependency && !\in_array($selected, $dependsOn, true)) {
-                    $dependsOn[] = $selected;
+                if ($hasSelectedDependency) {
+                    $dependsOn = \array_fill_keys($dependsOn, ['condition' => 'service_started']);
+                    $dependsOn[$selected] = $selector['condition'];
                 }
 
                 $service['depends_on'] = $dependsOn;

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -98,8 +98,8 @@ final class GeneratorTest extends TestCase
         ]);
 
         $this->assertSame(['appwrite'], $compose['services']['traefik']['depends_on']);
-        $this->assertContains('postgresql', $compose['services']['appwrite']['depends_on']);
-        $this->assertNotContains('${_APP_DB_HOST:-mongodb}', $compose['services']['appwrite']['depends_on']);
+        $this->assertArrayHasKey('postgresql', $compose['services']['appwrite']['depends_on']);
+        $this->assertArrayNotHasKey('${_APP_DB_HOST:-mongodb}', $compose['services']['appwrite']['depends_on']);
     }
 
     public function testKeepsLongCommandsReadable(): void

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -77,6 +77,20 @@ final class GeneratorTest extends TestCase
         $this->assertSame('/tmp/appwrite:/usr/src/code:rw', $compose['services']['appwrite']['volumes'][0]);
     }
 
+    public function testRewritesLocalRelativeBindMountsToHostPath(): void
+    {
+        $compose = $this->render([
+            'version' => 'local',
+            'hostPath' => '/tmp/appwrite',
+            'database' => 'mongodb',
+        ]);
+
+        $this->assertContains('/tmp/appwrite/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro', $compose['services']['mongodb']['volumes']);
+        $this->assertContains('/tmp/appwrite/mongo-entrypoint.sh:/mongo-entrypoint.sh:ro', $compose['services']['mongodb']['volumes']);
+        $this->assertNotContains('./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro', $compose['services']['mongodb']['volumes']);
+        $this->assertNotContains('./mongo-entrypoint.sh:/mongo-entrypoint.sh:ro', $compose['services']['mongodb']['volumes']);
+    }
+
     public function testDoesNotAddDatabaseDependencyWithoutPlaceholder(): void
     {
         $compose = $this->render([


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes local web installer compose output when Docker Compose runs inside the installer container while talking to the host Docker daemon.

For local installer renders, relative bind mounts such as `./mongo-entrypoint.sh:/mongo-entrypoint.sh:ro` are rewritten to use the known host install path. This prevents the host daemon from receiving container-only paths like `/usr/src/code/appwrite/mongo-entrypoint.sh`, creating empty directories, and causing MongoDB to fail with `Is a directory`.

## Test Plan

- Ran `./vendor/bin/phpunit --configuration phpunit.xml tests/unit/Docker/Compose/GeneratorTest.php`
- Ran `composer lint src/Appwrite/Docker/Compose/Generator.php`
- Ran `composer lint tests/unit/Docker/Compose/GeneratorTest.php`

## Related PRs and Issues

- #12737

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
