### PR TITLE
fix(vectorsdb): group text embeddings SDK method under "embeddings"

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
@@ -57,7 +57,7 @@ class Create extends CreateDocumentAction
             ->label('sdk', [
                 new Method(
                     namespace: 'vectorsDB',
-                    group: $this->getSdkGroup(),
+                    group: 'embeddings',
                     name: 'createTextEmbeddings',
                     desc: 'Create Text Embedding',
                     description: '/docs/references/vectorsdb/create-document.md',


### PR DESCRIPTION
## What

`POST /v1/vectorsdb/embeddings/text` (`vectorsDB.createTextEmbeddings`) was being generated into the **`documents`** SDK group instead of **`embeddings`**.

## Why

`Embeddings/Text/Create` extends `CreateDocumentAction` to reuse its request machinery, so it inherited `getSdkGroup()`, which returns `'documents'` (or `'rows'`) for the collections/tables document APIs. Generating text embeddings is not a document operation, so the method landed in the wrong SDK group.

Every other non-document VectorsDB endpoint sets its group explicitly (`vectorsdb`, `collections`, `transactions`). This does the same, hardcoding `'embeddings'`.

## Change

```diff
 new Method(
     namespace: 'vectorsDB',
-    group: $this->getSdkGroup(),
+    group: 'embeddings',
     name: 'createTextEmbeddings',
```

Group is SDK/docs-generation metadata only; no runtime behaviour changes. Affects how the method is grouped in generated SDKs and the API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)