### PR TITLE
Carry sdk and sdkVersion through audit event

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -611,6 +611,8 @@ Http::init()
         $auditContext->userAgent = $request->getUserAgent('');
         $auditContext->ip = $request->getIP();
         $auditContext->hostname = $request->getHostname();
+        $auditContext->sdk = \strtolower($request->getHeaderLine('x-sdk-name', ''));
+        $auditContext->sdkVersion = $request->getHeaderLine('x-sdk-version', '');
         $auditContext->event = $route->getLabel('audits.event', '');
         $auditContext->project = $project;
         $auditContext->impersonatorUser = $impersonatorUser->isEmpty() ? null : $impersonatorUser;

--- a/src/Appwrite/Event/Audit.php
+++ b/src/Appwrite/Event/Audit.php
@@ -12,6 +12,8 @@ class Audit extends Event
     protected string $userAgent = '';
     protected string $ip = '';
     protected string $hostname = '';
+    protected string $sdk = '';
+    protected string $sdkVersion = '';
 
     protected bool $critical = false;
 
@@ -141,6 +143,52 @@ class Audit extends Event
     }
 
     /**
+     * Set SDK name for this audit event.
+     *
+     * @param string $sdk
+     * @return self
+     */
+    public function setSdk(string $sdk): self
+    {
+        $this->sdk = $sdk;
+
+        return $this;
+    }
+
+    /**
+     * Returns the set audit SDK name.
+     *
+     * @return string
+     */
+    public function getSdk(): string
+    {
+        return $this->sdk;
+    }
+
+    /**
+     * Set SDK version for this audit event.
+     *
+     * @param string $sdkVersion
+     * @return self
+     */
+    public function setSdkVersion(string $sdkVersion): self
+    {
+        $this->sdkVersion = $sdkVersion;
+
+        return $this;
+    }
+
+    /**
+     * Returns the set audit SDK version.
+     *
+     * @return string
+     */
+    public function getSdkVersion(): string
+    {
+        return $this->sdkVersion;
+    }
+
+    /**
      * Prepare payload for queue.
      *
      * @return array
@@ -156,7 +204,9 @@ class Audit extends Event
             'ip' => $this->ip,
             'userAgent' => $this->userAgent,
             'event' => $this->event,
-            'hostname' => $this->hostname
+            'hostname' => $this->hostname,
+            'sdk' => $this->sdk,
+            'sdkVersion' => $this->sdkVersion
         ];
     }
 }

--- a/src/Appwrite/Event/Context/Audit.php
+++ b/src/Appwrite/Event/Context/Audit.php
@@ -14,6 +14,8 @@ class Audit
         public string $userAgent = '',
         public string $ip = '',
         public string $hostname = '',
+        public string $sdk = '',
+        public string $sdkVersion = '',
         public string $event = '',
         public string $resource = '',
         public array $payload = [],
@@ -29,6 +31,8 @@ class Audit
             && $this->userAgent === ''
             && $this->ip === ''
             && $this->hostname === ''
+            && $this->sdk === ''
+            && $this->sdkVersion === ''
             && $this->event === ''
             && $this->resource === ''
             && $this->payload === [];

--- a/src/Appwrite/Event/Message/Audit.php
+++ b/src/Appwrite/Event/Message/Audit.php
@@ -18,6 +18,8 @@ final class Audit extends Base
         public readonly string $ip = '',
         public readonly string $userAgent = '',
         public readonly string $hostname = '',
+        public readonly string $sdk = '',
+        public readonly string $sdkVersion = '',
     ) {
     }
 
@@ -38,6 +40,8 @@ final class Audit extends Base
             'userAgent' => $this->userAgent,
             'event' => $this->event,
             'hostname' => $this->hostname,
+            'sdk' => $this->sdk,
+            'sdkVersion' => $this->sdkVersion,
         ];
     }
 
@@ -54,6 +58,8 @@ final class Audit extends Base
             ip: $data['ip'] ?? '',
             userAgent: $data['userAgent'] ?? '',
             hostname: $data['hostname'] ?? '',
+            sdk: $data['sdk'] ?? '',
+            sdkVersion: $data['sdkVersion'] ?? '',
         );
     }
 
@@ -70,6 +76,8 @@ final class Audit extends Base
             ip: $context->ip,
             userAgent: $context->userAgent,
             hostname: $context->hostname,
+            sdk: $context->sdk,
+            sdkVersion: $context->sdkVersion,
         );
     }
 }


### PR DESCRIPTION
## What

Capture the SDK name and version from request headers at audit-trigger time and carry them through the audit event so the audit worker can persist them.

Reference: CLO-4553

## Changes

- **app/controllers/shared/api.php** — When populating the audit context (alongside `userAgent`, `ip`, `hostname`), read `x-sdk-name` (lowercased) into `sdk` and `x-sdk-version` into `sdkVersion`, defaulting to empty strings.
- **src/Appwrite/Event/Context/Audit.php** — Add `sdk` and `sdkVersion` promoted properties to the context and include them in `isEmpty()`.
- **src/Appwrite/Event/Message/Audit.php** — Add readonly `sdk` / `sdkVersion` to the message and thread them through `toArray()`, `fromArray()`, and `fromContext()`, mirroring `userAgent`/`hostname`.
- **src/Appwrite/Event/Audit.php** — For parity with the legacy event path, add `sdk` / `sdkVersion` properties, fluent `setSdk()` / `setSdkVersion()` setters, and include them in `preparePayload()`.

## Notes

This captures `x-sdk-name` / `x-sdk-version` at request time and carries them through AuditContext -> AuditMessage for the audit worker to persist as new `sdk` / `sdkVersion` columns. The audit library changes and the cloud audit worker persistence are handled in separate PRs.

Verified with `php -l` on all four changed files.