### PR TITLE
Restore branding for password recovery emails

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3827,6 +3827,14 @@ Http::post('/v1/account/recovery')
         $customTemplate =
             $project->getAttribute('templates', [])['email.recovery-' . $locale->default] ??
             $project->getAttribute('templates', [])['email.recovery-' . $locale->fallback] ?? [];
+        $smtpBaseTemplate = $project->getAttribute('smtpBaseTemplate', 'email-base');
+
+        $validator = new FileName();
+        if (!$validator->isValid($smtpBaseTemplate)) {
+            throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Invalid template path');
+        }
+
+        $bodyTemplate = __DIR__ . '/../../config/locale/templates/' . $smtpBaseTemplate . '.tpl';
 
         $message = Template::fromFile(__DIR__ . '/../../config/locale/templates/email-inner-base.tpl');
         $message
@@ -3906,12 +3914,27 @@ Http::post('/v1/account/recovery')
             'team' => ''
         ];
 
+        if ($smtpBaseTemplate === APP_BRANDED_EMAIL_BASE_TEMPLATE) {
+            $emailVariables = [
+                ...$emailVariables,
+                'accentColor' => $platform['accentColor'],
+                'logoUrl' => $platform['logoUrl'],
+                'twitter' => $platform['twitterUrl'],
+                'discord' => $platform['discordUrl'],
+                'github' => $platform['githubUrl'],
+                'terms' => $platform['termsUrl'],
+                'privacy' => $platform['privacyUrl'],
+                'platform' => $platform['platformName'],
+            ];
+        }
+
         $publisherForMails->enqueue(new MailMessage(
             project: $project,
             recipient: $profile->getAttribute('email', ''),
             name: $profile->getAttribute('name', ''),
             subject: $subject,
             template: MAIL_TEMPLATE_RECOVERY,
+            bodyTemplate: $bodyTemplate,
             body: $body,
             preview: $preview,
             smtp: $smtpConfig,

--- a/tests/e2e/Services/Account/AccountConsoleClientTest.php
+++ b/tests/e2e/Services/Account/AccountConsoleClientTest.php
@@ -16,6 +16,40 @@ final class AccountConsoleClientTest extends Scope
     use ProjectConsole;
     use SideClient;
 
+    public function testCreateRecoveryEmailBranding(): void
+    {
+        $email = ID::unique() . '@appwrite.io';
+
+        $response = $this->client->call(Client::METHOD_POST, '/account', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'userId' => ID::unique(),
+            'email' => $email,
+            'password' => 'password',
+            'name' => 'Recovery User',
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/account/recovery', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'email' => $email,
+            'url' => 'http://localhost/recovery',
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $lastEmail = $this->getLastEmailByAddress($email);
+
+        $this->assertNotEmpty($lastEmail, 'Email not found for address: ' . $email);
+        $this->assertStringContainsStringIgnoringCase('Appwrite logo', $lastEmail['html']);
+    }
+
     /**
      * Test that account deletion succeeds even with active team memberships.
      * When the user is the sole owner and only member of a team, the team

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1804,6 +1804,7 @@ final class AccountCustomClientTest extends Scope
         $this->assertEquals($name, $lastEmail['to'][0]['name']);
         $this->assertEquals('Password Reset for ' . $this->getProject()['name'], $lastEmail['subject']);
         $this->assertStringContainsStringIgnoringCase('Reset your ' . $this->getProject()['name'] . ' password using the link.', $lastEmail['text']);
+        $this->assertStringNotContainsStringIgnoringCase('Appwrite logo', $lastEmail['html']);
 
 
         $tokens = $this->extractQueryParamsFromEmailLink($lastEmail['html']);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Uses the project's configured base email template for password recovery emails and supplies the variables required by the branded template.

Console recovery emails previously omitted `bodyTemplate`, causing the mails worker to fall back to the plain template even though the console project configures `email-base-styled`. Normal projects continue using the non-branded template.

### Before

Console recovery incorrectly rendered with the non-branded fallback:

![Non-branded recovery email](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/recovery-email-non-branded-17c31357.png)

### After

Console recovery uses the configured branded template:

![Branded recovery email](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/recovery-email-branded-28f59045.png)

## Test Plan

- `composer format app/controllers/api/account.php tests/e2e/Services/Account/AccountCustomClientTest.php tests/e2e/Services/Account/AccountConsoleClientTest.php`
- `composer lint app/controllers/api/account.php tests/e2e/Services/Account/AccountCustomClientTest.php tests/e2e/Services/Account/AccountConsoleClientTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G app/controllers/api/account.php tests/e2e/Services/Account/AccountCustomClientTest.php tests/e2e/Services/Account/AccountConsoleClientTest.php`
- Added E2E coverage asserting that console recovery is branded and normal project recovery remains unbranded.
- Rendered both repository templates with Playwright and uploaded the screenshots with Gitshot.

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
