### PR TITLE
fix: harden flaky DocumentsDBCustomServerTest::testTimeout

### DIFF
--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -175,10 +175,12 @@ class Client
      * @param array $params
      * @param array $headers
      * @param bool $decode
+     * @param bool $followRedirects
+     * @param int $timeout Curl transfer timeout in seconds. Large payloads under CI load may need more than the default.
      * @return array
      * @throws Exception
      */
-    public function call(string $method, string $path = '', array $headers = [], mixed $params = [], bool $decode = true, bool $followRedirects = true): array
+    public function call(string $method, string $path = '', array $headers = [], mixed $params = [], bool $decode = true, bool $followRedirects = true, int $timeout = 120): array
     {
         $headers            = array_merge($this->headers, $headers);
         $ch                 = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
@@ -218,7 +220,7 @@ class Client
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36');
         curl_setopt($ch, CURLOPT_HTTPHEADER, $formattedHeaders);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         curl_setopt($ch, CURLOPT_COOKIEFILE, ''); // enable in-memory RFC 6265 cookie engine
         curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
             $len = strlen($header);

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -7436,8 +7436,7 @@ trait DatabasesBase
             $this->waitForAttribute($data['databaseId'], $data['$id'], 'longtext');
         }
 
-        // ~12MB payloads: under parallel CI load a single create can exceed the default 120s
-        // curl timeout (seen repeatedly as DocumentsDBCustomServerTest::testTimeout flakes).
+        // Large (~12MB) creates can exceed the default 120s client timeout under CI load.
         $longtextValue = file_get_contents(__DIR__ . '/../../../resources/longtext.txt');
         $this->assertNotFalse($longtextValue);
         $createTimeout = 300;

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -7436,21 +7436,29 @@ trait DatabasesBase
             $this->waitForAttribute($data['databaseId'], $data['$id'], 'longtext');
         }
 
+        // ~12MB payloads: under parallel CI load a single create can exceed the default 120s
+        // curl timeout (seen repeatedly as DocumentsDBCustomServerTest::testTimeout flakes).
+        $longtextValue = file_get_contents(__DIR__ . '/../../../resources/longtext.txt');
+        $this->assertNotFalse($longtextValue);
+        $createTimeout = 300;
+
         for ($i = 0; $i < 10; $i++) {
-            $this->client->call(Client::METHOD_POST, $this->getRecordUrl($data['databaseId'], $data['$id']), array_merge([
+            $document = $this->client->call(Client::METHOD_POST, $this->getRecordUrl($data['databaseId'], $data['$id']), array_merge([
                 'content-type' => 'application/json',
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], $this->getHeaders()), [
                 $this->getRecordIdParam() => ID::unique(),
                 'data' => [
-                    'longtext' => file_get_contents(__DIR__ . '/../../../resources/longtext.txt'),
+                    'longtext' => $longtextValue,
                 ],
                 'permissions' => [
                     Permission::read(Role::user($this->getUser()['$id'])),
                     Permission::update(Role::user($this->getUser()['$id'])),
                     Permission::delete(Role::user($this->getUser()['$id'])),
                 ]
-            ]);
+            ], true, true, $createTimeout);
+
+            $this->assertEquals(201, $document['headers']['status-code']);
         }
 
         $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($data['databaseId'], $data['$id']), array_merge([


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Audited recent merged PR "PHP-Retry Summary" comments. The most frequent flaky test was `DocumentsDBCustomServerTest::testTimeout` (10 occurrences), with the shared `DatabasesBase::testTimeout` also failing as TablesDB/Legacy variants.

**Root cause:** Setup creates 10 documents with ~12MB `longtext` payloads. Under parallel CI load, a single create exceeds the e2e client's hard 120s curl timeout:

```
Exception: Operation timed out after 120002 milliseconds with 0 bytes received with status code 100
Client.php → DatabasesBase.php (document create loop)
```

On retry in isolation the same test passes in ~14s.

**Fix:**
1. Allow `Client::call()` to take an optional per-request `$timeout` (default still 120s).
2. Use a 300s timeout for the large document creates in `testTimeout`.
3. Load the longtext fixture once and assert each create returns 201.

## Test Plan

- CI e2e (`DocumentsDBCustomServerTest::testTimeout` / Databases suite) — this environment has no local PHP/Docker to run the suite.
- Change is test-only; default client timeout for all other calls is unchanged.

## Related PRs and Issues

- #12832
- #12790
- #12778
- #12765
- #12757
- #12732
- #12702
- #12671
- #12658
- #12656

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1f4f433-2ee8-4e50-9d96-2b3b967caec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1f4f433-2ee8-4e50-9d96-2b3b967caec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

