### PR TITLE
Upgrade Messaging to 1.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "utopia-php/locale": "0.8.*",
         "utopia-php/lock": "0.2.*",
         "utopia-php/logger": "0.8.*",
-        "utopia-php/messaging": "^1.2",
+        "utopia-php/messaging": "^1.3",
         "utopia-php/migration": "1.17.*",
         "utopia-php/platform": "^1.0@RC",
         "utopia-php/pools": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcea2b6684445b7b5397e017c1eff89a",
+    "content-hash": "188ecad278dfe1db8beef12790f11843",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4459,16 +4459,16 @@
         },
         {
             "name": "utopia-php/messaging",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/messaging.git",
-                "reference": "3419ffbbeb242b3232b588430bd465024959720c"
+                "reference": "63a27be589fd998ad8489d66e570640c7cce9425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/3419ffbbeb242b3232b588430bd465024959720c",
-                "reference": "3419ffbbeb242b3232b588430bd465024959720c",
+                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/63a27be589fd998ad8489d66e570640c7cce9425",
+                "reference": "63a27be589fd998ad8489d66e570640c7cce9425",
                 "shasum": ""
             },
             "require": {
@@ -4505,9 +4505,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/messaging/issues",
-                "source": "https://github.com/utopia-php/messaging/tree/1.2.0"
+                "source": "https://github.com/utopia-php/messaging/tree/1.3.0"
             },
-            "time": "2026-06-23T04:24:43+00:00"
+            "time": "2026-07-14T07:21:08+00:00"
         },
         {
             "name": "utopia-php/migration",


### PR DESCRIPTION
## What does this PR do?

Updates `utopia-php/messaging` from 1.2.0 to 1.3.0.

This release surfaces FCM transport failures with the HTTP status and cURL error code instead of reporting an unknown error, improving push delivery diagnostics.

## Test Plan

- Ran `composer validate --no-check-publish --no-interaction`.
- Verified `composer show utopia-php/messaging` resolves version 1.3.0 at commit `63a27be589fd998ad8489d66e570640c7cce9425`.
- Ran `git diff --check`.

## Related PRs and Issues

- https://github.com/utopia-php/messaging/pull/136

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
