### PR TITLE
Restore localhost endpoint in SDK getting started docs

### DIFF
--- a/docs/sdks/cli/GETTING_STARTED.md
+++ b/docs/sdks/cli/GETTING_STARTED.md
@@ -9,7 +9,7 @@ $ appwrite login
 ? Enter your password ********
 ✓ Success 
 ```
-This will also prompt you to enter your Appwrite endpoint ( default: http://localhost:9520/v1 ) 
+This will also prompt you to enter your Appwrite endpoint ( default: http://localhost/v1 ) 
 
 * ### Initialising your project
 Once logged in, the CLI needs to be initialised before you can use it with your Appwrite project. You can do this with the `appwrite init project` command. 
@@ -139,5 +139,5 @@ $ appwrite client --reset
 The Appwrite CLI can also work in a CI environment. The initialisation of the CLI works a bit differently in CI. In CI, you set your `endpoint`, `projectId` and `API Key` using 
 
 ```sh
-appwrite client --endpoint http://localhost:9520/v1 --projectId <PROJECT_ID> --key <API KEY>
+appwrite client --endpoint http://localhost/v1 --projectId <PROJECT_ID> --key <API KEY>
 ```

--- a/docs/sdks/react-native/GETTING_STARTED.md
+++ b/docs/sdks/react-native/GETTING_STARTED.md
@@ -34,7 +34,7 @@ import { Client } from 'react-native-appwrite';
 const client = new Client();
 
 client
-    .setEndpoint('http://localhost:9520/v1') // Your Appwrite Endpoint
+    .setEndpoint('http://localhost/v1') // Your Appwrite Endpoint
     .setProject('455x34dfkj') // Your project ID
     .setPlatform('com.example.myappwriteapp') // Your application ID or bundle ID.
 ;
@@ -65,7 +65,7 @@ import { Client, Account } from 'react-native-appwrite';
 const client = new Client();
 
 client
-    .setEndpoint('http://localhost:9520/v1') // Your Appwrite Endpoint
+    .setEndpoint('http://localhost/v1') // Your Appwrite Endpoint
     .setProject('455x34dfkj')
     .setPlatform('com.example.myappwriteapp') // YOUR application ID
 ;

--- a/docs/sdks/web/GETTING_STARTED.md
+++ b/docs/sdks/web/GETTING_STARTED.md
@@ -15,7 +15,7 @@ Initialize your SDK with your Appwrite server API endpoint and project ID which 
 const client = new Client();
 
 client
-    .setEndpoint('http://localhost:9520/v1') // Your Appwrite Endpoint
+    .setEndpoint('http://localhost/v1') // Your Appwrite Endpoint
     .setProject('455x34dfkj') // Your project ID
 ;
 ```
@@ -44,7 +44,7 @@ account.create(ID.unique(), "email@example.com", "password", "Walter O'Brien")
 const client = new Client();
 
 client
-    .setEndpoint('http://localhost:9520/v1') // Your Appwrite Endpoint
+    .setEndpoint('http://localhost/v1') // Your Appwrite Endpoint
     .setProject('455x34dfkj')
 ;
 


### PR DESCRIPTION
## What does this PR do?

Reverts the SDK-facing `docs/sdks/{web,react-native,cli}/GETTING_STARTED.md` endpoint examples from `http://localhost:9520/v1` back to `http://localhost/v1`.

Commit a1308ad398 changed the default **development** port to 9520 and updated these docs along with the compose/CI files. However, the `docs/sdks/*/GETTING_STARTED.md` files are copied verbatim into the published SDK READMEs (e.g. `sdk-for-web`, `sdk-for-react-native`, the CLI) by the SDK generator. Their audience is self-hosted users, whose default install serves on port 80 — not contributors running the dev compose setup, so the 9520 examples would ship broken guidance in the next SDK releases.

The dev-environment references (docker-compose, CI, CONTRIBUTING.md, gitpod) are left untouched.

## Test Plan

Docs-only change; verified `grep -rn 9520 docs/sdks/` returns nothing.

## Related PRs and Issues

- a1308ad398 (port mapping update)