### PR TITLE
Expose bearer and mode auth schemes in SDK specs

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -153,6 +153,11 @@ class Specs extends Action
                     'description' => 'Your secret JSON Web Token',
                     'in' => 'header',
                 ],
+                'Bearer' => [
+                    'type' => 'http',
+                    'scheme' => 'bearer',
+                    'description' => 'The OAuth access token to authenticate with',
+                ],
                 'Locale' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Locale',
@@ -163,6 +168,12 @@ class Specs extends Action
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Session',
                     'description' => 'The user session to authenticate with',
+                    'in' => 'header',
+                ],
+                'Mode' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Mode',
+                    'description' => '',
                     'in' => 'header',
                 ],
                 'DevKey' => [
@@ -234,6 +245,11 @@ class Specs extends Action
                     'description' => 'Your secret JSON Web Token',
                     'in' => 'header',
                 ],
+                'Bearer' => [
+                    'type' => 'http',
+                    'scheme' => 'bearer',
+                    'description' => 'The OAuth access token to authenticate with',
+                ],
                 'Locale' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Locale',
@@ -244,6 +260,12 @@ class Specs extends Action
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Session',
                     'description' => 'The user session to authenticate with',
+                    'in' => 'header',
+                ],
+                'Mode' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Mode',
+                    'description' => '',
                     'in' => 'header',
                 ],
                 'ForwardedUserAgent' => [
@@ -320,6 +342,11 @@ class Specs extends Action
                     'name' => 'X-Appwrite-JWT',
                     'description' => 'Your secret JSON Web Token',
                     'in' => 'header',
+                ],
+                'Bearer' => [
+                    'type' => 'http',
+                    'scheme' => 'bearer',
+                    'description' => 'The OAuth access token to authenticate with',
                 ],
                 'Locale' => [
                     'type' => 'apiKey',

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -156,6 +156,7 @@ class Specs extends Action
                 'Bearer' => [
                     'type' => 'http',
                     'scheme' => 'bearer',
+                    'bearerFormat' => 'JWT',
                     'description' => 'The OAuth access token to authenticate with',
                 ],
                 'Locale' => [
@@ -248,6 +249,7 @@ class Specs extends Action
                 'Bearer' => [
                     'type' => 'http',
                     'scheme' => 'bearer',
+                    'bearerFormat' => 'JWT',
                     'description' => 'The OAuth access token to authenticate with',
                 ],
                 'Locale' => [
@@ -346,6 +348,7 @@ class Specs extends Action
                 'Bearer' => [
                     'type' => 'http',
                     'scheme' => 'bearer',
+                    'bearerFormat' => 'JWT',
                     'description' => 'The OAuth access token to authenticate with',
                 ],
                 'Locale' => [


### PR DESCRIPTION
## What does this PR do?

Part of the OAuth login rollout for the SDKs. Adds two security schemes to the generated API specs in `Specs.php`:

- **`Bearer`** (`type: http`, `scheme: bearer`) on the **client, server, and console** platforms — the SDK generator turns this into a global `Authorization` header, so every template-driven SDK gains a `setBearer` method for OAuth access tokens.
- **`Mode`** (`X-Appwrite-Mode`) on the **client and server** platforms (console already had it) — OAuth2 tokens act on project resources as a console user, which requires `setMode('admin')`; previously only the console SDK exposed it.

Neither scheme maps to an `AuthType`, so per-method `x-appwrite.auth` entries and `authCounts` are unaffected.

## Test plan

- `php app/cli.php specs latest normal --git=no` — both schemes present in all three generated spec files.
- Generated all SDKs against these specs: `setBearer`/`setMode` (per-language casing) appear in web, node, react-native, flutter, dart, apple, swift, android, kotlin, php, python, ruby, dotnet, go, unity, rust, and console SDKs. Rust output additionally verified with `cargo check`.
- `composer lint` passes.

## Related PRs

- appwrite/sdk-generator#1619 — makes all SDK clients generate global-header setters from the spec uniformly (Unity/Rust were hardcoded), and replaces the PHP bearer→self-signed-JWT behavior with plain forwarding (old behavior preserved as `setSigningKey()`). Both PRs need to land before regenerating and publishing the SDKs.