### PR TITLE
Fix build specification tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4437,16 +4437,16 @@
         },
         {
             "name": "utopia-php/migration",
-            "version": "1.17.2",
+            "version": "1.17.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "80f7f49e79ad57a0b5200b043e2b1bfeade8a190"
+                "reference": "daf1008800633416a186c18069e3a5784de88d1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/80f7f49e79ad57a0b5200b043e2b1bfeade8a190",
-                "reference": "80f7f49e79ad57a0b5200b043e2b1bfeade8a190",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/daf1008800633416a186c18069e3a5784de88d1c",
+                "reference": "daf1008800633416a186c18069e3a5784de88d1c",
                 "shasum": ""
             },
             "require": {
@@ -4486,9 +4486,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/1.17.2"
+                "source": "https://github.com/utopia-php/migration/tree/1.17.3"
             },
-            "time": "2026-07-09T19:53:43+00:00"
+            "time": "2026-07-14T14:04:00+00:00"
         },
         {
             "name": "utopia-php/mongo",

--- a/tests/e2e/Services/Functions/FunctionsBase.php
+++ b/tests/e2e/Services/Functions/FunctionsBase.php
@@ -492,4 +492,13 @@ trait FunctionsBase
 
         return $specifications;
     }
+
+    protected function getEnabledSpecification(array $specifications): string
+    {
+        $specification = array_find($specifications, fn (array $specification) => $specification['enabled']);
+
+        $this->assertNotNull($specification, 'Expected at least one enabled specification.');
+
+        return $specification['slug'];
+    }
 }

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -190,7 +190,10 @@ final class FunctionsCustomServerTest extends Scope
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
         $this->assertEquals(200, $buildSpecifications['headers']['status-code']);
         $this->assertEquals($specifications['body']['total'], $buildSpecifications['body']['total']);
-        $buildSpecification = $buildSpecifications['body']['specifications'][0]['slug'];
+        $buildSpecification = array_find(
+            $buildSpecifications['body']['specifications'],
+            fn (array $specification) => $specification['enabled']
+        )['slug'];
 
         $function = $this->createFunction([
             'functionId' => ID::unique(),

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -190,10 +190,7 @@ final class FunctionsCustomServerTest extends Scope
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
         $this->assertEquals(200, $buildSpecifications['headers']['status-code']);
         $this->assertEquals($specifications['body']['total'], $buildSpecifications['body']['total']);
-        $buildSpecification = array_find(
-            $buildSpecifications['body']['specifications'],
-            fn (array $specification) => $specification['enabled']
-        )['slug'];
+        $buildSpecification = $this->getEnabledSpecification($buildSpecifications['body']['specifications']);
 
         $function = $this->createFunction([
             'functionId' => ID::unique(),

--- a/tests/e2e/Services/Sites/SitesBase.php
+++ b/tests/e2e/Services/Sites/SitesBase.php
@@ -487,4 +487,13 @@ trait SitesBase
 
         return $specifications;
     }
+
+    protected function getEnabledSpecification(array $specifications): string
+    {
+        $specification = array_find($specifications, fn (array $specification) => $specification['enabled']);
+
+        $this->assertNotNull($specification, 'Expected at least one enabled specification.');
+
+        return $specification['slug'];
+    }
 }

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -43,7 +43,10 @@ final class SitesCustomServerTest extends Scope
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
         $this->assertEquals(200, $buildSpecifications['headers']['status-code']);
         $this->assertEquals($specifications['body']['total'], $buildSpecifications['body']['total']);
-        $buildSpecification = $buildSpecifications['body']['specifications'][0]['slug'];
+        $buildSpecification = array_find(
+            $buildSpecifications['body']['specifications'],
+            fn (array $specification) => $specification['enabled']
+        )['slug'];
 
         $site = $this->createSite([
             'buildRuntime' => 'node-22',
@@ -86,7 +89,10 @@ final class SitesCustomServerTest extends Scope
     public function testCreateSite(): void
     {
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
-        $buildSpecification = $buildSpecifications['body']['specifications'][0]['slug'];
+        $buildSpecification = array_find(
+            $buildSpecifications['body']['specifications'],
+            fn (array $specification) => $specification['enabled']
+        )['slug'];
 
         /**
          * Test for SUCCESS
@@ -748,7 +754,10 @@ final class SitesCustomServerTest extends Scope
          */
         $siteId = $this->setupSite([
             'buildRuntime' => 'node-22',
-            'buildSpecification' => $buildSpecifications['body']['specifications'][0]['slug'],
+            'buildSpecification' => array_find(
+                $buildSpecifications['body']['specifications'],
+                fn (array $specification) => $specification['enabled']
+            )['slug'],
             'fallbackFile' => '',
             'framework' => 'analog',
             'name' => 'Test List Sites',
@@ -894,7 +903,10 @@ final class SitesCustomServerTest extends Scope
 
         $siteId = $this->setupSite([
             'buildRuntime' => 'node-22',
-            'buildSpecification' => $buildSpecifications['body']['specifications'][0]['slug'],
+            'buildSpecification' => array_find(
+                $buildSpecifications['body']['specifications'],
+                fn (array $specification) => $specification['enabled']
+            )['slug'],
             'fallbackFile' => '',
             'framework' => 'other',
             'name' => 'Test Site',
@@ -1682,7 +1694,10 @@ final class SitesCustomServerTest extends Scope
     public function testUpdateSpecs(): void
     {
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
-        $buildSpecification = $buildSpecifications['body']['specifications'][0]['slug'];
+        $buildSpecification = array_find(
+            $buildSpecifications['body']['specifications'],
+            fn (array $specification) => $specification['enabled']
+        )['slug'];
 
         $siteId = $this->setupSite([
             'buildRuntime' => 'node-22',

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -43,10 +43,7 @@ final class SitesCustomServerTest extends Scope
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
         $this->assertEquals(200, $buildSpecifications['headers']['status-code']);
         $this->assertEquals($specifications['body']['total'], $buildSpecifications['body']['total']);
-        $buildSpecification = array_find(
-            $buildSpecifications['body']['specifications'],
-            fn (array $specification) => $specification['enabled']
-        )['slug'];
+        $buildSpecification = $this->getEnabledSpecification($buildSpecifications['body']['specifications']);
 
         $site = $this->createSite([
             'buildRuntime' => 'node-22',
@@ -89,10 +86,7 @@ final class SitesCustomServerTest extends Scope
     public function testCreateSite(): void
     {
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
-        $buildSpecification = array_find(
-            $buildSpecifications['body']['specifications'],
-            fn (array $specification) => $specification['enabled']
-        )['slug'];
+        $buildSpecification = $this->getEnabledSpecification($buildSpecifications['body']['specifications']);
 
         /**
          * Test for SUCCESS
@@ -754,10 +748,7 @@ final class SitesCustomServerTest extends Scope
          */
         $siteId = $this->setupSite([
             'buildRuntime' => 'node-22',
-            'buildSpecification' => array_find(
-                $buildSpecifications['body']['specifications'],
-                fn (array $specification) => $specification['enabled']
-            )['slug'],
+            'buildSpecification' => $this->getEnabledSpecification($buildSpecifications['body']['specifications']),
             'fallbackFile' => '',
             'framework' => 'analog',
             'name' => 'Test List Sites',
@@ -903,10 +894,7 @@ final class SitesCustomServerTest extends Scope
 
         $siteId = $this->setupSite([
             'buildRuntime' => 'node-22',
-            'buildSpecification' => array_find(
-                $buildSpecifications['body']['specifications'],
-                fn (array $specification) => $specification['enabled']
-            )['slug'],
+            'buildSpecification' => $this->getEnabledSpecification($buildSpecifications['body']['specifications']),
             'fallbackFile' => '',
             'framework' => 'other',
             'name' => 'Test Site',
@@ -1694,10 +1682,7 @@ final class SitesCustomServerTest extends Scope
     public function testUpdateSpecs(): void
     {
         $buildSpecifications = $this->listSpecifications(['type' => 'builds']);
-        $buildSpecification = array_find(
-            $buildSpecifications['body']['specifications'],
-            fn (array $specification) => $specification['enabled']
-        )['slug'];
+        $buildSpecification = $this->getEnabledSpecification($buildSpecifications['body']['specifications']);
 
         $siteId = $this->setupSite([
             'buildRuntime' => 'node-22',


### PR DESCRIPTION
## Summary
- select enabled build specifications in Sites E2E tests
- select an enabled build specification in the Functions specifications test
- support plans that expose runtime specifications disabled for builds

## Tests
- `php -l tests/e2e/Services/Sites/SitesCustomServerTest.php`
- `php -l tests/e2e/Services/Functions/FunctionsCustomServerTest.php`