### PR TITLE
Fix duplicate SDK methods for multi-method routes

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -832,7 +832,7 @@ class OpenAPI3 extends Format
                 $url = \implode('/', $segments);
             }
 
-            $methods = $route->getMethods();
+            $methods = \array_values($route->getMethods());
             foreach ($methods as $index => $method) {
                 $methodTemp = $temp;
                 if (\count($methods) > 1) {

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -833,10 +833,17 @@ class OpenAPI3 extends Format
             }
 
             $methods = $route->getMethods();
-            foreach ($methods as $method) {
+            foreach ($methods as $index => $method) {
                 $methodTemp = $temp;
                 if (\count($methods) > 1) {
-                    $methodTemp['operationId'] .= \ucfirst(\strtolower($method));
+                    $suffix = \ucfirst(\strtolower($method));
+                    $methodTemp['operationId'] .= $suffix;
+
+                    // Keep the first method's SDK name stable while ensuring
+                    // additional HTTP methods generate unique SDK methods.
+                    if ($index > 0) {
+                        $methodTemp['x-appwrite']['method'] .= $suffix;
+                    }
                 }
                 $body = [
                     'content' => [

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -188,6 +188,8 @@ final class FormatTest extends TestCase
 
         $this->assertSame('testGetOrUpdateTestGet', $get['operationId']);
         $this->assertSame('testGetOrUpdateTestPost', $post['operationId']);
+        $this->assertSame('getOrUpdateTest', $get['x-appwrite']['method']);
+        $this->assertSame('getOrUpdateTestPost', $post['x-appwrite']['method']);
         $this->assertSame('path', $get['parameters'][0]['in']);
         $this->assertSame('query', $get['parameters'][1]['in']);
         $this->assertArrayNotHasKey('requestBody', $get);

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -168,7 +168,12 @@ final class FormatTest extends TestCase
         Method::$processed = [];
         Method::$errors = [];
 
-        $route = (new Route(['GET', 'POST'], '/v1/tests/:testId'))
+        $route = (new class (['GET', 'POST'], '/v1/tests/:testId') extends Route {
+            public function getMethods(): array
+            {
+                return [2 => 'GET', 4 => 'POST'];
+            }
+        })
             ->desc('Get or update test')
             ->label('sdk', new Method(
                 namespace: 'test',


### PR DESCRIPTION
## What does this PR do?

Ensures OpenAPI operations emitted from a multi-method route have unique `x-appwrite.method` names. The first HTTP method retains its existing SDK name for backward compatibility, while each additional method receives its HTTP method suffix.

This fixes Cloud Console SDK preview generation for GET/POST OAuth2 routes, which generated duplicate `authorize()` and `logout()` TypeScript implementations after #12867.

## Test Plan

- `php vendor/bin/phpunit tests/unit/SDK`
- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php`
- `composer refactor:check`
- `git diff --check`
- `composer analyze` *(currently fails on 1,000+ pre-existing errors in generated `app/sdks/server-php`; no errors reference the changed files)*

## Related PRs and Issues

- Follow-up to #12867
- Fixes the SDK preview failure on appwrite-labs/cloud#4775

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
