### PR TITLE
Migrate resource events to typed Bus dispatch

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -9,10 +9,31 @@ use Appwrite\Auth\Validator\PasswordHistory;
 use Appwrite\Auth\Validator\PasswordStrength;
 use Appwrite\Auth\Validator\PersonalData;
 use Appwrite\Auth\Validator\Phone;
+use Appwrite\Bus\Events\UserDeleted;
+use Appwrite\Bus\Events\UserEmailUpdated;
+use Appwrite\Bus\Events\UserIdentityDeleted;
+use Appwrite\Bus\Events\UserImpersonatorUpdated;
+use Appwrite\Bus\Events\UserLabelsUpdated;
+use Appwrite\Bus\Events\UserMfaAuthenticatorDeleted;
+use Appwrite\Bus\Events\UserMfaRecoveryCodesCreated;
+use Appwrite\Bus\Events\UserMfaRecoveryCodesUpdated;
+use Appwrite\Bus\Events\UserMfaUpdated;
+use Appwrite\Bus\Events\UserNameUpdated;
+use Appwrite\Bus\Events\UserPasswordUpdated;
+use Appwrite\Bus\Events\UserPhoneUpdated;
+use Appwrite\Bus\Events\UserPreferencesUpdated;
+use Appwrite\Bus\Events\UserSessionCreated;
+use Appwrite\Bus\Events\UserSessionDeleted;
+use Appwrite\Bus\Events\UserSessionsDeleted;
+use Appwrite\Bus\Events\UserStatusUpdated;
+use Appwrite\Bus\Events\UserTargetCreated;
+use Appwrite\Bus\Events\UserTargetDeleted;
+use Appwrite\Bus\Events\UserTargetUpdated;
+use Appwrite\Bus\Events\UserTokenCreated;
+use Appwrite\Bus\Events\UserVerificationUpdated;
 use Appwrite\Deletes\Identities as DeleteIdentities;
 use Appwrite\Deletes\Targets as DeleteTargets;
 use Appwrite\Detector\Detector;
-use Appwrite\Event\Event;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -43,6 +64,7 @@ use Utopia\Auth\Hashes\Sha;
 use Utopia\Auth\Proofs\Password as ProofsPassword;
 use Utopia\Auth\Proofs\Token;
 use Utopia\Auth\Store;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -593,7 +615,6 @@ Http::post('/v1/users/:userId/targets')
     ->groups(['api', 'users'])
     ->label('audits.event', 'target.create')
     ->label('audits.resource', 'target/response.$id')
-    ->label('event', 'users.[userId].targets.[targetId].create')
     ->label('scope', 'users.write')
     ->label('sdk', new Method(
         namespace: 'users',
@@ -614,10 +635,12 @@ Http::post('/v1/users/:userId/targets')
     ->param('identifier', '', new Text(Database::LENGTH_KEY), 'The target identifier (token, email, phone etc.)')
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Message will be sent to this target from the specified provider ID. If no provider ID is set the first setup provider will be used.', true, ['dbForProject'])
     ->param('name', '', new Text(128), 'Target name. Max length: 128 chars. For example: My Awesome App Galaxy S23.', true)
-    ->inject('queueForEvents')
+    ->inject('bus')
     ->inject('response')
     ->inject('dbForProject')
-    ->action(function (string $targetId, string $userId, string $providerType, string $identifier, string $providerId, string $name, Event $queueForEvents, Response $response, Database $dbForProject) {
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $targetId, string $userId, string $providerType, string $identifier, string $providerId, string $name, Bus $bus, Response $response, Database $dbForProject, Document $project, Document $actor) {
         $targetId = $targetId == 'unique()' ? ID::unique() : $targetId;
 
         $provider = $dbForProject->getDocument('providers', $providerId);
@@ -674,13 +697,11 @@ Http::post('/v1/users/:userId/targets')
         }
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setParam('targetId', $target->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($target, Response::MODEL_TARGET);
+
+        $bus->dispatch(new UserTargetCreated($target, $user->getId(), $project, $actor));
     });
 
 Http::get('/v1/users')
@@ -1116,7 +1137,6 @@ Http::get('/v1/users/identities')
 Http::patch('/v1/users/:userId/status')
     ->desc('Update user status')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.status')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1138,8 +1158,10 @@ Http::patch('/v1/users/:userId/status')
     ->param('status', null, new Boolean(true), 'User Status. To activate the user pass `true` and to block the user pass `false`.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, bool $status, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, bool $status, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1149,16 +1171,14 @@ Http::patch('/v1/users/:userId/status')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['status' => (bool) $status]));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserStatusUpdated($user, $project, $actor));
     });
 
 Http::put('/v1/users/:userId/labels')
     ->desc('Update user labels')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.labels')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1179,8 +1199,10 @@ Http::put('/v1/users/:userId/labels')
     ->param('labels', [], new ArrayList(new Text(36, allowList: [...Text::NUMBERS, ...Text::ALPHABET_UPPER, ...Text::ALPHABET_LOWER]), APP_LIMIT_ARRAY_LABELS_SIZE), 'Array of user labels. Replaces the previous labels. Maximum of ' . APP_LIMIT_ARRAY_LABELS_SIZE . ' labels are allowed, each up to 36 alphanumeric characters long.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, array $labels, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, array $labels, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1192,16 +1214,14 @@ Http::put('/v1/users/:userId/labels')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['labels' => $user->getAttribute('labels')]));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserLabelsUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/impersonator')
     ->desc('Update user impersonator capability')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.impersonator')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1222,8 +1242,10 @@ Http::patch('/v1/users/:userId/impersonator')
     ->param('impersonator', false, new Boolean(true), 'Whether the user can impersonate other users. When true, the user can browse project users to choose a target and can pass impersonation headers to act as that user. Internal audit logs still attribute impersonated actions to the original impersonator and store the target user details only in internal audit payload data.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, bool $impersonator, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, bool $impersonator, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1233,16 +1255,14 @@ Http::patch('/v1/users/:userId/impersonator')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['impersonator' => $impersonator]));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserImpersonatorUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/verification/phone')
     ->desc('Update phone verification')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.verification')
     ->label('scope', 'users.write')
     ->label('audits.event', 'verification.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1263,8 +1283,10 @@ Http::patch('/v1/users/:userId/verification/phone')
     ->param('phoneVerification', false, new Boolean(), 'User phone verification status.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, bool $phoneVerification, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, bool $phoneVerification, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1274,16 +1296,14 @@ Http::patch('/v1/users/:userId/verification/phone')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['phoneVerification' => $phoneVerification]));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserVerificationUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/name')
     ->desc('Update name')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.name')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1305,8 +1325,10 @@ Http::patch('/v1/users/:userId/name')
     ->param('name', '', new Text(128, 0), 'User name. Max length: 128 chars.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, string $name, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, string $name, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1318,15 +1340,14 @@ Http::patch('/v1/users/:userId/name')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['name' => $user->getAttribute('name')]));
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserNameUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/password')
     ->desc('Update password')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.password')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1349,9 +1370,10 @@ Http::patch('/v1/users/:userId/password')
     ->inject('response')
     ->inject('project')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
+    ->inject('bus')
     ->inject('hooks')
-    ->action(function (string $userId, string $password, Response $response, Document $project, Database $dbForProject, Event $queueForEvents, Hooks $hooks) {
+    ->inject('user')
+    ->action(function (string $userId, string $password, Response $response, Document $project, Database $dbForProject, Bus $bus, Hooks $hooks, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1375,7 +1397,6 @@ Http::patch('/v1/users/:userId/password')
                 'password' => $user->getAttribute('password'),
                 'passwordUpdate' => $user->getAttribute('passwordUpdate'),
             ]));
-            $queueForEvents->setParam('userId', $user->getId());
             $response->dynamic($user, Response::MODEL_USER);
         }
 
@@ -1426,15 +1447,14 @@ Http::patch('/v1/users/:userId/password')
 
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserPasswordUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/email')
     ->desc('Update email')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.email')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1458,8 +1478,9 @@ Http::patch('/v1/users/:userId/email')
     ->inject('dbForProject')
     ->inject('project')
     ->inject('plan')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, string $email, Response $response, Database $dbForProject, Document $project, array $plan, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('user')
+    ->action(function (string $userId, string $email, Response $response, Database $dbForProject, Document $project, array $plan, Bus $bus, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1577,15 +1598,14 @@ Http::patch('/v1/users/:userId/email')
             throw new Exception(Exception::USER_EMAIL_ALREADY_EXISTS);
         }
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserEmailUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/phone')
     ->desc('Update phone')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.phone')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1606,8 +1626,10 @@ Http::patch('/v1/users/:userId/phone')
     ->param('number', '', new Phone(allowEmpty: true), 'User phone number.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, string $number, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, string $number, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1670,15 +1692,14 @@ Http::patch('/v1/users/:userId/phone')
             throw new Exception(Exception::USER_PHONE_ALREADY_EXISTS);
         }
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserPhoneUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/verification')
     ->desc('Update email verification')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.verification')
     ->label('scope', 'users.write')
     ->label('audits.event', 'verification.update')
     ->label('audits.resource', 'user/{request.userId}')
@@ -1700,8 +1721,10 @@ Http::patch('/v1/users/:userId/verification')
     ->param('emailVerification', false, new Boolean(), 'User email verification status.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, bool $emailVerification, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, bool $emailVerification, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1711,15 +1734,14 @@ Http::patch('/v1/users/:userId/verification')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['emailVerification' => $emailVerification]));
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserVerificationUpdated($user, $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/prefs')
     ->desc('Update user preferences')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.prefs')
     ->label('scope', 'users.write')
     ->label('sdk', new Method(
         namespace: 'users',
@@ -1738,8 +1760,10 @@ Http::patch('/v1/users/:userId/prefs')
     ->param('prefs', '', new Assoc(), 'Prefs key-value JSON object.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, array $prefs, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, array $prefs, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1749,10 +1773,9 @@ Http::patch('/v1/users/:userId/prefs')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['prefs' => $prefs]));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId());
-
         $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
+
+        $bus->dispatch(new UserPreferencesUpdated($user->getId(), new Document($prefs), $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/targets/:targetId')
@@ -1760,7 +1783,6 @@ Http::patch('/v1/users/:userId/targets/:targetId')
     ->groups(['api', 'users'])
     ->label('audits.event', 'target.update')
     ->label('audits.resource', 'target/{response.$id}')
-    ->label('event', 'users.[userId].targets.[targetId].update')
     ->label('scope', 'users.write')
     ->label('sdk', new Method(
         namespace: 'users',
@@ -1780,10 +1802,12 @@ Http::patch('/v1/users/:userId/targets/:targetId')
     ->param('identifier', '', new Text(Database::LENGTH_KEY), 'The target identifier (token, email, phone etc.)', true)
     ->param('providerId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Provider ID. Message will be sent to this target from the specified provider ID. If no provider ID is set the first setup provider will be used.', true, ['dbForProject'])
     ->param('name', '', new Text(128), 'Target name. Max length: 128 chars. For example: My Awesome App Galaxy S23.', true)
-    ->inject('queueForEvents')
+    ->inject('bus')
     ->inject('response')
     ->inject('dbForProject')
-    ->action(function (string $userId, string $targetId, string $identifier, string $providerId, string $name, Event $queueForEvents, Response $response, Database $dbForProject) {
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, string $targetId, string $identifier, string $providerId, string $name, Bus $bus, Response $response, Database $dbForProject, Document $project, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -1856,18 +1880,15 @@ Http::patch('/v1/users/:userId/targets/:targetId')
         ]));
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setParam('targetId', $target->getId());
-
         $response
             ->dynamic($target, Response::MODEL_TARGET);
+
+        $bus->dispatch(new UserTargetUpdated($target, $user->getId(), $project, $actor));
     });
 
 Http::patch('/v1/users/:userId/mfa')
     ->desc('Update MFA')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.mfa')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -1910,8 +1931,10 @@ Http::patch('/v1/users/:userId/mfa')
     ->param('mfa', null, new Boolean(), 'Enable or disable MFA.')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, bool $mfa, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, bool $mfa, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -1923,9 +1946,9 @@ Http::patch('/v1/users/:userId/mfa')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['mfa' => $user->getAttribute('mfa')]));
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $response->dynamic($user, Response::MODEL_USER);
+
+        $bus->dispatch(new UserMfaUpdated($user, $project, $actor));
     });
 
 Http::get('/v1/users/:userId/mfa/factors')
@@ -2051,7 +2074,6 @@ Http::get('/v1/users/:userId/mfa/recovery-codes')
 Http::patch('/v1/users/:userId/mfa/recovery-codes')
     ->desc('Create MFA recovery codes')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].create.mfa.recovery-codes')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -2093,8 +2115,10 @@ Http::patch('/v1/users/:userId/mfa/recovery-codes')
     ->param('userId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'User ID.', false, ['dbForProject'])
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -2111,19 +2135,18 @@ Http::patch('/v1/users/:userId/mfa/recovery-codes')
         $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
         $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $document = new Document([
             'recoveryCodes' => $mfaRecoveryCodes
         ]);
 
         $response->dynamic($document, Response::MODEL_MFA_RECOVERY_CODES);
+
+        $bus->dispatch(new UserMfaRecoveryCodesCreated($user->getId(), $document, $project, $actor));
     });
 
 Http::put('/v1/users/:userId/mfa/recovery-codes')
     ->desc('Update MFA recovery codes (regenerate)')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].update.mfa.recovery-codes')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{response.$id}')
@@ -2166,8 +2189,10 @@ Http::put('/v1/users/:userId/mfa/recovery-codes')
     ->param('userId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'User ID.', false, ['dbForProject'])
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -2183,19 +2208,18 @@ Http::put('/v1/users/:userId/mfa/recovery-codes')
         $user->setAttribute('mfaRecoveryCodes', $mfaRecoveryCodes);
         $dbForProject->updateDocument('users', $user->getId(), new Document(['mfaRecoveryCodes' => $mfaRecoveryCodes]));
 
-        $queueForEvents->setParam('userId', $user->getId());
-
         $document = new Document([
             'recoveryCodes' => $mfaRecoveryCodes
         ]);
 
         $response->dynamic($document, Response::MODEL_MFA_RECOVERY_CODES);
+
+        $bus->dispatch(new UserMfaRecoveryCodesUpdated($user->getId(), $document, $project, $actor));
     });
 
 Http::delete('/v1/users/:userId/mfa/authenticators/:type')
     ->desc('Delete authenticator')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].delete.mfa')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.update')
     ->label('audits.resource', 'user/{request.userId}')
@@ -2240,8 +2264,10 @@ Http::delete('/v1/users/:userId/mfa/authenticators/:type')
     ->param('type', null, new WhiteList([Type::TOTP]), 'Type of authenticator.', enum: new Enum(name: 'AuthenticatorType'))
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, string $type, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, string $type, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -2257,7 +2283,7 @@ Http::delete('/v1/users/:userId/mfa/authenticators/:type')
         $dbForProject->deleteDocument('authenticators', $authenticator->getId());
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $queueForEvents->setParam('userId', $user->getId());
+        $bus->dispatch(new UserMfaAuthenticatorDeleted($user, $project, $actor));
 
         $response->noContent();
     });
@@ -2265,7 +2291,6 @@ Http::delete('/v1/users/:userId/mfa/authenticators/:type')
 Http::post('/v1/users/:userId/sessions')
     ->desc('Create session')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].sessions.[sessionId].create')
     ->label('scope', ['users.write', 'sessions.write'])
     ->label('audits.event', 'session.create')
     ->label('audits.resource', 'user/{request.userId}')
@@ -2290,10 +2315,11 @@ Http::post('/v1/users/:userId/sessions')
     ->inject('project')
     ->inject('locale')
     ->inject('geodb')
-    ->inject('queueForEvents')
+    ->inject('bus')
     ->inject('store')
     ->inject('proofForToken')
-    ->action(function (string $userId, Request $request, Response $response, Database $dbForProject, Document $project, Locale $locale, Reader $geodb, Event $queueForEvents, Store $store, Token $proofForToken) {
+    ->inject('user')
+    ->action(function (string $userId, Request $request, Response $response, Database $dbForProject, Document $project, Locale $locale, Reader $geodb, Bus $bus, Store $store, Token $proofForToken, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
         if ($user->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
@@ -2345,19 +2371,15 @@ Http::post('/v1/users/:userId/sessions')
             ->setAttribute('secret', $encoded)
             ->setAttribute('countryName', $countryName);
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setParam('sessionId', $session->getId())
-            ->setPayload($response->output($session, Response::MODEL_SESSION));
-
         $response->setStatusCode(Response::STATUS_CODE_CREATED);
         $response->dynamic($session, Response::MODEL_SESSION);
+
+        $bus->dispatch(new UserSessionCreated($session, $user->getId(), $project, $actor));
     });
 
 Http::post('/v1/users/:userId/tokens')
     ->desc('Create token')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].tokens.[tokenId].create')
     ->label('scope', 'users.write')
     ->label('audits.event', 'tokens.create')
     ->label('audits.resource', 'user/{request.userId}')
@@ -2380,8 +2402,10 @@ Http::post('/v1/users/:userId/tokens')
     ->inject('request')
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, int $length, int $expire, Request $request, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, int $length, int $expire, Request $request, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -2409,19 +2433,15 @@ Http::post('/v1/users/:userId/tokens')
 
         $token->setAttribute('secret', $secret);
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setParam('tokenId', $token->getId())
-            ->setPayload($response->output($token, Response::MODEL_TOKEN));
-
         $response->setStatusCode(Response::STATUS_CODE_CREATED);
         $response->dynamic($token, Response::MODEL_TOKEN);
+
+        $bus->dispatch(new UserTokenCreated($token, $user->getId(), $project, $actor));
     });
 
 Http::delete('/v1/users/:userId/sessions/:sessionId')
     ->desc('Delete user session')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].sessions.[sessionId].delete')
     ->label('scope', ['users.write', 'sessions.write'])
     ->label('audits.event', 'session.delete')
     ->label('audits.resource', 'user/{request.userId}')
@@ -2443,8 +2463,10 @@ Http::delete('/v1/users/:userId/sessions/:sessionId')
     ->param('sessionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Session ID.', false, ['dbForProject'])
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, string $sessionId, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, string $sessionId, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -2461,10 +2483,7 @@ Http::delete('/v1/users/:userId/sessions/:sessionId')
         $dbForProject->deleteDocument('sessions', $session->getId());
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setParam('sessionId', $sessionId)
-            ->setPayload($response->output($session, Response::MODEL_SESSION));
+        $bus->dispatch(new UserSessionDeleted($session, $user->getId(), $project, $actor));
 
         $response->noContent();
     });
@@ -2472,7 +2491,6 @@ Http::delete('/v1/users/:userId/sessions/:sessionId')
 Http::delete('/v1/users/:userId/sessions')
     ->desc('Delete user sessions')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].sessions.delete')
     ->label('scope', ['users.write', 'sessions.write'])
     ->label('audits.event', 'session.delete')
     ->label('audits.resource', 'user/{user.$id}')
@@ -2493,8 +2511,10 @@ Http::delete('/v1/users/:userId/sessions')
     ->param('userId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'User ID.', false, ['dbForProject'])
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -2512,9 +2532,7 @@ Http::delete('/v1/users/:userId/sessions')
 
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setPayload($response->output($user, Response::MODEL_USER));
+        $bus->dispatch(new UserSessionsDeleted($user, $project, $actor));
 
         $response->noContent();
     });
@@ -2522,7 +2540,6 @@ Http::delete('/v1/users/:userId/sessions')
 Http::delete('/v1/users/:userId')
     ->desc('Delete user')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].delete')
     ->label('scope', 'users.write')
     ->label('audits.event', 'user.delete')
     ->label('audits.resource', 'user/{request.userId}')
@@ -2543,9 +2560,11 @@ Http::delete('/v1/users/:userId')
     ->param('userId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'User ID.', false, ['dbForProject'])
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
+    ->inject('bus')
     ->inject('publisherForDeletes')
-    ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents, DeletePublisher $publisherForDeletes) {
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, Response $response, Database $dbForProject, Bus $bus, DeletePublisher $publisherForDeletes, Document $project, Document $actor) {
 
         $user = $dbForProject->getDocument('users', $userId);
 
@@ -2561,14 +2580,12 @@ Http::delete('/v1/users/:userId')
         DeleteTargets::delete($dbForProject, Query::equal('userInternalId', [$user->getSequence()]));
 
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $clone,
         ));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setPayload($response->output($clone, Response::MODEL_USER));
+        $bus->dispatch(new UserDeleted($clone, $project, $actor));
 
         $response->noContent();
     });
@@ -2578,7 +2595,6 @@ Http::delete('/v1/users/:userId/targets/:targetId')
     ->groups(['api', 'users'])
     ->label('audits.event', 'target.delete')
     ->label('audits.resource', 'target/{request.$targetId}')
-    ->label('event', 'users.[userId].targets.[targetId].delete')
     ->label('scope', 'users.write')
     ->label('sdk', new Method(
         namespace: 'users',
@@ -2596,11 +2612,13 @@ Http::delete('/v1/users/:userId/targets/:targetId')
     ))
     ->param('userId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'User ID.', false, ['dbForProject'])
     ->param('targetId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Target ID.', false, ['dbForProject'])
-    ->inject('queueForEvents')
+    ->inject('bus')
     ->inject('publisherForDeletes')
     ->inject('response')
     ->inject('dbForProject')
-    ->action(function (string $userId, string $targetId, Event $queueForEvents, DeletePublisher $publisherForDeletes, Response $response, Database $dbForProject) {
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $userId, string $targetId, Bus $bus, DeletePublisher $publisherForDeletes, Response $response, Database $dbForProject, Document $project, Document $actor) {
         $user = $dbForProject->getDocument('users', $userId);
 
         if ($user->isEmpty()) {
@@ -2621,14 +2639,12 @@ Http::delete('/v1/users/:userId/targets/:targetId')
         $dbForProject->purgeCachedDocument('users', $user->getId());
 
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_TARGET,
             document: $target,
         ));
 
-        $queueForEvents
-            ->setParam('userId', $user->getId())
-            ->setParam('targetId', $target->getId());
+        $bus->dispatch(new UserTargetDeleted($target, $user->getId(), $project, $actor));
 
         $response->noContent();
     });
@@ -2636,7 +2652,6 @@ Http::delete('/v1/users/:userId/targets/:targetId')
 Http::delete('/v1/users/identities/:identityId')
     ->desc('Delete identity')
     ->groups(['api', 'users'])
-    ->label('event', 'users.[userId].identities.[identityId].delete')
     ->label('scope', 'users.write')
     ->label('audits.event', 'identity.delete')
     ->label('audits.resource', 'identity/{request.$identityId}')
@@ -2657,8 +2672,10 @@ Http::delete('/v1/users/identities/:identityId')
     ->param('identityId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Identity ID.', false, ['dbForProject'])
     ->inject('response')
     ->inject('dbForProject')
-    ->inject('queueForEvents')
-    ->action(function (string $identityId, Response $response, Database $dbForProject, Event $queueForEvents) {
+    ->inject('bus')
+    ->inject('project')
+    ->inject('user')
+    ->action(function (string $identityId, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor) {
 
         $identity = $dbForProject->getDocument('identities', $identityId);
 
@@ -2668,10 +2685,7 @@ Http::delete('/v1/users/identities/:identityId')
 
         $dbForProject->deleteDocument('identities', $identityId);
 
-        $queueForEvents
-            ->setParam('userId', $identity->getAttribute('userId'))
-            ->setParam('identityId', $identity->getId())
-            ->setPayload($response->output($identity, Response::MODEL_IDENTITY));
+        $bus->dispatch(new UserIdentityDeleted($identity, $identity->getAttribute('userId'), $project, $actor));
 
         $response->noContent();
     });

--- a/app/listeners.php
+++ b/app/listeners.php
@@ -1,11 +1,17 @@
 <?php
 
+use Appwrite\Bus\Listeners\Functions;
 use Appwrite\Bus\Listeners\Log;
 use Appwrite\Bus\Listeners\Mails;
+use Appwrite\Bus\Listeners\Realtime;
 use Appwrite\Bus\Listeners\Usage;
+use Appwrite\Bus\Listeners\Webhook;
 
 return [
     new Log(),
     new Mails(),
+    new Realtime(),
+    new Functions(),
+    new Webhook(),
     new Usage(),
 ];

--- a/src/Appwrite/Bus/Events/BucketCreated.php
+++ b/src/Appwrite/Bus/Events/BucketCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a storage bucket is created (`buckets.[bucketId].create`).
+ */
+class BucketCreated extends ResourceEvent
+{
+    public function __construct(Document $bucket, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'buckets.[bucketId].create',
+            params: ['bucketId' => $bucket->getId()],
+            document: $bucket,
+            model: Response::MODEL_BUCKET,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/BucketDeleted.php
+++ b/src/Appwrite/Bus/Events/BucketDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a storage bucket is deleted (`buckets.[bucketId].delete`).
+ */
+class BucketDeleted extends ResourceEvent
+{
+    public function __construct(Document $bucket, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'buckets.[bucketId].delete',
+            params: ['bucketId' => $bucket->getId()],
+            document: $bucket,
+            model: Response::MODEL_BUCKET,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/BucketUpdated.php
+++ b/src/Appwrite/Bus/Events/BucketUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a storage bucket is updated (`buckets.[bucketId].update`).
+ */
+class BucketUpdated extends ResourceEvent
+{
+    public function __construct(Document $bucket, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'buckets.[bucketId].update',
+            params: ['bucketId' => $bucket->getId()],
+            document: $bucket,
+            model: Response::MODEL_BUCKET,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/DeploymentCreated.php
+++ b/src/Appwrite/Bus/Events/DeploymentCreated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function deployment is created
+ * (`functions.[functionId].deployments.[deploymentId].create`).
+ */
+class DeploymentCreated extends ResourceEvent
+{
+    public function __construct(Document $deployment, string $functionId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].deployments.[deploymentId].create',
+            params: ['functionId' => $functionId, 'deploymentId' => $deployment->getId()],
+            document: $deployment,
+            model: Response::MODEL_DEPLOYMENT,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/DeploymentDeleted.php
+++ b/src/Appwrite/Bus/Events/DeploymentDeleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function deployment is deleted
+ * (`functions.[functionId].deployments.[deploymentId].delete`).
+ */
+class DeploymentDeleted extends ResourceEvent
+{
+    public function __construct(Document $deployment, string $functionId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].deployments.[deploymentId].delete',
+            params: ['functionId' => $functionId, 'deploymentId' => $deployment->getId()],
+            document: $deployment,
+            model: Response::MODEL_DEPLOYMENT,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/DeploymentUpdated.php
+++ b/src/Appwrite/Bus/Events/DeploymentUpdated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function deployment is updated
+ * (`functions.[functionId].deployments.[deploymentId].update`).
+ */
+class DeploymentUpdated extends ResourceEvent
+{
+    public function __construct(Document $deployment, string $functionId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].deployments.[deploymentId].update',
+            params: ['functionId' => $functionId, 'deploymentId' => $deployment->getId()],
+            document: $deployment,
+            model: Response::MODEL_DEPLOYMENT,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/ExecutionCreated.php
+++ b/src/Appwrite/Bus/Events/ExecutionCreated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function execution is created
+ * (`functions.[functionId].executions.[executionId].create`).
+ */
+class ExecutionCreated extends ResourceEvent
+{
+    public function __construct(Document $execution, Document $function, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].executions.[executionId].create',
+            params: ['functionId' => $function->getId(), 'executionId' => $execution->getId()],
+            document: $execution,
+            model: Response::MODEL_EXECUTION,
+            project: $project,
+            user: $actor,
+            context: ['function' => $function],
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/ExecutionDeleted.php
+++ b/src/Appwrite/Bus/Events/ExecutionDeleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function execution is deleted
+ * (`functions.[functionId].executions.[executionId].delete`).
+ */
+class ExecutionDeleted extends ResourceEvent
+{
+    public function __construct(Document $execution, string $functionId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].executions.[executionId].delete',
+            params: ['functionId' => $functionId, 'executionId' => $execution->getId()],
+            document: $execution,
+            model: Response::MODEL_EXECUTION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FileCreated.php
+++ b/src/Appwrite/Bus/Events/FileCreated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a file is created in a bucket
+ * (`buckets.[bucketId].files.[fileId].create`).
+ *
+ * Carries the bucket as context, which realtime uses for channel routing.
+ */
+class FileCreated extends ResourceEvent
+{
+    public function __construct(Document $file, Document $bucket, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'buckets.[bucketId].files.[fileId].create',
+            params: ['bucketId' => $bucket->getId(), 'fileId' => $file->getId()],
+            document: $file,
+            model: Response::MODEL_FILE,
+            project: $project,
+            user: $actor,
+            context: ['bucket' => $bucket],
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FileDeleted.php
+++ b/src/Appwrite/Bus/Events/FileDeleted.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a file is deleted
+ * (`buckets.[bucketId].files.[fileId].delete`).
+ *
+ * Carries the bucket as context, which realtime uses for channel routing.
+ */
+class FileDeleted extends ResourceEvent
+{
+    public function __construct(Document $file, Document $bucket, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'buckets.[bucketId].files.[fileId].delete',
+            params: ['bucketId' => $bucket->getId(), 'fileId' => $file->getId()],
+            document: $file,
+            model: Response::MODEL_FILE,
+            project: $project,
+            user: $actor,
+            context: ['bucket' => $bucket],
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FileUpdated.php
+++ b/src/Appwrite/Bus/Events/FileUpdated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a file is updated
+ * (`buckets.[bucketId].files.[fileId].update`).
+ *
+ * Carries the bucket as context, which realtime uses for channel routing.
+ */
+class FileUpdated extends ResourceEvent
+{
+    public function __construct(Document $file, Document $bucket, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'buckets.[bucketId].files.[fileId].update',
+            params: ['bucketId' => $bucket->getId(), 'fileId' => $file->getId()],
+            document: $file,
+            model: Response::MODEL_FILE,
+            project: $project,
+            user: $actor,
+            context: ['bucket' => $bucket],
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FunctionCreated.php
+++ b/src/Appwrite/Bus/Events/FunctionCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function is created (`functions.[functionId].create`).
+ */
+class FunctionCreated extends ResourceEvent
+{
+    public function __construct(Document $function, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].create',
+            params: ['functionId' => $function->getId()],
+            document: $function,
+            model: Response::MODEL_FUNCTION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FunctionDeleted.php
+++ b/src/Appwrite/Bus/Events/FunctionDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function is deleted (`functions.[functionId].delete`).
+ */
+class FunctionDeleted extends ResourceEvent
+{
+    public function __construct(Document $function, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].delete',
+            params: ['functionId' => $function->getId()],
+            document: $function,
+            model: Response::MODEL_FUNCTION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FunctionDeploymentUpdated.php
+++ b/src/Appwrite/Bus/Events/FunctionDeploymentUpdated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function's active deployment is changed
+ * (`functions.[functionId].deployments.[deploymentId].update`).
+ *
+ * The endpoint responds with the function, so the payload is the function
+ * (distinct from {@see DeploymentUpdated}, which carries the deployment).
+ */
+class FunctionDeploymentUpdated extends ResourceEvent
+{
+    public function __construct(Document $function, string $deploymentId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].deployments.[deploymentId].update',
+            params: ['functionId' => $function->getId(), 'deploymentId' => $deploymentId],
+            document: $function,
+            model: Response::MODEL_FUNCTION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/FunctionUpdated.php
+++ b/src/Appwrite/Bus/Events/FunctionUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a function is updated (`functions.[functionId].update`).
+ */
+class FunctionUpdated extends ResourceEvent
+{
+    public function __construct(Document $function, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'functions.[functionId].update',
+            params: ['functionId' => $function->getId()],
+            document: $function,
+            model: Response::MODEL_FUNCTION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/MembershipCreated.php
+++ b/src/Appwrite/Bus/Events/MembershipCreated.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team membership is created
+ * (`teams.[teamId].memberships.[membershipId].create`).
+ *
+ * The `userId` param is the invited member, not the acting user.
+ */
+class MembershipCreated extends ResourceEvent
+{
+    public function __construct(Document $membership, string $teamId, string $userId, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].memberships.[membershipId].create',
+            params: [
+                'userId' => $userId,
+                'teamId' => $teamId,
+                'membershipId' => $membership->getId(),
+            ],
+            document: $membership,
+            model: Response::MODEL_MEMBERSHIP,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/MembershipDeleted.php
+++ b/src/Appwrite/Bus/Events/MembershipDeleted.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team membership is deleted
+ * (`teams.[teamId].memberships.[membershipId].delete`).
+ *
+ * The `userId` param is the removed member, not the acting user.
+ */
+class MembershipDeleted extends ResourceEvent
+{
+    public function __construct(Document $membership, string $teamId, string $userId, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].memberships.[membershipId].delete',
+            params: [
+                'teamId' => $teamId,
+                'userId' => $userId,
+                'membershipId' => $membership->getId(),
+            ],
+            document: $membership,
+            model: Response::MODEL_MEMBERSHIP,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/MembershipStatusUpdated.php
+++ b/src/Appwrite/Bus/Events/MembershipStatusUpdated.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team membership is confirmed via its status endpoint
+ * (`teams.[teamId].memberships.[membershipId].update.status`).
+ *
+ * The `userId` param is the member accepting the invite, not necessarily an
+ * authenticated actor.
+ */
+class MembershipStatusUpdated extends ResourceEvent
+{
+    public function __construct(Document $membership, string $teamId, string $userId, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].memberships.[membershipId].update.status',
+            params: [
+                'userId' => $userId,
+                'teamId' => $teamId,
+                'membershipId' => $membership->getId(),
+            ],
+            document: $membership,
+            model: Response::MODEL_MEMBERSHIP,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/MembershipUpdated.php
+++ b/src/Appwrite/Bus/Events/MembershipUpdated.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team membership's roles are updated
+ * (`teams.[teamId].memberships.[membershipId].update`).
+ *
+ * The `userId` param is the member being updated, not the acting user.
+ */
+class MembershipUpdated extends ResourceEvent
+{
+    public function __construct(Document $membership, string $teamId, string $userId, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].memberships.[membershipId].update',
+            params: [
+                'userId' => $userId,
+                'teamId' => $teamId,
+                'membershipId' => $membership->getId(),
+            ],
+            document: $membership,
+            model: Response::MODEL_MEMBERSHIP,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/ResourceEvent.php
+++ b/src/Appwrite/Bus/Events/ResourceEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Utopia\Bus\Event;
+use Utopia\Database\Document;
+
+/**
+ * Base class for resource lifecycle events (create/update/delete/...).
+ *
+ * Each concrete resource+operation defines its own subclass (e.g. {@see TeamCreated})
+ * that fills in the event-name template, params, the raw resource document and its
+ * response model. Cross-cutting outbound listeners (realtime, functions, webhooks)
+ * subscribe to this base type and therefore receive every subtype; domain-specific
+ * listeners can subscribe to a concrete subclass.
+ *
+ * The event carries the *raw* document plus its model name rather than a pre-filtered
+ * payload: each consumer owns how it projects the resource for its own channel. It also
+ * carries the string event name + params because realtime channel routing and
+ * function/webhook subscription matching are all driven by event strings.
+ */
+abstract class ResourceEvent implements Event
+{
+    /**
+     * @param string $event                    event name template, e.g. "teams.[teamId].create"
+     * @param array<string, string> $params    placeholder values, e.g. ['teamId' => '...']
+     * @param Document $document                the raw resource document
+     * @param string $model                     response model used to project the document
+     * @param array<int, string> $sensitive    payload keys to omit from broadcasts
+     * @param array<string, Document> $context  database/collection/table/bucket for channel routing
+     * @param array<int, string> $subscribers   explicit project subscribers (worker-originated events)
+     */
+    public function __construct(
+        public readonly string $event,
+        public readonly array $params,
+        public readonly Document $document,
+        public readonly string $model,
+        public readonly ?Document $project = null,
+        public readonly ?Document $user = null,
+        public readonly ?string $userId = null,
+        public readonly array $sensitive = [],
+        public readonly array $context = [],
+        public readonly array $subscribers = [],
+    ) {
+    }
+}

--- a/src/Appwrite/Bus/Events/RuleCreated.php
+++ b/src/Appwrite/Bus/Events/RuleCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a proxy rule is created (`rules.[ruleId].create`).
+ */
+class RuleCreated extends ResourceEvent
+{
+    public function __construct(Document $rule, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'rules.[ruleId].create',
+            params: ['ruleId' => $rule->getId()],
+            document: $rule,
+            model: Response::MODEL_PROXY_RULE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/RuleDeleted.php
+++ b/src/Appwrite/Bus/Events/RuleDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a proxy rule is deleted (`rules.[ruleId].delete`).
+ */
+class RuleDeleted extends ResourceEvent
+{
+    public function __construct(Document $rule, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'rules.[ruleId].delete',
+            params: ['ruleId' => $rule->getId()],
+            document: $rule,
+            model: Response::MODEL_PROXY_RULE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/RuleUpdated.php
+++ b/src/Appwrite/Bus/Events/RuleUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a proxy rule is updated (`rules.[ruleId].update`).
+ */
+class RuleUpdated extends ResourceEvent
+{
+    public function __construct(Document $rule, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'rules.[ruleId].update',
+            params: ['ruleId' => $rule->getId()],
+            document: $rule,
+            model: Response::MODEL_PROXY_RULE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteActiveDeploymentUpdated.php
+++ b/src/Appwrite/Bus/Events/SiteActiveDeploymentUpdated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site's active deployment is changed
+ * (`sites.[siteId].deployments.[deploymentId].update`).
+ *
+ * The endpoint responds with the site, so the payload is the site
+ * (distinct from {@see SiteDeploymentUpdated}, which carries the deployment).
+ */
+class SiteActiveDeploymentUpdated extends ResourceEvent
+{
+    public function __construct(Document $site, string $deploymentId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].deployments.[deploymentId].update',
+            params: ['siteId' => $site->getId(), 'deploymentId' => $deploymentId],
+            document: $site,
+            model: Response::MODEL_SITE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteCreated.php
+++ b/src/Appwrite/Bus/Events/SiteCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site is created (`sites.[siteId].create`).
+ */
+class SiteCreated extends ResourceEvent
+{
+    public function __construct(Document $site, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].create',
+            params: ['siteId' => $site->getId()],
+            document: $site,
+            model: Response::MODEL_SITE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteDeleted.php
+++ b/src/Appwrite/Bus/Events/SiteDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site is deleted (`sites.[siteId].delete`).
+ */
+class SiteDeleted extends ResourceEvent
+{
+    public function __construct(Document $site, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].delete',
+            params: ['siteId' => $site->getId()],
+            document: $site,
+            model: Response::MODEL_SITE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteDeploymentCreated.php
+++ b/src/Appwrite/Bus/Events/SiteDeploymentCreated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site deployment is created
+ * (`sites.[siteId].deployments.[deploymentId].create`).
+ */
+class SiteDeploymentCreated extends ResourceEvent
+{
+    public function __construct(Document $deployment, string $siteId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].deployments.[deploymentId].create',
+            params: ['siteId' => $siteId, 'deploymentId' => $deployment->getId()],
+            document: $deployment,
+            model: Response::MODEL_DEPLOYMENT,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteDeploymentDeleted.php
+++ b/src/Appwrite/Bus/Events/SiteDeploymentDeleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site deployment is deleted
+ * (`sites.[siteId].deployments.[deploymentId].delete`).
+ */
+class SiteDeploymentDeleted extends ResourceEvent
+{
+    public function __construct(Document $deployment, string $siteId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].deployments.[deploymentId].delete',
+            params: ['siteId' => $siteId, 'deploymentId' => $deployment->getId()],
+            document: $deployment,
+            model: Response::MODEL_DEPLOYMENT,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteDeploymentUpdated.php
+++ b/src/Appwrite/Bus/Events/SiteDeploymentUpdated.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site deployment is updated — currently emitted by the
+ * duplicate-deployment endpoint (`sites.[siteId].deployments.[deploymentId].update`).
+ *
+ * Carries the deployment (distinct from {@see SiteActiveDeploymentUpdated}, which
+ * carries the site).
+ */
+class SiteDeploymentUpdated extends ResourceEvent
+{
+    public function __construct(Document $deployment, string $siteId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].deployments.[deploymentId].update',
+            params: ['siteId' => $siteId, 'deploymentId' => $deployment->getId()],
+            document: $deployment,
+            model: Response::MODEL_DEPLOYMENT,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteLogDeleted.php
+++ b/src/Appwrite/Bus/Events/SiteLogDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site log is deleted (`sites.[siteId].logs.[logId].delete`).
+ */
+class SiteLogDeleted extends ResourceEvent
+{
+    public function __construct(Document $log, string $siteId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].logs.[logId].delete',
+            params: ['siteId' => $siteId, 'logId' => $log->getId()],
+            document: $log,
+            model: Response::MODEL_EXECUTION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/SiteUpdated.php
+++ b/src/Appwrite/Bus/Events/SiteUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a site is updated (`sites.[siteId].update`).
+ */
+class SiteUpdated extends ResourceEvent
+{
+    public function __construct(Document $site, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'sites.[siteId].update',
+            params: ['siteId' => $site->getId()],
+            document: $site,
+            model: Response::MODEL_SITE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/TeamCreated.php
+++ b/src/Appwrite/Bus/Events/TeamCreated.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team is created (`teams.[teamId].create`).
+ */
+class TeamCreated extends ResourceEvent
+{
+    public function __construct(Document $team, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].create',
+            params: \array_filter([
+                'teamId' => $team->getId(),
+                'userId' => $user?->getId(),
+            ]),
+            document: $team,
+            model: Response::MODEL_TEAM,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/TeamDeleted.php
+++ b/src/Appwrite/Bus/Events/TeamDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team is deleted (`teams.[teamId].delete`).
+ */
+class TeamDeleted extends ResourceEvent
+{
+    public function __construct(Document $team, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].delete',
+            params: ['teamId' => $team->getId()],
+            document: $team,
+            model: Response::MODEL_TEAM,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/TeamPreferencesUpdated.php
+++ b/src/Appwrite/Bus/Events/TeamPreferencesUpdated.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team's preferences are updated (`teams.[teamId].update.prefs`).
+ *
+ * The broadcast payload is the preferences document (not the team), matching the
+ * endpoint's response.
+ */
+class TeamPreferencesUpdated extends ResourceEvent
+{
+    public function __construct(string $teamId, Document $prefs, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].update.prefs',
+            params: ['teamId' => $teamId],
+            document: $prefs,
+            model: Response::MODEL_PREFERENCES,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/TeamUpdated.php
+++ b/src/Appwrite/Bus/Events/TeamUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a team's name is updated (`teams.[teamId].update`).
+ */
+class TeamUpdated extends ResourceEvent
+{
+    public function __construct(Document $team, ?Document $project = null, ?Document $user = null)
+    {
+        parent::__construct(
+            event: 'teams.[teamId].update',
+            params: ['teamId' => $team->getId()],
+            document: $team,
+            model: Response::MODEL_TEAM,
+            project: $project,
+            user: $user,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserDeleted.php
+++ b/src/Appwrite/Bus/Events/UserDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user is deleted (`users.[userId].delete`).
+ */
+class UserDeleted extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].delete',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserEmailUpdated.php
+++ b/src/Appwrite/Bus/Events/UserEmailUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's email is updated (`users.[userId].update.email`).
+ */
+class UserEmailUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.email',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserIdentityDeleted.php
+++ b/src/Appwrite/Bus/Events/UserIdentityDeleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user identity is deleted
+ * (`users.[userId].identities.[identityId].delete`).
+ */
+class UserIdentityDeleted extends ResourceEvent
+{
+    public function __construct(Document $identity, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].identities.[identityId].delete',
+            params: ['userId' => $userId, 'identityId' => $identity->getId()],
+            document: $identity,
+            model: Response::MODEL_IDENTITY,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserImpersonatorUpdated.php
+++ b/src/Appwrite/Bus/Events/UserImpersonatorUpdated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's impersonator capability is updated
+ * (`users.[userId].update.impersonator`).
+ */
+class UserImpersonatorUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.impersonator',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserLabelsUpdated.php
+++ b/src/Appwrite/Bus/Events/UserLabelsUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's labels are updated (`users.[userId].update.labels`).
+ */
+class UserLabelsUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.labels',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserMfaAuthenticatorDeleted.php
+++ b/src/Appwrite/Bus/Events/UserMfaAuthenticatorDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's MFA authenticator is deleted (`users.[userId].delete.mfa`).
+ */
+class UserMfaAuthenticatorDeleted extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].delete.mfa',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserMfaRecoveryCodesCreated.php
+++ b/src/Appwrite/Bus/Events/UserMfaRecoveryCodesCreated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's MFA recovery codes are created
+ * (`users.[userId].create.mfa.recovery-codes`).
+ */
+class UserMfaRecoveryCodesCreated extends ResourceEvent
+{
+    public function __construct(string $userId, Document $recoveryCodes, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].create.mfa.recovery-codes',
+            params: ['userId' => $userId],
+            document: $recoveryCodes,
+            model: Response::MODEL_MFA_RECOVERY_CODES,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserMfaRecoveryCodesUpdated.php
+++ b/src/Appwrite/Bus/Events/UserMfaRecoveryCodesUpdated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's MFA recovery codes are regenerated
+ * (`users.[userId].update.mfa.recovery-codes`).
+ */
+class UserMfaRecoveryCodesUpdated extends ResourceEvent
+{
+    public function __construct(string $userId, Document $recoveryCodes, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.mfa.recovery-codes',
+            params: ['userId' => $userId],
+            document: $recoveryCodes,
+            model: Response::MODEL_MFA_RECOVERY_CODES,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserMfaUpdated.php
+++ b/src/Appwrite/Bus/Events/UserMfaUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's MFA setting is updated (`users.[userId].update.mfa`).
+ */
+class UserMfaUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.mfa',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserNameUpdated.php
+++ b/src/Appwrite/Bus/Events/UserNameUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's name is updated (`users.[userId].update.name`).
+ */
+class UserNameUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.name',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserPasswordUpdated.php
+++ b/src/Appwrite/Bus/Events/UserPasswordUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's password is updated (`users.[userId].update.password`).
+ */
+class UserPasswordUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.password',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserPhoneUpdated.php
+++ b/src/Appwrite/Bus/Events/UserPhoneUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's phone is updated (`users.[userId].update.phone`).
+ */
+class UserPhoneUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.phone',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserPreferencesUpdated.php
+++ b/src/Appwrite/Bus/Events/UserPreferencesUpdated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's preferences are updated (`users.[userId].update.prefs`).
+ *
+ * The broadcast payload is the preferences document, matching the endpoint response.
+ */
+class UserPreferencesUpdated extends ResourceEvent
+{
+    public function __construct(string $userId, Document $prefs, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.prefs',
+            params: ['userId' => $userId],
+            document: $prefs,
+            model: Response::MODEL_PREFERENCES,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserSessionCreated.php
+++ b/src/Appwrite/Bus/Events/UserSessionCreated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a session is created for a user
+ * (`users.[userId].sessions.[sessionId].create`).
+ */
+class UserSessionCreated extends ResourceEvent
+{
+    public function __construct(Document $session, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].sessions.[sessionId].create',
+            params: ['userId' => $userId, 'sessionId' => $session->getId()],
+            document: $session,
+            model: Response::MODEL_SESSION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserSessionDeleted.php
+++ b/src/Appwrite/Bus/Events/UserSessionDeleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a single user session is deleted
+ * (`users.[userId].sessions.[sessionId].delete`).
+ */
+class UserSessionDeleted extends ResourceEvent
+{
+    public function __construct(Document $session, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].sessions.[sessionId].delete',
+            params: ['userId' => $userId, 'sessionId' => $session->getId()],
+            document: $session,
+            model: Response::MODEL_SESSION,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserSessionsDeleted.php
+++ b/src/Appwrite/Bus/Events/UserSessionsDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when all of a user's sessions are deleted (`users.[userId].sessions.delete`).
+ */
+class UserSessionsDeleted extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].sessions.delete',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserStatusUpdated.php
+++ b/src/Appwrite/Bus/Events/UserStatusUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's status is updated (`users.[userId].update.status`).
+ */
+class UserStatusUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.status',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserTargetCreated.php
+++ b/src/Appwrite/Bus/Events/UserTargetCreated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user messaging target is created
+ * (`users.[userId].targets.[targetId].create`).
+ */
+class UserTargetCreated extends ResourceEvent
+{
+    public function __construct(Document $target, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].targets.[targetId].create',
+            params: ['userId' => $userId, 'targetId' => $target->getId()],
+            document: $target,
+            model: Response::MODEL_TARGET,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserTargetDeleted.php
+++ b/src/Appwrite/Bus/Events/UserTargetDeleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user messaging target is deleted
+ * (`users.[userId].targets.[targetId].delete`).
+ */
+class UserTargetDeleted extends ResourceEvent
+{
+    public function __construct(Document $target, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].targets.[targetId].delete',
+            params: ['userId' => $userId, 'targetId' => $target->getId()],
+            document: $target,
+            model: Response::MODEL_TARGET,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserTargetUpdated.php
+++ b/src/Appwrite/Bus/Events/UserTargetUpdated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user messaging target is updated
+ * (`users.[userId].targets.[targetId].update`).
+ */
+class UserTargetUpdated extends ResourceEvent
+{
+    public function __construct(Document $target, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].targets.[targetId].update',
+            params: ['userId' => $userId, 'targetId' => $target->getId()],
+            document: $target,
+            model: Response::MODEL_TARGET,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserTokenCreated.php
+++ b/src/Appwrite/Bus/Events/UserTokenCreated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a token is created for a user
+ * (`users.[userId].tokens.[tokenId].create`).
+ */
+class UserTokenCreated extends ResourceEvent
+{
+    public function __construct(Document $token, string $userId, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].tokens.[tokenId].create',
+            params: ['userId' => $userId, 'tokenId' => $token->getId()],
+            document: $token,
+            model: Response::MODEL_TOKEN,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/UserVerificationUpdated.php
+++ b/src/Appwrite/Bus/Events/UserVerificationUpdated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a user's email or phone verification status is updated
+ * (`users.[userId].update.verification`).
+ */
+class UserVerificationUpdated extends ResourceEvent
+{
+    public function __construct(Document $user, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'users.[userId].update.verification',
+            params: ['userId' => $user->getId()],
+            document: $user,
+            model: Response::MODEL_USER,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/VariableCreated.php
+++ b/src/Appwrite/Bus/Events/VariableCreated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a variable is created (`variables.[variableId].create`).
+ *
+ * Used by both function and site variable endpoints.
+ */
+class VariableCreated extends ResourceEvent
+{
+    public function __construct(Document $variable, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'variables.[variableId].create',
+            params: ['variableId' => $variable->getId()],
+            document: $variable,
+            model: Response::MODEL_VARIABLE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/VariableDeleted.php
+++ b/src/Appwrite/Bus/Events/VariableDeleted.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a variable is deleted (`variables.[variableId].delete`).
+ *
+ * Used by both function and site variable endpoints.
+ */
+class VariableDeleted extends ResourceEvent
+{
+    public function __construct(Document $variable, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'variables.[variableId].delete',
+            params: ['variableId' => $variable->getId()],
+            document: $variable,
+            model: Response::MODEL_VARIABLE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Events/VariableUpdated.php
+++ b/src/Appwrite/Bus/Events/VariableUpdated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Appwrite\Bus\Events;
+
+use Appwrite\Utopia\Response;
+use Utopia\Database\Document;
+
+/**
+ * Dispatched when a variable is updated (`variables.[variableId].update`).
+ *
+ * Used by both function and site variable endpoints.
+ */
+class VariableUpdated extends ResourceEvent
+{
+    public function __construct(Document $variable, ?Document $project = null, ?Document $actor = null)
+    {
+        parent::__construct(
+            event: 'variables.[variableId].update',
+            params: ['variableId' => $variable->getId()],
+            document: $variable,
+            model: Response::MODEL_VARIABLE,
+            project: $project,
+            user: $actor,
+        );
+    }
+}

--- a/src/Appwrite/Bus/Listeners/Functions.php
+++ b/src/Appwrite/Bus/Listeners/Functions.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Appwrite\Bus\Listeners;
+
+use Appwrite\Bus\Events\ResourceEvent;
+use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Event\Message\Func as FunctionMessage;
+use Appwrite\Event\Publisher\Func as FunctionPublisher;
+use Appwrite\Functions\EventProcessor;
+use Appwrite\Utopia\Response;
+use Utopia\Bus\Listener;
+use Utopia\Database\Database;
+
+/**
+ * Enqueues function executions for resource events that match a function's
+ * subscribed events. Mirrors the legacy shutdown fan-out, keyed off the
+ * project's cached function-event map, and projects the raw document through
+ * its response model before delivery.
+ */
+class Functions extends Listener
+{
+    public static function getName(): string
+    {
+        return 'functions';
+    }
+
+    public static function getEvents(): array
+    {
+        return [ResourceEvent::class];
+    }
+
+    public function __construct()
+    {
+        $this
+            ->desc('Enqueues function executions for matching resource events')
+            ->inject('dbForProject')
+            ->inject('publisherForFunctions')
+            ->inject('eventProcessor')
+            ->inject('response')
+            ->callback($this->handle(...));
+    }
+
+    public function handle(ResourceEvent $event, Database $dbForProject, FunctionPublisher $publisherForFunctions, EventProcessor $eventProcessor, Response $response): void
+    {
+        if (empty($event->event) || $event->project === null) {
+            return;
+        }
+
+        $functionsEvents = $eventProcessor->getFunctionsEvents($event->project, $dbForProject);
+        if (empty($functionsEvents)) {
+            return;
+        }
+
+        $generatedEvents = QueueEvent::generateEvents($event->event, $event->params);
+
+        foreach ($generatedEvents as $generated) {
+            if (isset($functionsEvents[$generated])) {
+                $payload = $response->applyFilters(
+                    $response->output($event->document, $event->model),
+                    $event->model,
+                    raw: $event->document,
+                );
+
+                $publisherForFunctions->enqueue(FunctionMessage::fromEvent(
+                    event: $event->event,
+                    params: $event->params,
+                    project: $event->project,
+                    user: $event->user,
+                    userId: $event->userId,
+                    payload: $payload,
+                ));
+                break;
+            }
+        }
+    }
+}

--- a/src/Appwrite/Bus/Listeners/Realtime.php
+++ b/src/Appwrite/Bus/Listeners/Realtime.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Appwrite\Bus\Listeners;
+
+use Appwrite\Bus\Events\ResourceEvent;
+use Appwrite\Event\Realtime as RealtimeEvent;
+use Appwrite\Utopia\Response;
+use Utopia\Bus\Listener;
+
+/**
+ * Broadcasts resource lifecycle events to realtime (WebSocket) subscribers.
+ *
+ * Subscribes to every {@see ResourceEvent}, projects the raw document through its
+ * response model, and drives the request-scoped realtime event — which computes the
+ * affected channels/roles and, only if any exist, publishes to the Redis "realtime"
+ * pub/sub channel consumed by the realtime servers.
+ */
+class Realtime extends Listener
+{
+    public static function getName(): string
+    {
+        return 'realtime';
+    }
+
+    public static function getEvents(): array
+    {
+        return [ResourceEvent::class];
+    }
+
+    public function __construct()
+    {
+        $this
+            ->desc('Broadcasts resource events to realtime subscribers')
+            ->inject('queueForRealtime')
+            ->inject('response')
+            ->callback($this->handle(...));
+    }
+
+    public function handle(ResourceEvent $event, RealtimeEvent $queueForRealtime, Response $response): void
+    {
+        if (empty($event->event) || $event->project === null) {
+            return;
+        }
+
+        // Preserve the legacy console realtime gate: the console project only receives
+        // realtime for allow-listed route groups (e.g. presences), none of which are
+        // migrated to typed events yet. Generalise this when they are.
+        if ($event->project->getId() === 'console') {
+            return;
+        }
+
+        $payload = $response->applyFilters(
+            $response->output($event->document, $event->model),
+            $event->model,
+            raw: $event->document,
+        );
+
+        $queueForRealtime
+            ->setEvent($event->event)
+            ->setPayload($payload, $event->sensitive)
+            ->setProject($event->project)
+            ->setSubscribers($event->subscribers);
+
+        foreach ($event->params as $key => $value) {
+            $queueForRealtime->setParam($key, $value);
+        }
+
+        if ($event->user !== null) {
+            $queueForRealtime->setUser($event->user);
+        }
+
+        if ($event->userId !== null) {
+            $queueForRealtime->setUserId($event->userId);
+        }
+
+        foreach ($event->context as $key => $document) {
+            $queueForRealtime->setContext($key, $document);
+        }
+
+        $queueForRealtime->trigger();
+    }
+}

--- a/src/Appwrite/Bus/Listeners/Webhook.php
+++ b/src/Appwrite/Bus/Listeners/Webhook.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Appwrite\Bus\Listeners;
+
+use Appwrite\Bus\Events\ResourceEvent;
+use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Event\Webhook as WebhookEvent;
+use Appwrite\Functions\EventProcessor;
+use Appwrite\Utopia\Response;
+use Utopia\Bus\Listener;
+
+/**
+ * Triggers project webhooks for resource events that match a webhook's
+ * subscribed events. Mirrors the legacy shutdown fan-out, keyed off the
+ * project's cached webhook-event map, and projects the raw document through
+ * its response model before delivery.
+ */
+class Webhook extends Listener
+{
+    public static function getName(): string
+    {
+        return 'webhook';
+    }
+
+    public static function getEvents(): array
+    {
+        return [ResourceEvent::class];
+    }
+
+    public function __construct()
+    {
+        $this
+            ->desc('Triggers project webhooks for matching resource events')
+            ->inject('eventProcessor')
+            ->inject('queueForWebhooks')
+            ->inject('response')
+            ->callback($this->handle(...));
+    }
+
+    public function handle(ResourceEvent $event, EventProcessor $eventProcessor, WebhookEvent $queueForWebhooks, Response $response): void
+    {
+        if (empty($event->event) || $event->project === null) {
+            return;
+        }
+
+        $webhooksEvents = $eventProcessor->getWebhooksEvents($event->project);
+        if (empty($webhooksEvents)) {
+            return;
+        }
+
+        $generatedEvents = QueueEvent::generateEvents($event->event, $event->params);
+
+        foreach ($generatedEvents as $generated) {
+            if (isset($webhooksEvents[$generated])) {
+                $payload = $response->applyFilters(
+                    $response->output($event->document, $event->model),
+                    $event->model,
+                    raw: $event->document,
+                );
+
+                $queueForWebhooks
+                    ->setEvent($event->event)
+                    ->setPayload($payload, $event->sensitive)
+                    ->setProject($event->project);
+
+                foreach ($event->params as $key => $value) {
+                    $queueForWebhooks->setParam($key, $value);
+                }
+
+                if ($event->user !== null) {
+                    $queueForWebhooks->setUser($event->user);
+                }
+
+                if ($event->userId !== null) {
+                    $queueForWebhooks->setUserId($event->userId);
+                }
+
+                $queueForWebhooks->trigger();
+                break;
+            }
+        }
+    }
+}

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\DeploymentCreated;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
@@ -12,6 +12,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -51,7 +52,6 @@ class Create extends Action
             ->desc('Create deployment')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
-            ->label('event', 'functions.[functionId].deployments.[deploymentId].create')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'function/{request.functionId}')
@@ -86,7 +86,7 @@ class Create extends Action
             ->inject('request')
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('project')
             ->inject('deviceForFunctions')
             ->inject('deviceForLocal')
@@ -95,6 +95,7 @@ class Create extends Action
             ->inject('authorization')
             ->inject('platform')
             ->inject('locks')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -107,7 +108,7 @@ class Create extends Action
         Request $request,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents,
+        Bus $bus,
         Document $project,
         Device $deviceForFunctions,
         Device $deviceForLocal,
@@ -115,7 +116,8 @@ class Create extends Action
         array $plan,
         Authorization $authorization,
         array $platform,
-        callable $locks
+        callable $locks,
+        Document $actor
     ) {
         $activate = \strval($activate) === 'true' || \strval($activate) === '1';
 
@@ -276,7 +278,6 @@ class Create extends Action
         }
 
         if ($completed) {
-            $queueForEvents->reset();
             return;
         }
 
@@ -287,7 +288,7 @@ class Create extends Action
         }
 
         try {
-            $locks($lockKey, 600, function () use ($activate, &$chunks, $chunksUploaded, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, $functionId, $path, &$metadata, $mergeUploadMetadata, $platform, $project, $publisherForBuilds, $queueForEvents, $response, $type): void {
+            $locks($lockKey, 600, function () use ($activate, &$chunks, $chunksUploaded, $commands, $dbForProject, $deploymentId, $deviceForFunctions, $entrypoint, $fileSize, &$function, $functionId, $path, &$metadata, $mergeUploadMetadata, $platform, $project, $publisherForBuilds, $bus, $actor, $response, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
                 $uploaded = 0;
 
@@ -297,8 +298,6 @@ class Create extends Action
                     $metadata = $mergeUploadMetadata($deployment->getAttribute('sourceMetadata', []), $metadata);
 
                     if ($uploaded === $chunks) {
-                        $queueForEvents->reset();
-
                         $response
                             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
@@ -377,15 +376,13 @@ class Create extends Action
 
                 $metadata = null;
 
-                if ($chunksUploaded === $chunks) {
-                    $queueForEvents
-                        ->setParam('functionId', $function->getId())
-                        ->setParam('deploymentId', $deployment->getId());
-                }
-
                 $response
                     ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                     ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+                if ($chunksUploaded === $chunks) {
+                    $bus->dispatch(new DeploymentCreated($deployment, $function->getId(), $project, $actor));
+                }
             }, timeout: 120.0);
         } catch (LockContention) {
             $response->addHeader('Retry-After', '5');

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\DeploymentDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -11,6 +11,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
@@ -38,7 +39,6 @@ class Delete extends Action
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].deployments.[deploymentId].delete')
             ->label('audits.event', 'deployment.delete')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -63,8 +63,10 @@ class Delete extends Action
             ->inject('response')
             ->inject('dbForProject')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('deviceForFunctions')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -74,8 +76,10 @@ class Delete extends Action
         Response $response,
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
-        Event $queueForEvents,
-        Device $deviceForFunctions
+        Bus $bus,
+        Device $deviceForFunctions,
+        Document $project,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
         if ($function->isEmpty()) {
@@ -135,15 +139,13 @@ class Delete extends Action
             ])));
         }
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $deployment,
         ));
+
+        $bus->dispatch(new DeploymentDeleted($deployment, $function->getId(), $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments\Duplicate;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\DeploymentUpdated;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -38,7 +39,6 @@ class Create extends Action
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -62,11 +62,12 @@ class Create extends Action
             ->param('buildId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Build unique ID.', true, ['dbForProject']) // added as optional param for backward compatibility
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('deviceForFunctions')
             ->inject('project')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -76,11 +77,12 @@ class Create extends Action
         string $buildId,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         Device $deviceForFunctions,
         Document $project,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -129,12 +131,10 @@ class Create extends Action
             platform: $platform,
         ));
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+        $bus->dispatch(new DeploymentUpdated($deployment, $function->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Template/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments\Template;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\DeploymentCreated;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
@@ -12,6 +12,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -44,7 +45,6 @@ class Create extends Base
             ->desc('Create template deployment')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
-            ->label('event', 'functions.[functionId].deployments.[deploymentId].create')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'function/{request.functionId}')
@@ -77,12 +77,13 @@ class Create extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('dbForPlatform')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('project')
             ->inject('publisherForBuilds')
             ->inject('gitHub')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -98,12 +99,13 @@ class Create extends Base
         Response $response,
         Database $dbForProject,
         Database $dbForPlatform,
-        Event $queueForEvents,
+        Bus $bus,
         Document $project,
         BuildPublisher $publisherForBuilds,
         GitHub $github,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -141,13 +143,11 @@ class Create extends Base
                 reference: $reference
             );
 
-            $queueForEvents
-                ->setParam('functionId', $function->getId())
-                ->setParam('deploymentId', $deployment->getId());
-
             $response
                 ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                 ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+            $bus->dispatch(new DeploymentCreated($deployment, $function->getId(), $project, $actor));
 
             return;
         }
@@ -186,12 +186,10 @@ class Create extends Base
             platform: $platform,
         ));
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+        $bus->dispatch(new DeploymentCreated($deployment, $function->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Vcs/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Vcs/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments\Vcs;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\DeploymentCreated;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
@@ -11,6 +11,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
@@ -40,7 +41,6 @@ class Create extends Base
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -71,10 +71,11 @@ class Create extends Base
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('gitHub')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -88,10 +89,11 @@ class Create extends Base
         Database $dbForProject,
         Database $dbForPlatform,
         Document $project,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         GitHub $github,
         array $platform,
+        Document $actor,
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -122,12 +124,10 @@ class Create extends Base
             referenceType: $type
         );
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+        $bus->dispatch(new DeploymentCreated($deployment, $function->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -3,7 +3,7 @@
 namespace Appwrite\Platform\Modules\Functions\Http\Executions;
 
 use Ahc\Jwt\JWT;
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\ExecutionCreated;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Message\Func as FunctionMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
@@ -23,6 +23,7 @@ use Executor\Executor;
 use MaxMind\Db\Reader;
 use Utopia\Auth\Proofs\Token;
 use Utopia\Auth\Store;
+use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Database\Database;
@@ -65,7 +66,6 @@ class Create extends Base
             ->groups(['api', 'functions'])
             ->label('scope', ['executions.write', 'execution.write'])
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].executions.[executionId].create')
             ->label('usage.resource', 'function/{request.functionId}')
             ->label('sdk', new Method(
                 namespace: 'functions',
@@ -95,7 +95,7 @@ class Create extends Base
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('user')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('usage')
             ->inject('publisherForFunctions')
             ->inject('geodb')
@@ -123,7 +123,7 @@ class Create extends Base
         Database $dbForProject,
         Database $dbForPlatform,
         User $user,
-        Event $queueForEvents,
+        Bus $bus,
         Context $usage,
         FunctionPublisher $publisherForFunctions,
         Reader $geodb,
@@ -288,11 +288,6 @@ class Create extends Base
             'duration' => 0.0,
         ]);
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('executionId', $execution->getId())
-            ->setContext('function', $function);
-
         if ($async) {
             if (is_null($scheduledAt)) {
                 $execution = $authorization->skip(fn () => $dbForProject->createDocument('executions', $execution));
@@ -350,6 +345,9 @@ class Create extends Base
 
             $response->setStatusCode(Response::STATUS_CODE_ACCEPTED);
             $response->dynamic($execution, Response::MODEL_EXECUTION);
+
+            $bus->dispatch(new ExecutionCreated($execution, $function, $project, $user));
+
             return;
         }
 
@@ -542,6 +540,8 @@ class Create extends Base
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($execution, Response::MODEL_EXECUTION);
+
+        $bus->dispatch(new ExecutionCreated($execution, $function, $project, $user));
     }
 
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Executions;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\ExecutionDeleted;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
@@ -10,6 +10,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -37,7 +38,6 @@ class Delete extends Base
             ->groups(['api', 'functions'])
             ->label('scope', ['executions.write', 'execution.write'])
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].executions.[executionId].delete')
             ->label('audits.event', 'executions.delete')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -62,8 +62,10 @@ class Delete extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('dbForPlatform')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('authorization')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -73,8 +75,10 @@ class Delete extends Base
         Response $response,
         Database $dbForProject,
         Database $dbForPlatform,
-        Event $queueForEvents,
-        Authorization $authorization
+        Bus $bus,
+        Authorization $authorization,
+        Document $project,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -128,10 +132,7 @@ class Delete extends Base
             }
         }
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('executionId', $execution->getId())
-            ->setPayload($response->output($execution, Response::MODEL_EXECUTION));
+        $bus->dispatch(new ExecutionDeleted($execution, $function->getId(), $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Create.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Functions;
 
+use Appwrite\Bus\Events\FunctionCreated;
 use Appwrite\Event\Event;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Message\Func as FunctionMessage;
@@ -21,6 +22,7 @@ use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model\Rule;
 use Utopia\Abuse\Abuse;
+use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -60,7 +62,6 @@ class Create extends Base
             ->desc('Create function')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
-            ->label('event', 'functions.[functionId].create')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'function.create')
             ->label('audits.resource', 'function/{response.$id}')
@@ -131,6 +132,8 @@ class Create extends Base
             ->inject('gitHub')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('bus')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -174,7 +177,9 @@ class Create extends Base
         Request $request,
         GitHub $github,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Bus $bus,
+        Document $actor
     ) {
 
         // Temporary abuse check
@@ -443,10 +448,10 @@ class Create extends Base
             }
         }
 
-        $queueForEvents->setParam('functionId', $function->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($function, Response::MODEL_FUNCTION);
+
+        $bus->dispatch(new FunctionCreated($function, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Functions;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\FunctionDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -12,6 +12,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -38,7 +39,6 @@ class Delete extends Base
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].delete')
             ->label('audits.event', 'function.delete')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -62,9 +62,11 @@ class Delete extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('authorization')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -73,9 +75,11 @@ class Delete extends Base
         Response $response,
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
-        Authorization $authorization
+        Authorization $authorization,
+        Document $project,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -100,12 +104,12 @@ class Delete extends Base
         }
 
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $function,
         ));
 
-        $queueForEvents->setParam('functionId', $function->getId());
+        $bus->dispatch(new FunctionDeleted($function, $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Functions\Deployment;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\FunctionDeploymentUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -37,7 +38,6 @@ class Update extends Base
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'functions.[functionId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -61,9 +61,10 @@ class Update extends Base
             ->inject('project')
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -73,9 +74,10 @@ class Update extends Base
         Document $project,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
-        Authorization $authorization
+        Authorization $authorization,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
         $deployment = $dbForProject->getDocument('deployments', $deploymentId);
@@ -130,10 +132,8 @@ class Update extends Base
             ])));
         }, $queries));
 
-        $queueForEvents
-            ->setParam('functionId', $function->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response->dynamic($function, Response::MODEL_FUNCTION);
+
+        $bus->dispatch(new FunctionDeploymentUpdated($function, $deployment->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Functions;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\FunctionUpdated;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Event\Validator\FunctionEvent;
 use Appwrite\Extend\Exception;
@@ -14,6 +14,7 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Task\Validator\Cron;
 use Appwrite\Utopia\Response;
 use Executor\Executor;
+use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -52,7 +53,6 @@ class Update extends Base
             ->desc('Update function')
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
-            ->label('event', 'functions.[functionId].update')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
             ->label('audits.event', 'function.update')
             ->label('audits.resource', 'function/{response.$id}')
@@ -109,13 +109,14 @@ class Update extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('dbForPlatform')
             ->inject('gitHub')
             ->inject('executor')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -146,13 +147,14 @@ class Update extends Base
         Response $response,
         Database $dbForProject,
         Document $project,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         Database $dbForPlatform,
         GitHub $github,
         Executor $executor,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         // TODO: If only branch changes, re-deploy
         $function = $dbForProject->getDocument('functions', $functionId);
@@ -344,8 +346,8 @@ class Update extends Base
             ->setAttribute('active', !empty($function->getAttribute('schedule')) && !empty($function->getAttribute('deploymentId')));
         $authorization->skip(fn () => $dbForPlatform->updateDocument('schedules', $schedule->getId(), $schedule));
 
-        $queueForEvents->setParam('functionId', $function->getId());
-
         $response->dynamic($function, Response::MODEL_FUNCTION);
+
+        $bus->dispatch(new FunctionUpdated($function, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Variables;
 
-use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Bus\Events\VariableCreated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -40,7 +41,6 @@ class Create extends Base
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'variables.[variableId].create')
             ->label('audits.event', 'variable.create')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -65,11 +65,12 @@ class Create extends Base
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.', false)
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only functions can read them during build and runtime.', true)
             ->inject('response')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('project')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -80,11 +81,12 @@ class Create extends Base
         string $value,
         bool $secret,
         Response $response,
-        QueueEvent $queueForEvents,
+        Bus $bus,
         Database $dbForProject,
         Database $dbForPlatform,
         Document $project,
-        Authorization $authorization
+        Authorization $authorization,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -128,10 +130,10 @@ class Create extends Base
             'active' => $schedule->getAttribute('active'),
         ])));
 
-        $queueForEvents->setParam('variableId', $variable->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($variable, Response::MODEL_VARIABLE);
+
+        $bus->dispatch(new VariableCreated($variable, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Variables;
 
-use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Bus\Events\VariableDeleted;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
@@ -10,6 +10,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -36,7 +37,6 @@ class Delete extends Base
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'variables.[variableId].delete')
             ->label('audits.event', 'variable.delete')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -59,10 +59,12 @@ class Delete extends Base
             ->param('functionId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Function unique ID.', false, ['dbForProject'])
             ->param('variableId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Variable unique ID.', false, ['dbForProject'])
             ->inject('response')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('authorization')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -70,10 +72,12 @@ class Delete extends Base
         string $functionId,
         string $variableId,
         Response $response,
-        QueueEvent $queueForEvents,
+        Bus $bus,
         Database $dbForProject,
         Database $dbForPlatform,
-        Authorization $authorization
+        Authorization $authorization,
+        Document $project,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -103,7 +107,7 @@ class Delete extends Base
             'active' => $schedule->getAttribute('active'),
         ])));
 
-        $queueForEvents->setParam('variableId', $variable->getId());
+        $bus->dispatch(new VariableDeleted($variable, $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Variables/Update.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Functions\Http\Variables;
 
-use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Bus\Events\VariableUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -39,7 +40,6 @@ class Update extends Base
             ->groups(['api', 'functions'])
             ->label('scope', 'functions.write')
             ->label('resourceType', RESOURCE_TYPE_FUNCTIONS)
-            ->label('event', 'variables.[variableId].update')
             ->label('audits.event', 'variable.update')
             ->label('audits.resource', 'function/{request.functionId}')
             ->label('usage.resource', 'function/{request.functionId}')
@@ -64,10 +64,12 @@ class Update extends Base
             ->param('value', null, new Nullable(new Text(8192, 0)), 'Variable value. Max length: 8192 chars.', true)
             ->param('secret', null, new Nullable(new Boolean()), 'Secret variables can be updated or deleted, but only functions can read them during build and runtime.', true)
             ->inject('response')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('authorization')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -78,10 +80,12 @@ class Update extends Base
         ?string $value,
         ?bool $secret,
         Response $response,
-        QueueEvent $queueForEvents,
+        Bus $bus,
         Database $dbForProject,
         Database $dbForPlatform,
-        Authorization $authorization
+        Authorization $authorization,
+        Document $project,
+        Document $actor
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -138,8 +142,8 @@ class Update extends Base
             'active' => $schedule->getAttribute('active'),
         ])));
 
-        $queueForEvents->setParam('variableId', $variable->getId());
-
         $response->dynamic($variable, Response::MODEL_VARIABLE);
+
+        $bus->dispatch(new VariableUpdated($variable, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/API/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Proxy\Http\Rules\API;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\RuleCreated;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Proxy\Action;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -38,7 +39,6 @@ class Create extends Action
             ->groups(['api', 'proxy'])
             ->desc('Create API rule')
             ->label('scope', 'rules.write')
-            ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
@@ -65,11 +65,12 @@ class Create extends Action
             ->inject('response')
             ->inject('project')
             ->inject('publisherForCertificates')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('platform')
             ->inject('log')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -78,11 +79,12 @@ class Create extends Action
         Response $response,
         Document $project,
         Certificate $publisherForCertificates,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
         array $platform,
         Log $log,
         Authorization $authorization,
+        Document $actor,
     ) {
         $this->validateDomainRestrictions($domain, $platform);
 
@@ -132,8 +134,6 @@ class Create extends Action
             ));
         }
 
-        $queueForEvents->setParam('ruleId', $rule->getId());
-
         // Rename 'created' status to 'unverified' for consistency.
         // 'verifying' and 'verified' statuses stay as is.
         // 'unverified' in the meaning of failed certificate generation stays as is.
@@ -144,5 +144,7 @@ class Create extends Action
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($rule, Response::MODEL_PROXY_RULE);
+
+        $bus->dispatch(new RuleCreated($rule, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Delete.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Proxy\Http\Rules;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\RuleDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -11,6 +11,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
@@ -35,7 +36,6 @@ class Delete extends Action
             ->desc('Delete rule')
             ->groups(['api', 'proxy'])
             ->label('scope', 'rules.write')
-            ->label('event', 'rules.[ruleId].delete')
             ->label('audits.event', 'rules.delete')
             ->label('audits.resource', 'rule/{request.ruleId}')
             ->label('sdk', new Method(
@@ -59,8 +59,9 @@ class Delete extends Action
             ->inject('project')
             ->inject('dbForPlatform')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -70,8 +71,9 @@ class Delete extends Action
         Document $project,
         Database $dbForPlatform,
         DeletePublisher $publisherForDeletes,
-        Event $queueForEvents,
+        Bus $bus,
         Authorization $authorization,
+        Document $actor,
     ) {
         $rule = $authorization->skip(fn () => $dbForPlatform->getDocument('rules', $ruleId));
 
@@ -87,7 +89,7 @@ class Delete extends Action
             document: $rule,
         ));
 
-        $queueForEvents->setParam('ruleId', $rule->getId());
+        $bus->dispatch(new RuleDeleted($rule, $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Function/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Proxy\Http\Rules\Function;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\RuleCreated;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Proxy\Action;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -40,7 +41,6 @@ class Create extends Action
             ->groups(['api', 'proxy'])
             ->desc('Create function rule')
             ->label('scope', 'rules.write')
-            ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
@@ -69,12 +69,13 @@ class Create extends Action
             ->inject('response')
             ->inject('project')
             ->inject('publisherForCertificates')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('dbForProject')
             ->inject('platform')
             ->inject('log')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -85,12 +86,13 @@ class Create extends Action
         Response $response,
         Document $project,
         Certificate $publisherForCertificates,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
         Database $dbForProject,
         array $platform,
         Log $log,
         Authorization $authorization,
+        Document $actor,
     ) {
 
         $this->validateDomainRestrictions($domain, $platform);
@@ -154,8 +156,6 @@ class Create extends Action
             ));
         }
 
-        $queueForEvents->setParam('ruleId', $rule->getId());
-
         // Rename 'created' status to 'unverified' for consistency.
         // 'verifying' and 'verified' statuses stay as is.
         // 'unverified' in the meaning of failed certificate generation stays as is.
@@ -166,5 +166,7 @@ class Create extends Action
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($rule, Response::MODEL_PROXY_RULE);
+
+        $bus->dispatch(new RuleCreated($rule, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Redirect/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Proxy\Http\Rules\Redirect;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\RuleCreated;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Proxy\Action;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -42,7 +43,6 @@ class Create extends Action
             ->groups(['api', 'proxy'])
             ->desc('Create redirect rule')
             ->label('scope', 'rules.write')
-            ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
@@ -87,12 +87,13 @@ class Create extends Action
             ->inject('response')
             ->inject('project')
             ->inject('publisherForCertificates')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('dbForProject')
             ->inject('platform')
             ->inject('log')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -105,12 +106,13 @@ class Create extends Action
         Response $response,
         Document $project,
         Certificate $publisherForCertificates,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
         Database $dbForProject,
         array $platform,
         Log $log,
         Authorization $authorization,
+        Document $actor,
     ) {
 
         $this->validateDomainRestrictions($domain, $platform);
@@ -176,8 +178,6 @@ class Create extends Action
             ));
         }
 
-        $queueForEvents->setParam('ruleId', $rule->getId());
-
         // Rename 'created' status to 'unverified' for consistency.
         // 'verifying' and 'verified' statuses stay as is.
         // 'unverified' in the meaning of failed certificate generation stays as is.
@@ -188,5 +188,7 @@ class Create extends Action
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($rule, Response::MODEL_PROXY_RULE);
+
+        $bus->dispatch(new RuleCreated($rule, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Site/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Proxy\Http\Rules\Site;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\RuleCreated;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Proxy\Action;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -40,7 +41,6 @@ class Create extends Action
             ->groups(['api', 'proxy'])
             ->desc('Create site rule')
             ->label('scope', 'rules.write')
-            ->label('event', 'rules.[ruleId].create')
             ->label('audits.event', 'rule.create')
             ->label('audits.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
@@ -69,12 +69,13 @@ class Create extends Action
             ->inject('response')
             ->inject('project')
             ->inject('publisherForCertificates')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('dbForProject')
             ->inject('platform')
             ->inject('log')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -85,12 +86,13 @@ class Create extends Action
         Response $response,
         Document $project,
         Certificate $publisherForCertificates,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
         Database $dbForProject,
         array $platform,
         Log $log,
         Authorization $authorization,
+        Document $actor,
     ) {
 
         $this->validateDomainRestrictions($domain, $platform);
@@ -154,8 +156,6 @@ class Create extends Action
             ));
         }
 
-        $queueForEvents->setParam('ruleId', $rule->getId());
-
         // Rename 'created' status to 'unverified' for consistency.
         // 'verifying' and 'verified' statuses stay as is.
         // 'unverified' in the meaning of failed certificate generation stays as is.
@@ -166,5 +166,7 @@ class Create extends Action
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($rule, Response::MODEL_PROXY_RULE);
+
+        $bus->dispatch(new RuleCreated($rule, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Http/Rules/Status/Update.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Proxy\Http\Rules\Status;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\RuleUpdated;
 use Appwrite\Event\Publisher\Certificate;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Proxy\Action;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -38,7 +39,6 @@ class Update extends Action
             ->desc('Update rule status')
             ->groups(['api', 'proxy'])
             ->label('scope', 'rules.write')
-            ->label('event', 'rules.[ruleId].update')
             ->label('audits.event', 'rule.update')
             ->label('audits.resource', 'rule/{response.$id}')
             ->label('sdk', new Method(
@@ -59,11 +59,12 @@ class Update extends Action
             ->param('ruleId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Rule ID.', false, ['dbForProject'])
             ->inject('response')
             ->inject('publisherForCertificates')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('project')
             ->inject('dbForPlatform')
             ->inject('log')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -71,11 +72,12 @@ class Update extends Action
         string $ruleId,
         Response $response,
         Certificate $publisherForCertificates,
-        Event $queueForEvents,
+        Bus $bus,
         Document $project,
         Database $dbForPlatform,
         Log $log,
         Authorization $authorization,
+        Document $actor,
     ) {
         $rule = $authorization->skip(fn () => $dbForPlatform->getDocument('rules', $ruleId));
 
@@ -83,11 +85,12 @@ class Update extends Action
             throw new Exception(Exception::RULE_NOT_FOUND);
         }
 
-        $queueForEvents->setParam('ruleId', $rule->getId());
-
         // If rule is already verified or in certificate generation state, don't queue for verification again
         if ($rule->getAttribute('status') === RULE_STATUS_VERIFIED || $rule->getAttribute('status') === RULE_STATUS_CERTIFICATE_GENERATING) {
             $response->dynamic($rule, Response::MODEL_PROXY_RULE);
+
+            $bus->dispatch(new RuleUpdated($rule, $project, $actor));
+
             return;
         }
 
@@ -127,5 +130,7 @@ class Update extends Action
         }
 
         $response->dynamic($rule, Response::MODEL_PROXY_RULE);
+
+        $bus->dispatch(new RuleUpdated($rule, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteDeploymentCreated;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
@@ -12,6 +12,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -52,7 +53,6 @@ class Create extends Action
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -85,7 +85,7 @@ class Create extends Action
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('deviceForSites')
             ->inject('deviceForLocal')
             ->inject('publisherForBuilds')
@@ -93,6 +93,7 @@ class Create extends Action
             ->inject('authorization')
             ->inject('platform')
             ->inject('locks')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -108,7 +109,7 @@ class Create extends Action
         Database $dbForProject,
         Database $dbForPlatform,
         Document $project,
-        Event $queueForEvents,
+        Bus $bus,
         Device $deviceForSites,
         Device $deviceForLocal,
         BuildPublisher $publisherForBuilds,
@@ -116,6 +117,7 @@ class Create extends Action
         Authorization $authorization,
         array $platform,
         callable $locks,
+        Document $actor,
     ) {
         $activate = \strval($activate) === 'true' || \strval($activate) === '1';
 
@@ -314,7 +316,6 @@ class Create extends Action
         }
 
         if ($completed) {
-            $queueForEvents->reset();
             return;
         }
 
@@ -325,7 +326,7 @@ class Create extends Action
         }
 
         try {
-            $locks($lockKey, 600, function () use ($activate, $authorization, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $publisherForBuilds, $queueForEvents, $response, &$site, $siteId, $type): void {
+            $locks($lockKey, 600, function () use ($activate, $authorization, $commands, &$chunks, $chunksUploaded, $dbForPlatform, $dbForProject, $deploymentId, $deviceForSites, $fileSize, &$metadata, $mergeUploadMetadata, $outputDirectory, $path, $platform, $project, $publisherForBuilds, $bus, $actor, $response, &$site, $siteId, $type): void {
                 $deployment = $dbForProject->getDocument('deployments', $deploymentId);
                 $uploaded = 0;
 
@@ -335,8 +336,6 @@ class Create extends Action
                     $metadata = $mergeUploadMetadata($deployment->getAttribute('sourceMetadata', []), $metadata);
 
                     if ($uploaded === $chunks) {
-                        $queueForEvents->reset();
-
                         $response
                             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
@@ -442,15 +441,13 @@ class Create extends Action
 
                 $metadata = null;
 
-                if ($chunksUploaded === $chunks) {
-                    $queueForEvents
-                        ->setParam('siteId', $site->getId())
-                        ->setParam('deploymentId', $deployment->getId());
-                }
-
                 $response
                     ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                     ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+                if ($chunksUploaded === $chunks) {
+                    $bus->dispatch(new SiteDeploymentCreated($deployment, $site->getId(), $project, $actor));
+                }
             }, timeout: 120.0);
         } catch (LockContention) {
             $response->addHeader('Retry-After', '5');

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteDeploymentDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -11,6 +11,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Transaction as TransactionException;
@@ -38,7 +39,6 @@ class Delete extends Action
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].deployments.[deploymentId].delete')
             ->label('audits.event', 'deployment.delete')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -63,8 +63,10 @@ class Delete extends Action
             ->inject('response')
             ->inject('dbForProject')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('deviceForSites')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -74,8 +76,10 @@ class Delete extends Action
         Response $response,
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
-        Event $queueForEvents,
-        Device $deviceForSites
+        Bus $bus,
+        Device $deviceForSites,
+        Document $project,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
         if ($site->isEmpty()) {
@@ -137,15 +141,13 @@ class Delete extends Action
             ])));
         }
 
-        $queueForEvents
-            ->setParam('siteId', $site->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $deployment,
         ));
+
+        $bus->dispatch(new SiteDeploymentDeleted($deployment, $site->getId(), $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments\Duplicate;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteDeploymentUpdated;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
@@ -10,6 +10,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -38,7 +39,6 @@ class Create extends Action
             ->desc('Create duplicate deployment')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
-            ->label('event', 'sites.[siteId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -64,11 +64,12 @@ class Create extends Action
             ->inject('project')
             ->inject('dbForProject')
             ->inject('dbForPlatform')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('deviceForSites')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -80,11 +81,12 @@ class Create extends Action
         Document $project,
         Database $dbForProject,
         Database $dbForPlatform,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         Device $deviceForSites,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -175,12 +177,10 @@ class Create extends Action
             platform: $platform,
         ));
 
-        $queueForEvents
-            ->setParam('siteId', $site->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+        $bus->dispatch(new SiteDeploymentUpdated($deployment, $site->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Template/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments\Template;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteDeploymentCreated;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
@@ -12,6 +12,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -46,7 +47,6 @@ class Create extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -79,11 +79,12 @@ class Create extends Base
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('gitHub')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -100,11 +101,12 @@ class Create extends Base
         Database $dbForProject,
         Database $dbForPlatform,
         Document $project,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         GitHub $github,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -141,13 +143,11 @@ class Create extends Base
                 platform: $platform
             );
 
-            $queueForEvents
-                ->setParam('siteId', $site->getId())
-                ->setParam('deploymentId', $deployment->getId());
-
             $response
                 ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
                 ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+            $bus->dispatch(new SiteDeploymentCreated($deployment, $site->getId(), $project, $actor));
 
             return;
         }
@@ -223,12 +223,10 @@ class Create extends Base
             platform: $platform,
         ));
 
-        $queueForEvents
-            ->setParam('siteId', $site->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+        $bus->dispatch(new SiteDeploymentCreated($deployment, $site->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Vcs/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Vcs/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments\Vcs;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteDeploymentCreated;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
@@ -11,6 +11,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\Authorization;
@@ -41,7 +42,6 @@ class Create extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].deployments.[deploymentId].create')
             ->label('audits.event', 'deployment.create')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -72,11 +72,12 @@ class Create extends Base
             ->inject('dbForProject')
             ->inject('dbForPlatform')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('gitHub')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -90,11 +91,12 @@ class Create extends Base
         Database $dbForProject,
         Database $dbForPlatform,
         Document $project,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         GitHub $github,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -127,12 +129,10 @@ class Create extends Base
             platform: $platform
         );
 
-        $queueForEvents
-            ->setParam('siteId', $site->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_ACCEPTED)
             ->dynamic($deployment, Response::MODEL_DEPLOYMENT);
+
+        $bus->dispatch(new SiteDeploymentCreated($deployment, $site->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Logs/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Logs/Delete.php
@@ -2,14 +2,16 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Logs;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteLogDeleted;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -32,7 +34,6 @@ class Delete extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'log.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].logs.[logId].delete')
             ->label('audits.event', 'logs.delete')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -55,11 +56,13 @@ class Delete extends Base
             ->param('logId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Log ID.', false, ['dbForProject'])
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
-    public function action(string $siteId, string $logId, Response $response, Database $dbForProject, Event $queueForEvents)
+    public function action(string $siteId, string $logId, Response $response, Database $dbForProject, Bus $bus, Document $project, Document $actor)
     {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -80,10 +83,7 @@ class Delete extends Base
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to remove log from DB');
         }
 
-        $queueForEvents
-            ->setParam('siteId', $site->getId())
-            ->setParam('logId', $log->getId())
-            ->setPayload($response->output($log, Response::MODEL_EXECUTION)); // TODO: Update model
+        $bus->dispatch(new SiteLogDeleted($log, $site->getId(), $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Sites;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteCreated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\Platform\Modules\Compute\Validator\Specification;
@@ -11,6 +11,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -44,7 +45,6 @@ class Create extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].create')
             ->label('audits.event', 'site.create')
             ->label('audits.resource', 'site/{response.$id}')
             ->label('usage.resource', 'site/{response.$id}')
@@ -100,8 +100,9 @@ class Create extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -132,8 +133,9 @@ class Create extends Base
         Response $response,
         Database $dbForProject,
         Document $project,
-        Event $queueForEvents,
-        Database $dbForPlatform
+        Bus $bus,
+        Database $dbForPlatform,
+        Document $actor
     ) {
         if (!empty($adapter)) {
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
@@ -224,10 +226,10 @@ class Create extends Base
             ]));
         }
 
-        $queueForEvents->setParam('siteId', $site->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($site, Response::MODEL_SITE);
+
+        $bus->dispatch(new SiteCreated($site, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Sites;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -12,7 +12,9 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -35,7 +37,6 @@ class Delete extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].delete')
             ->label('audits.event', 'site.delete')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -59,7 +60,9 @@ class Delete extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
+            ->inject('bus')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -68,7 +71,9 @@ class Delete extends Base
         Response $response,
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
-        Event $queueForEvents
+        Bus $bus,
+        Document $project,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -81,12 +86,12 @@ class Delete extends Base
         }
 
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $site,
         ));
 
-        $queueForEvents->setParam('siteId', $site->getId());
+        $bus->dispatch(new SiteDeleted($site, $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Sites\Deployment;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteActiveDeploymentUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
@@ -35,7 +36,6 @@ class Update extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].deployments.[deploymentId].update')
             ->label('audits.event', 'deployment.update')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -59,9 +59,10 @@ class Update extends Base
             ->inject('project')
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForPlatform')
             ->inject('authorization')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -71,9 +72,10 @@ class Update extends Base
         Document $project,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents,
+        Bus $bus,
         Database $dbForPlatform,
-        Authorization $authorization
+        Authorization $authorization,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
         $deployment = $dbForProject->getDocument('deployments', $deploymentId);
@@ -118,10 +120,8 @@ class Update extends Base
             ])));
         }, $queries));
 
-        $queueForEvents
-            ->setParam('siteId', $site->getId())
-            ->setParam('deploymentId', $deployment->getId());
-
         $response->dynamic($site, Response::MODEL_SITE);
+
+        $bus->dispatch(new SiteActiveDeploymentUpdated($site, $deployment->getId(), $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Sites;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\SiteUpdated;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
@@ -12,6 +12,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
 use Executor\Executor;
+use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -48,7 +49,6 @@ class Update extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'sites.[siteId].update')
             ->label('audits.event', 'sites.update')
             ->label('audits.resource', 'site/{response.$id}')
             ->label('usage.resource', 'site/{response.$id}')
@@ -105,12 +105,13 @@ class Update extends Base
             ->inject('response')
             ->inject('dbForProject')
             ->inject('project')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('publisherForBuilds')
             ->inject('dbForPlatform')
             ->inject('gitHub')
             ->inject('executor')
             ->inject('platform')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -142,12 +143,13 @@ class Update extends Base
         Response $response,
         Database $dbForProject,
         Document $project,
-        Event $queueForEvents,
+        Bus $bus,
         BuildPublisher $publisherForBuilds,
         Database $dbForPlatform,
         GitHub $github,
         Executor $executor,
-        array $platform
+        array $platform,
+        Document $actor
     ) {
         if (!empty($adapter)) {
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
@@ -312,8 +314,8 @@ class Update extends Base
             $this->redeployVcsFunction($request, $site, $project, $installation, $dbForProject, $publisherForBuilds, new Document(), $github, true, $platform);
         }
 
-        $queueForEvents->setParam('siteId', $site->getId());
-
         $response->dynamic($site, Response::MODEL_SITE);
+
+        $bus->dispatch(new SiteUpdated($site, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Variables;
 
-use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Bus\Events\VariableCreated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -38,7 +39,6 @@ class Create extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'variables.[variableId].create')
             ->label('audits.event', 'variable.create')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -63,13 +63,14 @@ class Create extends Base
             ->param('value', null, new Text(8192, 0), 'Variable value. Max length: 8192 chars.', false)
             ->param('secret', true, new Boolean(), 'Secret variables can be updated or deleted, but only sites can read them during build and runtime.', true)
             ->inject('response')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForProject')
             ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
-    public function action(string $siteId, string $variableId, string $key, string $value, bool $secret, Response $response, QueueEvent $queueForEvents, Database $dbForProject, Document $project)
+    public function action(string $siteId, string $variableId, string $key, string $value, bool $secret, Response $response, Bus $bus, Database $dbForProject, Document $project, Document $actor)
     {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -102,10 +103,10 @@ class Create extends Base
             'live' => false,
         ]));
 
-        $queueForEvents->setParam('variableId', $variable->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($variable, Response::MODEL_VARIABLE);
+
+        $bus->dispatch(new VariableCreated($variable, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Delete.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Variables;
 
-use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Bus\Events\VariableDeleted;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
@@ -10,6 +10,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
@@ -34,7 +35,6 @@ class Delete extends Base
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
             ->label('resourceType', RESOURCE_TYPE_SITES)
-            ->label('event', 'variables.[variableId].delete')
             ->label('audits.event', 'variable.delete')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -57,12 +57,14 @@ class Delete extends Base
             ->param('siteId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Site unique ID.', false, ['dbForProject'])
             ->param('variableId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Variable unique ID.', false, ['dbForProject'])
             ->inject('response')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForProject')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
-    public function action(string $siteId, string $variableId, Response $response, QueueEvent $queueForEvents, Database $dbForProject)
+    public function action(string $siteId, string $variableId, Response $response, Bus $bus, Database $dbForProject, Document $project, Document $actor)
     {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -81,7 +83,7 @@ class Delete extends Base
             'live' => false,
         ]));
 
-        $queueForEvents->setParam('variableId', $variable->getId());
+        $bus->dispatch(new VariableDeleted($variable, $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Variables/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Variables/Update.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Sites\Http\Variables;
 
-use Appwrite\Event\Event as QueueEvent;
+use Appwrite\Bus\Events\VariableUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -36,7 +37,6 @@ class Update extends Base
             ->desc('Update variable')
             ->groups(['api', 'sites'])
             ->label('scope', 'sites.write')
-            ->label('event', 'variables.[variableId].update')
             ->label('audits.event', 'variable.update')
             ->label('audits.resource', 'site/{request.siteId}')
             ->label('usage.resource', 'site/{request.siteId}')
@@ -62,8 +62,10 @@ class Update extends Base
             ->param('value', null, new Nullable(new Text(8192, 0)), 'Variable value. Max length: 8192 chars.', true)
             ->param('secret', null, new Nullable(new Boolean()), 'Secret variables can be updated or deleted, but only sites can read them during build and runtime.', true)
             ->inject('response')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('dbForProject')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -74,8 +76,10 @@ class Update extends Base
         ?string $value,
         ?bool $secret,
         Response $response,
-        QueueEvent $queueForEvents,
-        Database $dbForProject
+        Bus $bus,
+        Database $dbForProject,
+        Document $project,
+        Document $actor
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -121,8 +125,8 @@ class Update extends Base
             'live' => false,
         ]));
 
-        $queueForEvents->setParam('variableId', $variable->getId());
-
         $response->dynamic($variable, Response::MODEL_VARIABLE);
+
+        $bus->dispatch(new VariableUpdated($variable, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Storage\Http\Buckets;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\BucketCreated;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
@@ -46,7 +47,6 @@ class Create extends Action
             ->groups(['api', 'storage'])
             ->label('scope', 'buckets.write')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
-            ->label('event', 'buckets.[bucketId].create')
             ->label('audits.event', 'bucket.create')
             ->label('audits.resource', 'bucket/{response.$id}')
             ->label('usage.resource', 'bucket/{response.$id}')
@@ -76,7 +76,9 @@ class Create extends Action
             ->param('transformations', true, new Boolean(true), 'Are image transformations enabled?', true)
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -94,7 +96,9 @@ class Create extends Action
         bool $transformations,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents
+        Bus $bus,
+        Document $project,
+        Document $actor
     ) {
         $bucketId = $bucketId === 'unique()' ? ID::unique() : $bucketId;
 
@@ -158,11 +162,10 @@ class Create extends Action
             throw new Exception(Exception::STORAGE_BUCKET_ALREADY_EXISTS);
         }
 
-        $queueForEvents
-            ->setParam('bucketId', $bucket->getId());
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($bucket, Response::MODEL_BUCKET);
+
+        $bus->dispatch(new BucketCreated($bucket, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Storage\Http\Buckets;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\BucketDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -11,7 +11,9 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
@@ -35,7 +37,6 @@ class Delete extends Action
             ->label('scope', 'buckets.write')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('audits.event', 'bucket.delete')
-            ->label('event', 'buckets.[bucketId].delete')
             ->label('audits.resource', 'bucket/{request.bucketId}')
             ->label('usage.resource', 'bucket/{request.bucketId}')
             ->label('sdk', new Method(
@@ -56,7 +57,9 @@ class Delete extends Action
             ->inject('response')
             ->inject('dbForProject')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
+            ->inject('bus')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -65,7 +68,9 @@ class Delete extends Action
         Response $response,
         Database $dbForProject,
         DeletePublisher $publisherForDeletes,
-        Event $queueForEvents
+        Bus $bus,
+        Document $project,
+        Document $actor
     ) {
         $bucket = $dbForProject->getDocument('buckets', $bucketId);
 
@@ -78,15 +83,12 @@ class Delete extends Action
         }
 
         $publisherForDeletes->enqueue(new DeleteMessage(
-            project: $queueForEvents->getProject(),
+            project: $project,
             type: DELETE_TYPE_DOCUMENT,
             document: $bucket,
         ));
 
-        $queueForEvents
-            ->setParam('bucketId', $bucket->getId())
-            ->setPayload($response->output($bucket, Response::MODEL_BUCKET))
-        ;
+        $bus->dispatch(new BucketDeleted($bucket, $project, $actor));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -2,8 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Storage\Http\Buckets\Files;
 
+use Appwrite\Bus\Events\FileCreated;
 use Appwrite\ClamAV\Network;
-use Appwrite\Event\Event;
 use Appwrite\Extend\Exception;
 use Appwrite\OpenSSL\OpenSSL;
 use Appwrite\SDK\AuthType;
@@ -14,6 +14,7 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Compression\Algorithms\GZIP;
 use Utopia\Compression\Algorithms\Zstd;
 use Utopia\Compression\Compression;
@@ -60,7 +61,6 @@ class Create extends Action
             ->label('scope', 'files.write')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
             ->label('audits.event', 'file.create')
-            ->label('event', 'buckets.[bucketId].files.[fileId].create')
             ->label('audits.resource', 'file/{response.$id}')
             ->label('usage.resource', 'bucket/{request.bucketId}/file/{response.$id}')
             ->label('abuse-key', 'ip:{ip},method:{method},url:{url},userId:{userId},chunkId:{chunkId}')
@@ -90,7 +90,7 @@ class Create extends Action
             ->inject('dbForProject')
             ->inject('project')
             ->inject('user')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('deviceForFiles')
             ->inject('deviceForLocal')
             ->inject('authorization')
@@ -108,7 +108,7 @@ class Create extends Action
         Database $dbForProject,
         Document $project,
         User $user,
-        Event $queueForEvents,
+        Bus $bus,
         Device $deviceForFiles,
         Device $deviceForLocal,
         Authorization $authorization,
@@ -321,11 +321,10 @@ class Create extends Action
         }
 
         if ($completed) {
-            $queueForEvents->reset();
             return;
         }
 
-        $finalizeUpload = function (int $chunksUploaded) use ($authorization, $bucket, &$chunks, $contentRange, $dbForProject, $deviceForFiles, $fileId, $fileName, $fileSize, &$metadata, $mergeUploadMetadata, $path, $permissions, $queueForEvents, $response): void {
+        $finalizeUpload = function (int $chunksUploaded) use ($authorization, $bucket, &$chunks, $contentRange, $dbForProject, $deviceForFiles, $fileId, $fileName, $fileSize, &$metadata, $mergeUploadMetadata, $path, $permissions, $bus, $project, $user, $response): void {
             $file = $authorization->skip(fn () => $dbForProject->getDocument('bucket_' . $bucket->getSequence(), $fileId));
             $uploaded = 0;
 
@@ -338,8 +337,6 @@ class Create extends Action
                     if (empty($contentRange)) {
                         throw new Exception(Exception::STORAGE_FILE_ALREADY_EXISTS);
                     }
-
-                    $queueForEvents->reset();
 
                     $response
                         ->setStatusCode(Response::STATUS_CODE_OK)
@@ -494,12 +491,7 @@ class Create extends Action
             }
 
             if ($chunksUploaded === $chunks) {
-                $queueForEvents
-                    ->setParam('bucketId', $bucket->getId())
-                    ->setParam('fileId', $file->getId())
-                    ->setContext('bucket', $bucket);
-            } else {
-                $queueForEvents->reset();
+                $bus->dispatch(new FileCreated($file, $bucket, $project, $user));
             }
 
             $metadata = null; // was causing leaks as it was passed by reference

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Storage\Http\Buckets\Files;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\FileDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -12,7 +12,9 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Authorization\Input;
@@ -39,7 +41,6 @@ class Delete extends Action
             ->groups(['api', 'storage'])
             ->label('scope', 'files.write')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
-            ->label('event', 'buckets.[bucketId].files.[fileId].delete')
             ->label('audits.event', 'file.delete')
             ->label('audits.resource', 'file/{request.fileId}')
             ->label('usage.resource', 'bucket/{request.bucketId}/file/{request.fileId}')
@@ -64,11 +65,12 @@ class Delete extends Action
             ->param('fileId', '', new UID(), 'File ID.')
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('deviceForFiles')
             ->inject('publisherForDeletes')
             ->inject('authorization')
             ->inject('user')
+            ->inject('project')
             ->callback($this->action(...));
     }
 
@@ -77,11 +79,12 @@ class Delete extends Action
         string $fileId,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents,
+        Bus $bus,
         Device $deviceForFiles,
         DeletePublisher $publisherForDeletes,
         Authorization $authorization,
         User $user,
+        Document $project,
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
@@ -129,7 +132,7 @@ class Delete extends Action
 
         if ($deviceDeleted) {
             $publisherForDeletes->enqueue(new DeleteMessage(
-                project: $queueForEvents->getProject(),
+                project: $project,
                 type: DELETE_TYPE_CACHE_BY_RESOURCE,
                 resource: 'file/' . $fileId,
                 resourceType: 'bucket/' . $bucket->getId(),
@@ -156,12 +159,7 @@ class Delete extends Action
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed to delete file from device');
         }
 
-        $queueForEvents
-            ->setParam('bucketId', $bucket->getId())
-            ->setParam('fileId', $file->getId())
-            ->setContext('bucket', $bucket)
-            ->setPayload($response->output($file, Response::MODEL_FILE))
-        ;
+        $bus->dispatch(new FileDeleted($file, $bucket, $project, $user));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Update.php
@@ -2,14 +2,16 @@
 
 namespace Appwrite\Platform\Modules\Storage\Http\Buckets\Files;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\FileUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
@@ -40,7 +42,6 @@ class Update extends Action
             ->groups(['api', 'storage'])
             ->label('scope', 'files.write')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
-            ->label('event', 'buckets.[bucketId].files.[fileId].update')
             ->label('audits.event', 'file.update')
             ->label('audits.resource', 'file/{response.$id}')
             ->label('usage.resource', 'bucket/{request.bucketId}/file/{response.$id}')
@@ -63,9 +64,10 @@ class Update extends Action
             ->param('permissions', null, new Nullable(new Permissions(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of permission strings. By default, the current permissions are inherited. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('authorization')
             ->inject('user')
+            ->inject('project')
             ->callback($this->action(...));
     }
 
@@ -76,9 +78,10 @@ class Update extends Action
         ?array $permissions,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents,
+        Bus $bus,
         Authorization $authorization,
-        User $user
+        User $user,
+        Document $project
     ) {
         $bucket = $authorization->skip(fn () => $dbForProject->getDocument('buckets', $bucketId));
 
@@ -150,12 +153,8 @@ class Update extends Action
             throw new Exception(Exception::STORAGE_BUCKET_NOT_FOUND);
         }
 
-        $queueForEvents
-            ->setParam('bucketId', $bucket->getId())
-            ->setParam('fileId', $file->getId())
-            ->setContext('bucket', $bucket)
-        ;
-
         $response->dynamic($file, Response::MODEL_FILE);
+
+        $bus->dispatch(new FileUpdated($file, $bucket, $project, $user));
     }
 }

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
@@ -2,14 +2,16 @@
 
 namespace Appwrite\Platform\Modules\Storage\Http\Buckets;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\BucketUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Compression\Compression;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Validator\Permissions;
 use Utopia\Database\Validator\UID;
@@ -43,7 +45,6 @@ class Update extends Action
             ->groups(['api', 'storage'])
             ->label('scope', 'buckets.write')
             ->label('resourceType', RESOURCE_TYPE_BUCKETS)
-            ->label('event', 'buckets.[bucketId].update')
             ->label('audits.event', 'bucket.update')
             ->label('audits.resource', 'bucket/{response.$id}')
             ->label('usage.resource', 'bucket/{response.$id}')
@@ -73,7 +74,9 @@ class Update extends Action
             ->param('transformations', true, new Boolean(true), 'Are image transformations enabled?', true)
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('bus')
+            ->inject('project')
+            ->inject('user')
             ->callback($this->action(...));
     }
 
@@ -91,7 +94,9 @@ class Update extends Action
         bool $transformations,
         Response $response,
         Database $dbForProject,
-        Event $queueForEvents
+        Bus $bus,
+        Document $project,
+        Document $actor
     ) {
         $bucket = $dbForProject->getDocument('buckets', $bucketId);
 
@@ -121,9 +126,8 @@ class Update extends Action
 
         $dbForProject->updateCollection('bucket_' . $bucket->getSequence(), $permissions, $fileSecurity);
 
-        $queueForEvents
-            ->setParam('bucketId', $bucket->getId());
-
         $response->dynamic($bucket, Response::MODEL_BUCKET);
+
+        $bus->dispatch(new BucketUpdated($bucket, $project, $actor));
     }
 }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -3,7 +3,7 @@
 namespace Appwrite\Platform\Modules\Teams\Http\Memberships;
 
 use Appwrite\Auth\Validator\Phone;
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\MembershipCreated;
 use Appwrite\Event\Message\Mail as MailMessage;
 use Appwrite\Event\Message\Messaging as MessagingMessage;
 use Appwrite\Event\Publisher\Mail as MailPublisher;
@@ -21,6 +21,7 @@ use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
 use Utopia\Auth\Proofs\Password;
 use Utopia\Auth\Proofs\Token;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -56,7 +57,6 @@ class Create extends Action
             ->setHttpPath('/v1/teams/:teamId/memberships')
             ->desc('Create team membership')
             ->groups(['api', 'teams', 'auth'])
-            ->label('event', 'teams.[teamId].memberships.[membershipId].create')
             ->label('scope', 'teams.write')
             ->label('auth.type', 'invites')
             ->label('audits.event', 'membership.create')
@@ -91,7 +91,7 @@ class Create extends Action
             ->inject('locale')
             ->inject('publisherForMails')
             ->inject('publisherForMessaging')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('timelimit')
             ->inject('usage')
             ->inject('plan')
@@ -101,7 +101,7 @@ class Create extends Action
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $email, string $userId, string $phone, array $roles, string $url, string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Event $queueForEvents, callable $timelimit, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
+    public function action(string $teamId, string $email, string $userId, string $phone, array $roles, string $url, string $name, Response $response, Document $project, User $user, Database $dbForProject, Authorization $authorization, Locale $locale, MailPublisher $publisherForMails, MessagingPublisher $publisherForMessaging, Bus $bus, callable $timelimit, Context $usage, array $plan, array $platform, Password $proofForPassword, Token $proofForToken)
     {
         $isAppUser = $user->isKey($authorization->getRoles());
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
@@ -464,19 +464,15 @@ class Create extends Action
             }
         }
 
-        $queueForEvents
-            ->setParam('userId', $invitee->getId())
-            ->setParam('teamId', $team->getId())
-            ->setParam('membershipId', $membership->getId());
+        $membership
+            ->setAttribute('teamName', $team->getAttribute('name'))
+            ->setAttribute('userName', $invitee->getAttribute('name'))
+            ->setAttribute('userEmail', $invitee->getAttribute('email'));
 
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
-            ->dynamic(
-                $membership
-                    ->setAttribute('teamName', $team->getAttribute('name'))
-                    ->setAttribute('userName', $invitee->getAttribute('name'))
-                    ->setAttribute('userEmail', $invitee->getAttribute('email')),
-                Response::MODEL_MEMBERSHIP
-            );
+            ->dynamic($membership, Response::MODEL_MEMBERSHIP);
+
+        $bus->dispatch(new MembershipCreated($membership, $team->getId(), $invitee->getId(), $project, $user));
     }
 }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Delete.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Memberships;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\MembershipDeleted;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
@@ -10,6 +10,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Authorization as AuthorizationException;
@@ -34,7 +35,6 @@ class Delete extends Action
             ->setHttpPath('/v1/teams/:teamId/memberships/:membershipId')
             ->desc('Delete team membership')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].memberships.[membershipId].delete')
             ->label('scope', 'teams.write')
             ->label('audits.event', 'membership.delete')
             ->label('audits.resource', 'team/{request.teamId}')
@@ -59,11 +59,11 @@ class Delete extends Action
             ->inject('response')
             ->inject('dbForProject')
             ->inject('authorization')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $membershipId, Document $user, Document $project, Response $response, Database $dbForProject, Authorization $authorization, Event $queueForEvents)
+    public function action(string $teamId, string $membershipId, Document $user, Document $project, Response $response, Database $dbForProject, Authorization $authorization, Bus $bus)
     {
         $membership = $dbForProject->getDocument('memberships', $membershipId);
         if ($membership->isEmpty()) {
@@ -143,11 +143,7 @@ class Delete extends Action
             $authorization->skip(fn () => $dbForProject->decreaseDocumentAttribute('teams', $team->getId(), 'total', 1, 0));
         }
 
-        $queueForEvents
-            ->setParam('teamId', $team->getId())
-            ->setParam('userId', $profile->getId())
-            ->setParam('membershipId', $membership->getId())
-            ->setPayload($response->output($membership, Response::MODEL_MEMBERSHIP));
+        $bus->dispatch(new MembershipDeleted($membership, $team->getId(), $profile->getId(), $project, $user));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Status/Update.php
@@ -2,8 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Memberships\Status;
 
+use Appwrite\Bus\Events\MembershipStatusUpdated;
 use Appwrite\Detector\Detector;
-use Appwrite\Event\Event;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
@@ -14,6 +14,7 @@ use Appwrite\Utopia\Response;
 use MaxMind\Db\Reader;
 use Utopia\Auth\Proofs\Token;
 use Utopia\Auth\Store;
+use Utopia\Bus\Bus;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -42,7 +43,6 @@ class Update extends Action
             ->setHttpPath('/v1/teams/:teamId/memberships/:membershipId/status')
             ->desc('Update team membership status')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].memberships.[membershipId].update.status')
             ->label('scope', 'public')
             ->label('audits.event', 'membership.update')
             ->label('audits.resource', 'team/{request.teamId}')
@@ -71,7 +71,7 @@ class Update extends Action
             ->inject('authorization')
             ->inject('project')
             ->inject('geodb')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->inject('store')
             ->inject('proofForToken')
             ->inject('domainVerification')
@@ -79,7 +79,7 @@ class Update extends Action
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $membershipId, string $userId, string $secret, Request $request, Response $response, Document $targetUser, Database $dbForProject, Authorization $authorization, $project, Reader $geodb, Event $queueForEvents, Store $store, Token $proofForToken, bool $domainVerification, ?string $cookieDomain)
+    public function action(string $teamId, string $membershipId, string $userId, string $secret, Request $request, Response $response, Document $targetUser, Database $dbForProject, Authorization $authorization, $project, Reader $geodb, Bus $bus, Store $store, Token $proofForToken, bool $domainVerification, ?string $cookieDomain)
     {
         $protocol = $request->getProtocol();
 
@@ -198,18 +198,13 @@ class Update extends Action
 
         $authorization->skip(fn () => $dbForProject->increaseDocumentAttribute('teams', $team->getId(), 'total', 1));
 
-        $queueForEvents
-            ->setParam('userId', $targetUser->getId())
-            ->setParam('teamId', $team->getId())
-            ->setParam('membershipId', $membership->getId())
-        ;
+        $membership
+            ->setAttribute('teamName', $team->getAttribute('name'))
+            ->setAttribute('userName', $targetUser->getAttribute('name'))
+            ->setAttribute('userEmail', $targetUser->getAttribute('email'));
 
-        $response->dynamic(
-            $membership
-                ->setAttribute('teamName', $team->getAttribute('name'))
-                ->setAttribute('userName', $targetUser->getAttribute('name'))
-                ->setAttribute('userEmail', $targetUser->getAttribute('email')),
-            Response::MODEL_MEMBERSHIP
-        );
+        $response->dynamic($membership, Response::MODEL_MEMBERSHIP);
+
+        $bus->dispatch(new MembershipStatusUpdated($membership, $team->getId(), $targetUser->getId(), $project, $targetUser));
     }
 }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Update.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Memberships;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\MembershipUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
@@ -11,6 +11,7 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
@@ -36,7 +37,6 @@ class Update extends Action
             ->setHttpPath('/v1/teams/:teamId/memberships/:membershipId')
             ->desc('Update team membership')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].memberships.[membershipId].update')
             ->label('scope', 'teams.write')
             ->label('audits.event', 'membership.update')
             ->label('audits.resource', 'team/{request.teamId}')
@@ -62,11 +62,11 @@ class Update extends Action
             ->inject('project')
             ->inject('dbForProject')
             ->inject('authorization')
-            ->inject('queueForEvents')
+            ->inject('bus')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $membershipId, array $roles, Request $request, Response $response, User $user, Document $project, Database $dbForProject, Authorization $authorization, Event $queueForEvents)
+    public function action(string $teamId, string $membershipId, array $roles, Request $request, Response $response, User $user, Document $project, Database $dbForProject, Authorization $authorization, Bus $bus)
     {
         $team = $dbForProject->getDocument('teams', $teamId);
         if ($team->isEmpty()) {
@@ -127,17 +127,13 @@ class Update extends Action
          */
         $dbForProject->purgeCachedDocument('users', $profile->getId());
 
-        $queueForEvents
-            ->setParam('userId', $profile->getId())
-            ->setParam('teamId', $team->getId())
-            ->setParam('membershipId', $membership->getId());
+        $membership
+            ->setAttribute('teamName', $team->getAttribute('name'))
+            ->setAttribute('userName', $profile->getAttribute('name'))
+            ->setAttribute('userEmail', $profile->getAttribute('email'));
 
-        $response->dynamic(
-            $membership
-                ->setAttribute('teamName', $team->getAttribute('name'))
-                ->setAttribute('userName', $profile->getAttribute('name'))
-                ->setAttribute('userEmail', $profile->getAttribute('email')),
-            Response::MODEL_MEMBERSHIP
-        );
+        $response->dynamic($membership, Response::MODEL_MEMBERSHIP);
+
+        $bus->dispatch(new MembershipUpdated($membership, $team->getId(), $profile->getId(), $project, $user));
     }
 }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Preferences/Update.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Preferences;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\TeamPreferencesUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Structure as StructureException;
@@ -32,7 +33,6 @@ class Update extends Action
             ->setHttpPath('/v1/teams/:teamId/prefs')
             ->desc('Update team preferences')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].update.prefs')
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.update')
             ->label('audits.resource', 'team/{response.$id}')
@@ -54,11 +54,13 @@ class Update extends Action
             ->param('prefs', '', new Assoc(), 'Prefs key-value JSON object.')
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('project')
+            ->inject('user')
+            ->inject('bus')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, array $prefs, Response $response, Database $dbForProject, Event $queueForEvents)
+    public function action(string $teamId, array $prefs, Response $response, Database $dbForProject, Document $project, Document $user, Bus $bus)
     {
         try {
             $prefs = new Document($prefs);
@@ -76,8 +78,8 @@ class Update extends Action
             'prefs' => $prefs->getArrayCopy()
         ]));
 
-        $queueForEvents->setParam('teamId', $team->getId());
-
         $response->dynamic($prefs, Response::MODEL_PREFERENCES);
+
+        $bus->dispatch(new TeamPreferencesUpdated($team->getId(), $prefs, $project, $user));
     }
 }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Create.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Teams;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\TeamCreated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
@@ -11,6 +11,7 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -40,7 +41,6 @@ class Create extends Action
             ->setHttpPath('/v1/teams')
             ->desc('Create team')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].create')
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.create')
             ->label('audits.resource', 'team/{response.$id}')
@@ -64,11 +64,12 @@ class Create extends Action
             ->inject('user')
             ->inject('dbForProject')
             ->inject('authorization')
-            ->inject('queueForEvents')
+            ->inject('project')
+            ->inject('bus')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $name, array $roles, Response $response, User $user, Database $dbForProject, Authorization $authorization, Event $queueForEvents)
+    public function action(string $teamId, string $name, array $roles, Response $response, User $user, Database $dbForProject, Authorization $authorization, Document $project, Bus $bus)
     {
         $isPrivilegedUser = $user->isPrivileged($authorization->getRoles());
         $isAppUser = $user->isKey($authorization->getRoles());
@@ -125,14 +126,10 @@ class Create extends Action
             $dbForProject->purgeCachedDocument('users', $user->getId());
         }
 
-        $queueForEvents->setParam('teamId', $team->getId());
-
-        if (!empty($user->getId())) {
-            $queueForEvents->setParam('userId', $user->getId());
-        }
-
         $response
             ->setStatusCode(Response::STATUS_CODE_CREATED)
             ->dynamic($team, Response::MODEL_TEAM);
+
+        $bus->dispatch(new TeamCreated($team, $project, $user));
     }
 }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Delete.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Delete.php
@@ -2,7 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Teams;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\TeamDeleted;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Delete as DeletePublisher;
 use Appwrite\Extend\Exception;
@@ -13,6 +13,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
@@ -34,7 +35,6 @@ class Delete extends Action
             ->setHttpPath('/v1/teams/:teamId')
             ->desc('Delete team')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].delete')
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.delete')
             ->label('audits.resource', 'team/{request.teamId}')
@@ -57,12 +57,13 @@ class Delete extends Action
             ->inject('getProjectDB')
             ->inject('dbForProject')
             ->inject('publisherForDeletes')
-            ->inject('queueForEvents')
             ->inject('project')
+            ->inject('user')
+            ->inject('bus')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, Response $response, callable $getProjectDB, Database $dbForProject, DeletePublisher $publisherForDeletes, Event $queueForEvents, Document $project)
+    public function action(string $teamId, Response $response, callable $getProjectDB, Database $dbForProject, DeletePublisher $publisherForDeletes, Document $project, Document $user, Bus $bus)
     {
         $team = $dbForProject->getDocument('teams', $teamId);
 
@@ -93,10 +94,7 @@ class Delete extends Action
             document: $team,
         ));
 
-        $queueForEvents
-            ->setParam('teamId', $team->getId())
-            ->setPayload($response->output($team, Response::MODEL_TEAM))
-        ;
+        $bus->dispatch(new TeamDeleted($team, $project, $user));
 
         $response->noContent();
     }

--- a/src/Appwrite/Platform/Modules/Teams/Http/Teams/Name/Update.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Teams/Name/Update.php
@@ -2,13 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Teams\Http\Teams\Name;
 
-use Appwrite\Event\Event;
+use Appwrite\Bus\Events\TeamUpdated;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Utopia\Bus\Bus;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\UID;
@@ -31,7 +32,6 @@ class Update extends Action
             ->setHttpPath('/v1/teams/:teamId')
             ->desc('Update name')
             ->groups(['api', 'teams'])
-            ->label('event', 'teams.[teamId].update')
             ->label('scope', 'teams.write')
             ->label('audits.event', 'team.update')
             ->label('audits.resource', 'team/{response.$id}')
@@ -52,11 +52,13 @@ class Update extends Action
             ->param('name', null, new Text(128), 'New team name. Max length: 128 chars.')
             ->inject('response')
             ->inject('dbForProject')
-            ->inject('queueForEvents')
+            ->inject('project')
+            ->inject('user')
+            ->inject('bus')
             ->callback($this->action(...));
     }
 
-    public function action(string $teamId, string $name, Response $response, Database $dbForProject, Event $queueForEvents)
+    public function action(string $teamId, string $name, Response $response, Database $dbForProject, Document $project, Document $user, Bus $bus)
     {
         $team = $dbForProject->getDocument('teams', $teamId);
 
@@ -70,8 +72,8 @@ class Update extends Action
 
         $team = $dbForProject->updateDocument('teams', $team->getId(), new Document(['name' => $name, 'search' => implode(' ', [$teamId, $name])]));
 
-        $queueForEvents->setParam('teamId', $team->getId());
-
         $response->dynamic($team, Response::MODEL_TEAM);
+
+        $bus->dispatch(new TeamUpdated($team, $project, $user));
     }
 }

--- a/src/Utopia/Bus/Bus.php
+++ b/src/Utopia/Bus/Bus.php
@@ -33,7 +33,25 @@ class Bus
         }
 
         $resolver = $this->resolver;
-        $listeners = $this->listeners[$event::class] ?? [];
+
+        // Match listeners registered against the event's concrete class as well as any
+        // parent class or interface it derives from. This lets cross-cutting listeners
+        // subscribe to a base event (e.g. ResourceEvent) and receive every subtype,
+        // while listeners bound to a concrete class keep exact-match behaviour.
+        $types = [$event::class, ...class_parents($event), ...class_implements($event)];
+
+        $seen = [];
+        $listeners = [];
+        foreach ($types as $type) {
+            foreach ($this->listeners[$type] ?? [] as $listener) {
+                $id = \spl_object_id($listener);
+                if (isset($seen[$id])) {
+                    continue;
+                }
+                $seen[$id] = true;
+                $listeners[] = $listener;
+            }
+        }
 
         foreach ($listeners as $listener) {
             $deps = array_map($resolver, $listener->getInjections());


### PR DESCRIPTION
## What

Moves the realtime / functions / webhooks fan-out off the shutdown hook's string-keyed `queueForEvents` and onto **typed domain events** dispatched from each action via the in-process `Utopia\Bus`.

- `Bus::dispatch` now matches listeners against the event's **type hierarchy**, so the cross-cutting `Realtime` / `Functions` / `Webhook` listeners subscribe to the `ResourceEvent` base and receive every subtype (exact-match listeners like `Log`/`Mails`/`Usage` are unaffected).
- `ResourceEvent` base carries the **raw document + response model**; each listener owns its own model-filtered projection (via `Response::output` + `applyFilters`, preserving per-caller sensitive-field handling).
- Each converted action drops its `event` label + `queueForEvents`, injects `bus` (+ `project`/`user`), and dispatches its typed event. The legacy shutdown fan-out stays as the fallback for unconverted routes via its `empty(getEvent())` guard — no double-fire.

## Scope

63 typed event classes across **Teams, Users, Storage, Functions, Sites, Proxy** (69 endpoints). Each service was verified locally: PHPStan + Pint clean, E2E green (Teams 45/45, Users 51/51, Storage 76/76, Functions 76/76, Sites 49/49; Realtime 67/67), and runtime span logs confirm all three listeners fire per event.

**Account is intentionally not migrated** — it needs `showSensitive` support for recovery/verification token payloads and a `MODEL_ACCOUNT` vs `MODEL_USER` decision.

## Notes

- The Proxy E2E suite has 8 failures on some local Docker stacks (custom-domain router pre-checks); these reproduce on unmodified `main` locally and are green on CI — environmental, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9CYvcRkQx4AqtiRLvuyTJ