### PR TITLE
Fix usage attribution for database read endpoints

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/Get.php
@@ -45,7 +45,7 @@ class Get extends Action
             ->desc('Get attribute')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Attributes/XList.php
@@ -40,7 +40,7 @@ class XList extends Action
             ->desc('List attributes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Get.php
@@ -34,7 +34,7 @@ class Get extends Action
             ->desc('Get collection')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/Get.php
@@ -35,7 +35,7 @@ class Get extends Action
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Indexes/XList.php
@@ -41,7 +41,7 @@ class XList extends Action
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
@@ -43,7 +43,7 @@ class Update extends Action
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('event', 'databases.[databaseId].collections.[collectionId].update')
             ->label('audits.event', 'collection.update')
-            ->label('audits.resource', 'database/{request.databaseId}/collections/{request.collectionId}')
+            ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'databases',

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Update.php
@@ -44,7 +44,7 @@ class Update extends Action
             ->label('event', 'databases.[databaseId].collections.[collectionId].update')
             ->label('audits.event', 'collection.update')
             ->label('audits.resource', 'database/{request.databaseId}/collections/{request.collectionId}')
-            ->label('usage.resource', 'database/{request.databaseId}/collections/{request.collectionId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'databases',
                 group: $this->getSDKGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/Get.php
@@ -33,7 +33,7 @@ class Get extends DocumentGet
             ->desc('Get document')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Documents/XList.php
@@ -35,7 +35,7 @@ class XList extends DocumentXList
             ->desc('List documents')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Get.php
@@ -31,7 +31,7 @@ class Get extends CollectionGet
             ->desc('Get collection')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/Get.php
@@ -32,7 +32,7 @@ class Get extends IndexGet
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/DocumentsDB/Collections/Indexes/XList.php
@@ -33,7 +33,7 @@ class XList extends IndexXList
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'documentsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/Get.php
@@ -43,7 +43,7 @@ class Get extends AttributesGet
             ->desc('Get column')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'columns.read', 'attributes.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Columns/XList.php
@@ -34,7 +34,7 @@ class XList extends AttributesXList
             ->desc('List columns')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'columns.read', 'attributes.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Get.php
@@ -32,7 +32,7 @@ class Get extends CollectionGet
             ->desc('Get table')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Get.php
@@ -33,7 +33,7 @@ class Get extends IndexGet
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'indexes.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/XList.php
@@ -34,7 +34,7 @@ class XList extends IndexXList
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', ['tables.read', 'collections.read', 'indexes.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/Get.php
@@ -35,7 +35,7 @@ class Get extends DocumentGet
             ->desc('Get row')
             ->groups(['api', 'database'])
             ->label('scope', ['rows.read', 'documents.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Rows/XList.php
@@ -37,7 +37,7 @@ class XList extends DocumentXList
             ->desc('List rows')
             ->groups(['api', 'database'])
             ->label('scope', ['rows.read', 'documents.read'])
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/table/{request.tableId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: $this->getSDKNamespace(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/Get.php
@@ -33,7 +33,7 @@ class Get extends DocumentGet
             ->desc('Get document')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Documents/XList.php
@@ -35,7 +35,7 @@ class XList extends DocumentXList
             ->desc('List documents')
             ->groups(['api', 'database'])
             ->label('scope', 'documents.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Get.php
@@ -31,7 +31,7 @@ class Get extends CollectionGet
             ->desc('Get collection')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Create.php
@@ -42,7 +42,7 @@ class Create extends IndexCreate
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'index.create')
             ->label('audits.resource', 'database/{request.databaseId}/collection/{request.tableId}')
-            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.tableId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',
                 group: $this->getSdkGroup(),

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Create.php
@@ -41,7 +41,7 @@ class Create extends IndexCreate
             ->label('scope', 'collections.write')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('audits.event', 'index.create')
-            ->label('audits.resource', 'database/{request.databaseId}/collection/{request.tableId}')
+            ->label('audits.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Get.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/Get.php
@@ -32,7 +32,7 @@ class Get extends IndexGet
             ->desc('Get index')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',

--- a/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/XList.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/VectorsDB/Collections/Indexes/XList.php
@@ -33,7 +33,7 @@ class XList extends IndexXList
             ->desc('List indexes')
             ->groups(['api', 'database'])
             ->label('scope', 'collections.read')
-            ->label('usage.resource', 'database/{request.databaseId}')
+            ->label('usage.resource', 'database/{request.databaseId}/collection/{request.collectionId}')
             ->label('resourceType', RESOURCE_TYPE_DATABASES)
             ->label('sdk', new Method(
                 namespace: 'vectorsDB',


### PR DESCRIPTION
## What does this PR do?

Fixes usage reporting where database **table/row** (and collection/document/column/index) requests were being attributed to the parent **database** instead of the actual table/collection container.

Usage is attributed to a resource through the per-route `usage.resource` label. At request shutdown this label is rendered into a `resourcePath` string, and the cloud stats worker parses it back into `resourceType`/`resourceId`. The parser only caps a database path to the table/collection level when the rendered path actually contains a `table`/`collection` segment (with an id); otherwise it falls back to the database.

The **read** endpoints across TablesDB, DocumentsDB, VectorsDB, and the legacy Databases module declared only `database/{request.databaseId}`, dropping the table/collection they operate on — even though the id is present in the route path. Because reads (Get/List of rows, documents, tables, collections, columns, indexes, attributes) are the highest-volume operations, they were bucketed under the database, while the **write** endpoints (which include the container segment) attributed correctly. This is the source of the reported symptom: filtering usage by a database shows many table/row requests that should have been attributed to the table.

Changes (labels only — no behavior change to the endpoints themselves):

- **TablesDB** reads now include `/table/{request.tableId}`: `Tables/Get`, `Tables/Rows/{Get,XList}`, `Tables/Indexes/{Get,XList}`, `Tables/Columns/{Get,XList}`.
- **DocumentsDB** reads now include `/collection/{request.collectionId}`: `Collections/Get`, `Collections/Indexes/{Get,XList}`, `Collections/Documents/{Get,XList}`.
- **VectorsDB** reads now include `/collection/{request.collectionId}`: `Collections/Get`, `Collections/Indexes/{Get,XList}`, `Collections/Documents/{Get,XList}`.
- **Legacy Databases** reads now include `/collection/{request.collectionId}`: `Collections/Get`, `Collections/Attributes/{Get,XList}`, `Collections/Indexes/{Get,XList}`.

Two related label defects fixed along the way:

- `VectorsDB/Collections/Indexes/Create` referenced `{request.tableId}`, but the route param is `:collectionId` — it rendered an empty container id.
- Legacy `Databases/Collections/Update` used the plural `collections` segment, which the parser does not recognise, so collection updates fell back to the database.

Container-level operations (get/delete a database, list its tables or collections) are intentionally left at database scope, which is correct.

Note: this corrects attribution **going forward**. Already-aggregated warehouse rows would need a separate backfill if historical data is to be re-bucketed.

## Test Plan

- `php -l` passes on all 24 changed files.
- Manual verification of the attribution pipeline: for each edited read route, the route path contains the container id used in the new label (`:tableId` / `:collectionId`), so the rendered `resourcePath` now carries the `table`/`collection` segment and the cloud `Reference\Parser::forUsage` caps to the table/collection instead of the database.
- Recommend running the Databases E2E usage assertions against a project with table/row reads to confirm the metrics land on the table.

## Related PRs and Issues

- (Cloud-side parser: `Appwrite\Cloud\Reference\Parser::forUsage` — unchanged; it already handles the table-scoped path correctly and simply never received the container id for these routes.)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — `usage.resource` is an internal usage-attribution label; it is not part of the generated SDK specs or example docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2kBd7MvABcRZEA9uXhduY)_