### PR TITLE
fix: harden flaky RealtimeConsoleClientTest::testIndexesTablesAPI

### DIFF
--- a/tests/e2e/Services/Realtime/RealtimeConsoleClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeConsoleClientTest.php
@@ -12,6 +12,8 @@ use Tests\E2E\Services\Functions\FunctionsBase;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
+use WebSocket\Client as WebSocketClient;
+use WebSocket\TimeoutException;
 
 final class RealtimeConsoleClientTest extends Scope
 {
@@ -19,6 +21,37 @@ final class RealtimeConsoleClientTest extends Scope
     use RealtimeBase;
     use ProjectCustom;
     use SideConsole;
+
+    /**
+     * Console-channel subscriptions receive events from every project sharing
+     * the console session. Skip unrelated frames until the expected event arrives.
+     */
+    private function receiveUntilEvent(WebSocketClient $client, string $event, int $timeoutMs = 10000): array
+    {
+        $deadline = \microtime(true) + ($timeoutMs / 1000);
+        $lastMessage = [];
+
+        while (\microtime(true) < $deadline) {
+            try {
+                $message = \json_decode($client->receive(), true);
+            } catch (TimeoutException) {
+                continue;
+            }
+
+            if (!\is_array($message)) {
+                continue;
+            }
+
+            $lastMessage = $message;
+            if (($message['type'] ?? null) === 'event'
+                && \in_array($event, $message['data']['events'] ?? [], true)
+            ) {
+                return $message;
+            }
+        }
+
+        $this->fail('Timed out waiting for realtime event "' . $event . '". Last frame: ' . \json_encode($lastMessage));
+    }
 
     /**
      * Helper to create database + collection with a string attribute.
@@ -641,7 +674,10 @@ final class RealtimeConsoleClientTest extends Scope
 
         $projectId = $this->getProject()['$id'];
 
-        $response = json_decode($client->receive(), true);
+        $response = $this->receiveUntilEvent(
+            $client,
+            "databases.{$databaseId}.tables.{$actorsId}.indexes.*.create"
+        );
 
         $this->assertArrayHasKey('type', $response);
         $this->assertArrayHasKey('data', $response);
@@ -660,7 +696,10 @@ final class RealtimeConsoleClientTest extends Scope
         $this->assertNotEmpty($response['data']['payload']);
         $this->assertEquals('processing', $response['data']['payload']['status']);
 
-        $response = json_decode($client->receive(), true);
+        $response = $this->receiveUntilEvent(
+            $client,
+            "databases.{$databaseId}.tables.{$actorsId}.indexes.*.update"
+        );
 
         $this->assertArrayHasKey('type', $response);
         $this->assertArrayHasKey('data', $response);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Next flakiest test after `DocumentsDBCustomServerTest::testTimeout` in PHP-Retry Summary audits: `RealtimeConsoleClientTest::testIndexesTablesAPI` (9 occurrences).

**Root cause:** The test subscribes to the shared `console` websocket channel. Under ParaTest parallelism, the next frame after creating an index is often an unrelated console event from another project, so asserting on the first `receive()` fails:

```
Failed asserting that an array contains 'databases.{id}.tables.{id}.indexes.*.create'.
RealtimeConsoleClientTest.php:654
```

On retry in isolation the test passes.

**Fix:** Add `receiveUntilEvent()` that skips unrelated frames until the expected create/update event arrives (same pattern as PresenceRealtimeClientTest's `receiveUntil`). Only `testIndexesTablesAPI` is updated in this PR.

## Test Plan

- CI realtime e2e (`RealtimeConsoleClientTest::testIndexesTablesAPI`)
- Change is test-only

## Related PRs and Issues

- #12870
- #12769
- #12747
- #12740
- #12738
- #12728
- #12693
- #12641

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1f4f433-2ee8-4e50-9d96-2b3b967caec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1f4f433-2ee8-4e50-9d96-2b3b967caec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

