### PR TITLE
Fix empty database lists for Console OAuth tokens without admin mode

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -352,12 +352,14 @@ Http::init()
             && $project->getId() !== 'console'
             && $mode === APP_MODE_ADMIN;
         $isOAuthAdminKey = ! empty($apiKey)
-            && $apiKey->getType() === API_KEY_OAUTH2
-            && $apiKey->getRole() === User::ROLE_OWNER
+            && $apiKey->isOAuthOwner()
             && $project->getId() !== 'console';
 
         if ($isOAuthAdminKey) {
             $authorization->setDefaultStatus(false);
+            // Match console admin mode, which doesn't carry the 'account' scope on user
+            // projects: account endpoints would operate on the platform user against the project DB.
+            $scopes = \array_diff($scopes, ['account']);
         }
 
         if (!$impersonatorUser->isEmpty() && !$targetUser->isEmpty()) {
@@ -404,7 +406,9 @@ Http::init()
             if ($impersonatorUser->isEmpty() && DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_USER_ACCESS)) > $accessedAt) {
                 $user->setAttribute('accessedAt', DateTime::now());
 
-                if ($project->getId() !== 'console' && $mode !== APP_MODE_ADMIN) {
+                // OAuth owner tokens authenticate a platform user, so their activity
+                // must be written to the platform DB like admin mode requests.
+                if ($project->getId() !== 'console' && $mode !== APP_MODE_ADMIN && ! $isOAuthAdminKey) {
                     $dbForProject->updateDocument('users', $user->getId(), new Document([
                         'accessedAt' => $user->getAttribute('accessedAt')
                     ]));
@@ -616,12 +620,14 @@ Http::init()
         $auditContext->project = $project;
         $auditContext->impersonatorUser = $impersonatorUser->isEmpty() ? null : $impersonatorUser;
 
+        $isOAuthAdminKey = $apiKey !== null && $apiKey->isOAuthOwner() && $project->getId() !== 'console';
+
         /* If a session exists, use the target user (impersonated target or actor) for audit */
         if (! $targetUser->isEmpty()) {
             $userClone = clone $targetUser;
             // $user doesn't support `type` and can cause unintended effects.
             if (empty($targetUser->getAttribute('type'))) {
-                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
+                $userClone->setAttribute('type', ($mode === APP_MODE_ADMIN || $isOAuthAdminKey) ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
             }
             $auditContext->user = $userClone;
         }
@@ -928,7 +934,8 @@ Http::shutdown()
     ->inject('auditContext')
     ->inject('publisherForAudits')
     ->inject('mode')
-    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, User $targetUser, AuditContext $auditContext, Audit $publisherForAudits, string $mode) {
+    ->inject('apiKey')
+    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, User $targetUser, AuditContext $auditContext, Audit $publisherForAudits, string $mode, ?Key $apiKey) {
         $responsePayload = $response->getPayload();
 
         $pattern = $route->getLabel('audits.resource', null);
@@ -945,11 +952,13 @@ Http::shutdown()
             }
         }
 
+        $isOAuthAdminKey = $apiKey !== null && $apiKey->isOAuthOwner() && $project->getId() !== 'console';
+
         if (! $targetUser->isEmpty()) {
             $userClone = clone $targetUser;
             // $user doesn't support `type` and can cause unintended effects.
             if (empty($targetUser->getAttribute('type'))) {
-                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
+                $userClone->setAttribute('type', ($mode === APP_MODE_ADMIN || $isOAuthAdminKey) ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
             }
             $auditContext->user = $userClone;
         } elseif ($auditContext->user === null || $auditContext->user->isEmpty()) {
@@ -1183,6 +1192,7 @@ Http::shutdown()
             $byMethod = [];
         }
 
+        $isOAuthAdminKey = $apiKey !== null && $apiKey->isOAuthOwner() && $project->getId() !== 'console';
         $actorType = ($apiKey !== null && $apiKey->getRole() === User::ROLE_KEYS)
             ? match ($apiKey->getType()) {
                 API_KEY_ACCOUNT => ACTOR_TYPE_KEY_ACCOUNT,
@@ -1191,7 +1201,7 @@ Http::shutdown()
                 default => ACTOR_TYPE_KEY_PROJECT,
             }
         : (! $user->isEmpty()
-            ? ($mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER)
+            ? (($mode === APP_MODE_ADMIN || $isOAuthAdminKey) ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER)
             : ACTOR_TYPE_GUEST);
         $byMethod[$method] = [
             'status' => ONBOARDING_STATUS_COMPLETED,

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -355,7 +355,7 @@ Http::init()
             && $apiKey->getType() === API_KEY_OAUTH2
             && $apiKey->getRole() === User::ROLE_OWNER;
 
-        if ($isAdminProjectRequest && $isOAuthAdminKey) {
+        if ($isOAuthAdminKey && $project->getId() !== 'console') {
             $authorization->setDefaultStatus(false);
         }
 

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -371,8 +371,12 @@ Http::init()
          * We disable authorization checks above to ensure other endpoints (list teams, members, etc.) will continue working.
          * But, for actions on resources (sites, functions, etc.) in a non-console project, we explicitly check
          * whether the admin user has necessary permission on the project (sites, functions, etc. don't have permissions associated to them).
+         *
+         * OAuth owner keys are excluded: they skip the admin membership role-loading branch above, so a project
+         * READ check here would false-negative with PROJECT_NOT_FOUND. Ownership for those tokens is already
+         * enforced when the console OAuth grant is issued (scopes / authorization_details).
          */
-        if (($isAdminProjectRequest && empty($apiKey)) || $isOAuthAdminKey) {
+        if ($isAdminProjectRequest && empty($apiKey)) {
             $input = new Input(Database::PERMISSION_READ, $project->getPermissionsByType(Database::PERMISSION_READ));
             $initialStatus = $authorization->getStatus();
             $authorization->enable();

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -353,9 +353,10 @@ Http::init()
             && $mode === APP_MODE_ADMIN;
         $isOAuthAdminKey = ! empty($apiKey)
             && $apiKey->getType() === API_KEY_OAUTH2
-            && $apiKey->getRole() === User::ROLE_OWNER;
+            && $apiKey->getRole() === User::ROLE_OWNER
+            && $project->getId() !== 'console';
 
-        if ($isOAuthAdminKey && $project->getId() !== 'console') {
+        if ($isOAuthAdminKey) {
             $authorization->setDefaultStatus(false);
         }
 
@@ -369,7 +370,7 @@ Http::init()
          * But, for actions on resources (sites, functions, etc.) in a non-console project, we explicitly check
          * whether the admin user has necessary permission on the project (sites, functions, etc. don't have permissions associated to them).
          */
-        if ($isAdminProjectRequest && (empty($apiKey) || $isOAuthAdminKey)) {
+        if (($isAdminProjectRequest && empty($apiKey)) || $isOAuthAdminKey) {
             $input = new Input(Database::PERMISSION_READ, $project->getPermissionsByType(Database::PERMISSION_READ));
             $initialStatus = $authorization->getStatus();
             $authorization->enable();

--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -352,14 +352,11 @@ Http::init()
             && $project->getId() !== 'console'
             && $mode === APP_MODE_ADMIN;
         $isOAuthAdminKey = ! empty($apiKey)
-            && $apiKey->isOAuthOwner()
-            && $project->getId() !== 'console';
+            && $apiKey->getType() === API_KEY_OAUTH2
+            && $apiKey->getRole() === User::ROLE_OWNER;
 
-        if ($isOAuthAdminKey) {
+        if ($isAdminProjectRequest && $isOAuthAdminKey) {
             $authorization->setDefaultStatus(false);
-            // Match console admin mode, which doesn't carry the 'account' scope on user
-            // projects: account endpoints would operate on the platform user against the project DB.
-            $scopes = \array_diff($scopes, ['account']);
         }
 
         if (!$impersonatorUser->isEmpty() && !$targetUser->isEmpty()) {
@@ -371,10 +368,6 @@ Http::init()
          * We disable authorization checks above to ensure other endpoints (list teams, members, etc.) will continue working.
          * But, for actions on resources (sites, functions, etc.) in a non-console project, we explicitly check
          * whether the admin user has necessary permission on the project (sites, functions, etc. don't have permissions associated to them).
-         *
-         * OAuth owner keys are excluded: they skip the admin membership role-loading branch above, so a project
-         * READ check here would false-negative with PROJECT_NOT_FOUND. Ownership for those tokens is already
-         * enforced when the console OAuth grant is issued (scopes / authorization_details).
          */
         if ($isAdminProjectRequest && empty($apiKey)) {
             $input = new Input(Database::PERMISSION_READ, $project->getPermissionsByType(Database::PERMISSION_READ));
@@ -410,9 +403,7 @@ Http::init()
             if ($impersonatorUser->isEmpty() && DateTime::formatTz(DateTime::addSeconds(new \DateTime(), -APP_USER_ACCESS)) > $accessedAt) {
                 $user->setAttribute('accessedAt', DateTime::now());
 
-                // OAuth owner tokens authenticate a platform user, so their activity
-                // must be written to the platform DB like admin mode requests.
-                if ($project->getId() !== 'console' && $mode !== APP_MODE_ADMIN && ! $isOAuthAdminKey) {
+                if ($project->getId() !== 'console' && $mode !== APP_MODE_ADMIN) {
                     $dbForProject->updateDocument('users', $user->getId(), new Document([
                         'accessedAt' => $user->getAttribute('accessedAt')
                     ]));
@@ -624,14 +615,12 @@ Http::init()
         $auditContext->project = $project;
         $auditContext->impersonatorUser = $impersonatorUser->isEmpty() ? null : $impersonatorUser;
 
-        $isOAuthAdminKey = $apiKey !== null && $apiKey->isOAuthOwner() && $project->getId() !== 'console';
-
         /* If a session exists, use the target user (impersonated target or actor) for audit */
         if (! $targetUser->isEmpty()) {
             $userClone = clone $targetUser;
             // $user doesn't support `type` and can cause unintended effects.
             if (empty($targetUser->getAttribute('type'))) {
-                $userClone->setAttribute('type', ($mode === APP_MODE_ADMIN || $isOAuthAdminKey) ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
+                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
             }
             $auditContext->user = $userClone;
         }
@@ -938,8 +927,7 @@ Http::shutdown()
     ->inject('auditContext')
     ->inject('publisherForAudits')
     ->inject('mode')
-    ->inject('apiKey')
-    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, User $targetUser, AuditContext $auditContext, Audit $publisherForAudits, string $mode, ?Key $apiKey) {
+    ->action(function (Route $route, array $params, Request $request, Response $response, Document $project, User $user, User $targetUser, AuditContext $auditContext, Audit $publisherForAudits, string $mode) {
         $responsePayload = $response->getPayload();
 
         $pattern = $route->getLabel('audits.resource', null);
@@ -956,13 +944,11 @@ Http::shutdown()
             }
         }
 
-        $isOAuthAdminKey = $apiKey !== null && $apiKey->isOAuthOwner() && $project->getId() !== 'console';
-
         if (! $targetUser->isEmpty()) {
             $userClone = clone $targetUser;
             // $user doesn't support `type` and can cause unintended effects.
             if (empty($targetUser->getAttribute('type'))) {
-                $userClone->setAttribute('type', ($mode === APP_MODE_ADMIN || $isOAuthAdminKey) ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
+                $userClone->setAttribute('type', $mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER);
             }
             $auditContext->user = $userClone;
         } elseif ($auditContext->user === null || $auditContext->user->isEmpty()) {
@@ -1196,7 +1182,6 @@ Http::shutdown()
             $byMethod = [];
         }
 
-        $isOAuthAdminKey = $apiKey !== null && $apiKey->isOAuthOwner() && $project->getId() !== 'console';
         $actorType = ($apiKey !== null && $apiKey->getRole() === User::ROLE_KEYS)
             ? match ($apiKey->getType()) {
                 API_KEY_ACCOUNT => ACTOR_TYPE_KEY_ACCOUNT,
@@ -1205,7 +1190,7 @@ Http::shutdown()
                 default => ACTOR_TYPE_KEY_PROJECT,
             }
         : (! $user->isEmpty()
-            ? (($mode === APP_MODE_ADMIN || $isOAuthAdminKey) ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER)
+            ? ($mode === APP_MODE_ADMIN ? ACTOR_TYPE_ADMIN : ACTOR_TYPE_USER)
             : ACTOR_TYPE_GUEST);
         $byMethod[$method] = [
             'status' => ONBOARDING_STATUS_COMPLETED,

--- a/src/Appwrite/Auth/Key.php
+++ b/src/Appwrite/Auth/Key.php
@@ -104,6 +104,15 @@ class Key
     }
 
     /**
+     * Console-issued OAuth2 token acting with owner privileges (CLI/MCP).
+     * These behave like console admin requests but never carry the admin mode header.
+     */
+    public function isOAuthOwner(): bool
+    {
+        return $this->type === API_KEY_OAUTH2 && $this->role === User::ROLE_OWNER;
+    }
+
+    /**
      * Decode the given secret key into a Key object, containing the project ID, type, role, scopes, and name.
      * Can be a stored API key or an ephemeral key (JWT).
      *

--- a/src/Appwrite/Auth/Key.php
+++ b/src/Appwrite/Auth/Key.php
@@ -104,15 +104,6 @@ class Key
     }
 
     /**
-     * Console-issued OAuth2 token acting with owner privileges (CLI/MCP).
-     * These behave like console admin requests but never carry the admin mode header.
-     */
-    public function isOAuthOwner(): bool
-    {
-        return $this->type === API_KEY_OAUTH2 && $this->role === User::ROLE_OWNER;
-    }
-
-    /**
      * Decode the given secret key into a Key object, containing the project ID, type, role, scopes, and name.
      * Can be a stored API key or an ephemeral key (JWT).
      *


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Console OAuth bearer tokens (CLI / MCP) authenticate as project owners but typically do **not** send `X-Appwrite-Mode: admin`. The previous owner-token document-auth bypass only ran when admin mode was also set, so document authorization stayed enabled for those requests.

Databases are created without `$permissions`, so `GET /v1/tablesdb` and `GET /v1/databases` returned empty lists even though the caller was a valid owner. Resources that ship with `read("any")` (buckets, users, etc.) still appeared, which made the failure look like a TablesDB/Databases-specific bug.

This change disables document authorization for OAuth owner tokens on non-console projects regardless of admin mode, matching the intended owner bypass while still keeping authorization on for the console project itself.

```php
// BEFORE
if ($isAdminProjectRequest && $isOAuthAdminKey) {
    $authorization->setDefaultStatus(false);
}

// AFTER
if ($isOAuthAdminKey && $project->getId() !== 'console') {
    $authorization->setDefaultStatus(false);
}
```

## Test Plan

- [ ] Authenticate with a Console OAuth bearer token (CLI or MCP) against a non-console project **without** `X-Appwrite-Mode: admin`
- [ ] Confirm `GET /v1/tablesdb` and `GET /v1/databases` return existing databases (not an empty list)
- [ ] Confirm buckets/users listing still works as before
- [ ] Confirm console-project requests still keep document authorization enabled
- [ ] Confirm non-OAuth / non-owner flows are unchanged

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
