### PR TITLE
Handle mail adapter delivery failures

### DIFF
--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -216,7 +216,12 @@ class Mails extends Action
         $emailMessage->setOrigin(MESSAGE_SEND_TYPE_INTERNAL);
 
         try {
-            $adapter->send($emailMessage);
+            $result = $adapter->send($emailMessage);
+
+            if (($result['deliveredTo'] ?? 0) === 0) {
+                $error = $result['results'][0]['error'] ?? 'Unknown error';
+                throw new Exception($error);
+            }
         } catch (\Throwable $error) {
             Span::add('mail.status', 'failure');
 

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -219,7 +219,7 @@ class Mails extends Action
             $result = $adapter->send($emailMessage);
 
             if (($result['deliveredTo'] ?? 0) === 0) {
-                $error = $result['results'][0]['error'] ?? 'Unknown error';
+                $error = $result['results'][0]['error'] ?? ($result['error'] ?? 'Unknown error');
                 throw new Exception($error);
             }
         } catch (\Throwable $error) {

--- a/tests/unit/Platform/Workers/MailsTest.php
+++ b/tests/unit/Platform/Workers/MailsTest.php
@@ -19,6 +19,7 @@ final class SpyMailAdapter extends EmailAdapter
     public ?EmailMessage $captured = null;
     public int $deliveredTo = 1;
     public ?string $error = null;
+    public bool $emptyResults = false;
     public int $sendCount = 0;
 
     public function getName(): string
@@ -36,6 +37,20 @@ final class SpyMailAdapter extends EmailAdapter
         $this->sendCount++;
         $this->captured = $message;
 
+        $response = [
+            'deliveredTo' => $this->deliveredTo,
+            'type' => $this->getType(),
+            'results' => [],
+        ];
+
+        if ($this->emptyResults) {
+            if ($this->error !== null) {
+                $response['error'] = $this->error;
+            }
+
+            return $response;
+        }
+
         $result = [
             'recipient' => $message->getTo()[0]['email'] ?? '',
             'status' => $this->deliveredTo === 0 ? 'failure' : 'success',
@@ -45,11 +60,9 @@ final class SpyMailAdapter extends EmailAdapter
             $result['error'] = $this->error;
         }
 
-        return [
-            'deliveredTo' => $this->deliveredTo,
-            'type' => $this->getType(),
-            'results' => [$result],
-        ];
+        $response['results'] = [$result];
+
+        return $response;
     }
 }
 
@@ -115,6 +128,21 @@ final class MailsTest extends TestCase
         $adapter->deliveredTo = 0;
         $adapter->error = 'Domain not verified';
 
+        $this->assertMailWorkerThrows($adapter, 'Error sending mail: Domain not verified');
+    }
+
+    public function testMailDeliveryFailureUsesTopLevelErrorWhenResultsEmpty(): void
+    {
+        $adapter = new SpyMailAdapter();
+        $adapter->deliveredTo = 0;
+        $adapter->emptyResults = true;
+        $adapter->error = 'Provider rejected request';
+
+        $this->assertMailWorkerThrows($adapter, 'Error sending mail: Provider rejected request');
+    }
+
+    private function assertMailWorkerThrows(SpyMailAdapter $adapter, string $expectedMessage): void
+    {
         $registry = new Registry();
         $registry->set('smtp', static fn () => $adapter);
 
@@ -123,7 +151,7 @@ final class MailsTest extends TestCase
 
         try {
             $this->expectException(\Exception::class);
-            $this->expectExceptionMessage('Error sending mail: Domain not verified');
+            $this->expectExceptionMessage($expectedMessage);
 
             $worker = new Mails();
             $worker->action(

--- a/tests/unit/Platform/Workers/MailsTest.php
+++ b/tests/unit/Platform/Workers/MailsTest.php
@@ -17,6 +17,8 @@ use Utopia\Telemetry\Adapter\None;
 final class SpyMailAdapter extends EmailAdapter
 {
     public ?EmailMessage $captured = null;
+    public int $deliveredTo = 1;
+    public ?string $error = null;
     public int $sendCount = 0;
 
     public function getName(): string
@@ -34,10 +36,19 @@ final class SpyMailAdapter extends EmailAdapter
         $this->sendCount++;
         $this->captured = $message;
 
+        $result = [
+            'recipient' => $message->getTo()[0]['email'] ?? '',
+            'status' => $this->deliveredTo === 0 ? 'failure' : 'success',
+        ];
+
+        if ($this->error !== null) {
+            $result['error'] = $this->error;
+        }
+
         return [
-            'deliveredTo' => 1,
+            'deliveredTo' => $this->deliveredTo,
             'type' => $this->getType(),
-            'results' => [['recipient' => $message->getTo()[0]['email'] ?? '', 'status' => 'sent']],
+            'results' => [$result],
         ];
     }
 }
@@ -61,10 +72,12 @@ final class MailsTest extends TestCase
                     'queue' => 'v1-mails',
                     'timestamp' => \time(),
                     'payload' => [
+                        'smtp' => [],
                         'recipient' => 'legacy@example.test',
                         'name' => 'Legacy User',
                         'subject' => 'Hello {{name}}',
                         'body' => 'Body {{name}}',
+                        'bodyTemplate' => '',
                         'variables' => ['name' => 'Legacy'],
                         'customMailOptions' => [
                             'senderEmail' => 'sender@example.test',
@@ -94,5 +107,47 @@ final class MailsTest extends TestCase
         $this->assertSame('Custom Sender', $message->getFromName());
         $this->assertSame('reply@example.test', $message->getReplyToEmail());
         $this->assertSame('Custom Reply', $message->getReplyToName());
+    }
+
+    public function testMailDeliveryFailureIsThrownByMailsWorker(): void
+    {
+        $adapter = new SpyMailAdapter();
+        $adapter->deliveredTo = 0;
+        $adapter->error = 'Domain not verified';
+
+        $registry = new Registry();
+        $registry->set('smtp', static fn () => $adapter);
+
+        $previousSmtpHost = \getenv('_APP_SMTP_HOST');
+        \putenv('_APP_SMTP_HOST=spy.smtp.test');
+
+        try {
+            $this->expectException(\Exception::class);
+            $this->expectExceptionMessage('Error sending mail: Domain not verified');
+
+            $worker = new Mails();
+            $worker->action(
+                new Message([
+                    'pid' => 'pid',
+                    'queue' => 'v1-mails',
+                    'timestamp' => \time(),
+                    'payload' => [
+                        'smtp' => [],
+                        'recipient' => 'legacy@example.test',
+                        'name' => 'Legacy User',
+                        'subject' => 'Hello',
+                        'body' => 'Body',
+                        'bodyTemplate' => '',
+                        'variables' => [],
+                    ],
+                ]),
+                new Document(['$id' => 'project-x']),
+                $registry,
+                new Log(),
+                new None(),
+            );
+        } finally {
+            \putenv($previousSmtpHost === false ? '_APP_SMTP_HOST' : '_APP_SMTP_HOST=' . $previousSmtpHost);
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Checks the result returned by the mail adapter and treats a response with no delivered recipients as a delivery failure.

Previously, adapters such as Resend could return an error response without throwing an exception. The mails worker discarded that response and recorded the operation as successful. The worker now surfaces the provider error and records the mail as failed.

## Test Plan

- `composer format src/Appwrite/Platform/Workers/Mails.php tests/unit/Platform/Workers/MailsTest.php`
- `composer lint src/Appwrite/Platform/Workers/Mails.php tests/unit/Platform/Workers/MailsTest.php`
- `vendor/bin/phpunit --display-warnings tests/unit/Platform/Workers/MailsTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G src/Appwrite/Platform/Workers/Mails.php tests/unit/Platform/Workers/MailsTest.php`

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
