### PR TITLE
Bump utopia-php/audit to 2.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "utopia-php/abuse": "1.4.*",
         "utopia-php/agents": "2.*",
         "utopia-php/analytics": "0.15.*",
-        "utopia-php/audit": "2.6.*",
+        "utopia-php/audit": "2.7.*",
         "utopia-php/auth": "^0.9",
         "utopia-php/cache": "^3.0.0",
         "utopia-php/cli": "^0.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a453a68b2d3ee2f962af0f040f000a8a",
+    "content-hash": "8dca42b47d09371cb3f0f1c7dd9da7af",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3312,16 +3312,16 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "f5bb07841e335e9ea7d4bd5860da1f580447014a"
+                "reference": "9a32692e9c9123241312d515b74e2e397843aa62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/f5bb07841e335e9ea7d4bd5860da1f580447014a",
-                "reference": "f5bb07841e335e9ea7d4bd5860da1f580447014a",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/9a32692e9c9123241312d515b74e2e397843aa62",
+                "reference": "9a32692e9c9123241312d515b74e2e397843aa62",
                 "shasum": ""
             },
             "require": {
@@ -3356,9 +3356,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/2.6.0"
+                "source": "https://github.com/utopia-php/audit/tree/2.7.0"
             },
-            "time": "2026-06-22T03:33:28+00:00"
+            "time": "2026-07-13T03:55:19+00:00"
         },
         {
             "name": "utopia-php/auth",


### PR DESCRIPTION
Bumps `utopia-php/audit` from `2.6.*` to `2.7.*` (2.7.0).

Audit 2.7.0 adds the optional ClickHouse `sdk` / `sdkVersion` audit-log columns (utopia-php/audit#130). This bump lets consumers (Appwrite Cloud) resolve audit `2.7` while server-ce carries the SDK name/version through the audit event (added in #12852). The 2.7 change is confined to the ClickHouse adapter; the Database (MySQL) adapter used by CE is unchanged, so this is backward-compatible.

Part of CLO-4553 (SDK and version attribute in audit and usage logs). Only `composer.json` + `composer.lock` change; audit is the sole lock update (no transitive upgrades).