### PR TITLE
Skip Docker Hub login in CI when credentials are unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
   COMPOSE_FILE: docker-compose.yml:docker-compose.override.yml
   IMAGE: appwrite-dev
   K6_VERSION: '0.53.0'
+  DOCKERHUB_AUTH_AVAILABLE: ${{ secrets.DOCKERHUB_TOKEN != '' }}
 
 on:
   pull_request:
@@ -265,6 +266,7 @@ jobs:
           submodules: recursive
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -301,6 +303,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -365,6 +368,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -467,6 +471,7 @@ jobs:
           fi
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -567,6 +572,7 @@ jobs:
           fetch-depth: 1
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -643,6 +649,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -727,6 +734,7 @@ jobs:
           fetch-depth: 1
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## What does this PR do?

Allows CI to run on pull requests from forks. External contributors' PRs currently fail at the `Login to Docker Hub` step with `##[error]Username and password required` (see the Build job on #12766), because GitHub does not expose repository secrets to `pull_request` runs from forks — approving the workflow run grants execution, not secrets.

This gates all 7 `Login to Docker Hub` steps on secret availability. When `DOCKERHUB_TOKEN` is absent (fork PRs), login is skipped and image pulls happen anonymously. Internal PRs and pushes are unaffected.

The `secrets` context is not allowed in step-level `if` conditions (per GitHub's [context availability rules](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), enforced by actionlint), so the check is evaluated once into the workflow-level env var `DOCKERHUB_AUTH_AVAILABLE` and steps reference that.

Anonymous pulls are rate-limited, but two existing mechanisms soften this: the RunsOn runners use the `ecr-cache` extra (a Docker Hub pull-through mirror authenticated via runner AWS credentials, not GitHub secrets), and the compose-pull steps already retry 3 times. The internal `appwrite-dev` image is pushed/pulled via ECR and never needed Docker Hub auth.

Known remaining gap for fork PRs (out of scope here): `TESTS_OAUTH2_GITHUB_CLIENT_ID/SECRET` are also empty on forks, so OAuth-dependent e2e tests may still fail — but at the test stage rather than blocking the entire pipeline at login.

## Test Plan

- `actionlint` passes with no new findings (only the pre-existing `- parallel:` RunsOn-syntax warnings remain, identical on the unmodified file).
- CI on this PR itself exercises the authenticated path (secret present → login runs as before).
- The anonymous path is exercised by the next fork PR; behavior is equivalent to re-running #12766's CI without the failing login step.

## Related PRs and Issues

- #12766 (fork PR whose CI failed at Docker Hub login)