### PR TITLE
fix: rely on DB library to purge project cache after config updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,12 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/utopia-php/database"
+        }
+    ],
     "require": {
         "php": ">=8.3.0",
         "ext-curl": "*",
@@ -63,7 +69,7 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "^6.0.0",
+        "utopia-php/database": "dev-fix/defer-cache-purge-until-outermost-commit as 6.1.0",
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17128527d9ef62968ea12eb43a81fdfb",
+    "content-hash": "82f09213dd7f55ec3ff3eb2478b95aaa",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3676,16 +3676,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "6.1.0",
+            "version": "dev-fix/defer-cache-purge-until-outermost-commit",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "18120ddf0bc656fc448e6c9407d2f16371d6f0a6"
+                "reference": "664736bc2cef0a517d2a160d362cb91acecf62e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/18120ddf0bc656fc448e6c9407d2f16371d6f0a6",
-                "reference": "18120ddf0bc656fc448e6c9407d2f16371d6f0a6",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/664736bc2cef0a517d2a160d362cb91acecf62e3",
+                "reference": "664736bc2cef0a517d2a160d362cb91acecf62e3",
                 "shasum": ""
             },
             "require": {
@@ -3716,7 +3716,38 @@
                     "Utopia\\Database\\": "src/Database"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\E2E\\": "tests/e2e",
+                    "Tests\\Unit\\": "tests/unit"
+                }
+            },
+            "scripts": {
+                "build": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "docker compose build"
+                ],
+                "start": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "docker compose up -d"
+                ],
+                "test": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "docker compose exec tests vendor/bin/phpunit --configuration phpunit.xml"
+                ],
+                "lint": [
+                    "php -d memory_limit=2G ./vendor/bin/pint --test"
+                ],
+                "format": [
+                    "php -d memory_limit=2G ./vendor/bin/pint"
+                ],
+                "check": [
+                    "./vendor/bin/phpstan analyse --level 7 src tests --memory-limit 2G"
+                ],
+                "coverage": [
+                    "./vendor/bin/coverage-check ./tmp/clover.xml 90"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -3729,10 +3760,10 @@
                 "utopia"
             ],
             "support": {
-                "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/6.1.0"
+                "source": "https://github.com/utopia-php/database/tree/fix/defer-cache-purge-until-outermost-commit",
+                "issues": "https://github.com/utopia-php/database/issues"
             },
-            "time": "2026-06-23T11:28:30+00:00"
+            "time": "2026-07-01T05:43:21+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -8354,9 +8385,17 @@
             "time": "2026-05-30T17:09:26+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/database",
+            "version": "dev-fix/defer-cache-purge-until-outermost-commit",
+            "alias": "6.1.0",
+            "alias_normalized": "6.1.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "utopia-php/database": 20,
         "utopia-php/http": 5,
         "utopia-php/platform": 5
     },

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/AuthMethods/Update.php
@@ -82,7 +82,6 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'auths' => $auths,
         ])));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents->setParam('methodId', $methodId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php
@@ -425,10 +425,7 @@ abstract class Base extends Action
             'oAuthProviders' => $oAuthProviders
         ]);
 
-        $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
-
-        return $project;
+        return $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
     }
 
     public function action(

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/MembershipPrivacy/Update.php
@@ -103,7 +103,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordDictionary/Update.php
@@ -75,7 +75,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordHistory/Update.php
@@ -83,7 +83,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordPersonalData/Update.php
@@ -76,7 +76,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/PasswordStrength/Update.php
@@ -103,7 +103,6 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'auths' => $auths,
         ])));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionAlert/Update.php
@@ -75,7 +75,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionDuration/Update.php
@@ -75,7 +75,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionInvalidation/Update.php
@@ -75,7 +75,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/SessionLimit/Update.php
@@ -81,7 +81,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/UserLimit/Update.php
@@ -81,7 +81,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents
             ->setParam('projectId', $project->getId())

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Protocols/Update.php
@@ -79,7 +79,6 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'apis' => $protocols,
         ])));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents->setParam('protocolId', $protocolId);
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
@@ -170,7 +170,6 @@ class Update extends Action
         ]);
 
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), $updates));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $response->dynamic($project, Response::MODEL_PROJECT);
     }

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Services/Update.php
@@ -79,7 +79,6 @@ class Update extends Action
         $project = $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
             'services' => $services,
         ])));
-        $authorization->skip(fn () => $dbForPlatform->purgeCachedDocument('projects', $project->getId()));
 
         $queueForEvents->setParam('serviceId', $serviceId);
 


### PR DESCRIPTION
## Summary

Removes the manual `purgeCachedDocument('projects', ...)` band-aids added in #12654 and fixes the underlying stale read-after-write at its source in `utopia-php/database`.

## Background

Project config endpoints write the project document inside an endpoint-level `withTransaction()` (for lost-update safety) and are read back from the cached project document. `updateDocument()`'s "purge again after commit" guard only fired after the real `COMMIT` when the write owned the outermost transaction. Nested in a caller's transaction, that purge ran while still inside the transaction — before commit — so a concurrent reader could re-cache the pre-commit project. #12654 patched around it by purging the project cache again in each endpoint.

The proper fix lives in the DB library: **utopia-php/database#910** defers every in-transaction cache purge until the outermost transaction commits. That closes the race for all callers, so the manual purges here are redundant.

Reproduced (real MariaDB + Redis, 16 concurrent readers, single writer): **40.6% → 0%** stale reads after the library fix.

## Changes

- Removed the redundant `purgeCachedDocument('projects', ...)` from the 15 endpoints that write the **project** document directly (AuthMethods, OAuth2, Protocols, SMTP, Services, and 10 Policies).
- **Kept** the purges in Platforms / Keys / DevKeys / Webhooks endpoints — those write *child* collections but invalidate the project's `subQuery*`-populated cache, which the library cannot purge automatically (not a DB relationship).
- `composer.json` / `composer.lock` point `utopia-php/database` at the fix branch via a VCS repo.

## Blocked on / merge order

- [ ] Merge & tag **utopia-php/database#910**
- [ ] Repoint `composer.json` from `dev-fix/defer-cache-purge-until-outermost-commit as 6.1.0` to the tagged release and re-lock
- [ ] Then mark ready for review

Kept as draft until the library release is out — it must not merge against a dev branch.