### PR TITLE
Upgrade Messaging to 2.0.0

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -39,8 +39,6 @@ use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Database\Validator\Queries\Identities;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
-use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumberUtil;
 use Utopia\Auth\Hashes\Sha;
 use Utopia\Auth\Proofs\Code as ProofsCode;
 use Utopia\Auth\Proofs\Password as ProofsPassword;
@@ -65,6 +63,7 @@ use Utopia\Emails\Email;
 use Utopia\Emails\Validator\Email as EmailValidator;
 use Utopia\Http\Http;
 use Utopia\Locale\Locale;
+use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Platform\Enum;
 use Utopia\Storage\Validator\FileName;
 use Utopia\System\System;
@@ -3169,15 +3168,9 @@ Http::post('/v1/account/tokens/phone')
                 providerType: MESSAGE_TYPE_SMS,
             ));
 
-            $helper = PhoneNumberUtil::getInstance();
-            try {
-                $countryCode = $helper->parse($phone)->getCountryCode();
-
-                if (!empty($countryCode)) {
-                    $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
-                }
-            } catch (NumberParseException $e) {
-                // Ignore invalid phone number for country code stats
+            $countryCode = CallingCode::fromPhoneNumber($phone);
+            if (!empty($countryCode)) {
+                $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
             }
             $usage->addMetric(METRIC_AUTH_METHOD_PHONE, 1);
         }
@@ -4516,15 +4509,9 @@ Http::post('/v1/account/verifications/phone')
                 providerType: MESSAGE_TYPE_SMS,
             ));
 
-            $helper = PhoneNumberUtil::getInstance();
-            try {
-                $countryCode = $helper->parse($phone)->getCountryCode();
-
-                if (!empty($countryCode)) {
-                    $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
-                }
-            } catch (NumberParseException $e) {
-                // Ignore invalid phone number for country code stats
+            $countryCode = CallingCode::fromPhoneNumber($phone);
+            if (!empty($countryCode)) {
+                $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
             }
             $usage->addMetric(METRIC_AUTH_METHOD_PHONE, 1);
         }

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "utopia-php/locale": "0.8.*",
         "utopia-php/lock": "0.2.*",
         "utopia-php/logger": "0.8.*",
-        "utopia-php/messaging": "^1.3",
+        "utopia-php/messaging": "^2.0",
         "utopia-php/migration": "1.17.*",
         "utopia-php/platform": "^1.0@RC",
         "utopia-php/pools": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "188ecad278dfe1db8beef12790f11843",
+    "content-hash": "76d2d2fb21b35baa50a67393bd542e68",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -604,84 +604,6 @@
                 "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
             },
             "time": "2025-08-12T10:13:48+00:00"
-        },
-        {
-            "name": "giggsey/libphonenumber-for-php-lite",
-            "version": "9.0.23",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/giggsey/libphonenumber-for-php-lite.git",
-                "reference": "e8f6f896c1bef398136849934a934904bd9bf072"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/e8f6f896c1bef398136849934a934904bd9bf072",
-                "reference": "e8f6f896c1bef398136849934a934904bd9bf072",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1",
-                "symfony/polyfill-mbstring": "^1.17"
-            },
-            "conflict": {
-                "giggsey/libphonenumber-for-php": "*"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "friendsofphp/php-cs-fixer": "^3.71",
-                "infection/infection": "^0.29|^0.31.0",
-                "nette/php-generator": "^4.1",
-                "php-coveralls/php-coveralls": "^2.7",
-                "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.1.7",
-                "phpstan/phpstan-deprecation-rules": "^2.0.1",
-                "phpstan/phpstan-phpunit": "^2.0.4",
-                "phpstan/phpstan-strict-rules": "^2.0.3",
-                "phpunit/phpunit": "^10.5.45",
-                "symfony/console": "^6.4",
-                "symfony/filesystem": "^6.4",
-                "symfony/process": "^6.4"
-            },
-            "suggest": {
-                "giggsey/libphonenumber-for-php": "Use libphonenumber-for-php for geocoding, carriers, timezones and matching"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "libphonenumber\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Joshua Gigg",
-                    "email": "giggsey@gmail.com",
-                    "homepage": "https://giggsey.com/"
-                }
-            ],
-            "description": "A lite version of giggsey/libphonenumber-for-php, which is a PHP Port of Google's libphonenumber",
-            "homepage": "https://github.com/giggsey/libphonenumber-for-php-lite",
-            "keywords": [
-                "geocoding",
-                "geolocation",
-                "libphonenumber",
-                "mobile",
-                "phonenumber",
-                "validation"
-            ],
-            "support": {
-                "issues": "https://github.com/giggsey/libphonenumber-for-php-lite/issues",
-                "source": "https://github.com/giggsey/libphonenumber-for-php-lite"
-            },
-            "time": "2026-01-30T12:33:03+00:00"
         },
         {
             "name": "google/protobuf",
@@ -4459,30 +4381,34 @@
         },
         {
             "name": "utopia-php/messaging",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/messaging.git",
-                "reference": "63a27be589fd998ad8489d66e570640c7cce9425"
+                "reference": "8890c3b2e94bdf832c17fd3d7832cdf01b933eb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/63a27be589fd998ad8489d66e570640c7cce9425",
-                "reference": "63a27be589fd998ad8489d66e570640c7cce9425",
+                "url": "https://api.github.com/repos/utopia-php/messaging/zipball/8890c3b2e94bdf832c17fd3d7832cdf01b933eb7",
+                "reference": "8890c3b2e94bdf832c17fd3d7832cdf01b933eb7",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-openssl": "*",
-                "giggsey/libphonenumber-for-php-lite": "9.0.23",
-                "php": ">=8.1.0",
-                "phpmailer/phpmailer": "6.9.1",
+                "ext-swoole": "*",
+                "php": ">=8.5.0",
+                "phpmailer/phpmailer": "^6.9",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "utopia-php/client": "^0.2",
                 "utopia-php/telemetry": "^0.4"
             },
             "require-dev": {
-                "laravel/pint": "1.*",
-                "phpstan/phpstan": "1.*",
-                "phpunit/phpunit": "11.*"
+                "laravel/pint": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "swoole/ide-helper": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4505,9 +4431,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/messaging/issues",
-                "source": "https://github.com/utopia-php/messaging/tree/1.3.0"
+                "source": "https://github.com/utopia-php/messaging/tree/2.0.0"
             },
-            "time": "2026-07-14T07:21:08+00:00"
+            "time": "2026-07-14T10:22:03+00:00"
         },
         {
             "name": "utopia-php/migration",

--- a/pint.json
+++ b/pint.json
@@ -1,9 +1,9 @@
 {
     "preset": "psr12",
     "exclude": [
-        "./app/sdks",
-        "./tests/resources/functions",
-        "./app/console"
+        "app/sdks",
+        "tests/resources/functions",
+        "app/console"
     ],
     "rules": {
         "array_indentation": true,

--- a/src/Appwrite/Auth/Validator/Phone.php
+++ b/src/Appwrite/Auth/Validator/Phone.php
@@ -2,8 +2,7 @@
 
 namespace Appwrite\Auth\Validator;
 
-use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumberUtil;
+use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Validator;
 
 /**
@@ -14,12 +13,10 @@ use Utopia\Validator;
 class Phone extends Validator
 {
     protected bool $allowEmpty;
-    protected PhoneNumberUtil $helper;
 
     public function __construct(bool $allowEmpty = false)
     {
         $this->allowEmpty = $allowEmpty;
-        $this->helper = PhoneNumberUtil::getInstance();
     }
 
     /**
@@ -51,9 +48,7 @@ class Phone extends Validator
             return true;
         }
 
-        try {
-            $this->helper->parse($value);
-        } catch (NumberParseException $e) {
+        if (CallingCode::fromPhoneNumber($value) === null) {
             return false;
         }
 

--- a/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
+++ b/src/Appwrite/Platform/Modules/Account/Http/Account/MFA/Challenges/Create.php
@@ -20,8 +20,6 @@ use Appwrite\Template\Template;
 use Appwrite\Usage\Context;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
-use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumberUtil;
 use Utopia\Auth\Proofs\Code as ProofsCode;
 use Utopia\Auth\Proofs\Token as ProofsToken;
 use Utopia\Database\Database;
@@ -30,6 +28,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Locale\Locale;
+use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Validator\FileName;
@@ -196,15 +195,9 @@ class Create extends Action
                     providerType: MESSAGE_TYPE_SMS,
                 ));
 
-                $helper = PhoneNumberUtil::getInstance();
-                try {
-                    $countryCode = $helper->parse($phone)->getCountryCode();
-
-                    if (!empty($countryCode)) {
-                        $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
-                    }
-                } catch (NumberParseException $e) {
-                    // Ignore invalid phone number for country code stats
+                $countryCode = CallingCode::fromPhoneNumber($phone);
+                if (!empty($countryCode)) {
+                    $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
                 }
                 $usage->addMetric(METRIC_AUTH_METHOD_PHONE, 1);
                 break;

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -17,8 +17,6 @@ use Appwrite\Template\Template;
 use Appwrite\Usage\Context;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Response;
-use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumberUtil;
 use Utopia\Auth\Proofs\Password;
 use Utopia\Auth\Proofs\Token;
 use Utopia\Database\Database;
@@ -35,6 +33,7 @@ use Utopia\Database\Validator\UID;
 use Utopia\Emails\Email;
 use Utopia\Emails\Validator\Email as EmailValidator;
 use Utopia\Locale\Locale;
+use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\System\System;
 use Utopia\Validator\ArrayList;
@@ -450,15 +449,9 @@ class Create extends Action
                     providerType: 'SMS',
                 ));
 
-                $helper = PhoneNumberUtil::getInstance();
-                try {
-                    $countryCode = $helper->parse($phone)->getCountryCode();
-
-                    if (! empty($countryCode)) {
-                        $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
-                    }
-                } catch (NumberParseException $e) {
-                    // Ignore invalid phone number for country code stats
+                $countryCode = CallingCode::fromPhoneNumber($phone);
+                if (! empty($countryCode)) {
+                    $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
                 }
                 $usage->addMetric(METRIC_AUTH_METHOD_PHONE, 1);
             }

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -6,8 +6,6 @@ use Appwrite\Event\Message\Usage;
 use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Messaging\Status as MessageStatus;
 use Appwrite\Usage\Context as UsageContext;
-use libphonenumber\NumberParseException;
-use libphonenumber\PhoneNumberUtil;
 use Swoole\Runtime;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
@@ -30,6 +28,7 @@ use Utopia\Messaging\Adapter\Push\FCM;
 use Utopia\Messaging\Adapter\SMS as SMSAdapter;
 use Utopia\Messaging\Adapter\SMS\Fast2SMS;
 use Utopia\Messaging\Adapter\SMS\GEOSMS;
+use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Messaging\Adapter\SMS\Inforu;
 use Utopia\Messaging\Adapter\SMS\Mock;
 use Utopia\Messaging\Adapter\SMS\Msg91;
@@ -811,12 +810,7 @@ class Messaging extends Action
         $from = System::getEnv('_APP_SMS_FROM', '');
         Span::add('message.from', $from);
 
-        try {
-            $phoneNumber = PhoneNumberUtil::getInstance()->parse($recipients[0] ?? '');
-            Span::add('message.country_code', $phoneNumber->getCountryCode());
-        } catch (NumberParseException $e) {
-            Span::add('message.country_code', 'unknown');
-        }
+        Span::add('message.country_code', CallingCode::fromPhoneNumber($recipients[0] ?? '') ?? 'unknown');
 
         $sms = new SMS(
             $recipients,

--- a/src/Appwrite/Utopia/Messaging/Adapter/Console.php
+++ b/src/Appwrite/Utopia/Messaging/Adapter/Console.php
@@ -21,6 +21,7 @@ class Console extends Adapter
 
     public function __construct(protected Database $database)
     {
+        parent::__construct();
     }
 
     public function getName(): string


### PR DESCRIPTION
## What does this PR do?

Upgrades `utopia-php/messaging` from 1.3.0 to [2.0.0](https://github.com/utopia-php/messaging/releases/tag/2.0.0) and migrates off the `libphonenumber` dependency the library dropped.

### What changed in messaging 2.0.0

- The HTTP transport is now `utopia-php/client` (PSR-18) instead of raw curl. `requestMulti()` (batched FCM/APNS sends) fans out over Swoole coroutines with a bounded connection pool, keeping HTTP/2 via cURL for APNs. Adapter APIs and result shapes are unchanged.
- The base `Adapter` gained a constructor accepting an optional telemetry adapter and PSR-18 client factory.
- `Adapter::getCountryCode()` was removed along with the `giggsey/libphonenumber-for-php-lite` dependency; `CallingCode::fromPhoneNumber()` is the replacement.
- Requires PHP ≥ 8.5 and `ext-swoole` — both already satisfied by our `composer.json`.

No `clientFactory` is injected anywhere: the default client (HTTP/2 cURL) is exactly what our workers need. With `SWOOLE_HOOK_NATIVE_CURL` active (`app/worker.php` enables `SWOOLE_HOOK_ALL`; the Messaging worker sets `SWOOLE_HOOK_ALL ^ SWOOLE_HOOK_TCP`), the pooled cURL sends run concurrently inside coroutines. `Swoole\Coroutine\Http\Client` would actually be the wrong choice here since it cannot negotiate the HTTP/2 connections APNs requires.

### libphonenumber migration

`giggsey/libphonenumber-for-php-lite` only existed in our vendor tree transitively through messaging 1.x, but five files used it directly. All call sites only ever extracted the calling code (`parse($phone)->getCountryCode()`), so they now use the messaging library's `CallingCode::fromPhoneNumber()` table lookup instead.

The metric call sites in `app/controllers/api/account.php` (phone tokens + phone verifications), `Account/Http/Account/MFA/Challenges/Create.php`, and `Teams/Http/Memberships/Create.php` go from:

```php
$helper = PhoneNumberUtil::getInstance();
try {
    $countryCode = $helper->parse($phone)->getCountryCode();

    if (!empty($countryCode)) {
        $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
    }
} catch (NumberParseException $e) {
    // Ignore invalid phone number for country code stats
}
```

to:

```php
$countryCode = CallingCode::fromPhoneNumber($phone);
if (!empty($countryCode)) {
    $usage->addMetric(str_replace('{countryCode}', $countryCode, METRIC_AUTH_METHOD_PHONE_COUNTRY_CODE), 1);
}
```

The metric keys are unchanged (`"91"` as a string interpolates identically to libphonenumber's `91` int). The tracing span in the Messaging worker becomes a one-liner:

```php
Span::add('message.country_code', CallingCode::fromPhoneNumber($recipients[0] ?? '') ?? 'unknown');
```

The `Phone` validator needed more care. Its E.164 regex alone is not equivalent to the old `parse()` call — `PhoneTest` expects `+8020000000` to be rejected because 80 is not a valid calling code, and the regex would accept it. The validator now requires the calling code to resolve before applying the regex:

```php
if (CallingCode::fromPhoneNumber($value) === null) {
    return false;
}

return !!\preg_match('/^\+[1-9]\d{6,14}$/', $value);
```

`CallingCode::fromPhoneNumber()` was verified against every case in `PhoneTest` and produces the exact expected results. Semantics note for reviewers: it is a longest-prefix table lookup, not a full parse, so garbage input yields `null` instead of a `NumberParseException` — equivalent for all these call sites.

### Console adapter constructor

In 1.x the base `Adapter` had no constructor. In 2.0 it initializes a typed private `$sendCounter` property:

```php
public function __construct(?Telemetry $telemetry = null, private ?Closure $clientFactory = null)
{
    $this->sendCounter = ($telemetry ?? new NoTelemetry())->createCounter('messaging.send');
}
```

Our `Console` adapter defines its own constructor, which suppresses the implicit parent call, so it now calls `parent::__construct()`. Not strictly required today (`Console` overrides `send()` and never reads the counter), but skipping parent construction leaves the property uninitialized — a latent fatal if `Console` ever routes through the base `send()` wrapper or a future 2.x reads the property elsewhere.

### Pint exclude fix

Repo-wide `composer lint` was failing on the generated SDK under `app/sdks/` because Pint no longer honors `./`-prefixed paths in `exclude`. Dropped the `./` prefix in `pint.json`; `composer lint` passes across the repo again.

## Test plan

- [x] `composer lint` / `composer format` pass (repo-wide, after the pint.json fix)
- [x] PHPStan clean on all touched files
- [x] `tests/unit/` in container: 870/870 pass (includes `PhoneTest` and the 15 Console/Webhook adapter tests)
- [x] `tests/e2e/Services/Messaging`: 96 pass, 24 skipped (skips require real provider credentials, as on `main`) — exercises the rewritten PSR-18 transport through the messaging worker
- [x] `tests/e2e/Services/Account --filter=Phone`: 6/6 pass — covers the phone token/verification metric paths and the worker span change end-to-end

## Related PRs and Issues

- https://github.com/utopia-php/messaging/pull/137
