### PR TITLE
chore(deps): bump utopia-php/audit to 2.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "utopia-php/abuse": "1.4.*",
         "utopia-php/agents": "2.*",
         "utopia-php/analytics": "0.15.*",
-        "utopia-php/audit": "2.7.*",
+        "utopia-php/audit": "2.8.*",
         "utopia-php/auth": "^0.9",
         "utopia-php/cache": "^3.0.0",
         "utopia-php/cli": "^0.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8dca42b47d09371cb3f0f1c7dd9da7af",
+    "content-hash": "0719318e907ceeb432a49b5c421b6261",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -3312,16 +3312,16 @@
         },
         {
             "name": "utopia-php/audit",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/audit.git",
-                "reference": "9a32692e9c9123241312d515b74e2e397843aa62"
+                "reference": "a613b29f038c1cce953d3cec19f840c9eb705626"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/audit/zipball/9a32692e9c9123241312d515b74e2e397843aa62",
-                "reference": "9a32692e9c9123241312d515b74e2e397843aa62",
+                "url": "https://api.github.com/repos/utopia-php/audit/zipball/a613b29f038c1cce953d3cec19f840c9eb705626",
+                "reference": "a613b29f038c1cce953d3cec19f840c9eb705626",
                 "shasum": ""
             },
             "require": {
@@ -3356,9 +3356,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/audit/issues",
-                "source": "https://github.com/utopia-php/audit/tree/2.7.0"
+                "source": "https://github.com/utopia-php/audit/tree/2.8.0"
             },
-            "time": "2026-07-13T03:55:19+00:00"
+            "time": "2026-07-13T06:39:17+00:00"
         },
         {
             "name": "utopia-php/auth",


### PR DESCRIPTION
Bumps `utopia-php/audit` from `2.7.*` to `2.8.*`.

`2.8.0` adds the premium geo columns to the ClickHouse audit schema (CLO-4575). The value is written by appwrite-labs/cloud's audit `Activity` worker, but the version constraint lives here in server-ce and currently caps at `2.7.*`, so cloud can't resolve `2.8.0` until this widens.

Constraint-only change (composer.json + lock); no code changes.