### PR TITLE
Fix local installer startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -878,6 +878,7 @@ services:
       - _APP_MIGRATION_HOST
   appwrite-task-maintenance:
     entrypoint: maintenance
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -924,6 +925,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-interval:
     entrypoint: interval
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -965,6 +967,7 @@ services:
   appwrite-task-stats-resources:
     container_name: appwrite-task-stats-resources
     entrypoint: stats-resources
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -1068,6 +1071,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-functions:
     entrypoint: schedule-functions
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -1106,6 +1110,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-executions:
     entrypoint: schedule-executions
+    restart: on-failure:3
     logging:
       driver: json-file
       options:
@@ -1144,6 +1149,7 @@ services:
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-messages:
     entrypoint: schedule-messages
+    restart: on-failure:3
     logging:
       driver: json-file
       options:

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -36,6 +36,11 @@ class Generator
         ],
     ];
 
+    private const array HOST_PATH_REWRITABLE_BINDS = [
+        './mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro',
+        './mongo-entrypoint.sh:/mongo-entrypoint.sh:ro',
+    ];
+
     private const array PARAM_DEFAULTS = [
         'version' => 'latest',
         'database' => 'mongodb',
@@ -251,12 +256,16 @@ class Generator
      */
     private function rewriteRelativeBindMounts(array &$service): void
     {
-        if ($this->params['version'] !== 'local' || empty($this->params['hostPath']) || empty($service['volumes'])) {
+        if (empty($this->params['hostPath']) || empty($service['volumes'])) {
             return;
         }
 
         foreach ($service['volumes'] as &$volume) {
             if (!\is_string($volume) || !\str_starts_with($volume, './')) {
+                continue;
+            }
+
+            if ($this->params['version'] !== 'local' && !\in_array($volume, self::HOST_PATH_REWRITABLE_BINDS, true)) {
                 continue;
             }
 

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -106,6 +106,7 @@ class Generator
             }
 
             $this->rewriteDependencies($service);
+            $this->rewriteRelativeBindMounts($service);
             $this->rewriteLocalVolumes($name, $service);
         }
         unset($service);
@@ -242,6 +243,25 @@ class Generator
                 $service['depends_on'][$selected] = $selector['condition'];
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $service
+     */
+    private function rewriteRelativeBindMounts(array &$service): void
+    {
+        if ($this->params['version'] !== 'local' || empty($this->params['hostPath']) || empty($service['volumes'])) {
+            return;
+        }
+
+        foreach ($service['volumes'] as &$volume) {
+            if (!\is_string($volume) || !\str_starts_with($volume, './')) {
+                continue;
+            }
+
+            $volume = $this->params['hostPath'] . '/' . \substr($volume, 2);
+        }
+        unset($volume);
     }
 
     /**

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -222,8 +222,9 @@ class Generator
                     }
                 ));
 
-                if ($hasSelectedDependency && !\in_array($selected, $dependsOn, true)) {
-                    $dependsOn[] = $selected;
+                if ($hasSelectedDependency) {
+                    $dependsOn = \array_fill_keys($dependsOn, ['condition' => 'service_started']);
+                    $dependsOn[$selected] = $selector['condition'];
                 }
 
                 $service['depends_on'] = $dependsOn;

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -547,6 +547,10 @@ class Install extends Action
             $version = 'local';
         }
 
+        if (!$isLocalInstall && $this->hostPath === '') {
+            $this->hostPath = $this->detectInstallerHostPath($this->path) ?? '';
+        }
+
         $assistantKey = (string) ($input['_APP_ASSISTANT_OPENAI_API_KEY'] ?? '');
         $enableAssistant = trim($assistantKey) !== '';
         $enabledRuntimes = \array_unique(\array_filter(\array_map(
@@ -1386,6 +1390,61 @@ class Install extends Action
 
         $cwd = getcwd();
         return $cwd !== false ? $cwd : '.';
+    }
+
+    protected function detectInstallerHostPath(string $containerPath): ?string
+    {
+        if (!file_exists('/.dockerenv') && !file_exists('/run/.containerenv')) {
+            return null;
+        }
+
+        $containerId = trim((string) @file_get_contents('/etc/hostname'));
+        if ($containerId === '') {
+            return null;
+        }
+
+        $command = \implode(' ', \array_map(\escapeshellarg(...), [
+            'docker',
+            'inspect',
+            '--format',
+            '{{ json .Mounts }}',
+            $containerId,
+        ]));
+        $output = [];
+        @\exec($command . ' 2>/dev/null', $output, $exitCode);
+        if ($exitCode !== 0 || empty($output)) {
+            return null;
+        }
+
+        $mounts = \json_decode(\implode("\n", $output), true);
+        if (!\is_array($mounts)) {
+            return null;
+        }
+
+        $containerPath = \rtrim($containerPath, '/');
+        foreach ($mounts as $mount) {
+            if (!\is_array($mount)) {
+                continue;
+            }
+            $source = $mount['Source'] ?? null;
+            $destination = $mount['Destination'] ?? null;
+            if (!\is_string($source) || !\is_string($destination) || $source === '' || $destination === '') {
+                continue;
+            }
+
+            $destination = \rtrim($destination, '/');
+            $hostPath = match (true) {
+                $destination === $containerPath => \rtrim($source, '/'),
+                \str_starts_with($containerPath . '/', $destination . '/') => \rtrim($source, '/') . \substr($containerPath, \strlen($destination)),
+                default => null,
+            };
+
+            if ($hostPath !== null) {
+                return $hostPath;
+            }
+        }
+
+        return null;
     }
 
     protected function buildFromProjectPath(string $suffix): string

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -27,6 +27,7 @@ class Install extends Action
 
     private const int HEALTH_CHECK_ATTEMPTS = 30;
     private const int HEALTH_CHECK_DELAY_SECONDS = 1;
+    private const int DOCKER_COMPOSE_UP_TIMEOUT_SECONDS = 600;
     private const int PROC_CLOSE_TIMEOUT_SECONDS = 60;
 
     private const string PATTERN_ENV_VAR_NAME = '/^[A-Z0-9_]+$/';
@@ -1248,11 +1249,17 @@ class Install extends Action
         }
 
         stream_set_blocking($pipes[1], false);
-        $deadline = time() + self::PROC_CLOSE_TIMEOUT_SECONDS;
+        $deadline = time() + self::DOCKER_COMPOSE_UP_TIMEOUT_SECONDS;
         $buffer = '';
+        $timedOut = false;
 
-        while (time() < $deadline) {
+        while (true) {
             $status = proc_get_status($process);
+            if (time() >= $deadline && $status['running']) {
+                $timedOut = true;
+                $output[] = 'Docker Compose did not finish starting containers within ' . self::DOCKER_COMPOSE_UP_TIMEOUT_SECONDS . ' seconds.';
+                break;
+            }
 
             $read = [$pipes[1]];
             $write = null;
@@ -1301,7 +1308,17 @@ class Install extends Action
 
         fclose($pipes[1]);
 
-        $exit = $this->procCloseWithTimeout($process, self::PROC_CLOSE_TIMEOUT_SECONDS);
+        if ($timedOut) {
+            proc_terminate($process, SIGTERM);
+            usleep(500_000);
+
+            if (proc_get_status($process)['running']) {
+                proc_terminate($process, SIGKILL);
+            }
+        }
+
+        $closeExit = $this->procCloseWithTimeout($process, self::PROC_CLOSE_TIMEOUT_SECONDS);
+        $exit = $timedOut ? 124 : $closeExit;
 
         return ['output' => $output, 'exit' => $exit];
     }

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -98,8 +98,8 @@ final class GeneratorTest extends TestCase
         ]);
 
         $this->assertSame(['appwrite'], $compose['services']['traefik']['depends_on']);
-        $this->assertContains('postgresql', $compose['services']['appwrite']['depends_on']);
-        $this->assertNotContains('${_APP_DB_HOST:-mongodb}', $compose['services']['appwrite']['depends_on']);
+        $this->assertArrayHasKey('postgresql', $compose['services']['appwrite']['depends_on']);
+        $this->assertArrayNotHasKey('${_APP_DB_HOST:-mongodb}', $compose['services']['appwrite']['depends_on']);
     }
 
     public function testKeepsLongCommandsReadable(): void

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -77,6 +77,20 @@ final class GeneratorTest extends TestCase
         $this->assertSame('/tmp/appwrite:/usr/src/code:rw', $compose['services']['appwrite']['volumes'][0]);
     }
 
+    public function testRewritesLocalRelativeBindMountsToHostPath(): void
+    {
+        $compose = $this->render([
+            'version' => 'local',
+            'hostPath' => '/tmp/appwrite',
+            'database' => 'mongodb',
+        ]);
+
+        $this->assertContains('/tmp/appwrite/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro', $compose['services']['mongodb']['volumes']);
+        $this->assertContains('/tmp/appwrite/mongo-entrypoint.sh:/mongo-entrypoint.sh:ro', $compose['services']['mongodb']['volumes']);
+        $this->assertNotContains('./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro', $compose['services']['mongodb']['volumes']);
+        $this->assertNotContains('./mongo-entrypoint.sh:/mongo-entrypoint.sh:ro', $compose['services']['mongodb']['volumes']);
+    }
+
     public function testDoesNotAddDatabaseDependencyWithoutPlaceholder(): void
     {
         $compose = $this->render([


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Mirrors the 1.9.x installer startup fixes to `main`.

For local installer renders, relative bind mounts such as `./mongo-entrypoint.sh:/mongo-entrypoint.sh:ro` are rewritten to the known host install path. This prevents the host Docker daemon from receiving container-only paths and creating empty directories for Mongo helper files.

This also fixes the documented Docker installer flow:

```bash
docker run -it --rm \
    --publish 20080:20080 \
    --volume /var/run/docker.sock:/var/run/docker.sock \
    --volume "$(pwd)"/appwrite:/usr/src/code/appwrite:rw \
    --entrypoint="install" \
    appwrite/appwrite:1.9.5
```

When the installer runs inside a container, it now detects the host source path for `/usr/src/code/appwrite` from Docker mount metadata and passes that path into Compose generation. Non-local Compose generation only rewrites the Mongo helper mounts when that host path is known, while preserving the existing local installer rewrite behavior.

It also hardens generated compose startup by converting selected database dependencies to health-gated `depends_on` entries and adding capped `restart: on-failure:3` policies to the task and scheduler services.

## Test Plan

- Ran `php -l src/Appwrite/Docker/Compose/Generator.php`
- Ran `php -l src/Appwrite/Platform/Tasks/Install.php`
- Ran `./vendor/bin/phpunit tests/unit/Docker/Compose/GeneratorTest.php`
- Ran `composer lint src/Appwrite/Docker/Compose/Generator.php`
- Ran `composer lint src/Appwrite/Platform/Tasks/Install.php`
- Previously ran `composer lint tests/unit/Docker/Compose/GeneratorTest.php`

## Related PRs and Issues

- #12739
- #12745

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
