### PR TITLE
security: harden CodeQL workflow permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,8 +13,14 @@ on:
   schedule:
     - cron: '0 16 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      security-events: write
+      contents: read
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Backport workflow hardening (excessive-permissions) to release-sdks. Fixes #12716.