### PR TITLE
Migrate screenshots worker to Utopia client

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -17,6 +17,7 @@ use Appwrite\Event\Publisher\Notification as NotificationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
+use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client as ScreenshotsClient;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Executor\Executor;
 use OpenRuntimes\Orchestrator\Jobs;
@@ -26,6 +27,7 @@ use Utopia\Cache\Adapter\Sharding;
 use Utopia\Cache\Cache;
 use Utopia\Client;
 use Utopia\Client\Adapter\Curl\Client as CurlAdapter;
+use Utopia\Client\Adapter\SwooleCoroutine\Client as SwooleAdapter;
 use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Database\Document;
@@ -85,6 +87,12 @@ $container->set('jobs', function () {
 
     return new Jobs($client);
 }, []);
+
+$container->set('clientForScreenshots', fn () => new ScreenshotsClient(
+    (new Client(new SwooleAdapter()))
+        ->withTimeout((float) System::getEnv('_APP_SITES_TIMEOUT', 30)),
+    System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1') . '/screenshots',
+), []);
 
 $container->set('telemetry', fn () => new NoTelemetry(), []);
 

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -17,7 +17,6 @@ use Appwrite\Event\Publisher\Notification as NotificationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
-use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Executor\Executor;
 use OpenRuntimes\Orchestrator\Jobs;
@@ -25,9 +24,9 @@ use Utopia\Abuse\Adapters\TimeLimit\Redis as TimeLimitRedis;
 use Utopia\Cache\Adapter\Pool as CachePool;
 use Utopia\Cache\Adapter\Sharding;
 use Utopia\Cache\Cache;
+use Utopia\Client;
 use Utopia\Client\Adapter\Curl\Client as CurlAdapter;
 use Utopia\Client\Adapter\SwooleCoroutine\Client as SwooleAdapter;
-use Utopia\Client as UtopiaClient;
 use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Database\Document;
@@ -73,7 +72,7 @@ $container->set('localeCodes', fn () => array_map(fn ($locale) => $locale['code'
 $container->set('executor', fn () => new Executor(), []);
 
 $container->set('jobs', function () {
-    $client = (new UtopiaClient(new CurlAdapter()))
+    $client = (new Client(new CurlAdapter()))
         ->withBearerAuth(System::getEnv('_APP_JOBS_SECRET', ''))
         ->withTimeout(30);
 
@@ -88,8 +87,8 @@ $container->set('jobs', function () {
     return new Jobs($client);
 }, []);
 
-$container->set('screenshots', fn () => new Client(
-    (new UtopiaClient(new SwooleAdapter()))
+$container->set('screenshots', fn () => new \Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client(
+    (new Client(new SwooleAdapter()))
         ->withTimeout((float) System::getEnv('_APP_SITES_TIMEOUT', 30)),
     System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1') . '/screenshots',
 ), []);

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -17,7 +17,7 @@ use Appwrite\Event\Publisher\Notification as NotificationPublisher;
 use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
-use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client as ScreenshotsClient;
+use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
 use Executor\Executor;
 use OpenRuntimes\Orchestrator\Jobs;
@@ -25,9 +25,9 @@ use Utopia\Abuse\Adapters\TimeLimit\Redis as TimeLimitRedis;
 use Utopia\Cache\Adapter\Pool as CachePool;
 use Utopia\Cache\Adapter\Sharding;
 use Utopia\Cache\Cache;
-use Utopia\Client;
 use Utopia\Client\Adapter\Curl\Client as CurlAdapter;
 use Utopia\Client\Adapter\SwooleCoroutine\Client as SwooleAdapter;
+use Utopia\Client as UtopiaClient;
 use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Database\Document;
@@ -73,7 +73,7 @@ $container->set('localeCodes', fn () => array_map(fn ($locale) => $locale['code'
 $container->set('executor', fn () => new Executor(), []);
 
 $container->set('jobs', function () {
-    $client = (new Client(new CurlAdapter()))
+    $client = (new UtopiaClient(new CurlAdapter()))
         ->withBearerAuth(System::getEnv('_APP_JOBS_SECRET', ''))
         ->withTimeout(30);
 
@@ -88,8 +88,8 @@ $container->set('jobs', function () {
     return new Jobs($client);
 }, []);
 
-$container->set('screenshots', fn () => new ScreenshotsClient(
-    (new Client(new SwooleAdapter()))
+$container->set('screenshots', fn () => new Client(
+    (new UtopiaClient(new SwooleAdapter()))
         ->withTimeout((float) System::getEnv('_APP_SITES_TIMEOUT', 30)),
     System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1') . '/screenshots',
 ), []);

--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -88,7 +88,7 @@ $container->set('jobs', function () {
     return new Jobs($client);
 }, []);
 
-$container->set('clientForScreenshots', fn () => new ScreenshotsClient(
+$container->set('screenshots', fn () => new ScreenshotsClient(
     (new Client(new SwooleAdapter()))
         ->withTimeout((float) System::getEnv('_APP_SITES_TIMEOUT', 30)),
     System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1') . '/screenshots',

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -91,11 +91,10 @@ class Screenshots extends Action
         Span::add('site.framework', $site->getAttribute('framework', ''));
 
         // Realtime preparation
-        $event = "sites.[siteId].deployments.[deploymentId].update";
         $queueForRealtime
             ->setSubscribers(['console'])
             ->setProject($project)
-            ->setEvent($event)
+            ->setEvent('sites.[siteId].deployments.[deploymentId].update')
             ->setParam('siteId', $site->getId())
             ->setParam('deploymentId', $deployment->getId());
 
@@ -125,21 +124,7 @@ class Screenshots extends Action
                 $routerHost = "$protocol://{$rule->getAttribute('domain')}";
             }
 
-            $configs = [
-                'screenshotLight' => [
-                    'headers' => [ 'x-appwrite-hostname' => $rule->getAttribute('domain') ],
-                    'url' => $routerHost . '/?appwrite-preview=1&appwrite-theme=light',
-                    'theme' => 'light'
-                ],
-                'screenshotDark' => [
-                    'headers' => [ 'x-appwrite-hostname' => $rule->getAttribute('domain') ],
-                    'url' => $routerHost . '/?appwrite-preview=1&appwrite-theme=dark',
-                    'theme' => 'dark'
-                ],
-            ];
-
-            $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 900, 0);
-            $apiKey = $jwtObj->encode([
+            $apiKey = (new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 900, 0))->encode([
                 'hostnameOverride' => true,
                 'disabledMetrics' => [
                     METRIC_EXECUTIONS,
@@ -161,35 +146,33 @@ class Screenshots extends Action
                 'deploymentStatusIgnored' => true
             ]);
 
-            $screenshotError = null;
-            $captures = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $screenshots, &$screenshotError) {
-                return function () use ($key, $configs, $apiKey, $site, $screenshots, &$screenshotError) {
+            $sleep = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')]['screenshotSleep'] ?? 3000;
+            $tasks = [];
+            foreach (['screenshotLight' => 'light', 'screenshotDark' => 'dark'] as $key => $theme) {
+                $config = [
+                    'headers' => [
+                        'x-appwrite-hostname' => $rule->getAttribute('domain'),
+                        'x-appwrite-key' => API_KEY_EPHEMERAL . '_' . $apiKey,
+                    ],
+                    'url' => $routerHost . "/?appwrite-preview=1&appwrite-theme={$theme}",
+                    'theme' => $theme,
+                    'sleep' => $sleep,
+                ];
+                $tasks[] = function () use ($key, $config, $screenshots) {
                     try {
-                        $config = $configs[$key];
-
-                        $config['headers'] = \array_merge($config['headers'], [
-                            'x-appwrite-key' => API_KEY_EPHEMERAL . '_' . $apiKey
-                        ]);
-                        $config['sleep'] = 3000;
-
-                        $frameworks = Config::getParam('frameworks', []);
-                        $framework = $frameworks[$site->getAttribute('framework', '')] ?? null;
-                        if (!is_null($framework)) {
-                            $config['sleep'] = $framework['screenshotSleep'];
-                        }
-
-                        $screenshot = $screenshots->capture($config);
-
-                        return ['key' => $key, 'screenshot' => $screenshot];
+                        return ['key' => $key, 'screenshot' => $screenshots->capture($config)];
                     } catch (\Throwable $th) {
-                        $screenshotError = $th;
-                        return;
+                        return $th;
                     }
                 };
-            }, \array_keys($configs)));
+            }
 
-            if ($screenshotError instanceof \Throwable) {
-                throw $screenshotError;
+            $captures = batch($tasks);
+
+            foreach ($captures as $capture) {
+                if ($capture instanceof \Throwable) {
+                    throw $capture;
+                }
             }
 
             Span::add('screenshot.count', \count($captures));
@@ -252,7 +235,7 @@ class Screenshots extends Action
                 ->setPayload($deployment->getArrayCopy())
                 ->trigger();
 
-            $site = $dbForProject->updateDocument('sites', $site->getId(), new Document([
+            $dbForProject->updateDocument('sites', $site->getId(), new Document([
                 'deploymentScreenshotDark' => $deployment->getAttribute('screenshotDark', ''),
                 'deploymentScreenshotLight' => $deployment->getAttribute('screenshotLight', ''),
             ]));

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -182,14 +182,14 @@ class Screenshots extends Action
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {
-                        $screenshotError = $th->getMessage();
+                        $screenshotError = $th;
                         return;
                     }
                 };
             }, \array_keys($configs)));
 
-            if (!\is_null($screenshotError)) {
-                throw new \Exception($screenshotError);
+            if ($screenshotError instanceof \Throwable) {
+                throw $screenshotError;
             }
 
             Span::add('screenshot.count', \count($captures));

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -9,8 +9,6 @@ use Appwrite\Permission;
 use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client as ScreenshotsClient;
 use Appwrite\Role;
 use Exception;
-use Utopia\Client;
-use Utopia\Client\Adapter\SwooleCoroutine\Client as SwooleClient;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
@@ -49,6 +47,7 @@ class Screenshots extends Action
             ->inject('project')
             ->inject('deviceForFiles')
             ->inject('telemetry')
+            ->inject('clientForScreenshots')
             ->callback($this->action(...));
     }
 
@@ -59,7 +58,8 @@ class Screenshots extends Action
         Database $dbForProject,
         Document $project,
         Device $deviceForFiles,
-        Telemetry $telemetry
+        Telemetry $telemetry,
+        ScreenshotsClient $clientForScreenshots,
     ): void {
         Span::add('project.id', $project->getId());
 
@@ -113,8 +113,6 @@ class Screenshots extends Action
                 throw new \Exception("Rule for deployment not found");
             }
 
-            $timeout = \intval($site->getAttribute('timeout', '15'));
-
             $bucket = $dbForPlatform->getDocument('buckets', 'screenshots');
 
             if ($bucket->isEmpty()) {
@@ -164,8 +162,8 @@ class Screenshots extends Action
             ]);
 
             $screenshotError = null;
-            $screenshots = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $timeout, &$screenshotError) {
-                return function () use ($key, $configs, $apiKey, $site, $timeout, &$screenshotError) {
+            $screenshots = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $clientForScreenshots, &$screenshotError) {
+                return function () use ($key, $configs, $apiKey, $site, $clientForScreenshots, &$screenshotError) {
                     try {
                         $config = $configs[$key];
 
@@ -180,12 +178,7 @@ class Screenshots extends Action
                             $config['sleep'] = $framework['screenshotSleep'];
                         }
 
-                        $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
-                        $client = new ScreenshotsClient(
-                            (new Client(new SwooleClient()))
-                                ->withTimeout($timeout)
-                        );
-                        $screenshot = $client->capture($browserEndpoint . '/screenshots', $config);
+                        $screenshot = $clientForScreenshots->capture($config);
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -8,14 +8,17 @@ use Appwrite\Event\Realtime;
 use Appwrite\Permission;
 use Appwrite\Role;
 use Exception;
+use Utopia\Client;
+use Utopia\Client\Adapter\SwooleCoroutine\Client as SwooleClient;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
-use Utopia\Fetch\Client as FetchClient;
 use Utopia\Platform\Action;
+use Utopia\Psr7\Method;
+use Utopia\Psr7\Request;
 use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
@@ -111,7 +114,7 @@ class Screenshots extends Action
                 throw new \Exception("Rule for deployment not found");
             }
 
-            $timeout = \intval($site->getAttribute('timeout', '15')) * 1000;
+            $timeout = \intval($site->getAttribute('timeout', '15'));
 
             $bucket = $dbForPlatform->getDocument('buckets', 'screenshots');
 
@@ -179,21 +182,20 @@ class Screenshots extends Action
                         }
 
                         $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
-                        $client = new FetchClient();
-                        $client->setTimeout($timeout);
-                        $client->addHeader('content-type', FetchClient::CONTENT_TYPE_APPLICATION_JSON);
-
-                        $fetchResponse = $client->fetch(
-                            url: $browserEndpoint . '/screenshots',
-                            method: 'POST',
-                            body: $config
+                        $client = (new Client(new SwooleClient()))
+                            ->withTimeout($timeout);
+                        $request = (new Request\Factory())->json(
+                            Method::POST,
+                            $browserEndpoint . '/screenshots',
+                            $config
                         );
+                        $response = $client->sendRequest($request);
 
-                        if ($fetchResponse->getStatusCode() >= 400) {
-                            throw new \Exception($fetchResponse->getBody());
+                        if ($response->getStatusCode() >= 400) {
+                            throw new \Exception((string) $response->getBody());
                         }
 
-                        $screenshot = $fetchResponse->getBody();
+                        $screenshot = (string) $response->getBody();
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -6,7 +6,7 @@ use Ahc\Jwt\JWT;
 use Appwrite\Event\Message\Screenshot;
 use Appwrite\Event\Realtime;
 use Appwrite\Permission;
-use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client as ScreenshotsClient;
+use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client;
 use Appwrite\Role;
 use Exception;
 use Utopia\Compression\Compression;
@@ -59,7 +59,7 @@ class Screenshots extends Action
         Document $project,
         Device $deviceForFiles,
         Telemetry $telemetry,
-        ScreenshotsClient $screenshots,
+        Client $screenshots,
     ): void {
         Span::add('project.id', $project->getId());
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -47,7 +47,7 @@ class Screenshots extends Action
             ->inject('project')
             ->inject('deviceForFiles')
             ->inject('telemetry')
-            ->inject('clientForScreenshots')
+            ->inject('screenshots')
             ->callback($this->action(...));
     }
 
@@ -59,7 +59,7 @@ class Screenshots extends Action
         Document $project,
         Device $deviceForFiles,
         Telemetry $telemetry,
-        ScreenshotsClient $clientForScreenshots,
+        ScreenshotsClient $screenshots,
     ): void {
         Span::add('project.id', $project->getId());
 
@@ -162,8 +162,8 @@ class Screenshots extends Action
             ]);
 
             $screenshotError = null;
-            $screenshots = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $clientForScreenshots, &$screenshotError) {
-                return function () use ($key, $configs, $apiKey, $site, $clientForScreenshots, &$screenshotError) {
+            $captures = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $screenshots, &$screenshotError) {
+                return function () use ($key, $configs, $apiKey, $site, $screenshots, &$screenshotError) {
                     try {
                         $config = $configs[$key];
 
@@ -178,7 +178,7 @@ class Screenshots extends Action
                             $config['sleep'] = $framework['screenshotSleep'];
                         }
 
-                        $screenshot = $clientForScreenshots->capture($config);
+                        $screenshot = $screenshots->capture($config);
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {
@@ -192,12 +192,12 @@ class Screenshots extends Action
                 throw new \Exception($screenshotError);
             }
 
-            Span::add('screenshot.count', \count($screenshots));
+            Span::add('screenshot.count', \count($captures));
 
             $mimeType = "image/png";
             $updates = new Document([]);
 
-            foreach ($screenshots as $data) {
+            foreach ($captures as $data) {
                 $key = $data['key'];
                 $screenshot = $data['screenshot'];
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -23,8 +23,6 @@ use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Counter;
 
-use function Swoole\Coroutine\batch;
-
 class Screenshots extends Action
 {
     public static function getName(): string
@@ -147,7 +145,7 @@ class Screenshots extends Action
             ]);
 
             $sleep = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')]['screenshotSleep'] ?? 3000;
-            $tasks = [];
+            $captures = [];
             foreach (['screenshotLight' => 'light', 'screenshotDark' => 'dark'] as $key => $theme) {
                 $config = [
                     'headers' => [
@@ -158,21 +156,7 @@ class Screenshots extends Action
                     'theme' => $theme,
                     'sleep' => $sleep,
                 ];
-                $tasks[] = function () use ($key, $config, $screenshots) {
-                    try {
-                        return ['key' => $key, 'screenshot' => $screenshots->capture($config)];
-                    } catch (\Throwable $th) {
-                        return $th;
-                    }
-                };
-            }
-
-            $captures = batch($tasks);
-
-            foreach ($captures as $capture) {
-                if ($capture instanceof \Throwable) {
-                    throw $capture;
-                }
+                $captures[] = ['key' => $key, 'screenshot' => $screenshots->capture($config)];
             }
 
             Span::add('screenshot.count', \count($captures));

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -6,6 +6,7 @@ use Ahc\Jwt\JWT;
 use Appwrite\Event\Message\Screenshot;
 use Appwrite\Event\Realtime;
 use Appwrite\Permission;
+use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client as ScreenshotsClient;
 use Appwrite\Role;
 use Exception;
 use Utopia\Client;
@@ -17,8 +18,6 @@ use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
 use Utopia\Platform\Action;
-use Utopia\Psr7\Method;
-use Utopia\Psr7\Request;
 use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
@@ -182,20 +181,11 @@ class Screenshots extends Action
                         }
 
                         $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
-                        $client = (new Client(new SwooleClient()))
-                            ->withTimeout($timeout);
-                        $request = (new Request\Factory())->json(
-                            Method::POST,
-                            $browserEndpoint . '/screenshots',
-                            $config
+                        $client = new ScreenshotsClient(
+                            (new Client(new SwooleClient()))
+                                ->withTimeout($timeout)
                         );
-                        $response = $client->sendRequest($request);
-
-                        if ($response->getStatusCode() >= 400) {
-                            throw new \Exception((string) $response->getBody());
-                        }
-
-                        $screenshot = (string) $response->getBody();
+                        $screenshot = $client->capture($browserEndpoint . '/screenshots', $config);
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
@@ -17,9 +17,6 @@ final readonly class Client
     ) {
     }
 
-    /**
-     * @param array<string, mixed> $config
-     */
     public function capture(array $config): string
     {
         $request = $this->requests->json(Method::POST, $this->uri, $config);

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
@@ -8,16 +8,18 @@ use Utopia\Psr7\Request;
 
 final readonly class Client
 {
-    public function __construct(private ClientInterface $client)
-    {
+    public function __construct(
+        private ClientInterface $client,
+        private string $uri,
+    ) {
     }
 
     /**
      * @param array<string, mixed> $config
      */
-    public function capture(string $url, array $config): string
+    public function capture(array $config): string
     {
-        $request = (new Request\Factory())->json(Method::POST, $url, $config);
+        $request = (new Request\Factory())->json(Method::POST, $this->uri, $config);
         $response = $this->client->sendRequest($request);
 
         if ($response->getStatusCode() >= 400) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Functions\Workers\Screenshots;
+
+use Psr\Http\Client\ClientInterface;
+use Utopia\Psr7\Method;
+use Utopia\Psr7\Request;
+
+final readonly class Client
+{
+    public function __construct(private ClientInterface $client)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function capture(string $url, array $config): string
+    {
+        $request = (new Request\Factory())->json(Method::POST, $url, $config);
+        $response = $this->client->sendRequest($request);
+
+        if ($response->getStatusCode() >= 400) {
+            throw new \Exception((string) $response->getBody());
+        }
+
+        return (string) $response->getBody();
+    }
+}

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
@@ -11,6 +11,7 @@ final readonly class Client
     public function __construct(
         private ClientInterface $client,
         private string $uri,
+        private Request\Factory $requests = new Request\Factory(),
     ) {
     }
 
@@ -19,7 +20,7 @@ final readonly class Client
      */
     public function capture(array $config): string
     {
-        $request = (new Request\Factory())->json(Method::POST, $this->uri, $config);
+        $request = $this->requests->json(Method::POST, $this->uri, $config);
         $response = $this->client->sendRequest($request);
 
         if ($response->getStatusCode() >= 400) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Functions\Workers\Screenshots;
 
+use Appwrite\AppwriteException;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Utopia\Psr7\Method;
 use Utopia\Psr7\Request;
@@ -21,10 +23,26 @@ final readonly class Client
     public function capture(array $config): string
     {
         $request = $this->requests->json(Method::POST, $this->uri, $config);
-        $response = $this->client->sendRequest($request);
+        try {
+            $response = $this->client->sendRequest($request);
+        } catch (ClientExceptionInterface $error) {
+            throw new AppwriteException($error->getMessage());
+        }
 
         if ($response->getStatusCode() >= 400) {
-            throw new \Exception((string) $response->getBody());
+            $body = (string) $response->getBody();
+            $error = \json_decode($body, true);
+
+            if (\is_array($error)) {
+                throw new AppwriteException(
+                    \is_string($error['message'] ?? null) ? $error['message'] : $body,
+                    $response->getStatusCode(),
+                    \is_string($error['type'] ?? null) ? $error['type'] : '',
+                    $body,
+                );
+            }
+
+            throw new AppwriteException($body, $response->getStatusCode(), response: $body);
         }
 
         return (string) $response->getBody();

--- a/tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php
+++ b/tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Functions\Workers\Screenshots;
+
+use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Utopia\Psr7\Response;
+use Utopia\Psr7\Stream;
+
+final class ClientTest extends TestCase
+{
+    public function testCaptureSendsJsonRequestAndReturnsScreenshot(): void
+    {
+        $http = new FakeClient(new Response(body: new Stream('screenshot')));
+        $client = new Client($http);
+
+        $screenshot = $client->capture('http://browser/v1/screenshots', [
+            'url' => 'https://example.com',
+            'theme' => 'dark',
+        ]);
+
+        $this->assertSame('screenshot', $screenshot);
+        $this->assertNotNull($http->request);
+        $this->assertSame('POST', $http->request->getMethod());
+        $this->assertSame('http://browser/v1/screenshots', (string) $http->request->getUri());
+        $this->assertSame('application/json', $http->request->getHeaderLine('content-type'));
+        $this->assertSame(
+            ['url' => 'https://example.com', 'theme' => 'dark'],
+            \json_decode((string) $http->request->getBody(), true, flags: JSON_THROW_ON_ERROR)
+        );
+    }
+
+    public function testCaptureThrowsResponseBodyOnFailure(): void
+    {
+        $client = new Client(new FakeClient(
+            new Response(500, body: new Stream('browser failed'))
+        ));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('browser failed');
+
+        $client->capture('http://browser/v1/screenshots', []);
+    }
+}
+
+final class FakeClient implements ClientInterface
+{
+    public ?RequestInterface $request = null;
+
+    public function __construct(private readonly ResponseInterface $response)
+    {
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->request = $request;
+
+        return $this->response;
+    }
+}

--- a/tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php
+++ b/tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php
@@ -17,9 +17,9 @@ final class ClientTest extends TestCase
     public function testCaptureSendsJsonRequestAndReturnsScreenshot(): void
     {
         $http = new FakeClient(new Response(body: new Stream('screenshot')));
-        $client = new Client($http);
+        $client = new Client($http, 'http://browser/v1/screenshots');
 
-        $screenshot = $client->capture('http://browser/v1/screenshots', [
+        $screenshot = $client->capture([
             'url' => 'https://example.com',
             'theme' => 'dark',
         ]);
@@ -37,14 +37,15 @@ final class ClientTest extends TestCase
 
     public function testCaptureThrowsResponseBodyOnFailure(): void
     {
-        $client = new Client(new FakeClient(
-            new Response(500, body: new Stream('browser failed'))
-        ));
+        $client = new Client(
+            new FakeClient(new Response(500, body: new Stream('browser failed'))),
+            'http://browser/v1/screenshots',
+        );
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('browser failed');
 
-        $client->capture('http://browser/v1/screenshots', []);
+        $client->capture([]);
     }
 }
 

--- a/tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php
+++ b/tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Platform\Modules\Functions\Workers\Screenshots;
 
+use Appwrite\AppwriteException;
 use Appwrite\Platform\Modules\Functions\Workers\Screenshots\Client;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -35,15 +37,73 @@ final class ClientTest extends TestCase
         );
     }
 
-    public function testCaptureThrowsResponseBodyOnFailure(): void
+    public function testCaptureThrowsAppwriteErrorOnFailure(): void
     {
+        $body = \json_encode([
+            'message' => 'Browser failed',
+            'code' => 503,
+            'type' => 'general_server_error',
+            'version' => '1.8.0',
+        ], JSON_THROW_ON_ERROR);
         $client = new Client(
-            new FakeClient(new Response(500, body: new Stream('browser failed'))),
+            new FakeClient(new Response(503, body: new Stream($body))),
             'http://browser/v1/screenshots',
         );
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('browser failed');
+        try {
+            $client->capture([]);
+            $this->fail('Expected capture to throw');
+        } catch (AppwriteException $error) {
+            $this->assertSame('Browser failed', $error->getMessage());
+            $this->assertSame(503, $error->getCode());
+            $this->assertSame('general_server_error', $error->getType());
+            $this->assertSame($body, $error->getResponse());
+        }
+    }
+
+    public function testCapturePreservesNonJsonError(): void
+    {
+        $client = new Client(
+            new FakeClient(new Response(502, body: new Stream('Bad Gateway'))),
+            'http://browser/v1/screenshots',
+        );
+
+        try {
+            $client->capture([]);
+            $this->fail('Expected capture to throw');
+        } catch (AppwriteException $error) {
+            $this->assertSame('Bad Gateway', $error->getMessage());
+            $this->assertSame(502, $error->getCode());
+            $this->assertSame('', $error->getType());
+            $this->assertSame('Bad Gateway', $error->getResponse());
+        }
+    }
+
+    public function testCaptureFallsBackForMalformedAppwriteError(): void
+    {
+        $body = '{"message":[],"type":{}}';
+        $client = new Client(
+            new FakeClient(new Response(500, body: new Stream($body))),
+            'http://browser/v1/screenshots',
+        );
+
+        try {
+            $client->capture([]);
+            $this->fail('Expected capture to throw');
+        } catch (AppwriteException $error) {
+            $this->assertSame($body, $error->getMessage());
+            $this->assertSame(500, $error->getCode());
+            $this->assertSame('', $error->getType());
+            $this->assertSame($body, $error->getResponse());
+        }
+    }
+
+    public function testCaptureNormalizesTransportError(): void
+    {
+        $client = new Client(new FailingClient(), 'http://browser/v1/screenshots');
+
+        $this->expectException(AppwriteException::class);
+        $this->expectExceptionMessage('Connection failed');
 
         $client->capture([]);
     }
@@ -63,4 +123,16 @@ final class FakeClient implements ClientInterface
 
         return $this->response;
     }
+}
+
+final class FailingClient implements ClientInterface
+{
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        throw new TransportException('Connection failed');
+    }
+}
+
+final class TransportException extends \Exception implements ClientExceptionInterface
+{
 }


### PR DESCRIPTION
## What does this PR do?

Migrates the screenshots worker from `utopia-php/fetch` to `utopia-php/client` using the Swoole coroutine adapter.

The screenshots client is registered once as the cached `screenshots` resource and injected into the worker. `Screenshots/Client.php` depends on PSR-18 `ClientInterface`, owns the configured browser `/screenshots` URI, and exposes `capture($config)` without transport or endpoint parameters.

Because PSR-18 has no per-request timeout API, the shared transport uses `_APP_SITES_TIMEOUT`, the ceiling for valid site timeouts, so it does not terminate valid site captures early.

## Test Plan

- `vendor/bin/phpunit tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php`
- `composer lint app/init/resources.php src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php`
- `composer analyze -- app/init/resources.php src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php src/Appwrite/Platform/Modules/Functions/Workers/Screenshots/Client.php tests/unit/Platform/Modules/Functions/Workers/Screenshots/ClientTest.php`
- `vendor/bin/phpunit --testsuite unit` *(859/861 pass; environment failures: empty `_APP_OPENSSL_KEY_V1` and unavailable MaxMind extension)*
- `docker compose exec appwrite test tests/e2e/Services/Sites/SitesConsoleClientTest.php --filter=testSiteScreenshot` *(not run: local `appwrite` service is not running)*

