### PR TITLE
feat(projects): add dedicated database create methods to onboarding

### DIFF
--- a/app/config/onboarding.php
+++ b/app/config/onboarding.php
@@ -33,8 +33,7 @@ return [
     'databases.create' => true,
     'databases.createCollection' => true,
     'databases.createDocument' => true,
-    // Databases — dedicated (cloud, per engine). OR them in the UI for a single
-    // "created a dedicated database" milestone.
+    // Databases — dedicated
     'mysql.create' => true,
     'postgresql.create' => true,
     'mongo.create' => true,

--- a/app/config/onboarding.php
+++ b/app/config/onboarding.php
@@ -33,6 +33,11 @@ return [
     'databases.create' => true,
     'databases.createCollection' => true,
     'databases.createDocument' => true,
+    // Databases — dedicated (cloud, per engine). OR them in the UI for a single
+    // "created a dedicated database" milestone.
+    'mysql.create' => true,
+    'postgresql.create' => true,
+    'mongo.create' => true,
 
     // Storage
     'storage.createBucket' => true,


### PR DESCRIPTION
## What

Adds the dedicated-database `create` methods to the project onboarding config so provisioning a dedicated database is tracked as an onboarding stage.

```php
// Databases — dedicated (cloud, per engine)
'mysql.create' => true,
'postgresql.create' => true,
'mongo.create' => true,
```

## Why

Cloud exposes three registered dedicated-database engines (`mysql`, `postgresql`, `mongo`), each with a `POST /v1/{engine}` create route whose SDK method label is `namespace: {engine}`, `name: create`. The onboarding config (`app/config/onboarding.php`) is the single source consumed by the API shutdown hook and the Stages endpoints; cloud inherits it with no override. Adding these keys lets the shutdown hook record each engine's create call under `project.onboarding`.

The console can OR the three keys into a single "created a dedicated database" milestone, mirroring how the deployment methods are grouped.

## Notes

- No test change needed: `StagesBase.php` asserts `count(config) == count(stages)`, and both derive from this config.
- Harmless for self-hosted: these namespaces don't exist there, so the keys are never matched.

Resolves CLO-4530.
