### PR TITLE
Fix/users update prefs event payload

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1824,7 +1824,7 @@ Http::patch('/v1/users/:userId/prefs')
         responses: [
             new SDKResponse(
                 code: Response::STATUS_CODE_OK,
-                model: Response::MODEL_PREFERENCES,
+                model: Response::MODEL_USER,
             )
         ]
     ))
@@ -1846,7 +1846,7 @@ Http::patch('/v1/users/:userId/prefs')
         $queueForEvents
             ->setParam('userId', $user->getId());
 
-        $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
+        $response->dynamic($user, Response::MODEL_USER);
     });
 
 Http::patch('/v1/users/:userId/targets/:targetId')

--- a/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
@@ -46,7 +46,7 @@ class Update extends Action
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
-                        model: Response::MODEL_PREFERENCES,
+                        model: Response::MODEL_TEAM,
                     )
                 ]
             ))
@@ -78,6 +78,6 @@ class Update extends Action
 
         $queueForEvents->setParam('teamId', $team->getId());
 
-        $response->dynamic($prefs, Response::MODEL_PREFERENCES);
+        $response->dynamic($team, Response::MODEL_TEAM);
     }
 }


### PR DESCRIPTION
● What does this PR do?               

  When a function subscribes to `users.*.update` events, the event payload is inconsistent depending on which field was 
  updated. Updating email, name, status, or any other field dispatches the full user object — but updating preferences
   dispatches only the `prefs` object. The same inconsistency exists for teams`.*.update.prefs`.                          
                  
  This PR fixes both endpoints to return the full parent object, matching the behaviour of every other update endpoint
   in the users and teams APIs:

  - `PATCH /v1/users/:userId/prefs` — now responds with `MODEL_USER` instead of `MODEL_PREFERENCES`
  - `PUT /v1/teams/:teamId/prefs` — now responds with `MODEL_TEAM` instead of `MODEL_PREFERENCES`

  Test Plan

  1. Spin up a local Appwrite instance with `docker compose up -d --force-recreate --build`
  2. Create a function subscribed to the `users.*.update` event
  3. Call `PATCH /v1/users/:userId/pref`s with a `prefs` payload
  4. Verify the function receives the full user object (not just the `prefs` object)
  5. Repeat steps 2–4 for a function subscribed to `teams.*.update` using `PUT /v1/teams/:teamId/prefs`, and verify the
  full team object is received

  Related PRs and Issues

  - Fixes #7234

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

