### PR TITLE
chore(ci): optimize runner costs with spot instances and leaner matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
   build:
     name: Build
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+s3-cache+ecr-cache
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -289,6 +290,7 @@ jobs:
   unit:
     name: Tests / Unit
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
+    timeout-minutes: 15
     needs: build
     permissions:
       contents: read
@@ -352,6 +354,7 @@ jobs:
   e2e_general:
     name: Tests / E2E / General
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
+    timeout-minutes: 15
     needs: build
     permissions:
       contents: read
@@ -426,6 +429,7 @@ jobs:
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service.name }}
     runs-on: ${{ matrix.service.runner }}
+    timeout-minutes: 15
     needs: [build, matrix]
     permissions:
       contents: read
@@ -546,6 +550,7 @@ jobs:
   e2e_abuse:
     name: Tests / E2E / Abuse (${{ matrix.mode }})
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
+    timeout-minutes: 15
     needs: [build, matrix]
     permissions:
       contents: read
@@ -623,6 +628,7 @@ jobs:
   e2e_screenshots:
     name: Tests / E2E / Screenshots (${{ matrix.mode }})
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
+    timeout-minutes: 15
     needs: [build, matrix]
     permissions:
       contents: read
@@ -706,6 +712,7 @@ jobs:
     name: Benchmark
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
+    timeout-minutes: 20
     needs: build
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,33 +192,33 @@ jobs:
             const runner8 = `runs-on=${context.runId}/runner=8cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache`;
 
             const services = [
-              { name: 'Account',           runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Avatars',           runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Console',           runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Databases',         runner: runner8, functional: false, processes: 3,    timeout: 6 },
-              { name: 'TablesDB',          runner: runner8, functional: false, processes: 3,    timeout: 6 },
-              { name: 'Functions',         runner: runner4, functional: false, processes: null, timeout: 6 },
-              { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'GraphQL',           runner: runner4, functional: false, processes: null, timeout: 6 },
-              { name: 'Health',            runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Advisor',           runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Locale',            runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Projects',          runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Realtime',          runner: runner4, functional: false, processes: null, timeout: 6 },
-              { name: 'Sites',             runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Proxy',             runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Storage',           runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Tokens',            runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Teams',             runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Users',             runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'ProjectWebhooks',   runner: runner4, functional: false, processes: null, timeout: 6 },
-              { name: 'Webhooks',          runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'VCS',               runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Messaging',         runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Notifications',     runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1,    timeout: 6 },
-              { name: 'Project',           runner: runner4, functional: true,  processes: null, timeout: 6 },
-              { name: 'Presences',         runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Account',           runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Avatars',           runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Console',           runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Databases',         runner: runner8, functional: false, processes: 3,    timeout: 8 },
+              { name: 'TablesDB',          runner: runner8, functional: false, processes: 3,    timeout: 8 },
+              { name: 'Functions',         runner: runner4, functional: false, processes: null, timeout: 8 },
+              { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'GraphQL',           runner: runner4, functional: false, processes: null, timeout: 8 },
+              { name: 'Health',            runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Advisor',           runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Locale',            runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Projects',          runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Realtime',          runner: runner4, functional: false, processes: null, timeout: 8 },
+              { name: 'Sites',             runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Proxy',             runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Storage',           runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Tokens',            runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Teams',             runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Users',             runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'ProjectWebhooks',   runner: runner4, functional: false, processes: null, timeout: 8 },
+              { name: 'Webhooks',          runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'VCS',               runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Messaging',         runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Notifications',     runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1,    timeout: 8 },
+              { name: 'Project',           runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Presences',         runner: runner4, functional: true,  processes: null, timeout: 8 },
             ];
             core.setOutput('services', JSON.stringify(services));
 
@@ -429,7 +429,7 @@ jobs:
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service.name }}
     runs-on: ${{ matrix.service.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [build, matrix]
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,33 +192,33 @@ jobs:
             const runner8 = `runs-on=${context.runId}/runner=8cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache`;
 
             const services = [
-              { name: 'Account',           runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Avatars',           runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Console',           runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Databases',         runner: runner8, functional: false, processes: 3,    timeout: 15 },
-              { name: 'TablesDB',          runner: runner8, functional: false, processes: 3,    timeout: 15 },
-              { name: 'Functions',         runner: runner4, functional: false, processes: null, timeout: 15 },
-              { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'GraphQL',           runner: runner4, functional: false, processes: null, timeout: 15 },
-              { name: 'Health',            runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Advisor',           runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Locale',            runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Projects',          runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Realtime',          runner: runner4, functional: false, processes: null, timeout: 15 },
-              { name: 'Sites',             runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Proxy',             runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Storage',           runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Tokens',            runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Teams',             runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Users',             runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'ProjectWebhooks',   runner: runner4, functional: false, processes: null, timeout: 15 },
-              { name: 'Webhooks',          runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'VCS',               runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Messaging',         runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Notifications',     runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1,    timeout: 15 },
-              { name: 'Project',           runner: runner4, functional: true,  processes: null, timeout: 15 },
-              { name: 'Presences',         runner: runner4, functional: true,  processes: null, timeout: 15 },
+              { name: 'Account',           runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Avatars',           runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Console',           runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Databases',         runner: runner8, functional: false, processes: 3,    timeout: 6 },
+              { name: 'TablesDB',          runner: runner8, functional: false, processes: 3,    timeout: 6 },
+              { name: 'Functions',         runner: runner4, functional: false, processes: null, timeout: 6 },
+              { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'GraphQL',           runner: runner4, functional: false, processes: null, timeout: 6 },
+              { name: 'Health',            runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Advisor',           runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Locale',            runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Projects',          runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Realtime',          runner: runner4, functional: false, processes: null, timeout: 6 },
+              { name: 'Sites',             runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Proxy',             runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Storage',           runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Tokens',            runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Teams',             runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Users',             runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'ProjectWebhooks',   runner: runner4, functional: false, processes: null, timeout: 6 },
+              { name: 'Webhooks',          runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'VCS',               runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Messaging',         runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Notifications',     runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1,    timeout: 6 },
+              { name: 'Project',           runner: runner4, functional: true,  processes: null, timeout: 6 },
+              { name: 'Presences',         runner: runner4, functional: true,  processes: null, timeout: 6 },
             ];
             core.setOutput('services', JSON.stringify(services));
 
@@ -342,7 +342,7 @@ jobs:
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
-          timeout_minutes: 15
+          timeout_minutes: 5
           job_id: ${{ job.check_run_id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           test_dir: tests/unit
@@ -411,7 +411,7 @@ jobs:
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
-          timeout_minutes: 15
+          timeout_minutes: 5
           job_id: ${{ job.check_run_id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           test_dir: tests/e2e/General
@@ -610,7 +610,7 @@ jobs:
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
-          timeout_minutes: 15
+          timeout_minutes: 5
           job_id: ${{ job.check_run_id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           test_dir: tests/e2e
@@ -693,7 +693,7 @@ jobs:
         with:
           max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
           retry_wait_seconds: 60
-          timeout_minutes: 15
+          timeout_minutes: 5
           job_id: ${{ job.check_run_id }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           test_dir: tests/e2e/Services/Sites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const runner4 = `runs-on=${context.runId}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache`;
-            const runner8 = `runs-on=${context.runId}/runner=8cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache`;
+            const runner4 = `runs-on=${context.runId}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache`;
+            const runner8 = `runs-on=${context.runId}/runner=8cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache`;
 
             const services = [
               { name: 'Account',           runner: runner4, functional: true,  processes: null, timeout: 15 },
@@ -242,7 +242,10 @@ jobs:
               return getDbVersion(decode(base.content)) !== getDbVersion(decode(head.content));
             };
 
-            if (!pr || await isDatabaseVersionChanged()) {
+            const fullMatrix = context.eventName === 'workflow_dispatch'
+              || (pr && await isDatabaseVersionChanged());
+
+            if (fullMatrix) {
               core.setOutput('databases', JSON.stringify(['MariaDB', 'PostgreSQL', 'MongoDB']));
               core.setOutput('modes', JSON.stringify(['dedicated', 'shared']));
               return;
@@ -253,7 +256,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+s3-cache+ecr-cache
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+s3-cache+ecr-cache
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -285,7 +288,7 @@ jobs:
 
   unit:
     name: Tests / Unit
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
     needs: build
     permissions:
       contents: read
@@ -348,7 +351,7 @@ jobs:
 
   e2e_general:
     name: Tests / E2E / General
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
     needs: build
     permissions:
       contents: read
@@ -542,7 +545,7 @@ jobs:
 
   e2e_abuse:
     name: Tests / E2E / Abuse (${{ matrix.mode }})
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
     needs: [build, matrix]
     permissions:
       contents: read
@@ -619,7 +622,7 @@ jobs:
 
   e2e_screenshots:
     name: Tests / E2E / Screenshots (${{ matrix.mode }})
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
     needs: [build, matrix]
     permissions:
       contents: read
@@ -702,7 +705,7 @@ jobs:
   benchmark:
     name: Benchmark
     if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=120g/spot=false/extras=otel+ecr-cache
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/extras=otel+ecr-cache
     needs: build
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Appwrite Logs ==="
-          docker compose logs
+          docker compose logs --timestamps
 
   e2e_service:
     name: Tests / E2E / ${{ matrix.database }} (${{ matrix.mode }}) / ${{ matrix.service.name }}
@@ -545,7 +545,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Appwrite Logs ==="
-          docker compose logs
+          docker compose logs --timestamps
 
   e2e_abuse:
     name: Tests / E2E / Abuse (${{ matrix.mode }})
@@ -623,7 +623,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Appwrite Logs ==="
-          docker compose logs
+          docker compose logs --timestamps
 
   e2e_screenshots:
     name: Tests / E2E / Screenshots (${{ matrix.mode }})
@@ -706,7 +706,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Appwrite Logs ==="
-          docker compose logs
+          docker compose logs --timestamps
 
   benchmark:
     name: Benchmark


### PR DESCRIPTION
## What does this PR do?

Cuts the AWS cost of the `runs-on-for-appwrite` CI stack (~$1,285/month gross in June) with three runner-level changes to `ci.yml`:

1. **Spot instances** — all RunsOn jobs now use `spot=price-capacity-optimized` instead of `spot=false` (on-demand). On-demand EC2 was 84% of this stack's cost. The workload profile is spot-safe: jobs are short (median ~2 min, max ~8 min), the matrix runs with `fail-fast: false`, and PR test steps already retry. `price-capacity-optimized` picks spot pools with the lowest interruption risk.
2. **Leaner push-to-main matrix** — merges to `main` previously ran 27 services × 3 databases × 2 modes (~175 jobs, ~400 runner-minutes); they now run the same MongoDB/dedicated matrix as PRs (~38 jobs, ~90 runner-minutes). The full sweep still runs on `workflow_dispatch` (manual escape hatch) and on PRs that change the `utopia-php/database` version (unchanged behavior).
3. **60GB volumes instead of 120GB** — measured worst-case disk usage per job is ~30GB (OS/AMI ~20GB + compose images ~4GB + open-runtimes images ~1.5GB + writable layers/volumes/logs). 60GB keeps a 2x margin. gp3 performance is independent of size, so no I/O impact.

Expected stack cost after this change: roughly $300–400/month.

## Test Plan

- CI on this PR exercises the changed runner specs directly (all jobs on spot, 60GB volumes).
- The matrix logic change is verified by this PR running MongoDB/dedicated only, and can be verified for the full sweep via a manual `workflow_dispatch` run on this branch.

## Watch items

- Spot interruptions show up as infrastructure-failed jobs — if the longer jobs (Project ~8 min, Databases ~6 min) get interrupted repeatedly, pin just those back to on-demand.
- Any "no space left on device" failure (most likely `build` or `benchmark`) means bumping that job's volume back up.

## Related PRs and Issues

None.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?