### PR TITLE
Run independent CI workflow steps in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,44 +119,46 @@ jobs:
         id: install
         run: composer install --prefer-dist --no-progress --ignore-platform-reqs
 
-      - name: Install Node dependencies
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        run: npm ci
+      - parallel:
+          - name: Install Node dependencies
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            run: npm ci
 
-      - name: Cache PHPStan result cache
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .phpstan-cache
-          key: phpstan-${{ github.sha }}
-          restore-keys: |
-            phpstan-
+          - name: Cache PHPStan result cache
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+            with:
+              path: .phpstan-cache
+              key: phpstan-${{ github.sha }}
+              restore-keys: |
+                phpstan-
 
-      - name: Audit dependencies
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        env:
-          COMPOSER_NO_AUDIT: 0
-        run: composer audit
+      - parallel:
+          - name: Audit dependencies
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            env:
+              COMPOSER_NO_AUDIT: 0
+            run: composer audit
 
-      - name: Run Linter
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        run: composer lint
+          - name: Run Linter
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            run: composer lint
 
-      - name: Check Docker Compose formatting
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        run: npm run lint:compose
+          - name: Check Docker Compose formatting
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            run: npm run lint:compose
 
-      - name: Run Rector
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        run: composer refactor:check
+          - name: Run Rector
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            run: composer refactor:check
 
-      - name: Run PHPStan
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        run: composer analyze -- --no-progress
+          - name: Run PHPStan
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            run: composer analyze -- --no-progress
 
-      - name: Generate specs
-        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
-        run: _APP_STORAGE_LIMIT=5368709120 php app/cli.php specs --version=latest --git=no
+          - name: Generate specs
+            if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+            run: _APP_STORAGE_LIMIT=5368709120 php app/cli.php specs --version=latest --git=no
 
   locale:
     name: Checks / Locale
@@ -298,28 +300,32 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull Docker Image
-        run: |
-          docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+      - parallel:
+          - name: Pull Docker Image
+            run: |
+              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+
+          - name: Pull Docker Compose images
+            timeout-minutes: 5
+            run: |
+              # Docker Hub registry timeouts are a common transient CI failure
+              # (e.g. a traefik manifest fetch timing out). Retry the image pull;
+              # keep `up` single-shot so genuine container health failures still surface.
+              for attempt in 1 2 3; do
+                if docker compose pull --quiet --ignore-buildable; then
+                  break
+                elif [ "$attempt" -eq 3 ]; then
+                  echo "::error::docker compose pull failed after 3 attempts; aborting"
+                  exit 1
+                fi
+                echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
+                sleep 15
+              done
 
       - name: Load and Start Appwrite
         timeout-minutes: 5
-        run: |
-          # Docker Hub registry timeouts are a common transient CI failure
-          # (e.g. a traefik manifest fetch timing out). Retry the image pull;
-          # keep `up` single-shot so genuine container health failures still surface.
-          for attempt in 1 2 3; do
-            if docker compose pull --quiet --ignore-buildable; then
-              break
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error::docker compose pull failed after 3 attempts; aborting"
-              exit 1
-            fi
-            echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
-            sleep 15
-          done
-          docker compose up -d --quiet-pull --wait
+        run: docker compose up -d --quiet-pull --wait
 
       - name: Environment Variables
         run: docker compose exec -T appwrite vars
@@ -357,28 +363,32 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull Docker Image
-        run: |
-          docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+      - parallel:
+          - name: Pull Docker Image
+            run: |
+              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+
+          - name: Pull Docker Compose images
+            timeout-minutes: 5
+            run: |
+              # Docker Hub registry timeouts are a common transient CI failure
+              # (e.g. a traefik manifest fetch timing out). Retry the image pull;
+              # keep `up` single-shot so genuine container health failures still surface.
+              for attempt in 1 2 3; do
+                if docker compose pull --quiet --ignore-buildable; then
+                  break
+                elif [ "$attempt" -eq 3 ]; then
+                  echo "::error::docker compose pull failed after 3 attempts; aborting"
+                  exit 1
+                fi
+                echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
+                sleep 15
+              done
 
       - name: Load and Start Appwrite
         timeout-minutes: 5
-        run: |
-          # Docker Hub registry timeouts are a common transient CI failure
-          # (e.g. a traefik manifest fetch timing out). Retry the image pull;
-          # keep `up` single-shot so genuine container health failures still surface.
-          for attempt in 1 2 3; do
-            if docker compose pull --quiet --ignore-buildable; then
-              break
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error::docker compose pull failed after 3 attempts; aborting"
-              exit 1
-            fi
-            echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
-            sleep 15
-          done
-          docker compose up -d --quiet-pull --wait
+        run: docker compose up -d --quiet-pull --wait
 
       - name: Wait for Open Runtimes
         timeout-minutes: 3
@@ -454,10 +464,28 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull Docker Image
-        run: |
-          docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+      - parallel:
+          - name: Pull Docker Image
+            run: |
+              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+
+          - name: Pull Docker Compose images
+            timeout-minutes: 5
+            run: |
+              # Docker Hub registry timeouts are a common transient CI failure
+              # (e.g. a traefik manifest fetch timing out). Retry the image pull;
+              # keep `up` single-shot so genuine container health failures still surface.
+              for attempt in 1 2 3; do
+                if docker compose pull --quiet --ignore-buildable; then
+                  break
+                elif [ "$attempt" -eq 3 ]; then
+                  echo "::error::docker compose pull failed after 3 attempts; aborting"
+                  exit 1
+                fi
+                echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
+                sleep 15
+              done
 
       - name: Load and Start Appwrite
         timeout-minutes: 5
@@ -466,21 +494,7 @@ jobs:
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
-        run: |
-          # Docker Hub registry timeouts are a common transient CI failure
-          # (e.g. a traefik manifest fetch timing out). Retry the image pull;
-          # keep `up` single-shot so genuine container health failures still surface.
-          for attempt in 1 2 3; do
-            if docker compose pull --quiet --ignore-buildable; then
-              break
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error::docker compose pull failed after 3 attempts; aborting"
-              exit 1
-            fi
-            echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
-            sleep 15
-          done
-          docker compose up -d --quiet-pull --wait
+        run: docker compose up -d --quiet-pull --wait
 
       - name: Wait for Open Runtimes
         timeout-minutes: 3
@@ -549,10 +563,28 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull Docker Image
-        run: |
-          docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+      - parallel:
+          - name: Pull Docker Image
+            run: |
+              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+
+          - name: Pull Docker Compose images
+            timeout-minutes: 5
+            run: |
+              # Docker Hub registry timeouts are a common transient CI failure
+              # (e.g. a traefik manifest fetch timing out). Retry the image pull;
+              # keep `up` single-shot so genuine container health failures still surface.
+              for attempt in 1 2 3; do
+                if docker compose pull --quiet --ignore-buildable; then
+                  break
+                elif [ "$attempt" -eq 3 ]; then
+                  echo "::error::docker compose pull failed after 3 attempts; aborting"
+                  exit 1
+                fi
+                echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
+                sleep 15
+              done
 
       - name: Load and Start Appwrite
         timeout-minutes: 5
@@ -561,21 +593,7 @@ jobs:
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
-        run: |
-          # Docker Hub registry timeouts are a common transient CI failure
-          # (e.g. a traefik manifest fetch timing out). Retry the image pull;
-          # keep `up` single-shot so genuine container health failures still surface.
-          for attempt in 1 2 3; do
-            if docker compose pull --quiet --ignore-buildable; then
-              break
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error::docker compose pull failed after 3 attempts; aborting"
-              exit 1
-            fi
-            echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
-            sleep 15
-          done
-          docker compose up -d --quiet-pull --wait
+        run: docker compose up -d --quiet-pull --wait
 
       - name: Run tests
         timeout-minutes: 15
@@ -620,10 +638,28 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull Docker Image
-        run: |
-          docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+      - parallel:
+          - name: Pull Docker Image
+            run: |
+              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+
+          - name: Pull Docker Compose images
+            timeout-minutes: 5
+            run: |
+              # Docker Hub registry timeouts are a common transient CI failure
+              # (e.g. a traefik manifest fetch timing out). Retry the image pull;
+              # keep `up` single-shot so genuine container health failures still surface.
+              for attempt in 1 2 3; do
+                if docker compose pull --quiet --ignore-buildable; then
+                  break
+                elif [ "$attempt" -eq 3 ]; then
+                  echo "::error::docker compose pull failed after 3 attempts; aborting"
+                  exit 1
+                fi
+                echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
+                sleep 15
+              done
 
       - name: Load and Start Appwrite
         timeout-minutes: 5
@@ -631,21 +667,7 @@ jobs:
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
-        run: |
-          # Docker Hub registry timeouts are a common transient CI failure
-          # (e.g. a traefik manifest fetch timing out). Retry the image pull;
-          # keep `up` single-shot so genuine container health failures still surface.
-          for attempt in 1 2 3; do
-            if docker compose pull --quiet --ignore-buildable; then
-              break
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error::docker compose pull failed after 3 attempts; aborting"
-              exit 1
-            fi
-            echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
-            sleep 15
-          done
-          docker compose up -d --quiet-pull --wait
+        run: docker compose up -d --quiet-pull --wait
 
       - name: Wait for Open Runtimes
         timeout-minutes: 3
@@ -699,16 +721,17 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull Appwrite image
-        run: |
-          docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
-          docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}:after
+      - parallel:
+          - name: Pull Appwrite image
+            run: |
+              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
+              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}:after
 
-      - name: Setup k6
-        uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
-        with:
-          k6-version: ${{ env.K6_VERSION }}
+          - name: Setup k6
+            uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
+            with:
+              k6-version: ${{ env.K6_VERSION }}
 
       - name: Prepare benchmark before
         id: benchmark_before_prepare

--- a/.github/workflows/sdk-preview.yml
+++ b/.github/workflows/sdk-preview.yml
@@ -35,10 +35,15 @@ jobs:
           fi
           echo "platform=$PLATFORM" >> $GITHUB_OUTPUT
         
-      - name: Load and Start Appwrite
-        run: |
-          docker compose build
-          docker compose up -d
+      - parallel:
+          - name: Load and Start Appwrite
+            run: |
+              docker compose build
+              docker compose up -d
+
+          - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+            with:
+              node-version: 20
 
       - name: Generate Specs
         run: |
@@ -48,10 +53,6 @@ jobs:
         run: |
           docker compose exec appwrite sdks --platform=${{ steps.set-sdk.outputs.platform }} --sdk=${{ steps.set-sdk.outputs.sdk_type }} --version=latest --git=no
           sudo chown -R $USER:$USER ./app/sdks/${{ steps.set-sdk.outputs.platform }}-${{ steps.set-sdk.outputs.sdk_type }}
-          
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
 
       - name: Build and Publish SDK
         working-directory: ./app/sdks/${{ steps.set-sdk.outputs.platform }}-${{ steps.set-sdk.outputs.sdk_type }}

--- a/.github/workflows/sdk-preview.yml
+++ b/.github/workflows/sdk-preview.yml
@@ -41,7 +41,8 @@ jobs:
               docker compose build
               docker compose up -d
 
-          - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          - name: Setup Node
+            uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
             with:
               node-version: 20
 


### PR DESCRIPTION
## What does this PR do?

Uses GitHub Actions' new step-level `parallel` syntax for independent work inside existing CI jobs.

This parallelizes:
- independent static checks after dependencies are installed
- Appwrite image pulls alongside Docker Compose service image pulls in test jobs
- benchmark image pull alongside k6 setup
- SDK preview Appwrite startup alongside Node setup

Baseline from the latest 10 successful PR `CI` workflow runs before this change:
- Workflow wall-clock average: 32m 20s
- Checks average: 4m 40s
- Tests / Unit average: 1m 26s
- Tests / E2E / General average: 2m 10s
- Tests / E2E / Service matrix average: 2m 59s across 261 jobs
- Tests / E2E / Abuse average: 2m 15s
- Tests / E2E / Screenshots average: 1m 32s
- Benchmark average: 4m 31s

## Test Plan

- Parsed edited workflow YAML locally with Ruby `YAML.load_file`.
- Ran `git diff --check` successfully.
- Ran `actionlint v1.7.12`; it reports `parallel` as unknown because this local version predates GitHub's June 2026 workflow syntax update.
- This draft PR is intended to measure the actual GitHub Actions runtime impact.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
