### PR TITLE
Fix: remove no-effect `use Throwable;` in shared api controller

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -24,7 +24,6 @@ use Appwrite\Usage\Context;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
-use Throwable;
 use Utopia\Abuse\Abuse;
 use Utopia\Bus\Bus;
 use Utopia\Cache\Adapter\Filesystem;
@@ -1177,7 +1176,7 @@ Http::shutdown()
             $authorization->skip(fn () => $dbForPlatform->updateDocument('projects', $project->getId(), new Document([
                 'onboarding' => $byMethod,
             ])));
-        } catch (Throwable) {
+        } catch (\Throwable) {
             // Missing `onboarding` attribute on upgraded installs must not break the request lifecycle.
         }
     });


### PR DESCRIPTION
## What does this PR do?

Removes the `use Throwable;` statement from `app/controllers/shared/api.php`, which emits a PHP warning on every load:

```
Warning: The use statement with non-compound name 'Throwable' has no effect in .../app/controllers/shared/api.php on line 27
```

The file is in the global namespace, so importing `Throwable` (a global class) has no effect and PHP warns about it. The catch on line 1180 is qualified as `\Throwable` to match the existing style at line 526.

Introduced in 7b24acb5b6, which only exists on `main` — hence this PR targets `main` rather than the version branch.

## Test Plan

- `php -l` and `composer lint` pass.
- The warning no longer appears when the file is loaded.

## Related PRs and Issues

None.