### PR TITLE
feat(usage): declare setResourceType and setIp stubs on base Usage Context

### DIFF
--- a/src/Appwrite/Usage/Context.php
+++ b/src/Appwrite/Usage/Context.php
@@ -71,6 +71,26 @@ class Context
         return '';
     }
 
+    public function setResourceType(string $type): self
+    {
+        return $this;
+    }
+
+    public function getResourceType(): string
+    {
+        return '';
+    }
+
+    public function setIp(string $ip): self
+    {
+        return $this;
+    }
+
+    public function getIp(): string
+    {
+        return '';
+    }
+
     /**
      * Reset the context
      */


### PR DESCRIPTION
## Summary

Adds no-op stubs for `setResourceType` / `getResourceType` / `setIp` / `getIp` on `Appwrite\Usage\Context`. This mirrors the existing `setResourcePath` / `getResourcePath` no-op stub pattern so that the Cloud override can implement the real storage while any code holding a base-typed reference still compiles / statically checks against the same API surface.

## Context

Coordinated with the upstream library change [utopia-php/usage#19](https://github.com/utopia-php/usage/pull/19) (`feat: resourceType rename + queued time + ip dim + gauge fill`), which:

- Renames the events column from `resource` to `resourceType`.
- Adds an `ip` column on the events row.
- Threads an optional `?\DateTime $time` through `Accumulator::collect()` so consumers can pass a queued timestamp.
- Adds a gauge LOCF fill.

CE itself does not depend on `utopia-php/usage` and does not populate any of the Context's dimensional fields — that plumbing (`hostname`, `country`, `userAgent`, `region`, `resourceType`, `ip`) has lived in the Cloud override since the CE usage / audit worker sweep. So this PR is intentionally minimal: only the API contract on the base class moves; no CE listener, caller, or composer requirement is touched.

The parallel Cloud PR (CLO-4383) renames `setResource` -> `setResourceType` on `Appwrite\Cloud\Usage\Context`, adds the real `ip` storage, populates `->setIp(\$request->getIP())` in `app/controllers/general.php`, and wires the queued timestamp through `Cloud\Bus\Listeners\Usage`.

## Breaking

No public SDK / HTTP surface change. The Context class is internal (`src/Appwrite/Usage/`).

## Test plan

- [x] `php -l src/Appwrite/Usage/Context.php` - no syntax errors.
- [x] `composer lint src/Appwrite/Usage/Context.php` - Pint passes.
- [x] `composer analyze` - PHPStan level 4 clean.
- [ ] CI on this PR passes (Pint, PHPStan, Rector, unit + e2e).