### PR TITLE
Fix truncated site detection logs

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -731,6 +731,8 @@ class Builds extends Action
 
             $response = null;
             $err = null;
+            $detectionLogs = '';
+            $pendingDetectionLogs = '';
 
             if ($dbForProject->getDocument('deployments', $deploymentId)->getAttribute('status') === 'canceled') {
                 $this->finalizeCanceledDeployment($deployment->getId(), $dbForProject, $queueForRealtime);
@@ -792,7 +794,7 @@ class Builds extends Action
                         $err = $error;
                     }
                 }),
-                Co\go(function () use ($executor, $project, &$deployment, &$response, $dbForProject, $timeout, &$err, $queueForRealtime, &$isCanceled, $span) {
+                Co\go(function () use ($executor, $project, &$deployment, &$response, $dbForProject, $timeout, &$err, $queueForRealtime, &$isCanceled, &$detectionLogs, &$pendingDetectionLogs, $span) {
                     try {
                         $insideSeparation = false;
 
@@ -800,7 +802,7 @@ class Builds extends Action
                             deploymentId: $deployment->getId(),
                             projectId: $project->getId(),
                             timeout: $timeout,
-                            callback: function ($logs) use (&$response, &$err, $dbForProject, &$isCanceled, &$deployment, $queueForRealtime, &$insideSeparation, $span) {
+                            callback: function ($logs) use (&$response, &$err, $dbForProject, &$isCanceled, &$deployment, $queueForRealtime, &$insideSeparation, &$detectionLogs, &$pendingDetectionLogs, $span) {
                                 if ($isCanceled) {
                                     return;
                                 }
@@ -819,37 +821,8 @@ class Builds extends Action
                                     // Get only valid UTF8 part - removes leftover half-multibytes causing SQL errors
                                     $logs = \mb_substr($logs, 0, null, 'UTF-8');
 
-                                    // Do not stream logs added for SSR detection
-                                    if (! $insideSeparation) {
-                                        $separator = \strpos($logs, '{APPWRITE_DETECTION_SEPARATOR_START}');
-                                        if ($separator !== false) {
-                                            $leftover = \substr($logs, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_START}'));
-                                            $logs = \substr($logs, 0, $separator);
-                                            $insideSeparation = true;
-
-                                            $separator = \strpos($leftover, '{APPWRITE_DETECTION_SEPARATOR_END}');
-                                            if ($separator !== false) {
-                                                $logs .= \substr($leftover, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_END}'));
-                                                $insideSeparation = false;
-                                            }
-                                        }
-                                    } else {
-                                        $separator = \strpos($logs, '{APPWRITE_DETECTION_SEPARATOR_END}');
-                                        if ($separator !== false) {
-                                            $logs = \substr($logs, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_END}'));
-                                            $insideSeparation = false;
-                                        } else {
-                                            $logs = '';
-                                        }
-                                    }
-
-                                    if (empty($logs)) {
-                                        return;
-                                    }
-
                                     $currentLogs = $deployment->getAttribute('buildLogs', '');
-                                    $affected = false;
-
+                                    $logsContent = '';
                                     $streamLogs = \str_replace('\\n', '{APPWRITE_LINEBREAK_PLACEHOLDER}', $logs);
                                     foreach (\explode("\n", $streamLogs) as $streamLog) {
                                         if (empty($streamLog)) {
@@ -864,14 +837,17 @@ class Builds extends Action
                                         }
 
                                         // TODO: use part[0] as timestamp when switching to dbForLogs for build logs
-                                        $currentLogs .= $streamParts[1];
-
-                                        if (! empty($streamParts[1])) {
-                                            $affected = true;
-                                        }
+                                        $logsContent .= $streamParts[1];
                                     }
 
-                                    if ($affected) {
+                                    $logsContent = $this->extractSiteDetectionLogs($logsContent, $insideSeparation, $pendingDetectionLogs, $detectionLogs);
+
+                                    if (empty($logsContent)) {
+                                        return;
+                                    }
+
+                                    $currentLogs .= $logsContent;
+                                    if (! empty($logsContent)) {
                                         $deployment = $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($currentLogs));
                                         $deployment = $dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
                                             'buildLogs' => $this->truncateBuildLogs($currentLogs),
@@ -928,7 +904,10 @@ class Builds extends Action
                 $logs .= $log['content'];
             }
 
-            ['logs' => $logs, 'detectionLogs' => $detectionLogs] = $this->splitSiteDetectionLogs($logs);
+            ['logs' => $logs, 'detectionLogs' => $responseDetectionLogs] = $this->splitSiteDetectionLogs($logs);
+            if (empty($detectionLogs)) {
+                $detectionLogs = $responseDetectionLogs;
+            }
 
             $deployment->setAttribute('buildLogs', $this->truncateBuildLogs($logs));
 
@@ -1424,6 +1403,44 @@ class Builds extends Action
     }
 
     /**
+     * Removes site detection logs from user-facing logs while collecting only
+     * complete detection blocks for rendering detection.
+     */
+    protected function extractSiteDetectionLogs(string $logs, bool &$insideSeparation, string &$pendingDetectionLogs, string &$detectionLogs): string
+    {
+        $visibleLogs = '';
+
+        while ($logs !== '') {
+            if ($insideSeparation) {
+                $separator = \strpos($logs, '{APPWRITE_DETECTION_SEPARATOR_END}');
+                if ($separator === false) {
+                    $pendingDetectionLogs .= $logs;
+                    return $visibleLogs;
+                }
+
+                $detectionLogs .= $pendingDetectionLogs . \substr($logs, 0, $separator);
+                $pendingDetectionLogs = '';
+                $insideSeparation = false;
+                $logs = \substr($logs, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_END}'));
+
+                continue;
+            }
+
+            $separator = \strpos($logs, '{APPWRITE_DETECTION_SEPARATOR_START}');
+            if ($separator === false) {
+                $visibleLogs .= $logs;
+                return $visibleLogs;
+            }
+
+            $visibleLogs .= \substr($logs, 0, $separator);
+            $logs = \substr($logs, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_START}'));
+            $insideSeparation = true;
+        }
+
+        return $visibleLogs;
+    }
+
+    /**
      * @return array{logs: string, detectionLogs: string}
      */
     protected function splitSiteDetectionLogs(string $logs): array
@@ -1438,7 +1455,7 @@ class Builds extends Action
         [$logsBefore, $detectionLogsStart] = \explode('{APPWRITE_DETECTION_SEPARATOR_START}', $logs, 2);
         if (! \str_contains($detectionLogsStart, '{APPWRITE_DETECTION_SEPARATOR_END}')) {
             return [
-                'logs' => $logsBefore . $detectionLogsStart,
+                'logs' => $logsBefore,
                 'detectionLogs' => '',
             ];
         }

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -823,10 +823,10 @@ class Builds extends Action
                                     if (! $insideSeparation) {
                                         $separator = \strpos($logs, '{APPWRITE_DETECTION_SEPARATOR_START}');
                                         if ($separator !== false) {
+                                            $leftover = \substr($logs, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_START}'));
                                             $logs = \substr($logs, 0, $separator);
                                             $insideSeparation = true;
 
-                                            $leftover = \substr($logs, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_START}'));
                                             $separator = \strpos($leftover, '{APPWRITE_DETECTION_SEPARATOR_END}');
                                             if ($separator !== false) {
                                                 $logs .= \substr($leftover, $separator + strlen('{APPWRITE_DETECTION_SEPARATOR_END}'));
@@ -1436,6 +1436,13 @@ class Builds extends Action
         }
 
         [$logsBefore, $detectionLogsStart] = \explode('{APPWRITE_DETECTION_SEPARATOR_START}', $logs, 2);
+        if (! \str_contains($detectionLogsStart, '{APPWRITE_DETECTION_SEPARATOR_END}')) {
+            return [
+                'logs' => $logsBefore . $detectionLogsStart,
+                'detectionLogs' => '',
+            ];
+        }
+
         [$detectionLogs, $logsAfter] = \explode('{APPWRITE_DETECTION_SEPARATOR_END}', $detectionLogsStart, 2);
 
         return [

--- a/tests/unit/Functions/BuildsTest.php
+++ b/tests/unit/Functions/BuildsTest.php
@@ -74,6 +74,17 @@ final class BuildsTest extends TestCase
         $this->assertSame("\n./index.html\n./server/entry.mjs\n", $result['detectionLogs']);
     }
 
+    public function testSplitSiteDetectionLogsKeepsLogsWhenDetectionBlockWasTruncated(): void
+    {
+        $result = $this->callBuilds(
+            'splitSiteDetectionLogs',
+            "before\n{APPWRITE_DETECTION_SEPARATOR_START}\n./index.html\n"
+        );
+
+        $this->assertSame("before\n\n./index.html\n", $result['logs']);
+        $this->assertSame('', $result['detectionLogs']);
+    }
+
     public function testDetectSiteRenderingFindsStaticFallbackFile(): void
     {
         $detection = $this->callBuilds('detectSiteRendering', 'other', "./main.html\n");

--- a/tests/unit/Functions/BuildsTest.php
+++ b/tests/unit/Functions/BuildsTest.php
@@ -81,8 +81,39 @@ final class BuildsTest extends TestCase
             "before\n{APPWRITE_DETECTION_SEPARATOR_START}\n./index.html\n"
         );
 
-        $this->assertSame("before\n\n./index.html\n", $result['logs']);
+        $this->assertSame("before\n", $result['logs']);
         $this->assertSame('', $result['detectionLogs']);
+    }
+
+    public function testExtractSiteDetectionLogsCollectsCompleteBlockAcrossChunks(): void
+    {
+        $insideSeparation = false;
+        $pendingDetectionLogs = '';
+        $detectionLogs = '';
+
+        $visibleLogs = $this->callBuildsByRef('extractSiteDetectionLogs', [
+            "before\n{APPWRITE_DETECTION_SEPARATOR_START}\n./index.html\n",
+            &$insideSeparation,
+            &$pendingDetectionLogs,
+            &$detectionLogs,
+        ]);
+
+        $this->assertSame("before\n", $visibleLogs);
+        $this->assertTrue($insideSeparation);
+        $this->assertSame("\n./index.html\n", $pendingDetectionLogs);
+        $this->assertSame('', $detectionLogs);
+
+        $visibleLogs = $this->callBuildsByRef('extractSiteDetectionLogs', [
+            "./server/entry.mjs\n{APPWRITE_DETECTION_SEPARATOR_END}\nafter\n",
+            &$insideSeparation,
+            &$pendingDetectionLogs,
+            &$detectionLogs,
+        ]);
+
+        $this->assertSame("\nafter\n", $visibleLogs);
+        $this->assertFalse($insideSeparation);
+        $this->assertSame('', $pendingDetectionLogs);
+        $this->assertSame("\n./index.html\n./server/entry.mjs\n", $detectionLogs);
     }
 
     public function testDetectSiteRenderingFindsStaticFallbackFile(): void
@@ -178,5 +209,10 @@ final class BuildsTest extends TestCase
     private function callBuilds(string $method, mixed ...$arguments): mixed
     {
         return (new ReflectionMethod($this->builds, $method))->invoke($this->builds, ...$arguments);
+    }
+
+    private function callBuildsByRef(string $method, array $arguments): mixed
+    {
+        return (new ReflectionMethod($this->builds, $method))->invokeArgs($this->builds, $arguments);
     }
 }


### PR DESCRIPTION
## What
- Keep site rendering detection logs in memory, separate from persisted `buildLogs`.
- Strip detection separator blocks from user-facing logs before writing to the deployment document.
- Ignore incomplete detection blocks instead of using partial file lists for SSR/static detection.
- Preserve a fallback to complete detection logs from the executor response when stream collection is unavailable.

## Why
`buildLogs` is intentionally truncated to fit the deployment document limit, but rendering detection should not depend on that truncated persisted value. This keeps truncation limited to DB writes while preserving complete detection data for worker logic.

## Testing
- `composer lint src/Appwrite/Platform/Modules/Functions/Workers/Builds.php tests/unit/Functions/BuildsTest.php`
- `vendor/bin/phpunit tests/unit/Functions/BuildsTest.php --filter='testSplitSiteDetectionLogs|testExtractSiteDetectionLogs'`

Note: local PHPUnit emits a Swoole cleanup warning because `Swoole\\Timer` is unavailable in this shell.