### PR TITLE
fix(vectorsdb): point text embeddings at its own docs reference

### DIFF
--- a/docs/references/vectorsdb/create-text-embeddings.md
+++ b/docs/references/vectorsdb/create-text-embeddings.md
@@ -1,0 +1,1 @@
+Generate vector embeddings for an array of text using the selected embedding model. Use the returned vectors to power semantic search and similarity queries against your vector collections.

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Embeddings/Text/Create.php
@@ -60,7 +60,7 @@ class Create extends CreateDocumentAction
                     group: 'embeddings',
                     name: 'createTextEmbeddings',
                     desc: 'Create Text Embedding',
-                    description: '/docs/references/vectorsdb/create-document.md',
+                    description: '/docs/references/vectorsdb/create-text-embeddings.md',
                     auth: [AuthType::ADMIN, AuthType::KEY, AuthType::JWT],
                     responses: [
                         new SDKResponse(


### PR DESCRIPTION
## What

`POST /v1/vectorsdb/embeddings/text` (`vectorsDB.createTextEmbeddings`) pointed its API-reference/SDK `description` at `create-document.md`, so its docs described creating a document rather than generating embeddings.

## Change

- Add `docs/references/vectorsdb/create-text-embeddings.md`.
- Repoint the endpoint's `description` at it.

Docs-generation metadata only; no runtime behaviour changes. Follow-up to #12757.

## Note on VectorsDB index grouping

While here I checked the sibling concern that `VectorsDB/Collections/Indexes/*` also use `getSdkGroup()`. They are **correct**: those endpoints extend `Databases\...\Indexes\Create`, whose `Indexes/Action::getSDKGroup()` is `final` and returns `'indexes'`. The embeddings endpoint was the odd one out only because it extended the *documents* action. No change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)