### PR TITLE
test(realtime): tolerate non-growing build logs between deployment updates

### DIFF
--- a/tests/e2e/Services/Realtime/RealtimeConsoleClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeConsoleClientTest.php
@@ -1090,8 +1090,11 @@ final class RealtimeConsoleClientTest extends Scope
         // waiting → building → ready/failed (the jobs backend has no intermediate
         // "processing" phase and may interleave extra update events), so assert
         // the meaningful milestones tolerantly rather than a fixed positional
-        // sequence: the build reaches "building" with a growing log, then a
-        // terminal "ready" carrying the build metadata.
+        // sequence: the build reaches "building" with an accumulating log, then
+        // a terminal "ready" carrying the build metadata. Consecutive updates
+        // may carry unchanged (even still-empty) logs when triggered by a
+        // non-log attribute change, so logs are only required to never shrink;
+        // the terminal assertions below guarantee they eventually streamed.
         $sawBuilding = false;
         $previousBuildLogs = null;
         $payload = null;
@@ -1108,9 +1111,13 @@ final class RealtimeConsoleClientTest extends Scope
             if ($payload['status'] === 'building') {
                 $sawBuilding = true;
                 if ($previousBuildLogs !== null) {
-                    $this->assertNotEquals($previousBuildLogs, $payload['buildLogs']);
+                    $this->assertGreaterThanOrEqual(
+                        \strlen($previousBuildLogs),
+                        \strlen((string) $payload['buildLogs']),
+                        'Build logs must never shrink between deployment updates.'
+                    );
                 }
-                $previousBuildLogs = $payload['buildLogs'];
+                $previousBuildLogs = (string) $payload['buildLogs'];
             }
 
             if ($payload['status'] === 'ready' && !empty($payload['buildDuration']) && !empty($payload['buildEndedAt'])) {


### PR DESCRIPTION
## What does this PR do?

Follow-up to 6276a5f3bd ("Make the realtime deployment test backend-tolerant"). The tolerant consume loop in `RealtimeConsoleClientTest::testCreateDeployment` still asserted that build logs strictly change between consecutive `building` updates:

```
Failed asserting that '' is not equal to ''.
RealtimeConsoleClientTest.php:1111
```

A deployment update event triggered by a non-log attribute change can legitimately carry unchanged logs — including two still-empty payloads early in the build — so the strict `assertNotEquals` fails intermittently (seen consistently across in-job retries on cloud CI, e.g. appwrite-labs/cloud#4729).

Build logs accumulate, so the real invariant is that they never shrink between updates. This PR replaces the strict inequality with a non-shrinking length assertion. The terminal `assertNotEmpty($payload['buildLogs'])` already guarantees logs eventually streamed, so no coverage is lost.

## Test plan

- `php -l` and Pint pass on the file.
- Realtime E2E suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)