### PR TITLE
Fix migration failing to create new attributes when batch contains existing ones

### DIFF
--- a/src/Appwrite/Migration/Migration.php
+++ b/src/Appwrite/Migration/Migration.php
@@ -325,7 +325,7 @@ abstract class Migration
         );
 
         foreach ($attributeIds as $attributeId) {
-            if (\in_array($attributeId, $existingIds)) {
+            if (\in_array($attributeId, $existingIds, true)) {
                 Console::warning("Skipping attribute \"{$attributeId}\" in collection {$collectionId}: Attribute already exists");
                 continue;
             }

--- a/src/Appwrite/Migration/Migration.php
+++ b/src/Appwrite/Migration/Migration.php
@@ -317,7 +317,19 @@ abstract class Migration
         $attributes = $collection['attributes'];
         $attributeKeys = \array_column($collection['attributes'], '$id');
 
+        $database->purgeCachedCollection($collectionId);
+
+        $existingIds = \array_map(
+            fn ($attribute) => $attribute->getId(),
+            $database->getCollection($collectionId)->getAttribute('attributes', [])
+        );
+
         foreach ($attributeIds as $attributeId) {
+            if (\in_array($attributeId, $existingIds)) {
+                Console::warning("Skipping attribute \"{$attributeId}\" in collection {$collectionId}: Attribute already exists");
+                continue;
+            }
+
             $attributeKey = \array_search($attributeId, $attributeKeys);
 
             if ($attributeKey === false) {
@@ -334,10 +346,36 @@ abstract class Migration
             $attributesToCreate[] = $attribute;
         }
 
-        $database->createAttributes(
-            collection: $collectionId,
-            attributes: $attributesToCreate,
-        );
+        if (empty($attributesToCreate)) {
+            return;
+        }
+
+        try {
+            $database->createAttributes(
+                collection: $collectionId,
+                attributes: $attributesToCreate,
+            );
+        } catch (Duplicate) {
+            foreach ($attributesToCreate as $attribute) {
+                try {
+                    $database->createAttribute(
+                        collection: $collectionId,
+                        id: $attribute['$id'],
+                        type: $attribute['type'],
+                        size: $attribute['size'],
+                        required: $attribute['required'],
+                        default: $attribute['default'],
+                        signed: $attribute['signed'] ?? true,
+                        array: $attribute['array'] ?? false,
+                        format: $attribute['format'] ?? '',
+                        formatOptions: $attribute['formatOptions'] ?? [],
+                        filters: $attribute['filters'],
+                    );
+                } catch (Duplicate) {
+                    Console::warning("Skipping attribute \"{$attribute['$id']}\" in collection {$collectionId}: Attribute already exists");
+                }
+            }
+        }
     }
 
     /**

--- a/tests/unit/Migration/MigrationVersionsTest.php
+++ b/tests/unit/Migration/MigrationVersionsTest.php
@@ -132,4 +132,55 @@ final class MigrationVersionsTest extends TestCase
         $this->assertArrayHasKey('firstSeen', $attributes);
         $this->assertArrayHasKey('lastSeen', $attributes);
     }
+
+    public function testCreateAttributesFromCollectionSkipsExistingAttributes(): void
+    {
+        require_once __DIR__ . '/../../../app/init.php';
+
+        $authorization = new Authorization();
+        $database = new Database(new Memory(), new Cache(new NoCache()));
+        $database
+            ->setAuthorization($authorization)
+            ->setDatabase('migrationV24Functions')
+            ->setNamespace('migration_functions_' . \uniqid());
+        $database->create();
+        $database->createCollection('functions');
+
+        $migration = new V24();
+        $migration->setProject(
+            new Document(['$id' => 'project', '$sequence' => '1']),
+            $database,
+            $database,
+            $authorization,
+        );
+
+        $existing = [
+            'deploymentRetention',
+            'startCommand',
+            'buildSpecification',
+            'runtimeSpecification',
+        ];
+        $new = [
+            'providerBranches',
+            'providerPaths',
+        ];
+
+        \ob_start();
+        try {
+            $migration->createAttributesFromCollection($database, 'functions', $existing);
+            $migration->createAttributesFromCollection($database, 'functions', [...$existing, ...$new]);
+            $migration->createAttributesFromCollection($database, 'functions', [...$existing, ...$new]);
+        } finally {
+            \ob_end_clean();
+        }
+
+        $attributes = [];
+        foreach ($database->getCollection('functions')->getAttribute('attributes', []) as $attribute) {
+            $attributes[] = $attribute instanceof Document ? $attribute->getAttribute('$id') : ($attribute['$id'] ?? '');
+        }
+
+        foreach ([...$existing, ...$new] as $id) {
+            $this->assertContains($id, $attributes);
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Makes `Migration::createAttributesFromCollection` idempotent so re-running a migration no longer fails when part of its attribute batch already exists.

**The bug (reported by a self-hosted user):** V24 creates `deploymentRetention`, `startCommand`, `buildSpecification`, `runtimeSpecification`, `providerBranches` and `providerPaths` on the `functions` and `sites` collections in a single `createAttributes()` batch. Installs coming from 1.9.0 already have the first four attributes (created by the V24 revision that shipped with 1.9.0), so the batch throws `Duplicate`, V24 downgrades it to a console warning, and `providerBranches` / `providerPaths` are **never created** — leading to unknown-attribute errors at runtime after the "successful" upgrade.

**The fix**, in the shared helper (covers all 15 batch call sites across V22–V24):
- Purge the collection cache and skip attributes that already exist on the live collection before building the batch (with a warning per skipped attribute)
- Return early when nothing is left to create
- If the batch still hits `Duplicate` (check-then-act race), fall back to creating the remaining attributes one-by-one, swallowing only `Duplicate`

Users already affected self-heal by re-running the migration: the four duplicates are skipped and the two missing attributes get created.

Note: 1.9.x's V24 also contains the six-attribute batch, so a backport to `1.9.x` fixes the same failure for 1.9.0 → 1.9.5 patch upgrades.

## Test Plan

Added `testCreateAttributesFromCollectionSkipsExistingAttributes` to `tests/unit/Migration/MigrationVersionsTest.php`, reproducing the exact upgrade path: seed `functions` with the four 1.9.0-era attributes, re-run the helper with the full six-attribute batch, run it once more with everything existing, and assert all six attributes exist.

- Fails with `Duplicate` against the unfixed helper (verified via `git stash`), passes with the fix
- `vendor/bin/phpunit tests/unit/Migration/MigrationVersionsTest.php` — 4 tests, 80 assertions, green
- Pint, PHPStan level 4, and Rector dry-run all clean on both touched files

## Related PRs and Issues

- Self-hosted user report: v24 migration cannot create `providerBranches` / `providerPaths` because the other four attributes in the batch already exist

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?