### PR TITLE
(fix): remove mode auth scheme from client and server SDK specs

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -171,12 +171,6 @@ class Specs extends Action
                     'description' => 'The user session to authenticate with',
                     'in' => 'header',
                 ],
-                'Mode' => [
-                    'type' => 'apiKey',
-                    'name' => 'X-Appwrite-Mode',
-                    'description' => '',
-                    'in' => 'header',
-                ],
                 'DevKey' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Dev-Key',
@@ -262,12 +256,6 @@ class Specs extends Action
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Session',
                     'description' => 'The user session to authenticate with',
-                    'in' => 'header',
-                ],
-                'Mode' => [
-                    'type' => 'apiKey',
-                    'name' => 'X-Appwrite-Mode',
-                    'description' => '',
                     'in' => 'header',
                 ],
                 'ForwardedUserAgent' => [


### PR DESCRIPTION
## What does this PR do?

Removes the `Mode` auth scheme (`X-Appwrite-Mode` header) from the client and server platform key definitions in the specs task, keeping it only for the console platform.

This partially reverts #12822's predecessor change (`261a4d671f`), which exposed the `Mode` scheme across all platforms. We won't need this anymore for user-side (client and server) SDKs — the `X-Appwrite-Mode` header is only relevant to the console, so it shouldn't appear in the generated client/server SDK specs. The `Bearer` scheme additions from that change are kept as-is.

## Test Plan

- `composer lint src/Appwrite/Platform/Tasks/Specs.php` passes.
- Verified the committed specs under `app/config/specs/` already only include `X-Appwrite-Mode` in the console specs, so generated output stays consistent.

## Related PRs and Issues

- Follow-up to the change introduced in commit `261a4d671f` ((feat): expose bearer and mode auth schemes in SDK specs)