### PR TITLE
fix: filter Sites build runtimes by _APP_SITES_RUNTIMES

### DIFF
--- a/src/Appwrite/Platform/Modules/Sites/Http/Frameworks/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Frameworks/XList.php
@@ -11,6 +11,7 @@ use Utopia\Config\Config;
 use Utopia\Database\Document;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\System\System;
 
 class XList extends Base
 {
@@ -52,10 +53,18 @@ class XList extends Base
     public function action(Response $response)
     {
         $frameworks = Config::getParam('frameworks');
+        $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
 
         foreach ($frameworks as $key => $framework) {
             if (!empty($framework['adapters'])) {
                 $frameworks[$key]['adapters'] = \array_values($framework['adapters']);
+            }
+
+            if (!empty($allowList) && !empty($framework['runtimes'])) {
+                $frameworks[$key]['runtimes'] = \array_values(\array_filter(
+                    $framework['runtimes'],
+                    fn ($runtime) => \in_array($runtime, $allowList, true)
+                ));
             }
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Frameworks/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Frameworks/XList.php
@@ -69,6 +69,12 @@ class XList extends Base
                 // Drop frameworks that have no enabled build runtimes left.
                 if (empty($frameworks[$key]['runtimes'])) {
                     unset($frameworks[$key]);
+                    continue;
+                }
+
+                // Keep the default buildRuntime aligned with the filtered allowlist.
+                if (!\in_array($frameworks[$key]['buildRuntime'] ?? '', $frameworks[$key]['runtimes'], true)) {
+                    $frameworks[$key]['buildRuntime'] = $frameworks[$key]['runtimes'][0];
                 }
             }
         }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Frameworks/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Frameworks/XList.php
@@ -65,6 +65,11 @@ class XList extends Base
                     $framework['runtimes'],
                     fn ($runtime) => \in_array($runtime, $allowList, true)
                 ));
+
+                // Drop frameworks that have no enabled build runtimes left.
+                if (empty($frameworks[$key]['runtimes'])) {
+                    unset($frameworks[$key]);
+                }
             }
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -144,6 +144,12 @@ class Create extends Base
             }
         }
 
+        $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
+
+        if (!empty($allowList) && !\in_array($buildRuntime, $allowList, true)) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
+        }
+
         $siteId = ($siteId == 'unique()') ? ID::unique() : $siteId;
 
         $installation = $dbForPlatform->getDocument('installations', $installationId);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -158,6 +158,12 @@ class Update extends Base
             }
         }
 
+        $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
+
+        if (!empty($allowList) && !empty($buildRuntime) && !\in_array($buildRuntime, $allowList, true)) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
+        }
+
         // TODO: If only branch changes, re-deploy
         $site = $dbForProject->getDocument('sites', $siteId);
 

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -135,6 +135,21 @@ final class SitesCustomServerTest extends Scope
         $this->assertEquals(201, $variable2['headers']['status-code']);
         $this->assertEquals(201, $variable3['headers']['status-code']);
 
+        /**
+         * Test for FAILURE
+         * Reject buildRuntime values outside _APP_SITES_RUNTIMES (static-1,node-22 in test env).
+         */
+        $site = $this->createSite([
+            'buildRuntime' => 'node-24',
+            'framework' => 'other',
+            'name' => 'Unsupported Runtime Site',
+            'siteId' => ID::unique(),
+        ]);
+
+        $this->assertEquals(400, $site['headers']['status-code']);
+        $this->assertEquals('general_argument_invalid', $site['body']['type']);
+        $this->assertStringContainsString('Runtime "node-24" is not supported', $site['body']['message']);
+
         $this->cleanupSite($siteId);
     }
 

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -148,7 +148,7 @@ final class SitesCustomServerTest extends Scope
 
         $this->assertEquals(400, $site['headers']['status-code']);
         $this->assertEquals('general_argument_invalid', $site['body']['type']);
-        $this->assertStringContainsString('Runtime "node-24" is not supported', $site['body']['message']);
+        $this->assertStringContainsString('Runtime "node-24" is not supported', (string) $site['body']['message']);
 
         $this->cleanupSite($siteId);
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Self-hosted Sites settings showed **all** build runtimes (including Bun/Deno/uninstalled Node versions) in the Console dropdown, while Functions correctly filters by `_APP_FUNCTIONS_RUNTIMES`.

This mirrors the Functions `listRuntimes` behavior for Sites:

- `GET /v1/sites/frameworks` now filters each framework's `runtimes` list against `_APP_SITES_RUNTIMES`
- Site create/update reject a `buildRuntime` that is not in the allowlist (when the allowlist is set)

Reported in community threads: https://appwrite.io/threads/1525087225895718983

## Test Plan

1. Set `_APP_SITES_RUNTIMES=static-1,node-22,node-24` (leave Bun/Deno out)
2. Restart Appwrite
3. Open a Site → Settings → Runtime settings
4. Confirm the build runtime dropdown only lists runtimes from the allowlist (same idea as Functions)
5. Attempt create/update with a runtime outside the allowlist via API → expect `general_argument_invalid`

## Related PRs and Issues

- Thread: https://appwrite.io/threads/1525087225895718983
- Related Greptile note on #12337 about `_APP_SITES_RUNTIMES` not being respected by frameworks config

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
