### PR TITLE
Replace doctor healthcheck with HTTP health endpoint check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,11 +43,12 @@ services:
     image: ${_APP_IMAGE:-appwrite/appwrite}:${_APP_VERSION:-latest}
     healthcheck:
       test:
-        - CMD
-        - doctor
+        - CMD-SHELL
+        - 'curl -fsS -o /dev/null -H "Host: $${_APP_DOMAIN:-localhost}" http://localhost/v1/health/version'
       interval: 5s
       timeout: 5s
       retries: 12
+      start_period: 120s
     networks:
       - appwrite
     labels:


### PR DESCRIPTION
## What does this PR do?

Removes `doctor` from the `appwrite` service Docker healthcheck and replaces it with a curl against the public `/v1/health/version` endpoint.

## Why?

The `doctor` CLI task sends a **real "Test SMTP Connection" email to `demo@example.com`** as part of its SMTP connectivity check (`src/Appwrite/Platform/Tasks/Doctor.php`). Since 33ce469ab0 (shipped in 1.9.0) made `doctor` the Docker healthcheck with `interval: 5s`, every self-hosted instance with a real SMTP provider configured has been firing that email up to every 5 seconds, 24/7 — Docker healthchecks run for the container's whole lifetime, not just startup. Users see their provider dashboards flooded with "Test SMTP Connection" sends, it burns quota, and repeatedly mailing a nonexistent example.com address risks getting the sender domain flagged for spam.

## Implementation notes

- `/v1/health/version` is `scope: public`, needs no key or project header, and is side-effect-free.
- The `Host` header is set from `_APP_DOMAIN` (container-side expansion via `$$`) because router protection defaults to enabled and rejects hostnames outside `platform.hostnames` — a bare `curl localhost` would 401 on any instance with a real domain, leaving the container permanently unhealthy.
- `start_period: 120s` gives boot/migrations headroom; `docker compose up --wait` (used in CI) still unblocks on the first passing check.
- This is also a stronger readiness gate than before: `doctor` prints check failures but exits 0 regardless, so it never actually verified the HTTP server was serving.

## Verification

- `docker compose config` parses and renders the escaped `$` correctly.
- curl 8.19 is present in the image; `${_APP_DOMAIN:-localhost}` expansion verified in the container's busybox sh against `appwrite/appwrite:1.9.5`.
- CI's `docker compose up --wait` exercises the new healthcheck end-to-end.

## Follow-up

`doctor` itself still emails `demo@example.com` when run manually — worth making it a handshake-only check, but it's no longer on any automatic path.