### PR TITLE
fix(users): guard permanent console user deletion (#11393)

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -2661,7 +2661,7 @@ Http::delete('/v1/users/:userId')
                     'users',
                     [
                         Query::equal('status', [true]),
-                        Query::notEqual('$id', [$target->getId()]),
+                        Query::notEqual('$id', $target->getId()),
                     ],
                     1
                 );

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -2639,20 +2639,45 @@ Http::delete('/v1/users/:userId')
     ->inject('dbForProject')
     ->inject('queueForEvents')
     ->inject('publisherForDeletes')
-    ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents, DeletePublisher $publisherForDeletes) {
+    ->inject('user')
+    ->inject('project')
+    ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents, DeletePublisher $publisherForDeletes, Document $user, Document $project) {
 
-        $user = $dbForProject->getDocument('users', $userId);
+        $target = $dbForProject->getDocument('users', $userId);
 
-        if ($user->isEmpty()) {
+        if ($target->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
+        // Session actors cannot delete themselves via the Users API.
+        // Self-service account removal must use DELETE /v1/account.
+        if (!$user->isEmpty() && $user->getId() === $target->getId()) {
+            throw new Exception(
+                Exception::USER_DELETION_PROHIBITED,
+                'You cannot delete your own account with the Users API. Use the account delete endpoint instead.'
+            );
+        }
+
+        // Extra safeguards when managing console (platform) accounts.
+        // Membership cleanup is handled asynchronously by the deletes worker
+        // (same model as DELETE /v1/account for console users).
+        if ($project->getId() === 'console') {
+            // Never delete the last remaining console user — that bricks the instance.
+            $consoleUsersCount = $dbForProject->count('users', [], 2);
+            if ($consoleUsersCount <= 1) {
+                throw new Exception(
+                    Exception::USER_DELETION_PROHIBITED,
+                    'Cannot delete the last remaining console user.'
+                );
+            }
+        }
+
         // clone user object to send to workers
-        $clone = clone $user;
+        $clone = clone $target;
 
         $dbForProject->deleteDocument('users', $userId);
-        DeleteIdentities::delete($dbForProject, Query::equal('userInternalId', [$user->getSequence()]));
-        DeleteTargets::delete($dbForProject, Query::equal('userInternalId', [$user->getSequence()]));
+        DeleteIdentities::delete($dbForProject, Query::equal('userInternalId', [$target->getSequence()]));
+        DeleteTargets::delete($dbForProject, Query::equal('userInternalId', [$target->getSequence()]));
 
         $publisherForDeletes->enqueue(new DeleteMessage(
             project: $queueForEvents->getProject(),
@@ -2661,7 +2686,7 @@ Http::delete('/v1/users/:userId')
         ));
 
         $queueForEvents
-            ->setParam('userId', $user->getId())
+            ->setParam('userId', $target->getId())
             ->setPayload($response->output($clone, Response::MODEL_USER));
 
         $response->noContent();

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -2643,36 +2643,54 @@ Http::delete('/v1/users/:userId')
     ->inject('project')
     ->action(function (string $userId, Response $response, Database $dbForProject, Event $queueForEvents, DeletePublisher $publisherForDeletes, Document $user, Document $project) {
 
+        $assertCanDelete = function (Document $target) use ($user, $project, $dbForProject): void {
+            // Session actors cannot delete themselves via the Users API.
+            // Self-service account removal must use DELETE /v1/account.
+            if (!$user->isEmpty() && $user->getId() === $target->getId()) {
+                throw new Exception(
+                    Exception::USER_DELETION_PROHIBITED,
+                    'You cannot delete your own account with the Users API. Use the account delete endpoint instead.'
+                );
+            }
+
+            // Console (platform) accounts: refuse deleting the last *active*
+            // user so the instance cannot be locked out. Blocked users do not
+            // count as usable admins.
+            if ($project->getId() === 'console' && $target->getAttribute('status', true) === true) {
+                $otherActiveCount = $dbForProject->count(
+                    'users',
+                    [
+                        Query::equal('status', [true]),
+                        Query::notEqual('$id', [$target->getId()]),
+                    ],
+                    1
+                );
+
+                if ($otherActiveCount === 0) {
+                    throw new Exception(
+                        Exception::USER_DELETION_PROHIBITED,
+                        'Cannot delete the last remaining active console user.'
+                    );
+                }
+            }
+        };
+
         $target = $dbForProject->getDocument('users', $userId);
 
         if ($target->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
-        // Session actors cannot delete themselves via the Users API.
-        // Self-service account removal must use DELETE /v1/account.
-        if (!$user->isEmpty() && $user->getId() === $target->getId()) {
-            throw new Exception(
-                Exception::USER_DELETION_PROHIBITED,
-                'You cannot delete your own account with the Users API. Use the account delete endpoint instead.'
-            );
-        }
+        $assertCanDelete($target);
 
-        // Extra safeguards when managing console (platform) accounts.
-        // Membership cleanup is handled asynchronously by the deletes worker
-        // (same model as DELETE /v1/account for console users).
-        if ($project->getId() === 'console') {
-            // Never delete the last remaining console user — that bricks the instance.
-            $consoleUsersCount = $dbForProject->count('users', [], 2);
-            if ($consoleUsersCount <= 1) {
-                throw new Exception(
-                    Exception::USER_DELETION_PROHIBITED,
-                    'Cannot delete the last remaining console user.'
-                );
-            }
+        // Re-check immediately before mutating to shrink the concurrent-delete
+        // race window (two admins deleting the last two active accounts).
+        $target = $dbForProject->getDocument('users', $userId);
+        if ($target->isEmpty()) {
+            throw new Exception(Exception::USER_NOT_FOUND);
         }
+        $assertCanDelete($target);
 
-        // clone user object to send to workers
         $clone = clone $target;
 
         $dbForProject->deleteDocument('users', $userId);

--- a/tests/e2e/Services/Users/UsersConsoleClientTest.php
+++ b/tests/e2e/Services/Users/UsersConsoleClientTest.php
@@ -84,6 +84,39 @@ final class UsersConsoleClientTest extends Scope
         $this->assertNotEmpty($set['body']['password']);
     }
 
+    /**
+     * Console project user permanent deletion guards and happy path.
+     *
+     * Covers the API used by self-hosted platform user management
+     * (issue #11393): org-scoped admin session can delete another console
+     * user, but cannot delete itself or the last remaining console user.
+     */
+    public function testConsoleUserPermanentDeleteGuards(): void
+    {
+        $projectId = $this->getProject()['$id'];
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders());
+
+        // Create a disposable user to delete
+        $targetId = ID::unique();
+        $created = $this->client->call(Client::METHOD_POST, '/users', $headers, [
+            'userId' => $targetId,
+            'email' => $targetId . '@example.com',
+            'password' => 'password123',
+            'name' => 'Delete Target',
+        ]);
+        $this->assertEquals(201, $created['headers']['status-code']);
+
+        // Happy path: admin can permanently delete another user
+        $deleted = $this->client->call(Client::METHOD_DELETE, '/users/' . $targetId, $headers);
+        $this->assertEquals(204, $deleted['headers']['status-code']);
+
+        $missing = $this->client->call(Client::METHOD_GET, '/users/' . $targetId, $headers);
+        $this->assertEquals(404, $missing['headers']['status-code']);
+    }
+
     public function testImpersonateQueryParams(): void
     {
         $projectId = $this->getProject()['$id'];

--- a/tests/e2e/Services/Users/UsersConsoleClientTest.php
+++ b/tests/e2e/Services/Users/UsersConsoleClientTest.php
@@ -85,11 +85,11 @@ final class UsersConsoleClientTest extends Scope
     }
 
     /**
-     * Console project user permanent deletion guards and happy path.
+     * Permanent user deletion happy path + self-delete guard (issue #11393).
      *
-     * Covers the API used by self-hosted platform user management
-     * (issue #11393): org-scoped admin session can delete another console
-     * user, but cannot delete itself or the last remaining console user.
+     * Self-delete is enforced for any project when the session actor id matches
+     * the target. The last-active-console-user guard only applies on project
+     * "console" and is covered separately where multi-user isolation allows it.
      */
     public function testConsoleUserPermanentDeleteGuards(): void
     {
@@ -115,6 +115,38 @@ final class UsersConsoleClientTest extends Scope
 
         $missing = $this->client->call(Client::METHOD_GET, '/users/' . $targetId, $headers);
         $this->assertEquals(404, $missing['headers']['status-code']);
+    }
+
+    /**
+     * Session actors must not delete themselves via the Users API.
+     * Create a project user with the same ID as the console root actor so the
+     * actor/target id comparison fires under admin mode.
+     */
+    public function testUsersDeleteRejectsSelfDelete(): void
+    {
+        $projectId = $this->getProject()['$id'];
+        $rootId = $this->getRoot()['$id'];
+        $headers = array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders());
+
+        // Best-effort: create a user whose $id matches the console session actor.
+        $created = $this->client->call(Client::METHOD_POST, '/users', $headers, [
+            'userId' => $rootId,
+            'email' => 'self-delete-' . $rootId . '@example.com',
+            'password' => 'password123',
+            'name' => 'Self Delete Target',
+        ]);
+
+        // If the id already exists from a prior run, fetch and proceed.
+        if ($created['headers']['status-code'] === 201 || $created['headers']['status-code'] === 409) {
+            $selfDelete = $this->client->call(Client::METHOD_DELETE, '/users/' . $rootId, $headers);
+            $this->assertEquals(400, $selfDelete['headers']['status-code']);
+            $this->assertEquals('user_deletion_prohibited', $selfDelete['body']['type']);
+        } else {
+            $this->markTestSkipped('Could not create self-delete target user: ' . ($created['body']['message'] ?? ''));
+        }
     }
 
     public function testImpersonateQueryParams(): void


### PR DESCRIPTION
## Summary

Related to #11393 (GUI: [appwrite/console#3117](https://github.com/appwrite/console/pull/3117)).

When self-hosted admins permanently delete console (platform) accounts via `DELETE /v1/users/{userId}` with organization context, add safety guards:

1. **No self-delete via Users API** — session actors cannot delete their own user id (must use `DELETE /v1/account`)
2. **No last console user** — refuse deleting the only remaining account on the console project (would lock out the instance)

These guard the permanent-delete flow exposed in the console UI for self-hosted instances.

## Test plan

- [x] PHP syntax check on `app/controllers/api/users.php`
- [x] Local 1.9.5 verification of existing delete path (org-scoped admin → 204)
- [x] E2E test added: `UsersConsoleClientTest::testConsoleUserPermanentDeleteGuards` (happy path delete + 404 after)
- [ ] CI e2e suite for Users console client
- [ ] Verify self-delete via Users API returns `user_deletion_prohibited`
- [ ] Verify deleting last console user returns `user_deletion_prohibited`

## Notes

- Project-scoped Auth user deletion is unchanged for non-console projects (only self-delete actor check applies)
- Membership cleanup remains async via the deletes worker (same model as `DELETE /v1/account` for console)