### PR TITLE
fix(builds): truncate buildLogs to attribute limit to avoid oversized-log build failures

### DIFF
--- a/app/config/collections/projects.php
+++ b/app/config/collections/projects.php
@@ -1872,7 +1872,7 @@ return [
                 '$id' => ID::custom('buildLogs'),
                 'type' => Database::VAR_STRING,
                 'format' => '',
-                'size' => 1000000,
+                'size' => APP_LOG_LENGTH_LIMIT,
                 'signed' => true,
                 'required' => false,
                 'default' => '',

--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -269,8 +269,9 @@ const APP_AUTH_TYPE_ADMIN = 'Admin';
 // Response related
 const MAX_OUTPUT_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
 const APP_LIMIT_UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024; // 5MB
-const APP_FUNCTION_LOG_LENGTH_LIMIT = 1000000;
-const APP_FUNCTION_ERROR_LENGTH_LIMIT = 1000000;
+const APP_LOG_LENGTH_LIMIT = 1000000; // Single source of truth for log/error length limits (matches the related attribute sizes)
+const APP_FUNCTION_LOG_LENGTH_LIMIT = APP_LOG_LENGTH_LIMIT;
+const APP_FUNCTION_ERROR_LENGTH_LIMIT = APP_LOG_LENGTH_LIMIT;
 // Function headers
 const FUNCTION_ALLOWLIST_HEADERS_REQUEST = ['content-type', 'agent', 'content-length', 'host', 'x-appwrite-client-ip'];
 const FUNCTION_ALLOWLIST_HEADERS_RESPONSE = ['content-type', 'content-length'];

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -53,6 +53,26 @@ class Builds extends Action
     }
 
     /**
+     * Truncate build logs to the length allowed by the deployments "buildLogs"
+     * attribute. Large site builds (heavy prerender/bundle output) can exceed
+     * it, which makes persisting the deployment throw a Structure exception and
+     * report the build as failed even though it actually succeeded. Keep the
+     * tail — it holds the build result and any error — mirroring how execution
+     * logs are trimmed elsewhere in this codebase.
+     */
+    private function truncateBuildLogs(string $logs): string
+    {
+        $limit = APP_LOG_LENGTH_LIMIT;
+        if (\strlen($logs) <= $limit) {
+            return $logs;
+        }
+
+        $warning = "[WARNING] Logs truncated. The output exceeded {$limit} characters.\n";
+
+        return $warning . \substr($logs, -($limit - \strlen($warning)));
+    }
+
+    /**
      * @throws Exception
      */
     public function __construct()
@@ -852,9 +872,9 @@ class Builds extends Action
                                     }
 
                                     if ($affected) {
-                                        $deployment = $deployment->setAttribute('buildLogs', $currentLogs);
+                                        $deployment = $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($currentLogs));
                                         $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
-                                            'buildLogs' => $currentLogs,
+                                            'buildLogs' => $this->truncateBuildLogs($currentLogs),
                                         ]));
 
                                         $queueForRealtime
@@ -910,7 +930,7 @@ class Builds extends Action
 
             ['logs' => $logs, 'detectionLogs' => $detectionLogs] = $this->splitSiteDetectionLogs($logs);
 
-            $deployment->setAttribute('buildLogs', $logs);
+            $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($logs));
 
             $adapter = null;
             if ($resource->getCollection() === 'sites' && ! empty($detectionLogs)) {
@@ -946,7 +966,7 @@ class Builds extends Action
             $logs = $deployment->getAttribute('buildLogs', '');
             $date = \date('H:i:s');
             $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[32m Deployment finished. \033[0m\n";
-            $deployment->setAttribute('buildLogs', $logs);
+            $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($logs));
 
             /** Update the status */
             $endTime = DateTime::now();
@@ -1200,12 +1220,12 @@ class Builds extends Action
             Span::add('deployment.status', 'failed');
             Span::add('build.duration', $deployment->getAttribute('buildDuration'));
 
-            $deployment->setAttribute('buildLogs', $message);
+            $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($message));
             $deployment = $dbForProject->updateDocument('deployments', $deploymentId, new Document([
                 'buildEndedAt' => $deployment->getAttribute('buildEndedAt'),
                 'buildDuration' => $deployment->getAttribute('buildDuration'),
                 'status' => 'failed',
-                'buildLogs' => $message,
+                'buildLogs' => $this->truncateBuildLogs($message),
             ]));
 
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
@@ -1563,7 +1583,7 @@ class Builds extends Action
             $date = \date('H:i:s');
             $logs .= "[90m[$date] [90m[[0mappwrite[90m][33m Git action failed. Deployment will continue. [0m\n";
 
-            $deployment->setAttribute('buildLogs', $logs);
+            $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($logs));
             $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
                 'buildLogs' => $deployment->getAttribute('buildLogs'),
             ]));
@@ -1635,7 +1655,7 @@ class Builds extends Action
                 $date = \date('H:i:s');
                 $logs .= "\033[90m[$date] \033[90m[\033[0mappwrite\033[90m]\033[33m Build has been canceled. \033[0m\n";
 
-                $deployment->setAttribute('buildLogs', $logs);
+                $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($logs));
                 $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
                     'buildLogs' => $deployment->getAttribute('buildLogs'),
                 ]));

--- a/tests/unit/Functions/BuildsTest.php
+++ b/tests/unit/Functions/BuildsTest.php
@@ -144,6 +144,24 @@ final class BuildsTest extends TestCase
         $this->callBuilds('disconnectVcs', $resource, $dbForProject, $dbForPlatform);
     }
 
+    public function testTruncateBuildLogsKeepsShortLogsUnchanged(): void
+    {
+        $logs = "Build finished.\n";
+
+        $this->assertSame($logs, $this->callBuilds('truncateBuildLogs', $logs));
+    }
+
+    public function testTruncateBuildLogsTrimsOversizedLogsToLimitKeepingTail(): void
+    {
+        $oversized = \str_repeat('a', APP_LOG_LENGTH_LIMIT + 5000) . 'TAIL_MARKER';
+
+        $result = (string) $this->callBuilds('truncateBuildLogs', $oversized);
+
+        $this->assertLessThanOrEqual(APP_LOG_LENGTH_LIMIT, \strlen($result));
+        $this->assertStringContainsString('[WARNING] Logs truncated.', $result);
+        $this->assertStringEndsWith('TAIL_MARKER', $result);
+    }
+
     private function callBuilds(string $method, mixed ...$arguments): mixed
     {
         return (new ReflectionMethod($this->builds, $method))->invoke($this->builds, ...$arguments);


### PR DESCRIPTION
## What

Truncate the deployment `buildLogs` to the attribute's maximum length before every write in the Builds worker, reusing the same trimming convention already used for execution logs.

## Why

Large Sites builds (heavy prerender / bundle output — a big site emits thousands of `vite build` lines) can produce build logs longer than the `deployments.buildLogs` attribute limit (1,000,000). Persisting the deployment then throws:

```
Utopia\Database\Exception\Structure:
Attribute "buildLogs" ... must be ... no longer than 1000000 chars
```

Crucially this also fires **inside the build-failure handler**, which prepends the previous (huge) logs to the error message and writes again — so the handler re-throws the same exception uncaught. The result: the build is reported as failed even though it **succeeded** and the artifact was uploaded, and because nothing could be persisted the user sees a generic "internal error" placeholder with no logs. Trimming log verbosity at the source doesn't reliably help — the framework's own build output is large enough on its own.

## How

- Add `APP_BUILD_LOGS_LENGTH_LIMIT` (sibling to `APP_FUNCTION_LOG_LENGTH_LIMIT`, matching the `buildLogs` attribute size).
- Add a `truncateBuildLogs()` helper that mirrors the existing execution-log trimming (`Functions.php` / `Executions/Create.php` / `general.php`): **byte-based `strlen`/`substr`**, the standard `"[WARNING] Logs truncated. The output exceeded {N} characters."` prefix, keeping the **tail** (which holds the build result and any error).
- Apply it at every `buildLogs` write, including the failure handler, so the invariant "persisted `buildLogs` is always within the limit" holds on all paths (streamed, final, and error).

Byte-based trimming is used deliberately: capping bytes ≤ limit guarantees the value fits regardless of whether length is enforced by bytes or characters (`mb_strlen ≤ strlen`).

## Notes

A more thorough long-term direction would be to store full build logs outside the document (storage) and keep only a tail on the deployment, removing the size ceiling and data loss entirely. This PR is the right-sized fix that stops the failures and matches existing conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
