### PR TITLE
fix(compute): drop duplicate building realtime event in executor builds

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -622,10 +622,6 @@ class Builds extends Action
 
             $resource = $this->updateLatestDeployment($dbForProject, $resource);
 
-            $queueForRealtime
-                ->setPayload($deployment->getArrayCopy())
-                ->trigger();
-
             if ($isVcsEnabled) {
                 $this->runGitAction('building', $github, $providerCommitHash, $owner, $repositoryName, $project, $resource, $deployment->getId(), $dbForProject, $dbForPlatform, $queueForRealtime, $platform);
             }

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -2378,7 +2378,7 @@ final class RealtimeCustomClientTest extends Scope
                 'origin' => 'http://localhost',
                 'cookie' => 'a_session_' . $projectId . '=' . $session
             ],
-            timeout: 10
+            timeout: 30
         );
 
         $response = json_decode($client->receive(), true);


### PR DESCRIPTION
## What does this PR do?

Removes a redundant realtime trigger in the executor build path and de-flakes `testChannelExecutions`.

In `Workers/Builds.php`, the status→`building` transition fired realtime **twice** with an identical empty-`buildLogs` payload: once immediately after `updateLatestDeployment`, and again moments later as part of the canonical webhook/functions/realtime triplet. This PR drops the first (stray) trigger and keeps the triplet.

The duplicate was harmless until 6276a5f3bd (#12806) rewrote `RealtimeConsoleClientTest::testCreateDeployment` to assert that `buildLogs` change between consecutive `building` events. On the **executor** backend (`_APP_BUILDS_BACKEND` unset — the code default) the duplicate pair makes that assertion fail deterministically as `assertNotEquals('', '')` at line 1111. This repo's CI runs the **orchestrator** backend (set in `.env`), where manual-upload builds never reach this worker, so CE CI never sees it — downstream executor-mode CI (Appwrite Cloud, where the CE E2E suites run against the cloud stack) has been hard-red on `Tests / CE / E2E / Realtime (dedicated)` since the bump landed there.

Also bumps the `testChannelExecutions` websocket read timeout 10s → 30s: the 10s timeout knife-edge races the deliberately-timing-out execution (~10.3s) whose only realtime `update` fires at completion — a long-standing pre-existing flake (it failed attempt 1 even on green runs) that compounds the failure above under retry.

## Test Plan

- `testCreateDeployment` is the regression test for the worker change: with `_APP_BUILDS_BACKEND=executor` it fails without this fix (`assertNotEquals('', '')`) and passes with it; orchestrator behavior is untouched (that path returns before this code).
- Existing Realtime E2E suites cover both changed paths in CI.
- Verified the log-streaming callback only triggers realtime when logs actually changed (`$affected` gate), so after this change the executor path emits exactly one empty-logs `building` event followed by growing-logs events.

## Related PRs and Issues

- Root-cause analysis: [DAT-1782](https://linear.app/appwrite/issue/DAT-1782/ce-realtime-dedicated-ci-suite-broke-between-07-09-and-07-11)
- Fallout from #12806 (jobs build backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)