### PR TITLE
Fix static site serving 404 for pre-selected static adapter with single non-index file

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -923,12 +923,9 @@ class Builds extends Action
 
                         $deployment->setAttribute('adapter', $adapter);
                         $deployment->setAttribute('fallbackFile', $detection->getFallbackFile() ?? '');
-                        Span::add('build.adapter', $adapter);
-                        Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
                     }
                 } else {
                     $deployment->setAttribute('adapter', $adapter);
-                    Span::add('build.adapter', $adapter);
 
                     if (!empty($detectionLogs)) {
                         $detection = $this->detectSiteRendering($resource->getAttribute('framework', ''), $detectionLogs);
@@ -943,7 +940,6 @@ class Builds extends Action
                                     $resource = $dbForProject->updateDocument('sites', $resource->getId(), new Document(['fallbackFile' => $detectedFallback]));
                                 }
                                 $deployment->setAttribute('fallbackFile', $detectedFallback);
-                                Span::add('build.fallback_file', $detectedFallback);
                             } else {
                                 $deployment->setAttribute('fallbackFile', $resource->getAttribute('fallbackFile', ''));
                             }
@@ -953,6 +949,13 @@ class Builds extends Action
                             $deployment->setAttribute('fallbackFile', $resource->getAttribute('fallbackFile', ''));
                         }
                     }
+                }
+
+                if ($deployment->getAttribute('adapter') !== null) {
+                    Span::add('build.adapter', $deployment->getAttribute('adapter'));
+                }
+                if ($deployment->getAttribute('fallbackFile') !== null) {
+                    Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
                 }
             }
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -913,19 +913,46 @@ class Builds extends Action
             $deployment->setAttribute('buildLogs', $logs);
 
             $adapter = null;
-            if ($resource->getCollection() === 'sites' && ! empty($detectionLogs)) {
-                $detection = $this->detectSiteRendering($resource->getAttribute('framework', ''), $detectionLogs);
-
+            if ($resource->getCollection() === 'sites') {
                 $adapter = $resource->getAttribute('adapter', '');
                 if (empty($adapter)) {
-                    $resource = $dbForProject->updateDocument('sites', $resource->getId(), new Document(['adapter' => $detection->getName(), 'fallbackFile' => $detection->getFallbackFile() ?? '']));
+                    if (!empty($detectionLogs)) {
+                        $detection = $this->detectSiteRendering($resource->getAttribute('framework', ''), $detectionLogs);
+                        $adapter = $detection->getName();
+                        $resource = $dbForProject->updateDocument('sites', $resource->getId(), new Document(['adapter' => $adapter, 'fallbackFile' => $detection->getFallbackFile() ?? '']));
 
-                    $deployment->setAttribute('adapter', $detection->getName());
-                    $deployment->setAttribute('fallbackFile', $detection->getFallbackFile() ?? '');
-                    Span::add('build.adapter', $deployment->getAttribute('adapter'));
-                    Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
-                } elseif ($adapter === 'ssr' && $detection->getName() === 'static') {
-                    throw new BuildException('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
+                        $deployment->setAttribute('adapter', $adapter);
+                        $deployment->setAttribute('fallbackFile', $detection->getFallbackFile() ?? '');
+                        Span::add('build.adapter', $adapter);
+                        Span::add('build.fallback_file', $deployment->getAttribute('fallbackFile'));
+                    }
+                } else {
+                    $deployment->setAttribute('adapter', $adapter);
+                    Span::add('build.adapter', $adapter);
+
+                    if (!empty($detectionLogs)) {
+                        $detection = $this->detectSiteRendering($resource->getAttribute('framework', ''), $detectionLogs);
+                        if ($adapter === 'ssr' && $detection->getName() === 'static') {
+                            throw new BuildException('Adapter mismatch. Detected: ' . $detection->getName() . ' does not match with the set adapter: ' . $adapter);
+                        }
+
+                        if ($adapter === 'static') {
+                            $detectedFallback = $detection->getFallbackFile() ?? '';
+                            if (!empty($detectedFallback)) {
+                                if ($resource->getAttribute('fallbackFile', '') !== $detectedFallback) {
+                                    $resource = $dbForProject->updateDocument('sites', $resource->getId(), new Document(['fallbackFile' => $detectedFallback]));
+                                }
+                                $deployment->setAttribute('fallbackFile', $detectedFallback);
+                                Span::add('build.fallback_file', $detectedFallback);
+                            } else {
+                                $deployment->setAttribute('fallbackFile', $resource->getAttribute('fallbackFile', ''));
+                            }
+                        }
+                    } else {
+                        if ($adapter === 'static') {
+                            $deployment->setAttribute('fallbackFile', $resource->getAttribute('fallbackFile', ''));
+                        }
+                    }
                 }
             }
 

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2521,6 +2521,69 @@ final class SitesCustomServerTest extends Scope
         $this->cleanupSite($siteId);
     }
 
+    /**
+     * Regression test for https://github.com/appwrite/appwrite/issues/12715
+     *
+     * A static site that contains a single, non-index HTML file (e.g. "main.html")
+     * and has its "static" adapter pre-selected - as the Console does for the
+     * "Other" framework, which only exposes a static adapter - must still be served
+     * at "/", instead of returning a 404. The build worker is expected to backfill
+     * the detected fallback file even when the adapter was already set.
+     */
+    public function testServeStaticSinglePageWithStaticAdapter(): void
+    {
+        $siteId = $this->setupSite([
+            'buildRuntime' => 'node-22',
+            'framework' => 'other',
+            'name' => 'Static single page site',
+            'siteId' => ID::unique(),
+            'adapter' => 'static',
+            'outputDirectory' => './',
+        ]);
+        $this->assertNotEmpty($siteId);
+
+        $domain = $this->setupSiteDomain($siteId);
+        $this->assertNotEmpty($domain);
+        $proxyClient = new Client();
+        $proxyClient->setEndpoint('http://' . $domain);
+
+        $deploymentId = $this->setupDeployment($siteId, [
+            'code' => $this->packageSite('static-single-file'),
+            'activate' => true,
+        ]);
+        $this->assertNotEmpty($deploymentId);
+
+        // The package has no index.html, only main.html. The build worker must
+        // detect and persist it as the fallback file so it can be served at "/".
+        $site = $this->getSite($siteId);
+        $this->assertEquals(200, $site['headers']['status-code']);
+        $this->assertEquals('static', $site['body']['adapter']);
+        $this->assertEquals('main.html', $site['body']['fallbackFile']);
+
+        $response = $proxyClient->call(Client::METHOD_GET, '/');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringContainsString('Main page', (string) $response['body']);
+
+        // Re-deployment must keep serving correctly: the fallback file should stay
+        // synced on the site and the new deployment, not regress to a 404.
+        $redeploymentId = $this->setupDeployment($siteId, [
+            'code' => $this->packageSite('static-single-file'),
+            'activate' => true,
+        ]);
+        $this->assertNotEmpty($redeploymentId);
+        $this->assertNotEquals($deploymentId, $redeploymentId);
+
+        $site = $this->getSite($siteId);
+        $this->assertEquals(200, $site['headers']['status-code']);
+        $this->assertEquals('main.html', $site['body']['fallbackFile']);
+
+        $response = $proxyClient->call(Client::METHOD_GET, '/');
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringContainsString('Main page', (string) $response['body']);
+
+        $this->cleanupSite($siteId);
+    }
+
     public function testPreviewDomain(): void
     {
         $siteId = $this->setupSite([


### PR DESCRIPTION
### Summary
This PR fixes issue #12715 where a static site deployed with a pre-selected adapter (e.g. static for the 'Other' framework) and containing only a single non-index file (e.g. abc.html) would return a 404 error on /.

### Details
Previously, if a site's adapter was pre-selected (such as static), the build worker would entirely skip the auto-detection block. This resulted in the deployment's fallbackFile and adapter attributes never being set, leading to a 404 when serving static packages containing only a single non-index HTML page.

This PR optimizes the fallback and adapter resolution in the build worker (Builds.php) to:
1\. Always populate the deployment's adapter attribute matching the site's adapter when pre-selected (or auto-detected).
2\. Sync the detected fallback file to both the site document and the deployment document if it is resolved during building.
3\. Fallback to using the site's existing fallback file (if any) when the detection logs do not resolve an explicit fallback, avoiding clobbering user-defined configurations.
4\. Correctly raise BuildException on adapter mismatch (e.g. SSR site detecting static content).

We also added a comprehensive E2E regression test (testServeStaticSinglePageWithStaticAdapter) in SitesCustomServerTest.php to verify successful resolution and persistence across deployments and redeployments.