### PR TITLE
Fix installer Mongo helper host paths

### DIFF
--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -36,6 +36,11 @@ class Generator
         ],
     ];
 
+    private const array HOST_PATH_REWRITABLE_BINDS = [
+        './mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro',
+        './mongo-entrypoint.sh:/mongo-entrypoint.sh:ro',
+    ];
+
     private const array PARAM_DEFAULTS = [
         'version' => 'latest',
         'database' => 'mongodb',
@@ -251,12 +256,16 @@ class Generator
      */
     private function rewriteRelativeBindMounts(array &$service): void
     {
-        if ($this->params['version'] !== 'local' || empty($this->params['hostPath']) || empty($service['volumes'])) {
+        if (empty($this->params['hostPath']) || empty($service['volumes'])) {
             return;
         }
 
         foreach ($service['volumes'] as &$volume) {
             if (!\is_string($volume) || !\str_starts_with($volume, './')) {
+                continue;
+            }
+
+            if ($this->params['version'] !== 'local' && !\in_array($volume, self::HOST_PATH_REWRITABLE_BINDS, true)) {
                 continue;
             }
 

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -547,6 +547,10 @@ class Install extends Action
             $version = 'local';
         }
 
+        if (!$isLocalInstall && $this->hostPath === '') {
+            $this->hostPath = $this->detectInstallerHostPath($this->path) ?? '';
+        }
+
         $assistantKey = (string) ($input['_APP_ASSISTANT_OPENAI_API_KEY'] ?? '');
         $enableAssistant = trim($assistantKey) !== '';
         $enabledRuntimes = \array_unique(\array_filter(\array_map(
@@ -1386,6 +1390,61 @@ class Install extends Action
 
         $cwd = getcwd();
         return $cwd !== false ? $cwd : '.';
+    }
+
+    protected function detectInstallerHostPath(string $containerPath): ?string
+    {
+        if (!file_exists('/.dockerenv') && !file_exists('/run/.containerenv')) {
+            return null;
+        }
+
+        $containerId = trim((string) @file_get_contents('/etc/hostname'));
+        if ($containerId === '') {
+            return null;
+        }
+
+        $command = \implode(' ', \array_map(\escapeshellarg(...), [
+            'docker',
+            'inspect',
+            '--format',
+            '{{ json .Mounts }}',
+            $containerId,
+        ]));
+        $output = [];
+        @\exec($command . ' 2>/dev/null', $output, $exitCode);
+        if ($exitCode !== 0 || empty($output)) {
+            return null;
+        }
+
+        $mounts = \json_decode(\implode("\n", $output), true);
+        if (!\is_array($mounts)) {
+            return null;
+        }
+
+        $containerPath = \rtrim($containerPath, '/');
+        foreach ($mounts as $mount) {
+            if (!\is_array($mount)) {
+                continue;
+            }
+            $source = $mount['Source'] ?? null;
+            $destination = $mount['Destination'] ?? null;
+            if (!\is_string($source) || !\is_string($destination) || $source === '' || $destination === '') {
+                continue;
+            }
+
+            $destination = \rtrim($destination, '/');
+            $hostPath = match (true) {
+                $destination === $containerPath => \rtrim($source, '/'),
+                \str_starts_with($containerPath . '/', $destination . '/') => \rtrim($source, '/') . \substr($containerPath, \strlen($destination)),
+                default => null,
+            };
+
+            if ($hostPath !== null) {
+                return $hostPath;
+            }
+        }
+
+        return null;
     }
 
     protected function buildFromProjectPath(string $suffix): string


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the documented Docker installer flow for MongoDB installs by resolving Mongo helper script bind mounts to host-visible paths when the installer container is talking to the host Docker daemon.

The installer now detects the host source path for `/usr/src/code/appwrite` from Docker mount metadata and passes it into Compose generation. Compose generation keeps existing local bind mount rewriting, and only rewrites the Mongo helper mounts for non-local installs.

## Test Plan

- `php -l src/Appwrite/Docker/Compose/Generator.php`
- `php -l src/Appwrite/Platform/Tasks/Install.php`
- `./vendor/bin/phpunit tests/unit/Docker/Compose/GeneratorTest.php`

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
