### PR TITLE
fix(sites): route domain traffic to the active deployment instead of pinning to the first

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
@@ -115,7 +115,6 @@ class Update extends Base
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceType', ['function']),
             Query::equal('deploymentResourceInternalId', [$function->getSequence()]),
-            Query::equal('deploymentVcsProviderBranch', ['']),
             Query::equal('projectInternalId', [$project->getSequence()])
         ];
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -1058,7 +1058,6 @@ class Builds extends Action
                             Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
                             Query::equal('deploymentResourceType', ['function']),
                             Query::equal('trigger', ['manual']),
-                            Query::equal('deploymentVcsProviderBranch', ['']),
                         ];
 
                         $rulesUpdated = false;
@@ -1083,7 +1082,6 @@ class Builds extends Action
                             Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
                             Query::equal('deploymentResourceType', ['site']),
                             Query::equal('trigger', ['manual']),
-                            Query::equal('deploymentVcsProviderBranch', ['']),
                         ];
 
                         $dbForPlatform->forEach('rules', function (Document $rule) use ($dbForPlatform, $deployment) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -358,7 +358,6 @@ class Jobs extends Action
             Query::equal('deploymentResourceInternalId', [$function->getSequence()]),
             Query::equal('deploymentResourceType', ['function']),
             Query::equal('trigger', ['manual']),
-            Query::equal('deploymentVcsProviderBranch', ['']),
         ]);
     }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -103,7 +103,6 @@ class Update extends Base
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceType', ['site']),
             Query::equal('deploymentResourceInternalId', [$site->getSequence()]),
-            Query::equal('deploymentVcsProviderBranch', ['']),
             Query::equal('projectInternalId', [$project->getSequence()])
         ];
 


### PR DESCRIPTION
## What does this PR do?

Fixes a critical routing bug in Appwrite Sites where domain traffic would permanently route to the very first deployment made, ignoring subsequent active deployments. The resolution logic has been updated to correctly target the active deployment ID rather than pulling the oldest record or maintaining a stale initial reference.

## Test Plan

1. Create a static site in Appwrite.
2. Deploy a first container/build (Build A) and activate it -> verify the domain serves Build A.
3. Deploy a second build (Build B) with distinct visual changes and activate it.
4. Verify via a web request/curl that the site immediately routes to and serves Build B with the correct deployment header.

## Related PRs and Issues

- Closes #12849

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.MD)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?