### PR TITLE
Replace deprecated route method access

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -1313,7 +1313,7 @@ Http::error()
             $log->setMessage($error->getMessage());
 
             $log->addTag('database', $dsn->getHost());
-            $log->addTag('method', $route?->getMethod() ?? $request->getMethod());
+            $log->addTag('method', \implode(',', $route?->getMethods() ?? [$request->getMethod()]));
             $log->addTag('url', $request->getURI());
             $log->addTag('verboseType', get_class($error));
             $log->addTag('code', $error->getCode());

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -303,12 +303,13 @@ Http::shutdown()
         $result = [];
         $path   = APP_STORAGE_CACHE . '/tests.json';
         $tests  = (\file_exists($path)) ? \json_decode(\file_get_contents($path), true) : [];
+        $methods = \implode(',', $route->getMethods());
 
         if (!\is_array($tests)) {
             throw new Exception(Exception::GENERAL_MOCK, 'Failed to read results', 500);
         }
 
-        $result[$route->getMethod() . ':' . $route->getPath()] = true;
+        $result[$methods . ':' . $route->getPath()] = true;
 
         $tests = \array_merge($tests, $result);
 
@@ -316,5 +317,5 @@ Http::shutdown()
             throw new Exception(Exception::GENERAL_MOCK, 'Failed to save results', 500);
         }
 
-        $response->dynamic(new Document(['result' => $route->getMethod() . ':' . $route->getPath() . ':passed']), Response::MODEL_MOCK);
+        $response->dynamic(new Document(['result' => $methods . ':' . $route->getPath() . ':passed']), Response::MODEL_MOCK);
     });

--- a/app/controllers/mock.php
+++ b/app/controllers/mock.php
@@ -303,13 +303,15 @@ Http::shutdown()
         $result = [];
         $path   = APP_STORAGE_CACHE . '/tests.json';
         $tests  = (\file_exists($path)) ? \json_decode(\file_get_contents($path), true) : [];
-        $methods = \implode(',', $route->getMethods());
+        $methods = $route->getMethods();
 
         if (!\is_array($tests)) {
             throw new Exception(Exception::GENERAL_MOCK, 'Failed to read results', 500);
         }
 
-        $result[$methods . ':' . $route->getPath()] = true;
+        foreach ($methods as $method) {
+            $result[$method . ':' . $route->getPath()] = true;
+        }
 
         $tests = \array_merge($tests, $result);
 
@@ -317,5 +319,5 @@ Http::shutdown()
             throw new Exception(Exception::GENERAL_MOCK, 'Failed to save results', 500);
         }
 
-        $response->dynamic(new Document(['result' => $methods . ':' . $route->getPath() . ':passed']), Response::MODEL_MOCK);
+        $response->dynamic(new Document(['result' => \implode(',', $methods) . ':' . $route->getPath() . ':passed']), Response::MODEL_MOCK);
     });

--- a/app/http.php
+++ b/app/http.php
@@ -557,7 +557,7 @@ $swoole->onRequest(function ($utopiaRequest, $utopiaResponse) use ($files, $swoo
             $log->setType(Log::TYPE_ERROR);
             $log->setMessage($th->getMessage());
 
-            $log->addTag('method', $route?->getMethod() ?? $request->getMethod());
+            $log->addTag('method', \implode(',', $route?->getMethods() ?? [$request->getMethod()]));
             $log->addTag('url', $route?->getPath() ?? $request->getURI());
             $log->addTag('verboseType', get_class($th));
             $log->addTag('code', $th->getCode());

--- a/src/Appwrite/GraphQL/Resolvers.php
+++ b/src/Appwrite/GraphQL/Resolvers.php
@@ -72,13 +72,15 @@ class Resolvers
      *
      * @param Http $utopia
      * @param ?Route $route
+     * @param string $method
      * @return callable
      */
     public static function api(
         Http $utopia,
         ?Route $route,
+        string $method,
     ): callable {
-        return static fn ($type, $args, $context, $info) => new Swoole(function (callable $resolve, callable $reject) use ($utopia, $route, $args) {
+        return static fn ($type, $args, $context, $info) => new Swoole(function (callable $resolve, callable $reject) use ($utopia, $route, $method, $args) {
             $utopia = $utopia->context()->get('utopia:graphql');
             $request = $utopia->context()->get('request');
             $response = $utopia->context()->get('response');
@@ -89,7 +91,7 @@ class Resolvers
                 $response,
                 $resolve,
                 $reject,
-                prepareRequest: static function (Request $request) use ($route, $args): void {
+                prepareRequest: static function (Request $request) use ($route, $method, $args): void {
                     $path = $route->getPath();
                     foreach ($args as $key => $value) {
                         if (\str_contains($path, '/:' . $key)) {
@@ -97,10 +99,10 @@ class Resolvers
                         }
                     }
 
-                    $request->setMethod($route->getMethod());
+                    $request->setMethod($method);
                     $request->setURI($path);
 
-                    switch ($route->getMethod()) {
+                    switch ($method) {
                         case 'GET':
                             $request->setQueryString($args);
                             break;

--- a/src/Appwrite/GraphQL/Schema.php
+++ b/src/Appwrite/GraphQL/Schema.php
@@ -90,7 +90,7 @@ class Schema
         $queries = [];
         $mutations = [];
 
-        foreach ($utopia->getRoutes() as $routes) {
+        foreach ($utopia->getRoutes() as $httpMethod => $routes) {
             foreach ($routes as $route) {
                 /** @var Route $route */
 
@@ -109,8 +109,8 @@ class Schema
                     $methodName = $method->getMethodName();
                     $name = $namespace . \ucfirst($methodName);
 
-                    foreach (Mapper::route($utopia, $route, $method, $complexity) as $field) {
-                        switch ($route->getMethod()) {
+                    foreach (Mapper::route($utopia, $route, $method, $httpMethod, $complexity) as $field) {
+                        switch ($httpMethod) {
                             case 'GET':
                                 $queries[$name] = $field;
                                 break;
@@ -121,7 +121,7 @@ class Schema
                                 $mutations[$name] = $field;
                                 break;
                             default:
-                                throw new \Exception("Unsupported method: {$route->getMethod()}");
+                                throw new \Exception("Unsupported method: {$httpMethod}");
                         }
                     }
                 }

--- a/src/Appwrite/GraphQL/Types/Mapper.php
+++ b/src/Appwrite/GraphQL/Types/Mapper.php
@@ -83,6 +83,7 @@ class Mapper
         Http $utopia,
         Route $route,
         Method $method,
+        string $httpMethod,
         callable $complexity
     ): iterable {
         foreach (self::$blacklist as $blacklist) {
@@ -151,7 +152,7 @@ class Mapper
                 'type' => $type,
                 'description' => $description,
                 'args' => $params,
-                'resolve' => Resolvers::api($utopia, $route)
+                'resolve' => Resolvers::api($utopia, $route, $httpMethod)
             ];
 
             if ($list) {

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -832,8 +832,12 @@ class OpenAPI3 extends Format
                 $url = \implode('/', $segments);
             }
 
-            foreach ($route->getMethods() as $method) {
+            $methods = $route->getMethods();
+            foreach ($methods as $method) {
                 $methodTemp = $temp;
+                if (\count($methods) > 1) {
+                    $methodTemp['operationId'] .= \ucfirst(\strtolower($method));
+                }
                 $body = [
                     'content' => [
                         $consumes[0]  => [

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -419,18 +419,7 @@ class OpenAPI3 extends Format
                 $temp['security'][] = $securities;
             }
 
-            $body = [
-                'content' => [
-                    $consumes[0]  => [
-                        'schema'  => [
-                            'type' => 'object',
-                            'properties' => [],
-                        ],
-                    ],
-                ],
-            ];
-
-            $bodyRequired = [];
+            $parameterNodes = [];
 
             $parameters = \array_merge(
                 $route->getParams(),
@@ -826,55 +815,12 @@ class OpenAPI3 extends Format
                     }
                 }
 
-                if ($isPathParam) { // Param is in URL path (directly or through alias)
-                    $node['in'] = 'path';
-                    $temp['parameters'][] = $node;
-                } elseif (\in_array($route->getMethod(), ['GET', 'DELETE'], true)) { // Param is in query
-                    $node['in'] = 'query';
-                    $temp['parameters'][] = $node;
-                } else { // Param is in payload
-                    if ($node['required']) {
-                        $bodyRequired[] = $name;
-                    }
-
-                    $body['content'][$consumes[0]]['schema']['properties'][$name] = [
-                        'type' => $node['schema']['type'],
-                        'description' => $node['description'],
-                    ];
-
-                    if (\array_key_exists('default', $node['schema'])) {
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['default'] = $node['schema']['default'];
-                    }
-
-                    $body['content'][$consumes[0]]['schema']['properties'][$name]['x-example'] = $node['schema']['x-example'] ?? null;
-
-                    if (isset($node['schema']['format'])) {
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['format'] = $node['schema']['format'];
-                    }
-
-                    if (isset($node['schema']['enum'])) {
-                        /// If the enum flag is Set, add the enum values to the body
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['enum'] = $node['schema']['enum'];
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-name'] = $node['schema']['x-enum-name'] ?? null;
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-keys'] = $node['schema']['x-enum-keys'];
-                    }
-
-                    if ($node['schema']['x-upload-id'] ?? false) {
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-upload-id'] = $node['schema']['x-upload-id'];
-                    }
-
-                    if (isset($node['schema']['x-appwrite'])) {
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-appwrite'] = $node['schema']['x-appwrite'];
-                    }
-
-                    if (\array_key_exists('items', $node['schema'])) {
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['items'] = $node['schema']['items'];
-                    }
-
-                    if ($parameter['nullable']) {
-                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-nullable'] = true;
-                    }
-                }
+                $parameterNodes[] = [
+                    'name' => $name,
+                    'config' => $parameter,
+                    'node' => $node,
+                    'path' => $isPathParam,
+                ];
 
                 $segments = \explode('/', $url);
                 foreach ($segments as &$segment) {
@@ -886,15 +832,86 @@ class OpenAPI3 extends Format
                 $url = \implode('/', $segments);
             }
 
-            if (!empty($bodyRequired)) {
-                $body['content'][$consumes[0]]['schema']['required'] = $bodyRequired;
-            }
+            foreach ($route->getMethods() as $method) {
+                $methodTemp = $temp;
+                $body = [
+                    'content' => [
+                        $consumes[0]  => [
+                            'schema'  => [
+                                'type' => 'object',
+                                'properties' => [],
+                            ],
+                        ],
+                    ],
+                ];
+                $bodyRequired = [];
 
-            if (!empty($body['content'][$consumes[0]]['schema']['properties'])) {
-                $temp['requestBody'] = $body;
-            }
+                foreach ($parameterNodes as $parameterNode) {
+                    $name = $parameterNode['name'];
+                    $parameter = $parameterNode['config'];
+                    $node = $parameterNode['node'];
 
-            $output['paths'][$url][\strtolower($route->getMethod())] = $temp;
+                    if ($parameterNode['path']) { // Param is in URL path (directly or through alias)
+                        $node['in'] = 'path';
+                        $methodTemp['parameters'][] = $node;
+                    } elseif (\in_array($method, ['GET', 'DELETE'], true)) { // Param is in query
+                        $node['in'] = 'query';
+                        $methodTemp['parameters'][] = $node;
+                    } else { // Param is in payload
+                        if ($node['required']) {
+                            $bodyRequired[] = $name;
+                        }
+
+                        $body['content'][$consumes[0]]['schema']['properties'][$name] = [
+                            'type' => $node['schema']['type'],
+                            'description' => $node['description'],
+                        ];
+
+                        if (\array_key_exists('default', $node['schema'])) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['default'] = $node['schema']['default'];
+                        }
+
+                        $body['content'][$consumes[0]]['schema']['properties'][$name]['x-example'] = $node['schema']['x-example'] ?? null;
+
+                        if (isset($node['schema']['format'])) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['format'] = $node['schema']['format'];
+                        }
+
+                        if (isset($node['schema']['enum'])) {
+                            /// If the enum flag is Set, add the enum values to the body
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['enum'] = $node['schema']['enum'];
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-name'] = $node['schema']['x-enum-name'] ?? null;
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-enum-keys'] = $node['schema']['x-enum-keys'];
+                        }
+
+                        if ($node['schema']['x-upload-id'] ?? false) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-upload-id'] = $node['schema']['x-upload-id'];
+                        }
+
+                        if (isset($node['schema']['x-appwrite'])) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-appwrite'] = $node['schema']['x-appwrite'];
+                        }
+
+                        if (\array_key_exists('items', $node['schema'])) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['items'] = $node['schema']['items'];
+                        }
+
+                        if ($parameter['nullable']) {
+                            $body['content'][$consumes[0]]['schema']['properties'][$name]['x-nullable'] = true;
+                        }
+                    }
+                }
+
+                if (!empty($bodyRequired)) {
+                    $body['content'][$consumes[0]]['schema']['required'] = $bodyRequired;
+                }
+
+                if (!empty($body['content'][$consumes[0]]['schema']['properties'])) {
+                    $methodTemp['requestBody'] = $body;
+                }
+
+                $output['paths'][$url][\strtolower($method)] = $methodTemp;
+            }
         }
 
         foreach ($this->models as $model) {

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -186,6 +186,8 @@ final class FormatTest extends TestCase
         $get = $openApi['paths']['/tests/{testId}']['get'];
         $post = $openApi['paths']['/tests/{testId}']['post'];
 
+        $this->assertSame('testGetOrUpdateTestGet', $get['operationId']);
+        $this->assertSame('testGetOrUpdateTestPost', $post['operationId']);
         $this->assertSame('path', $get['parameters'][0]['in']);
         $this->assertSame('query', $get['parameters'][1]['in']);
         $this->assertArrayNotHasKey('requestBody', $get);

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -163,6 +163,37 @@ final class FormatTest extends TestCase
 
     }
 
+    public function testMultiMethodRouteEmitsEveryOperation(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route(['GET', 'POST'], '/v1/tests/:testId'))
+            ->desc('Get or update test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getOrUpdateTest',
+                description: 'Get or update test.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('testId', '', new Text(256), 'Test ID.')
+            ->param('name', null, new Nullable(new Text(256)), 'Test name.', true);
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+
+        $get = $openApi['paths']['/tests/{testId}']['get'];
+        $post = $openApi['paths']['/tests/{testId}']['post'];
+
+        $this->assertSame('path', $get['parameters'][0]['in']);
+        $this->assertSame('query', $get['parameters'][1]['in']);
+        $this->assertArrayNotHasKey('requestBody', $get);
+        $this->assertSame('path', $post['parameters'][0]['in']);
+        $this->assertCount(1, $post['parameters']);
+        $this->assertArrayHasKey('name', $post['requestBody']['content']['application/json']['schema']['properties']);
+    }
+
     public function testModelReferencesDoNotEmitItemsOnObjectProperties(): void
     {
         Method::$processed = [];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Replaces deprecated `Utopia\Http\Route::getMethod()` calls with the multi-method `getMethods()` API.

Route methods are preserved rather than defaulting to the first entry: logs and mock output use comma-separated methods, GraphQL resolvers receive the concrete registered method, and OpenAPI emits an operation for every method. This removes PHP 8.5 deprecation warnings and keeps multi-method routes accurate.

## Test Plan

- Run `composer lint` on all changed PHP files.
- Run `docker compose exec appwrite test tests/unit/SDK/Specification/FormatTest.php`.
- Run `docker compose exec appwrite test tests/unit/GraphQL`.
- Run `docker compose exec appwrite test tests/e2e/Services/GraphQL/PresenceTest.php`.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
