### PR TITLE
chore: trigger release workflow on tag push instead of release published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: "Release"
 on:
   push:
     tags:
-      - '*.*.*'
+      - '[0-9]*.[0-9]*.[0-9]*'
+      - '!cl-*'
 
 jobs:
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: "Release"
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*.*.*'
 
 jobs:
   tests:


### PR DESCRIPTION
### Summary
This PR addresses issue #12753 where the release tag `1.9.5` had to be deleted, recreated, and republished several times to include hotfixes. Each time a release was republished on GitHub, watchers received duplicate notifications, and the release tags pointed to mutable commits during the transition.

### Changes
* Modify the `Release` workflow (`.github/workflows/release.yml`) to trigger on a semver tag push event (`*.*.*`) rather than the `release: published` event.
* This aligns with how the Cloud image build pipeline (`publish.yml`) handles tag-based building.
* It allows maintainers to push tags, trigger the automated Docker multi-platform builds, verify that build results and installers are fully functional, and only publish the GitHub release when they are certain of the stability. 
* Watchers will receive exactly one notification when the release is finally published, and tags will remain immutable and stable on release.

Closes #12753
