### PR TITLE
Remove folder param from listFiles in favor of queries

### DIFF
--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/XList.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/XList.php
@@ -7,7 +7,6 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
-use Appwrite\Utopia\Database\Validator\Folder;
 use Appwrite\Utopia\Database\Validator\Queries\Files;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
@@ -23,7 +22,6 @@ use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Validator\Boolean;
-use Utopia\Validator\Nullable;
 use Utopia\Validator\Text;
 
 class XList extends Action
@@ -62,7 +60,6 @@ class XList extends Action
             ->param('queries', [], new Files(), 'Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' queries are allowed, each ' . APP_LIMIT_ARRAY_ELEMENT_SIZE . ' characters long. You may filter on the following attributes: ' . implode(', ', Files::ALLOWED_ATTRIBUTES), true)
             ->param('search', '', new Text(256), 'Search term to filter your list results. Max length: 256 chars.', true)
             ->param('total', true, new Boolean(true), 'When set to false, the total count returned will be 0 and will not be calculated.', true)
-            ->param('folder', null, new Nullable(new Folder()), 'Filter results to files directly inside this virtual folder. Pass an empty string for the bucket root. Returns files from all folders when omitted.', true)
             ->inject('response')
             ->inject('dbForProject')
             ->inject('mode')
@@ -76,7 +73,6 @@ class XList extends Action
         array $queries,
         string $search,
         bool $includeTotal,
-        ?string $folder,
         Response $response,
         Database $dbForProject,
         string $mode,
@@ -106,13 +102,6 @@ class XList extends Action
 
         if (!empty($search)) {
             $queries[] = Query::search('search', $search);
-        }
-
-        if (!\is_null($folder)) {
-            $folder = Folder::normalize($folder);
-            $queries[] = $folder === ''
-                ? Query::or([Query::equal('folder', ['']), Query::isNull('folder')])
-                : Query::equal('folder', [$folder]);
         }
 
         $cursor = Query::getCursorQueries($queries, false);

--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -491,7 +491,7 @@ trait StorageBase
         $this->assertNotEmpty($webpView['body']);
     }
 
-    public function testCreateBucketFileWithParent(): void
+    public function testCreateBucketFileWithFolder(): void
     {
         $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
             'content-type' => 'application/json',
@@ -2036,7 +2036,7 @@ trait StorageBase
         $this->assertGreaterThanOrEqual(0, $bucket['body']['totalSize']);
     }
 
-    public function testListFilesByParent(): void
+    public function testListFilesByFolder(): void
     {
         $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', [
             'content-type' => 'application/json',
@@ -2083,24 +2083,22 @@ trait StorageBase
         // no filter -- all files
         $this->assertEquals(3, $list([])['total']);
 
-        // exact match -- immediate children only
-        $this->assertEquals(1, $list(['folder' => 'photos'])['total']);
-        $this->assertEquals('photos/', $list(['folder' => 'photos'])['files'][0]['folder']);
+        // exact match -- immediate children only, canonical form with trailing slash
+        $exact = $list(['queries' => [Query::equal('folder', ['photos/'])->toString()]]);
+        $this->assertEquals(1, $exact['total']);
+        $this->assertEquals('photos/', $exact['files'][0]['folder']);
+
+        // equality is against the stored canonical form -- no normalization on query values
+        $this->assertEquals(0, $list(['queries' => [Query::equal('folder', ['photos'])->toString()]])['total']);
 
         // root only
-        $this->assertEquals(1, $list(['folder' => ''])['total']);
-        $this->assertEquals('', $list(['folder' => ''])['files'][0]['folder']);
+        $root = $list(['queries' => [Query::equal('folder', [''])->toString()]]);
+        $this->assertEquals(1, $root['total']);
+        $this->assertEquals('', $root['files'][0]['folder']);
 
-        // recursive via queries
+        // recursive via prefix
         $recursive = $list(['queries' => [Query::startsWith('folder', 'photos/')->toString()]]);
         $this->assertEquals(2, $recursive['total']);
-
-        // invalid parent
-        $response = $this->client->call(Client::METHOD_GET, '/storage/buckets/' . $bucketId . '/files', array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], $this->getHeaders()), ['folder' => '/photos']);
-        $this->assertEquals(400, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_DELETE, '/storage/buckets/' . $bucketId, [
             'content-type' => 'application/json',


### PR DESCRIPTION
## What does this PR do?

Follow-up to #12802: removes the dedicated `folder` param from `GET /v1/storage/buckets/:bucketId/files` in favor of the standard query system, which already whitelists the `folder` attribute.

- Exact-match filtering: `Query.equal('folder', ['photos/2026/'])`
- Root only: `Query.equal('folder', [''])`
- Recursive: `Query.startsWith('folder', 'photos/')`

One surface for filtering instead of two overlapping ones. Two behavioral notes:

- Query values are not normalized (unlike the removed param): equality matches the stored canonical form, so callers must pass the trailing-slash form (`photos/`, not `photos`). A test documents this.
- The removed param's root case (`''`) included an `isNull('folder')` fallback for files uploaded before the V25 migration (the column is added `DEFAULT NULL`). With plain `Query.equal('folder', [''])`, pre-2.0 files are not matched at root until their `folder` is backfilled — tracked as a follow-up decision on the V25 migration.

## Test Plan

- `testListFilesByFolder` (all three Storage e2e suites) rewritten to use queries: exact match, root, unnormalized-value-matches-nothing, recursive prefix.
- Renamed stale test names left over from the `parent` → `folder` rename (`testCreateBucketFileWithParent` → `testCreateBucketFileWithFolder`).
- Pint, PHPStan level 4, and Rector clean (one pre-existing unrelated PHPStan error on `main` in `Functions/Workers/Builds.php:1410`).

## Related PRs and Issues

- #12802 — storage virtual folders (merged); this removes the redundant filter param introduced there

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — Param removed from the action definition; API specs are regenerated by the specs pipeline.
