### PR TITLE
Stop doctor SMTP healthcheck from sending real emails (#12760)

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -577,6 +577,15 @@ return [
                 'question' => '',
                 'filter' => ''
             ],
+            [
+                'name' => '_APP_SMTP_TEST_EMAIL',
+                'description' => 'Recipient address for the SMTP send-test performed by the `doctor` command. Leave empty (default) and `doctor` will only verify that the SMTP server is reachable without sending any email. Set this to an address you own to opt in to an end-to-end send test. Empty by default.',
+                'introduction' => '1.9.6',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -212,20 +212,45 @@ class Doctor extends Action
             }
         }
 
+        // The Docker healthcheck runs `doctor` on a short interval, so this check must
+        // stay side-effect free. By default we only verify that the SMTP server is
+        // reachable, without sending any message. Sending a real test email is opt-in
+        // through `_APP_SMTP_TEST_EMAIL`, which must be a recipient the operator owns —
+        // we never fall back to a real third-party address. See issue #12760.
         try {
-            /** @var EmailAdapter $smtp */
-            $smtp = $register->get('smtp');
+            $smtpTestEmail = System::getEnv('_APP_SMTP_TEST_EMAIL', '');
 
-            $emailMessage = new EmailMessage(
-                to: ['demo@example.com'],
-                subject: 'Test SMTP Connection',
-                content: 'Hello World',
-                fromName: \urldecode(System::getEnv('_APP_SYSTEM_EMAIL_NAME', APP_NAME . ' Server')),
-                fromEmail: System::getEnv('_APP_SYSTEM_EMAIL_ADDRESS', APP_EMAIL_TEAM),
-            );
+            if (!empty($smtpTestEmail)) {
+                /** @var EmailAdapter $smtp */
+                $smtp = $register->get('smtp');
 
-            $smtp->send($emailMessage);
-            Console::success('🟢 ' . str_pad("SMTP", 50, '.') . 'connected');
+                $emailMessage = new EmailMessage(
+                    to: [$smtpTestEmail],
+                    subject: 'Test SMTP Connection',
+                    content: 'Hello World',
+                    fromName: \urldecode(System::getEnv('_APP_SYSTEM_EMAIL_NAME', APP_NAME . ' Server')),
+                    fromEmail: System::getEnv('_APP_SYSTEM_EMAIL_ADDRESS', APP_EMAIL_TEAM),
+                );
+
+                $smtp->send($emailMessage);
+                Console::success('🟢 ' . str_pad("SMTP", 50, '.') . 'connected');
+            } else {
+                $smtpHost = System::getEnv('_APP_SMTP_HOST', '');
+                $smtpPort = (int) System::getEnv('_APP_SMTP_PORT', 25);
+
+                if (empty($smtpHost)) {
+                    Console::info('⚪ ' . str_pad("SMTP", 50, '.') . 'not configured');
+                } else {
+                    $connection = @\fsockopen($smtpHost, $smtpPort, $errno, $errstr, 5);
+
+                    if ($connection !== false) {
+                        \fclose($connection);
+                        Console::success('🟢 ' . str_pad("SMTP", 50, '.') . 'connected');
+                    } else {
+                        Console::error('🔴 ' . str_pad("SMTP", 47, '.') . 'disconnected');
+                    }
+                }
+            }
         } catch (\Throwable) {
             Console::error('🔴 ' . str_pad("SMTP", 47, '.') . 'disconnected');
         }


### PR DESCRIPTION
## What does this PR do?

Fixes #12760.

The Docker healthcheck for the `appwrite` container runs the `doctor` command every ~5 seconds:

```yaml
healthcheck:
  test: ["CMD", "doctor"]
  interval: 5s
```

`doctor`'s SMTP check sent a **live** test email on every invocation, to a hardcoded third-party recipient (`demo@example.com`):

```php
$emailMessage = new EmailMessage(
    to: ['demo@example.com'],
    ...
);
$smtp->send($emailMessage);
```

On any self-hosted install with system SMTP configured, this means a real email is sent roughly every 5 seconds — matching the healthcheck interval. As the reporter notes, this risks provider rate-limiting, blacklisting / reputation damage, billing overage, and spams a domain the operator does not own.

## Changes

- **`doctor`'s SMTP check is now side-effect free by default.** When no test recipient is configured it only verifies that the SMTP server is reachable (a TCP connectivity probe) — **no email is sent**.
- **Sending a real end-to-end test email is now opt-in** via a new `_APP_SMTP_TEST_EMAIL` variable. It must be an address the operator owns; there is no third-party fallback recipient.
- Documented the new `_APP_SMTP_TEST_EMAIL` variable in `app/config/variables.php`.

This directly implements the reporter's suggested fixes: verify connectivity without sending, make sending opt-in via env, and never default the recipient to a real third-party address.

### Behavior summary

| `_APP_SMTP_HOST` | `_APP_SMTP_TEST_EMAIL` | Behavior |
|---|---|---|
| empty | (any) | `⚪ SMTP … not configured`, no send |
| set | empty (default) | `🟢 connected` via TCP probe, **no email sent** |
| set | set (operator address) | Real test email sent to that address |

## Test Plan

1. Self-host Appwrite via Docker Compose with system SMTP configured in `.env`.
2. `docker compose up -d` and watch the SMTP provider's outbound logs.
3. **Before:** one test email every ~5s to `demo@example.com`.
4. **After:** no emails are sent by the healthcheck; `doctor` reports SMTP connectivity via a passive probe.
5. Optionally set `_APP_SMTP_TEST_EMAIL=you@yourdomain.com` and run `docker compose exec appwrite doctor` to confirm the opt-in end-to-end send still works.

## Related PRs and Issues

Closes #12760

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.