### PR TITLE
Add .gitattributes rule to force LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@ public/scripts/** linguist-detectable=false
 public/dist/scripts/** linguist-detectable=false
 
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+
+# Force LF so Docker images built from Windows (autocrlf) checkouts don't break
+bin/*  text eol=lf
+*.sh   text eol=lf


### PR DESCRIPTION
What this does: Adds `.gitattributes` rules forcing LF line endings for the` bin/*` CLI/worker scripts and all `*.sh` files.

Why: On Windows, Git's default `core.autocrlf=true` rewrites these extensionless shell scripts to CRLF on checkout. `docker compose build` copies them into the image (`Dockerfile → COPY ./bin /usr/local/bin`) and the CRLF shebang makes every worker crash-loop with `exec /usr/local/bin/...: ``no such file or directory.` The repo had no` eol `rules only linguist ones.

How I tested it: `git check-attr eol -- bin/worker-databases` reports `eol: lf`; a fresh Windows clone with `core.autocrlf=true `now checks the scripts out as LF and the containers start cleanly. No-op on Linux/macOS (files are already LF).

for the reviewer: Kept the rules targeted (`bin/*, *.sh`) rather than a repo-wide` * text=auto eol=lf` to avoid a mass renormalization; happy to switch to the global form if you prefer.