### PR TITLE
fix(sdk): register notifications service in SDK config

### DIFF
--- a/app/config/services.php
+++ b/app/config/services.php
@@ -323,6 +323,20 @@ return [
         'icon' => '/images/services/messaging.png',
         'platforms' => ['client', 'server', 'console'],
     ],
+    'notifications' => [
+        'key' => 'notifications',
+        'name' => 'Notifications',
+        'subtitle' => 'The Notifications service allows you to read and manage your Appwrite Console notifications.',
+        'description' => '',
+        'controller' => '', // Uses modules
+        'sdk' => true,
+        'docs' => true,
+        'docsUrl' => '',
+        'tests' => true,
+        'optional' => false,
+        'icon' => '',
+        'platforms' => ['client', 'server', 'console'],
+    ],
     'advisor' => [
         'key' => 'advisor',
         'name' => 'Advisor',

--- a/app/config/services.php
+++ b/app/config/services.php
@@ -327,7 +327,7 @@ return [
         'key' => 'notifications',
         'name' => 'Notifications',
         'subtitle' => 'The Notifications service allows you to read and manage your Appwrite Console notifications.',
-        'description' => '',
+        'description' => '/docs/services/notifications.md',
         'controller' => '', // Uses modules
         'sdk' => true,
         'docs' => true,

--- a/docs/services/notifications.md
+++ b/docs/services/notifications.md
@@ -1,0 +1,3 @@
+The Notifications service allows you to read and manage the notifications shown in your Appwrite Console. Use it to list the notifications delivered to the currently logged-in user, mark a notification as read, and retrieve the Appwrite logo used when rendering notifications.
+
+Notifications keep you informed about important events and updates related to your account and projects. This service operates in the scope of the current Console user and is intended for Console integrations.


### PR DESCRIPTION
## What

Register the `notifications` service in `app/config/services.php` so it is included in the generated client, server, and console SDKs.

## Why

The Notifications module already exists and is wired into `src/Appwrite/Platform/Appwrite.php`:

- `src/Appwrite/Platform/Modules/Notifications/` — `Module.php`, `Services/Http.php`
- Endpoints under the `notifications` SDK namespace: `list` (`GET /v1/notifications`), `update` (`PATCH /v1/notifications/:notificationId`), `getLogo` (`GET /v1/notifications/logos/appwrite`)
- Response models `MODEL_NOTIFICATION` / `MODEL_NOTIFICATION_LIST` and `docs/references/notifications/*.md`

However, `app/config/services.php` had no `notifications` entry. `Specs` builds the spec's top-level services/tags list exclusively from `Config::getParam('services')` (config/services.php), gated on `sdk`/`docs`/`platforms`, and the OpenAPI formatter sets `tags` from that list. Route paths are collected independently, but with no service tag the SDK generator produces **no `notifications` service class** — so the service is missing from every generated SDK.

## Change

Add a `notifications` service entry modeled on the other module-based services (`console`, `advisor`), with `platforms: ['client', 'server', 'console']` to match the route auth (SESSION → client, JWT → server; console spec is a superset).

## Verification

- `php -l app/config/services.php` — no syntax errors
- Config includes and parses; `notifications` present with `sdk => true`, `docs => true`
- Pint (PSR-12) passes on the file
