### PR TITLE
fix(usage): pass resource on ExecutionCompleted dispatches

### DIFF
--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -327,6 +327,7 @@ class Functions extends Action
         $bus->dispatch(new ExecutionCompleted(
             execution: $execution->getArrayCopy(),
             project: $project->getArrayCopy(),
+            resource: $function->getArrayCopy(),
         ));
     }
 
@@ -630,6 +631,7 @@ class Functions extends Action
                 execution: $execution->getArrayCopy(),
                 project: $project->getArrayCopy(),
                 spec: $spec,
+                resource: $function->getArrayCopy(),
             ));
         }
 


### PR DESCRIPTION
## Summary

Two `ExecutionCompleted` dispatches inside the Functions worker construct the event without a `resource:` payload. Downstream listeners that read `$this->resource` — notably the cloud usage listener — then get an empty `Document`, so the resulting metric row ends up with `resourceId=''` even though `resourceInternalId` is populated from the execution. Async function executions were losing the human-readable function id on every usage row.

The sibling dispatch in `Cloud/Regions/Events/Executions/Create.php` (sync path) already passes the resource. This patch mirrors that here so both surfaces emit the same shape.

## Dispatch sites fixed

- **`src/Appwrite/Platform/Workers/Functions.php:327-331`** — `fail()` path (function/deployment lookup failed).
  Before:
  ```php
  $bus->dispatch(new ExecutionCompleted(
      execution: $execution->getArrayCopy(),
      project: $project->getArrayCopy(),
  ));
  ```
  After:
  ```php
  $bus->dispatch(new ExecutionCompleted(
      execution: $execution->getArrayCopy(),
      project: $project->getArrayCopy(),
      resource: $function->getArrayCopy(),
  ));
  ```

- **`src/Appwrite/Platform/Workers/Functions.php:629-634`** — async execution completion `finally` block.
  Before:
  ```php
  $bus->dispatch(new ExecutionCompleted(
      execution: $execution->getArrayCopy(),
      project: $project->getArrayCopy(),
      spec: $spec,
  ));
  ```
  After:
  ```php
  $bus->dispatch(new ExecutionCompleted(
      execution: $execution->getArrayCopy(),
      project: $project->getArrayCopy(),
      spec: $spec,
      resource: $function->getArrayCopy(),
  ));
  ```

`$function` (`Document`) is in scope at both call sites — passed into `fail()` as a parameter and resolved earlier in the async execute path.

## Test plan

- [x] `php -l src/Appwrite/Platform/Workers/Functions.php` — no syntax errors
- [ ] Trigger an async function execution on a cloud stack and confirm the usage metric row carries `resourceId` = function id (not `''`)
- [ ] Trigger a synthetic failure (e.g. deleted deployment) and confirm the `fail()` path also propagates the resource

## Notes

CE-only change; pairs with (but doesn't require) the cloud-side usage-tagging work — the cloud listener already knows how to read `resource`, it was just never receiving one for async function invocations.