### PR TITLE
Migrate screenshots worker to utopia-php/client

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -18,6 +18,7 @@ use Appwrite\Event\Publisher\Screenshot as ScreenshotPublisher;
 use Appwrite\Event\Publisher\StatsResources as StatsResourcesPublisher;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Platform\Modules\Storage\Config\StorageCacheControl;
+use Appwrite\Screenshots\Client as ScreenshotsClient;
 use Executor\Executor;
 use OpenRuntimes\Orchestrator\Jobs;
 use Utopia\Abuse\Adapters\TimeLimit\Redis as TimeLimitRedis;
@@ -84,6 +85,14 @@ $container->set('jobs', function () {
     }
 
     return new Jobs($client);
+}, []);
+
+$container->set('screenshots', function () {
+    $client = (new Client(new CurlAdapter()))
+        ->withBaseUri(System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1'))
+        ->withTimeout((int) System::getEnv('_APP_SITES_TIMEOUT', 30));
+
+    return new ScreenshotsClient($client);
 }, []);
 
 $container->set('telemetry', fn () => new NoTelemetry(), []);

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -8,14 +8,17 @@ use Appwrite\Event\Realtime;
 use Appwrite\Permission;
 use Appwrite\Role;
 use Exception;
+use Utopia\Client;
+use Utopia\Client\Adapter\Curl\Client as CurlAdapter;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
-use Utopia\Fetch\Client as FetchClient;
 use Utopia\Platform\Action;
+use Utopia\Psr7\Method;
+use Utopia\Psr7\Request\Factory as RequestFactory;
 use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
@@ -111,7 +114,7 @@ class Screenshots extends Action
                 throw new \Exception("Rule for deployment not found");
             }
 
-            $timeout = \intval($site->getAttribute('timeout', '15')) * 1000;
+            $timeout = \intval($site->getAttribute('timeout', '15'));
 
             $bucket = $dbForPlatform->getDocument('buckets', 'screenshots');
 
@@ -161,9 +164,13 @@ class Screenshots extends Action
                 'deploymentStatusIgnored' => true
             ]);
 
+            $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
+            $client = (new Client(new CurlAdapter()))->withTimeout($timeout);
+            $factory = new RequestFactory();
+
             $screenshotError = null;
-            $screenshots = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $timeout, &$screenshotError) {
-                return function () use ($key, $configs, $apiKey, $site, $timeout, &$screenshotError) {
+            $screenshots = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $browserEndpoint, $client, $factory, &$screenshotError) {
+                return function () use ($key, $configs, $apiKey, $site, $browserEndpoint, $client, $factory, &$screenshotError) {
                     try {
                         $config = $configs[$key];
 
@@ -178,22 +185,13 @@ class Screenshots extends Action
                             $config['sleep'] = $framework['screenshotSleep'];
                         }
 
-                        $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
-                        $client = new FetchClient();
-                        $client->setTimeout($timeout);
-                        $client->addHeader('content-type', FetchClient::CONTENT_TYPE_APPLICATION_JSON);
+                        $response = $client->sendRequest($factory->json(Method::POST, $browserEndpoint . '/screenshots', $config));
 
-                        $fetchResponse = $client->fetch(
-                            url: $browserEndpoint . '/screenshots',
-                            method: 'POST',
-                            body: $config
-                        );
-
-                        if ($fetchResponse->getStatusCode() >= 400) {
-                            throw new \Exception($fetchResponse->getBody());
+                        if ($response->getStatusCode() >= 400) {
+                            throw new \Exception((string)$response->getBody());
                         }
 
-                        $screenshot = $fetchResponse->getBody();
+                        $screenshot = (string)$response->getBody();
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -23,8 +23,6 @@ use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Counter;
 
-use function Swoole\Coroutine\batch;
-
 class Screenshots extends Action
 {
     public static function getName(): string
@@ -156,29 +154,16 @@ class Screenshots extends Action
             $framework = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')] ?? null;
             $sleep = $framework['screenshotSleep'] ?? 3000;
 
-            $tasks = [];
-            foreach (['screenshotLight' => 'light', 'screenshotDark' => 'dark'] as $key => $theme) {
-                // batch() doesn't propagate exceptions out of coroutines; return them instead.
-                $tasks[] = function () use ($key, $theme, $screenshots, $routerHost, $headers, $sleep) {
-                    try {
-                        return ['key' => $key, 'screenshot' => $screenshots->create(
-                            url: $routerHost . '/?appwrite-preview=1&appwrite-theme=' . $theme,
-                            theme: $theme,
-                            headers: $headers,
-                            sleep: $sleep,
-                        )];
-                    } catch (\Throwable $th) {
-                        return $th;
-                    }
-                };
-            }
-
+            // Concurrency comes from the worker's coroutines (_APP_WORKER_MAX_COROUTINES),
+            // so the two themes are captured sequentially within a message.
             $captures = [];
-            foreach (batch($tasks) as $capture) {
-                if ($capture instanceof \Throwable) {
-                    throw $capture;
-                }
-                $captures[] = $capture;
+            foreach (['screenshotLight' => 'light', 'screenshotDark' => 'dark'] as $key => $theme) {
+                $captures[$key] = $screenshots->create(
+                    url: $routerHost . '/?appwrite-preview=1&appwrite-theme=' . $theme,
+                    theme: $theme,
+                    headers: $headers,
+                    sleep: $sleep,
+                );
             }
 
             Span::add('screenshot.count', \count($captures));
@@ -186,10 +171,7 @@ class Screenshots extends Action
             $mimeType = "image/png";
             $updates = new Document([]);
 
-            foreach ($captures as $data) {
-                $key = $data['key'];
-                $screenshot = $data['screenshot'];
-
+            foreach ($captures as $key => $screenshot) {
                 $fileId = ID::unique();
                 $fileName = $fileId . '.png';
                 $path = $deviceForFiles->getPath($fileName);

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -154,8 +154,6 @@ class Screenshots extends Action
             $framework = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')] ?? null;
             $sleep = $framework['screenshotSleep'] ?? 3000;
 
-            // Concurrency comes from the worker's coroutines (_APP_WORKER_MAX_COROUTINES),
-            // so the two themes are captured sequentially within a message.
             $captures = [];
             foreach (['screenshotLight' => 'light', 'screenshotDark' => 'dark'] as $key => $theme) {
                 $captures[$key] = $screenshots->create(

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -7,6 +7,7 @@ use Appwrite\Event\Message\Screenshot;
 use Appwrite\Event\Realtime;
 use Appwrite\Permission;
 use Appwrite\Role;
+use Appwrite\Screenshots\Client as ScreenshotsClient;
 use Exception;
 use Utopia\Client;
 use Utopia\Client\Adapter\Curl\Client as CurlAdapter;
@@ -17,8 +18,6 @@ use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Query;
 use Utopia\Platform\Action;
-use Utopia\Psr7\Method;
-use Utopia\Psr7\Request\Factory as RequestFactory;
 use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
@@ -128,19 +127,6 @@ class Screenshots extends Action
                 $routerHost = "$protocol://{$rule->getAttribute('domain')}";
             }
 
-            $configs = [
-                'screenshotLight' => [
-                    'headers' => [ 'x-appwrite-hostname' => $rule->getAttribute('domain') ],
-                    'url' => $routerHost . '/?appwrite-preview=1&appwrite-theme=light',
-                    'theme' => 'light'
-                ],
-                'screenshotDark' => [
-                    'headers' => [ 'x-appwrite-hostname' => $rule->getAttribute('domain') ],
-                    'url' => $routerHost . '/?appwrite-preview=1&appwrite-theme=dark',
-                    'theme' => 'dark'
-                ],
-            ];
-
             $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 900, 0);
             $apiKey = $jwtObj->encode([
                 'hostnameOverride' => true,
@@ -165,33 +151,33 @@ class Screenshots extends Action
             ]);
 
             $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
-            $client = (new Client(new CurlAdapter()))->withTimeout($timeout);
-            $factory = new RequestFactory();
+            $client = new ScreenshotsClient(
+                (new Client(new CurlAdapter()))
+                    ->withBaseUri($browserEndpoint)
+                    ->withTimeout($timeout)
+            );
+
+            $headers = [
+                'x-appwrite-hostname' => $rule->getAttribute('domain'),
+                'x-appwrite-key' => API_KEY_EPHEMERAL . '_' . $apiKey,
+            ];
+
+            $framework = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')] ?? null;
+            $sleep = $framework['screenshotSleep'] ?? 3000;
+
+            $themes = ['screenshotLight' => 'light', 'screenshotDark' => 'dark'];
 
             $screenshotError = null;
-            $screenshots = batch(\array_map(function ($key) use ($configs, $apiKey, $site, $browserEndpoint, $client, $factory, &$screenshotError) {
-                return function () use ($key, $configs, $apiKey, $site, $browserEndpoint, $client, $factory, &$screenshotError) {
+            $screenshots = batch(\array_map(function ($key) use ($themes, $client, $routerHost, $headers, $sleep, &$screenshotError) {
+                return function () use ($key, $themes, $client, $routerHost, $headers, $sleep, &$screenshotError) {
                     try {
-                        $config = $configs[$key];
-
-                        $config['headers'] = \array_merge($config['headers'], [
-                            'x-appwrite-key' => API_KEY_EPHEMERAL . '_' . $apiKey
-                        ]);
-                        $config['sleep'] = 3000;
-
-                        $frameworks = Config::getParam('frameworks', []);
-                        $framework = $frameworks[$site->getAttribute('framework', '')] ?? null;
-                        if (!is_null($framework)) {
-                            $config['sleep'] = $framework['screenshotSleep'];
-                        }
-
-                        $response = $client->sendRequest($factory->json(Method::POST, $browserEndpoint . '/screenshots', $config));
-
-                        if ($response->getStatusCode() >= 400) {
-                            throw new \Exception((string)$response->getBody());
-                        }
-
-                        $screenshot = (string)$response->getBody();
+                        $theme = $themes[$key];
+                        $screenshot = $client->create(
+                            url: $routerHost . '/?appwrite-preview=1&appwrite-theme=' . $theme,
+                            theme: $theme,
+                            headers: $headers,
+                            sleep: $sleep,
+                        );
 
                         return ['key' => $key, 'screenshot' => $screenshot];
                     } catch (\Throwable $th) {
@@ -199,7 +185,7 @@ class Screenshots extends Action
                         return;
                     }
                 };
-            }, \array_keys($configs)));
+            }, \array_keys($themes)));
 
             if (!\is_null($screenshotError)) {
                 throw new \Exception($screenshotError);

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -7,7 +7,7 @@ use Appwrite\Event\Message\Screenshot;
 use Appwrite\Event\Realtime;
 use Appwrite\Permission;
 use Appwrite\Role;
-use Appwrite\Screenshots\Client as ScreenshotsClient;
+use Appwrite\Screenshots\Client;
 use Exception;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
@@ -59,7 +59,7 @@ class Screenshots extends Action
         Document $project,
         Device $deviceForFiles,
         Telemetry $telemetry,
-        ScreenshotsClient $screenshots
+        Client $screenshots
     ): void {
         Span::add('project.id', $project->getId());
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -9,8 +9,6 @@ use Appwrite\Permission;
 use Appwrite\Role;
 use Appwrite\Screenshots\Client as ScreenshotsClient;
 use Exception;
-use Utopia\Client;
-use Utopia\Client\Adapter\Curl\Client as CurlAdapter;
 use Utopia\Compression\Compression;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
@@ -49,6 +47,7 @@ class Screenshots extends Action
             ->inject('project')
             ->inject('deviceForFiles')
             ->inject('telemetry')
+            ->inject('screenshots')
             ->callback($this->action(...));
     }
 
@@ -59,7 +58,8 @@ class Screenshots extends Action
         Database $dbForProject,
         Document $project,
         Device $deviceForFiles,
-        Telemetry $telemetry
+        Telemetry $telemetry,
+        ScreenshotsClient $screenshots
     ): void {
         Span::add('project.id', $project->getId());
 
@@ -113,8 +113,6 @@ class Screenshots extends Action
                 throw new \Exception("Rule for deployment not found");
             }
 
-            $timeout = \intval($site->getAttribute('timeout', '15'));
-
             $bucket = $dbForPlatform->getDocument('buckets', 'screenshots');
 
             if ($bucket->isEmpty()) {
@@ -150,13 +148,6 @@ class Screenshots extends Action
                 'deploymentStatusIgnored' => true
             ]);
 
-            $browserEndpoint = System::getEnv('_APP_BROWSER_HOST', 'http://appwrite-browser:3000/v1');
-            $client = new ScreenshotsClient(
-                (new Client(new CurlAdapter()))
-                    ->withBaseUri($browserEndpoint)
-                    ->withTimeout($timeout)
-            );
-
             $headers = [
                 'x-appwrite-hostname' => $rule->getAttribute('domain'),
                 'x-appwrite-key' => API_KEY_EPHEMERAL . '_' . $apiKey,
@@ -168,11 +159,11 @@ class Screenshots extends Action
             $themes = ['screenshotLight' => 'light', 'screenshotDark' => 'dark'];
 
             $screenshotError = null;
-            $screenshots = batch(\array_map(function ($key) use ($themes, $client, $routerHost, $headers, $sleep, &$screenshotError) {
-                return function () use ($key, $themes, $client, $routerHost, $headers, $sleep, &$screenshotError) {
+            $captures = batch(\array_map(function ($key) use ($themes, $screenshots, $routerHost, $headers, $sleep, &$screenshotError) {
+                return function () use ($key, $themes, $screenshots, $routerHost, $headers, $sleep, &$screenshotError) {
                     try {
                         $theme = $themes[$key];
-                        $screenshot = $client->create(
+                        $screenshot = $screenshots->create(
                             url: $routerHost . '/?appwrite-preview=1&appwrite-theme=' . $theme,
                             theme: $theme,
                             headers: $headers,
@@ -191,12 +182,12 @@ class Screenshots extends Action
                 throw new \Exception($screenshotError);
             }
 
-            Span::add('screenshot.count', \count($screenshots));
+            Span::add('screenshot.count', \count($captures));
 
             $mimeType = "image/png";
             $updates = new Document([]);
 
-            foreach ($screenshots as $data) {
+            foreach ($captures as $data) {
                 $key = $data['key'];
                 $screenshot = $data['screenshot'];
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Screenshots.php
@@ -156,30 +156,29 @@ class Screenshots extends Action
             $framework = Config::getParam('frameworks', [])[$site->getAttribute('framework', '')] ?? null;
             $sleep = $framework['screenshotSleep'] ?? 3000;
 
-            $themes = ['screenshotLight' => 'light', 'screenshotDark' => 'dark'];
-
-            $screenshotError = null;
-            $captures = batch(\array_map(function ($key) use ($themes, $screenshots, $routerHost, $headers, $sleep, &$screenshotError) {
-                return function () use ($key, $themes, $screenshots, $routerHost, $headers, $sleep, &$screenshotError) {
+            $tasks = [];
+            foreach (['screenshotLight' => 'light', 'screenshotDark' => 'dark'] as $key => $theme) {
+                // batch() doesn't propagate exceptions out of coroutines; return them instead.
+                $tasks[] = function () use ($key, $theme, $screenshots, $routerHost, $headers, $sleep) {
                     try {
-                        $theme = $themes[$key];
-                        $screenshot = $screenshots->create(
+                        return ['key' => $key, 'screenshot' => $screenshots->create(
                             url: $routerHost . '/?appwrite-preview=1&appwrite-theme=' . $theme,
                             theme: $theme,
                             headers: $headers,
                             sleep: $sleep,
-                        );
-
-                        return ['key' => $key, 'screenshot' => $screenshot];
+                        )];
                     } catch (\Throwable $th) {
-                        $screenshotError = $th->getMessage();
-                        return;
+                        return $th;
                     }
                 };
-            }, \array_keys($themes)));
+            }
 
-            if (!\is_null($screenshotError)) {
-                throw new \Exception($screenshotError);
+            $captures = [];
+            foreach (batch($tasks) as $capture) {
+                if ($capture instanceof \Throwable) {
+                    throw $capture;
+                }
+                $captures[] = $capture;
             }
 
             Span::add('screenshot.count', \count($captures));

--- a/src/Appwrite/Screenshots/Client.php
+++ b/src/Appwrite/Screenshots/Client.php
@@ -22,9 +22,6 @@ class Client
     /**
      * Capture a screenshot of a page and return the PNG bytes.
      *
-     * The browser service responds with raw image bytes on success and
-     * `{"error": message}` with a 4xx status on failure.
-     *
      * @param array<string, string> $headers
      * @throws Exception on an error response
      * @throws ClientExceptionInterface on transport failure

--- a/src/Appwrite/Screenshots/Client.php
+++ b/src/Appwrite/Screenshots/Client.php
@@ -22,8 +22,11 @@ class Client
     /**
      * Capture a screenshot of a page and return the PNG bytes.
      *
+     * The browser service responds with raw image bytes on success and
+     * `{"error": message}` with a 4xx status on failure.
+     *
      * @param array<string, string> $headers
-     * @throws \Exception on an error response
+     * @throws Exception on an error response
      * @throws ClientExceptionInterface on transport failure
      */
     public function create(string $url, string $theme, array $headers = [], int $sleep = 3000): string
@@ -35,10 +38,19 @@ class Client
             'sleep' => $sleep,
         ]));
 
-        if ($response->getStatusCode() >= 400) {
-            throw new \Exception((string)$response->getBody());
+        $status = $response->getStatusCode();
+        $body = (string)$response->getBody();
+
+        if ($status >= 400) {
+            $error = \json_decode($body, true)['error'] ?? null;
+            throw new Exception(\is_string($error) ? $error : 'Screenshot failed with status ' . $status, $status);
         }
 
-        return (string)$response->getBody();
+        $contentType = $response->getHeaderLine('Content-Type');
+        if (!\str_starts_with($contentType, 'image/')) {
+            throw new Exception('Expected an image response, got ' . ($contentType === '' ? 'no content type' : $contentType), $status);
+        }
+
+        return $body;
     }
 }

--- a/src/Appwrite/Screenshots/Client.php
+++ b/src/Appwrite/Screenshots/Client.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Appwrite\Screenshots;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Utopia\Psr7\Method;
+use Utopia\Psr7\Request\Factory;
+
+class Client
+{
+    private Factory $factory;
+
+    /**
+     * @param ClientInterface $client Configured with the browser service base URI.
+     */
+    public function __construct(private readonly ClientInterface $client)
+    {
+        $this->factory = new Factory();
+    }
+
+    /**
+     * Capture a screenshot of a page and return the PNG bytes.
+     *
+     * @param array<string, string> $headers
+     * @throws \Exception on an error response
+     * @throws ClientExceptionInterface on transport failure
+     */
+    public function create(string $url, string $theme, array $headers = [], int $sleep = 3000): string
+    {
+        $response = $this->client->sendRequest($this->factory->json(Method::POST, 'screenshots', [
+            'url' => $url,
+            'theme' => $theme,
+            'headers' => $headers,
+            'sleep' => $sleep,
+        ]));
+
+        if ($response->getStatusCode() >= 400) {
+            throw new \Exception((string)$response->getBody());
+        }
+
+        return (string)$response->getBody();
+    }
+}

--- a/src/Appwrite/Screenshots/Exception.php
+++ b/src/Appwrite/Screenshots/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Appwrite\Screenshots;
+
+class Exception extends \Exception
+{
+}

--- a/tests/unit/Screenshots/ClientTest.php
+++ b/tests/unit/Screenshots/ClientTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Screenshots;
+
+use Appwrite\Screenshots\Client;
+use Appwrite\Screenshots\Exception;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Utopia\Psr7\Response;
+use Utopia\Psr7\Stream;
+
+final class ClientTest extends TestCase
+{
+    private ?RequestInterface $request = null;
+
+    private function client(ResponseInterface $response): Client
+    {
+        $test = $this;
+        return new Client(new class ($response, $test) implements ClientInterface {
+            public function __construct(private ResponseInterface $response, private ClientTest $test)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                $this->test->setRequest($request);
+                return $this->response;
+            }
+        });
+    }
+
+    public function setRequest(RequestInterface $request): void
+    {
+        $this->request = $request;
+    }
+
+    public function testCreate(): void
+    {
+        $response = (new Response(200, body: new Stream('png-bytes')))
+            ->withHeader('Content-Type', 'image/png');
+
+        $screenshot = $this->client($response)->create(
+            url: 'http://appwrite/',
+            theme: 'dark',
+            headers: ['x-appwrite-hostname' => 'example.com'],
+            sleep: 500,
+        );
+
+        $this->assertSame('png-bytes', $screenshot);
+        $this->assertSame('POST', $this->request->getMethod());
+        $this->assertSame('screenshots', (string)$this->request->getUri());
+        $this->assertEquals([
+            'url' => 'http://appwrite/',
+            'theme' => 'dark',
+            'headers' => ['x-appwrite-hostname' => 'example.com'],
+            'sleep' => 500,
+        ], \json_decode((string)$this->request->getBody(), true));
+    }
+
+    public function testCreateError(): void
+    {
+        $response = (new Response(400, body: new Stream('{"error":"Timeout exceeded"}')))
+            ->withHeader('Content-Type', 'application/json');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Timeout exceeded');
+        $this->expectExceptionCode(400);
+
+        $this->client($response)->create('http://appwrite/', 'light');
+    }
+
+    public function testCreateErrorWithoutBody(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Screenshot failed with status 502');
+
+        $this->client(new Response(502))->create('http://appwrite/', 'light');
+    }
+
+    public function testCreateUnexpectedContentType(): void
+    {
+        $response = (new Response(200, body: new Stream('<html>')))
+            ->withHeader('Content-Type', 'text/html');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Expected an image response, got text/html');
+
+        $this->client($response)->create('http://appwrite/', 'light');
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Migrates the screenshots worker from `utopia-php/fetch` to the PSR-18 `utopia-php/client`, extracting the browser-service HTTP logic into a new `Appwrite\Screenshots\Client` provided as a DI resource.

- `Screenshots\Client` takes any `Psr\Http\Client\ClientInterface`, so the transport is swappable in tests. It exposes `create(url, theme, headers, sleep): string` returning the PNG bytes.
- The client is registered once as the `screenshots` resource in `app/init/resources.php` (next to `jobs`), configured with the `_APP_BROWSER_HOST` base URI and a timeout of `_APP_SITES_TIMEOUT` (default 30s), and injected into the worker.
- Error handling matches the browser service contract ([appwrite/docker-browser 0.3.2](https://github.com/appwrite/docker-browser)): raw image bytes on success, 4xx JSON `{"error": message}` on failure. Errors surface as a typed `Screenshots\Exception` carrying the message and status code, and non-image success responses are rejected instead of being saved as PNG files.
- The per-message `batch()` coroutine fan-out is removed: the worker already runs with `_APP_WORKERS_NUM=1` and `_APP_WORKER_MAX_COROUTINES=8`, so concurrency across messages comes from the queue adapter. Light/dark themes are captured sequentially, which deletes the task closures and the by-reference error plumbing, and lets failures propagate as plain exceptions.

**Behavior notes:**
- The HTTP timeout was previously the per-site `timeout` attribute (in ms via fetch); it is now the sites timeout upper bound (`_APP_SITES_TIMEOUT`), since a shared resource can't carry per-site state. This also avoids failures where a site's timeout was shorter than the screenshot sleep.
- Per-deployment screenshot latency roughly doubles (two sequential captures instead of parallel), while overall throughput is preserved by the worker's coroutine pool.

## Test Plan

- New unit tests (`tests/unit/Screenshots/ClientTest.php`) cover the request shape, success path, JSON error responses, empty error bodies, and unexpected content types via a stubbed PSR-18 client.
- `composer lint` / `composer analyze` / `composer refactor:check` pass.
- Not exercised end-to-end locally (requires a full stack with the browser service and a sites deployment); relying on the sites E2E suite in CI.

## Related PRs and Issues

None.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include the necessary specs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)