### PR TITLE
Canonicalize verified OAuth emails

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1914,6 +1914,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                     && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false)
                     && $oauth2->isEmailVerified($accessToken);
                 $email = $canonicalize ? $canonical : $providerEmail;
+                $emails = array_values(array_unique([$email, $providerEmail]));
                 $emailMetadata = [
                     'emailCanonical' => $canonical,
                     'emailIsCanonical' => $canonicalize || $parsedEmail->get() === $canonical,
@@ -1923,6 +1924,14 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 ];
             } catch (\Throwable) {
                 $failureRedirect(Exception::GENERAL_INVALID_EMAIL);
+            }
+
+            $userWithMatchingEmail = $dbForProject->find('users', [
+                Query::equal('email', $emails),
+                Query::notEqual('$id', $user->getId()),
+            ]);
+            if (!empty($userWithMatchingEmail)) {
+                $failureRedirect(Exception::USER_ALREADY_EXISTS);
             }
 
             if ((($project->getId() === 'console') || ($plan['supportsDisposableEmailValidation'] ?? false)) && ($project->getAttribute('auths', [])['disposableEmails'] ?? false) && $emailMetadata['emailIsDisposable']) {

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1642,14 +1642,15 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 $name = $userDecoded['name']['firstName'] . ' ' . $userDecoded['name']['lastName'];
             }
         }
-        $email = $oauth2->getUserEmail($accessToken);
+        $providerEmail = $oauth2->getUserEmail($accessToken);
+        $email = $providerEmail;
 
         // Check if this identity is connected to a different user
         if (!$user->isEmpty()) {
             $userId = $user->getId();
 
             $identityWithMatchingEmail = $dbForProject->findOne('identities', [
-                Query::equal('providerEmail', [$email]),
+                Query::equal('providerEmail', [$providerEmail]),
                 Query::notEqual('userInternalId', $user->getSequence()),
             ]);
             if (!$identityWithMatchingEmail->isEmpty()) {
@@ -1703,10 +1704,42 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 $user = $dbForProject->getDocument('users', $identity->getAttribute('userId'));
             }
 
+            $emailMetadata = [
+                'emailCanonical' => null,
+                'emailIsCanonical' => null,
+                'emailIsCorporate' => null,
+                'emailIsDisposable' => null,
+                'emailIsFree' => null,
+            ];
+            $emails = [$email];
+            if ($user->isEmpty()) {
+                try {
+                    $parsedEmail = new Email($providerEmail);
+                    $canonical = $parsedEmail->getCanonical();
+                    $canonicalize = (
+                        $project->getId() === 'console'
+                        || ($plan['supportsCanonicalEmailValidation'] ?? false)
+                    )
+                        && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false)
+                        && $isVerified;
+                    $email = $canonicalize ? $canonical : $providerEmail;
+                    $emails = array_values(array_unique([$email, $providerEmail]));
+                    $emailMetadata = [
+                        'emailCanonical' => $canonical,
+                        'emailIsCanonical' => $canonicalize || $parsedEmail->get() === $canonical,
+                        'emailIsCorporate' => $parsedEmail->isCorporate(),
+                        'emailIsDisposable' => $parsedEmail->isDisposable(),
+                        'emailIsFree' => $parsedEmail->isFree(),
+                    ];
+                } catch (\Throwable) {
+                    $failureRedirect(Exception::GENERAL_INVALID_EMAIL);
+                }
+            }
+
             // If user is not found, check if there is a user with the same email
             if ($user->isEmpty()) {
                 $userWithEmail = $dbForProject->findOne('users', [
-                    Query::equal('email', [$email]),
+                    Query::equal('email', $emails),
                 ]);
                 if (!$userWithEmail->isEmpty()) {
                     if (!$isVerified) {
@@ -1719,7 +1752,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             // If user is not found, check if there is an identity with the same email
             if ($user->isEmpty()) {
                 $identityWithMatchingEmail = $dbForProject->findOne('identities', [
-                    Query::equal('providerEmail', [$email]),
+                    Query::equal('providerEmail', [$providerEmail]),
                 ]);
                 if (!$identityWithMatchingEmail->isEmpty()) {
                     if (!$isVerified) {
@@ -1738,28 +1771,6 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                     if ($total >= $limit) {
                         $failureRedirect(Exception::USER_COUNT_EXCEEDED);
                     }
-                }
-
-                $emailMetadata = [
-                    'emailCanonical' => null,
-                    'emailIsCanonical' => null,
-                    'emailIsCorporate' => null,
-                    'emailIsDisposable' => null,
-                    'emailIsFree' => null,
-                ];
-
-                try {
-                    $parsedEmail = new Email($email);
-                    $canonical = $parsedEmail->getCanonical();
-                    $emailMetadata = [
-                        'emailCanonical' => $canonical,
-                        'emailIsCanonical' => $parsedEmail->get() === $canonical,
-                        'emailIsCorporate' => $parsedEmail->isCorporate(),
-                        'emailIsDisposable' => $parsedEmail->isDisposable(),
-                        'emailIsFree' => $parsedEmail->isFree(),
-                    ];
-                } catch (\Throwable) {
-                    $failureRedirect(Exception::GENERAL_INVALID_EMAIL);
                 }
 
                 if ((($project->getId() === 'console') || ($plan['supportsDisposableEmailValidation'] ?? false)) && ($project->getAttribute('auths', [])['disposableEmails'] ?? false) && $emailMetadata['emailIsDisposable']) {
@@ -1848,7 +1859,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             $userId = $user->getId();
 
             $identitiesWithMatchingEmail = $dbForProject->find('identities', [
-                Query::equal('providerEmail', [$email]),
+                Query::equal('providerEmail', [$providerEmail]),
                 Query::notEqual('userInternalId', $user->getSequence()),
             ]);
             if (!empty($identitiesWithMatchingEmail)) {
@@ -1867,7 +1878,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 'userId' => $userId,
                 'provider' => $provider,
                 'providerUid' => $oauth2ID,
-                'providerEmail' => $email,
+                'providerEmail' => $providerEmail,
                 'providerAccessToken' => $accessToken,
                 'providerRefreshToken' => $refreshToken,
                 'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry),
@@ -1885,7 +1896,6 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
         }
 
         if (empty($user->getAttribute('email'))) {
-            $email = $oauth2->getUserEmail($accessToken);
             $emailMetadata = [
                 'emailCanonical' => null,
                 'emailIsCanonical' => null,
@@ -1895,11 +1905,18 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             ];
 
             try {
-                $parsedEmail = new Email($email);
+                $parsedEmail = new Email($providerEmail);
                 $canonical = $parsedEmail->getCanonical();
+                $canonicalize = (
+                    $project->getId() === 'console'
+                    || ($plan['supportsCanonicalEmailValidation'] ?? false)
+                )
+                    && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false)
+                    && $oauth2->isEmailVerified($accessToken);
+                $email = $canonicalize ? $canonical : $providerEmail;
                 $emailMetadata = [
                     'emailCanonical' => $canonical,
-                    'emailIsCanonical' => $parsedEmail->get() === $canonical,
+                    'emailIsCanonical' => $canonicalize || $parsedEmail->get() === $canonical,
                     'emailIsCorporate' => $parsedEmail->isCorporate(),
                     'emailIsDisposable' => $parsedEmail->isDisposable(),
                     'emailIsFree' => $parsedEmail->isFree(),

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1849,52 +1849,6 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             $failureRedirect(Exception::USER_BLOCKED); // User is in status blocked
         }
 
-        $identity = $dbForProject->findOne('identities', [
-            Query::equal('userInternalId', [$user->getSequence()]),
-            Query::equal('provider', [$provider]),
-            Query::equal('providerUid', [$oauth2ID]),
-        ]);
-        if ($identity->isEmpty()) {
-            // Before creating the identity, check if the email is already associated with another user
-            $userId = $user->getId();
-
-            $identitiesWithMatchingEmail = $dbForProject->find('identities', [
-                Query::equal('providerEmail', [$providerEmail]),
-                Query::notEqual('userInternalId', $user->getSequence()),
-            ]);
-            if (!empty($identitiesWithMatchingEmail)) {
-                $failureRedirect(Exception::GENERAL_BAD_REQUEST);
-                /** Return a generic bad request to prevent exposing existing accounts */
-            }
-
-            $dbForProject->createDocument('identities', new Document([
-                '$id' => ID::unique(),
-                '$permissions' => [
-                    Permission::read(Role::any()),
-                    Permission::update(Role::user($userId)),
-                    Permission::delete(Role::user($userId)),
-                ],
-                'userInternalId' => $user->getSequence(),
-                'userId' => $userId,
-                'provider' => $provider,
-                'providerUid' => $oauth2ID,
-                'providerEmail' => $providerEmail,
-                'providerAccessToken' => $accessToken,
-                'providerRefreshToken' => $refreshToken,
-                'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry),
-            ]));
-        } else {
-            $identity
-                ->setAttribute('providerAccessToken', $accessToken)
-                ->setAttribute('providerRefreshToken', $refreshToken)
-                ->setAttribute('providerAccessTokenExpiry', DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry));
-            $dbForProject->updateDocument('identities', $identity->getId(), new Document([
-                'providerAccessToken' => $identity->getAttribute('providerAccessToken'),
-                'providerRefreshToken' => $identity->getAttribute('providerRefreshToken'),
-                'providerAccessTokenExpiry' => $identity->getAttribute('providerAccessTokenExpiry'),
-            ]));
-        }
-
         if (empty($user->getAttribute('email'))) {
             $emailMetadata = [
                 'emailCanonical' => null,
@@ -1956,6 +1910,52 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             $user->setAttribute('emailIsCorporate', $emailMetadata['emailIsCorporate']);
             $user->setAttribute('emailIsDisposable', $emailMetadata['emailIsDisposable']);
             $user->setAttribute('emailIsFree', $emailMetadata['emailIsFree']);
+        }
+
+        $identity = $dbForProject->findOne('identities', [
+            Query::equal('userInternalId', [$user->getSequence()]),
+            Query::equal('provider', [$provider]),
+            Query::equal('providerUid', [$oauth2ID]),
+        ]);
+        if ($identity->isEmpty()) {
+            // Before creating the identity, check if the email is already associated with another user
+            $userId = $user->getId();
+
+            $identitiesWithMatchingEmail = $dbForProject->find('identities', [
+                Query::equal('providerEmail', [$providerEmail]),
+                Query::notEqual('userInternalId', $user->getSequence()),
+            ]);
+            if (!empty($identitiesWithMatchingEmail)) {
+                $failureRedirect(Exception::GENERAL_BAD_REQUEST);
+                /** Return a generic bad request to prevent exposing existing accounts */
+            }
+
+            $dbForProject->createDocument('identities', new Document([
+                '$id' => ID::unique(),
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::user($userId)),
+                    Permission::delete(Role::user($userId)),
+                ],
+                'userInternalId' => $user->getSequence(),
+                'userId' => $userId,
+                'provider' => $provider,
+                'providerUid' => $oauth2ID,
+                'providerEmail' => $providerEmail,
+                'providerAccessToken' => $accessToken,
+                'providerRefreshToken' => $refreshToken,
+                'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry),
+            ]));
+        } else {
+            $identity
+                ->setAttribute('providerAccessToken', $accessToken)
+                ->setAttribute('providerRefreshToken', $refreshToken)
+                ->setAttribute('providerAccessTokenExpiry', DateTime::addSeconds(new \DateTime(), (int) $accessTokenExpiry));
+            $dbForProject->updateDocument('identities', $identity->getId(), new Document([
+                'providerAccessToken' => $identity->getAttribute('providerAccessToken'),
+                'providerRefreshToken' => $identity->getAttribute('providerRefreshToken'),
+                'providerAccessTokenExpiry' => $identity->getAttribute('providerAccessTokenExpiry'),
+            ]));
         }
 
         if (empty($user->getAttribute('name'))) {

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -69,7 +69,9 @@ Http::get('/v1/mock/tests/general/oauth2/token')
     ->inject('response')
     ->action(function (string $client_id, string $client_secret, string $grantType, string $redirectURI, string $code, string $refreshToken, Response $response) {
 
-        if ($client_id != '1') {
+        $canonicalEmail = \str_starts_with($client_id, 'canonical-');
+
+        if ($client_id != '1' && !$canonicalEmail) {
             throw new Exception(Exception::GENERAL_MOCK, 'Invalid client ID');
         }
 
@@ -78,7 +80,7 @@ Http::get('/v1/mock/tests/general/oauth2/token')
         }
 
         $responseJson = [
-            'access_token' => '123456',
+            'access_token' => $canonicalEmail ? $client_id : '123456',
             'refresh_token' => 'tuvwxyz',
             'expires_in' => 14400
         ];
@@ -109,16 +111,26 @@ Http::get('/v1/mock/tests/general/oauth2/user')
     ->inject('response')
     ->action(function (string $token, Response $response) {
 
-        if ($token != '123456') {
+        if ($token === '123456') {
+            $user = [
+                'id' => 1,
+                'name' => 'User Name',
+                'email' => 'useroauth@localhost.test',
+                'verified' => true,
+            ];
+        } elseif (\str_starts_with($token, 'canonical-')) {
+            $id = \substr($token, \strlen('canonical-'));
+            $user = [
+                'id' => $id,
+                'name' => 'Canonical Email User',
+                'email' => 'oauth.' . $id . '@gmail.com',
+                'verified' => true,
+            ];
+        } else {
             throw new Exception(Exception::GENERAL_MOCK, 'Invalid token');
         }
 
-        $response->json([
-            'id' => 1,
-            'name' => 'User Name',
-            'email' => 'useroauth@localhost.test',
-            'verified' => true,
-        ]);
+        $response->json($user);
     });
 
 Http::get('/v1/mock/tests/general/oauth2/user-unverified')


### PR DESCRIPTION
## What does this PR do?

Canonicalizes verified OAuth provider emails when canonical email enforcement is enabled, while preserving the provider-returned address in identities.providerEmail.

This fixes a partial-write regression for anonymous and phone-only accounts. A provider alias such as a dotted Gmail address could canonicalize to an email already owned by another user. Previously, the OAuth identity was written before the canonical collision was detected. The request then failed, but the identity remained orphaned and blocked future retries.

### Before

```mermaid
flowchart TD
    A[OAuth callback] --> B[Create or update identity]
    B --> C[Canonicalize provider email]
    C --> D{Canonical email already used?}
    D -- Yes --> E[Fail OAuth request]
    E --> F[Identity remains orphaned]
    D -- No --> G[Update user email]
```

### After

```mermaid
flowchart TD
    A[OAuth callback] --> B[Read provider email]
    B --> C[Canonicalize verified email]
    C --> D[Check canonical and raw email collisions]
    D --> E{Validation passes?}
    E -- No --> F[Fail without writing identity]
    E -- Yes --> G[Create or update identity]
    G --> H[Persist canonical user email]
```

New-user lookups also consider both canonical and provider-returned forms to avoid duplicate accounts. The raw provider address remains available on the identity for provider matching and auditing.

The mock OAuth endpoint supports unique dotted Gmail addresses for Cloud regression coverage.

## Test Plan

- Ran testCreateOAuth2AccountSession successfully: 1 test, 57 assertions.
- Ran Pint formatting and lint checks on the changed files.
- Ran PHP syntax checks on the changed files.
- Ran focused PHPStan analysis on app/controllers/api/account.php and app/controllers/mock.php with no errors.
- Added end-to-end Cloud regression coverage in the related Cloud PR.
- Full repository PHPStan reached 98% before Composer timeout; no errors were reported before the timeout.

## Related PRs and Issues

- Cloud PR: https://github.com/appwrite-labs/cloud/pull/4712

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API metadata, does it also include updated API specs and example docs?
