### PR TITLE
feat: add generic 'limit' route label for downstream usage/quota enforcement

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -265,6 +265,7 @@ Http::post('/v1/users')
     ->desc('Create user')
     ->groups(['api', 'users'])
     ->label('scope', 'users.write')
+    ->label('limit', 'usage:users')
     ->label('audits.event', 'user.create')
     ->label('audits.resource', 'user/{response.$id}')
     ->label('sdk', new Method(

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Screenshots/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Screenshots/Get.php
@@ -45,6 +45,7 @@ class Get extends Action
             ->desc('Get webpage screenshot')
             ->groups(['api', 'avatars'])
             ->label('scope', 'avatars.read')
+            ->label('limit', 'usage:screenshotsGenerated')
             ->label('usage.metric', METRIC_AVATARS_SCREENSHOTS_GENERATED)
             ->label('abuse-limit', 60)
             ->label('cache', true)

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -51,6 +51,7 @@ class Create extends Action
             ->desc('Create deployment')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
+            ->label('limit', ['usage:storage', 'usage:GBHours'])
             ->label('event', 'functions.[functionId].deployments.[deploymentId].create')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'deployment.create')

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -37,6 +37,7 @@ class Create extends Action
             ->desc('Create duplicate deployment')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
+            ->label('limit', 'usage:GBHours')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('event', 'functions.[functionId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -64,6 +64,7 @@ class Create extends Base
             ->desc('Create execution')
             ->groups(['api', 'functions'])
             ->label('scope', ['executions.write', 'execution.write'])
+            ->label('limit', ['usage:executions', 'usage:GBHours'])
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('event', 'functions.[functionId].executions.[executionId].create')
             ->label('usage.resource', 'function/{request.functionId}')

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->desc('Create project web platform')
             ->groups(['api', 'project'])
             ->label('scope', 'platforms.write')
+            ->label('limit', 'count:platforms')
             ->label('event', 'platforms.[platformId].create')
             ->label('audits.event', 'project.platform.create')
             ->label('audits.resource', 'project.platform/{response.$id}')

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/SMTP/Update.php
@@ -42,6 +42,7 @@ class Update extends Action
             ->desc('Update project SMTP configuration')
             ->groups(['api', 'project'])
             ->label('scope', 'project.write')
+            ->label('limit', 'feature:customSmtp')
             // ->label('event', 'project.smtp.update')
             ->label('audits.event', 'project.smtp.update')
             ->label('audits.resource', 'project.smtp/{response.$id}')

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Preview/Get.php
@@ -53,6 +53,7 @@ class Get extends Action
             ->desc('Get file preview')
             ->groups(['api', 'storage'])
             ->label('scope', 'files.read')
+            ->label('limit', 'usage:imageTransformations')
             ->label('usage.resource', 'bucket/{request.bucketId}/file/{request.fileId}')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('cache', true)

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -58,6 +58,7 @@ class Create extends Action
             ->groups(['api', 'teams', 'auth'])
             ->label('event', 'teams.[teamId].memberships.[membershipId].create')
             ->label('scope', 'teams.write')
+            ->label('limit', 'count:seats')
             ->label('auth.type', 'invites')
             ->label('audits.event', 'membership.create')
             ->label('audits.resource', 'team/{request.teamId}')

--- a/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Create.php
+++ b/src/Appwrite/Platform/Modules/Webhooks/Http/Webhooks/Create.php
@@ -44,6 +44,7 @@ class Create extends Action
             ->desc('Create webhook')
             ->groups(['api', 'webhooks'])
             ->label('scope', 'webhooks.write')
+            ->label('limit', 'count:webhooks')
             ->label('event', 'webhooks.[webhookId].create')
             ->label('audits.event', 'webhook.create')
             ->label('audits.resource', 'webhook/{response.$id}')


### PR DESCRIPTION
## What

Adds a generic `limit` route label to a selected set of API routes.

The label declares the metered resource/feature that an endpoint consumes, expressed as a `<kind>:<name>` value:

- `usage:*` — a usage metric consumed on each request (e.g. `usage:executions`, `usage:GBHours`, `usage:imageTransformations`)
- `count:*` — a countable resource created by the endpoint (e.g. `count:webhooks`, `count:platforms`, `count:seats`)
- `feature:*` — a gated feature the endpoint enables (e.g. `feature:customSmtp`)

## Why

The label is a plain, generic declaration. It carries no billing logic and causes no behavior change in CE. It exists so downstream enterprise billing hooks can read the metered resource/feature an endpoint touches and apply usage/quota enforcement, without each route needing to know about billing.

## Routes tagged

| Method | Path | limit |
| --- | --- | --- |
| POST | /v1/users | usage:users |
| GET | /v1/avatars/screenshots | usage:screenshotsGenerated |
| GET | /v1/storage/buckets/:bucketId/files/:fileId/preview | usage:imageTransformations |
| POST | /v1/functions/:functionId/executions | usage:executions, usage:GBHours |
| POST | /v1/functions/:functionId/deployments | usage:storage, usage:GBHours |
| POST | /v1/functions/:functionId/deployments (build alias) | usage:GBHours |
| POST | /v1/webhooks | count:webhooks |
| POST | /v1/project/platforms/web | count:platforms |
| PATCH | /v1/project/smtp | feature:customSmtp |
| POST | /v1/teams/:teamId/memberships | count:seats |

## Notes

- No behavior change in CE.
- POC scope.