### PR TITLE
Bump auth dependency to 0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "utopia-php/agents": "2.*",
         "utopia-php/analytics": "0.15.*",
         "utopia-php/audit": "2.6.*",
-        "utopia-php/auth": "^0.7",
+        "utopia-php/auth": "^0.8",
         "utopia-php/cache": "^3.0.0",
         "utopia-php/cli": "^0.24",
         "utopia-php/compression": "0.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17128527d9ef62968ea12eb43a81fdfb",
+    "content-hash": "091a71ba9518a11bacfa660d4df558ba",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3319,16 +3319,16 @@
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "22a2cf6ca604e5cc6bf10f0f8240195f0baa063a"
+                "reference": "1d77657e9c91e48e873e6e096f9d4f55f778b11f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/22a2cf6ca604e5cc6bf10f0f8240195f0baa063a",
-                "reference": "22a2cf6ca604e5cc6bf10f0f8240195f0baa063a",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/1d77657e9c91e48e873e6e096f9d4f55f778b11f",
+                "reference": "1d77657e9c91e48e873e6e096f9d4f55f778b11f",
                 "shasum": ""
             },
             "require": {
@@ -3336,7 +3336,7 @@
                 "ext-openssl": "*",
                 "ext-scrypt": "*",
                 "ext-sodium": "*",
-                "php": ">=8.1"
+                "php": ">=8.3"
             },
             "type": "library",
             "autoload": {
@@ -3363,9 +3363,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/auth/issues",
-                "source": "https://github.com/utopia-php/auth/tree/0.7.0"
+                "source": "https://github.com/utopia-php/auth/tree/0.8.0"
             },
-            "time": "2026-06-22T11:58:24+00:00"
+            "time": "2026-07-08T05:10:32+00:00"
         },
         {
             "name": "utopia-php/cache",


### PR DESCRIPTION
## What does this PR do?

Bumps `utopia-php/auth` from `^0.7` to `^0.8` and updates the lockfile to `utopia-php/auth` `0.8.0`.

The new auth release raises its PHP requirement to `>=8.3`, which matches Appwrite's current Composer platform requirement and CI PHP version.

## Test Plan

- `composer validate --strict --no-check-publish`
- `composer lint composer.json composer.lock`
- `_APP_OPENSSL_KEY_V1=unit-test-secret composer test -- --filter 'Auth|Hash|Password|Token' tests/unit/`
- Auth hash smoke test for `Utopia\Auth\Hashes\Sha` and `Utopia\Auth\Hashes\Scrypt`

Notes:
- A first targeted unit run without `_APP_OPENSSL_KEY_V1` failed in `Tests\Unit\Auth\KeyTest::testDecode` because the signing key env var was empty; rerunning with a test key passed.
- `composer check -- --memory-limit=1G` reached 98% and hit Composer's 300s process timeout. A no-timeout rerun is still in progress locally.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
