### PR TITLE
feat(console): bump console to 8.7.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/console:8.7.5
+    image: appwrite/console:8.7.11
     restart: unless-stopped
     networks:
       - appwrite


### PR DESCRIPTION
## Summary

- Bumps `appwrite/console` image from `8.7.5` to `8.7.11` in `docker-compose.yml`