### PR TITLE
Handle GitHub OAuth token errors

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -347,6 +347,11 @@ return [
         'description' => 'OAuth2 provider returned some error.',
         'code' => 424,
     ],
+    Exception::USER_OAUTH2_PROVIDER_FAILURE => [
+        'name' => Exception::USER_OAUTH2_PROVIDER_FAILURE,
+        'description' => '%s couldn\'t complete sign-in (%s). Please try again.',
+        'code' => 424,
+    ],
     Exception::USER_EMAIL_NOT_VERIFIED => [
         'name' => Exception::USER_EMAIL_NOT_VERIFIED,
         'description' => 'User email is not verified',

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1617,11 +1617,12 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             $accessTokenExpiry = $oauth2->getAccessTokenExpiry($code);
 
         } catch (OAuth2Exception $ex) {
+            $providerError = $ex->getError() ?: $ex->getMessage();
 
             $failureRedirect(
                 Exception::USER_OAUTH2_PROVIDER_FAILURE,
                 previous: $ex,
-                params: [$providerName, $ex->getError()],
+                params: [$providerName, $providerError],
             );
         }
 

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1570,8 +1570,8 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             $failure = URLParser::parse($state['failure']);
         }
 
-        $failureRedirect = (function (string $type, ?string $message = null, ?int $code = null) use ($failure, $response) {
-            $exception = new Exception($type, $message, $code);
+        $failureRedirect = (function (string $type, ?string $message = null, ?int $code = null, ?\Throwable $previous = null, array $params = []) use ($failure, $response) {
+            $exception = new Exception($type, $message, $code, $previous, params: $params);
             if (!empty($failure)) {
                 $query = URLParser::parseQuery($failure['query']);
                 $query['error'] = json_encode([
@@ -1619,9 +1619,9 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
         } catch (OAuth2Exception $ex) {
 
             $failureRedirect(
-                $ex->getType(),
-                'Failed to obtain access token. The ' . $providerName . ' OAuth2 provider returned an error: ' . $ex->getMessage(),
-                $ex->getCode(),
+                Exception::USER_OAUTH2_PROVIDER_FAILURE,
+                previous: $ex,
+                params: [$providerName, $ex->getError()],
             );
         }
 

--- a/src/Appwrite/Auth/OAuth2/Github.php
+++ b/src/Appwrite/Auth/OAuth2/Github.php
@@ -112,7 +112,10 @@ class Github extends OAuth2
         }
 
         if (isset($tokens['error'])) {
-            throw new Exception(\json_encode($tokens) ?: $response, 400);
+            throw new Exception(\json_encode(
+                $tokens,
+                JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR,
+            ), 400);
         }
 
         if (empty($tokens['access_token'])) {

--- a/src/Appwrite/Auth/OAuth2/Github.php
+++ b/src/Appwrite/Auth/OAuth2/Github.php
@@ -56,7 +56,7 @@ class Github extends OAuth2
             $response = $this->request(
                 'POST',
                 'https://github.com/login/oauth/access_token',
-                [],
+                ['Accept: application/json'],
                 \http_build_query([
                     'client_id' => $this->appID,
                     'redirect_uri' => $this->callback,
@@ -65,9 +65,7 @@ class Github extends OAuth2
                 ])
             );
 
-            $output = [];
-            \parse_str($response, $output);
-            $this->tokens = $output;
+            $this->tokens = $this->parseTokens($response);
         }
 
         return $this->tokens;
@@ -83,7 +81,7 @@ class Github extends OAuth2
         $response = $this->request(
             'POST',
             'https://github.com/login/oauth/access_token',
-            [],
+            ['Accept: application/json'],
             \http_build_query([
                 'client_id' => $this->appID,
                 'client_secret' => $this->appSecret,
@@ -92,15 +90,39 @@ class Github extends OAuth2
             ])
         );
 
-        $output = [];
-        \parse_str($response, $output);
-        $this->tokens = $output;
+        $this->tokens = $this->parseTokens($response);
 
         if (empty($this->tokens['refresh_token'])) {
             $this->tokens['refresh_token'] = $refreshToken;
         }
 
         return $this->tokens;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseTokens(string $response): array
+    {
+        $tokens = \json_decode($response, true);
+
+        if (!\is_array($tokens)) {
+            $tokens = [];
+            \parse_str($response, $tokens);
+        }
+
+        if (isset($tokens['error'])) {
+            throw new Exception(\json_encode($tokens) ?: $response, 400);
+        }
+
+        if (empty($tokens['access_token'])) {
+            throw new Exception(\json_encode([
+                'error' => 'access_token_missing',
+                'error_description' => 'GitHub did not return an access token.',
+            ]), 400);
+        }
+
+        return $tokens;
     }
 
     /**

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -108,6 +108,7 @@ class Exception extends \Exception
     public const string USER_OAUTH2_BAD_REQUEST = 'user_oauth2_bad_request';
     public const string USER_OAUTH2_UNAUTHORIZED = 'user_oauth2_unauthorized';
     public const string USER_OAUTH2_PROVIDER_ERROR = 'user_oauth2_provider_error';
+    public const string USER_OAUTH2_PROVIDER_FAILURE = 'user_oauth2_provider_failure';
     public const string USER_EMAIL_ALREADY_VERIFIED = 'user_email_already_verified';
     public const string USER_PHONE_ALREADY_VERIFIED = 'user_phone_already_verified';
     public const string USER_DELETION_PROHIBITED = 'user_deletion_prohibited';

--- a/tests/unit/Auth/OAuth2/GithubTest.php
+++ b/tests/unit/Auth/OAuth2/GithubTest.php
@@ -40,6 +40,40 @@ final class GithubTest extends TestCase
         }
     }
 
+    public function testFormEncodedProviderError(): void
+    {
+        $github = $this->createGithub(
+            'error=bad_verification_code&error_description=The+code+passed+is+incorrect+or+expired.',
+            'expired-code',
+        );
+
+        try {
+            $github->getAccessToken('expired-code');
+            $this->fail('Expected the form-encoded GitHub OAuth2 provider error to be thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(AppwriteException::USER_OAUTH2_BAD_REQUEST, $exception->getType());
+            $this->assertSame('bad_verification_code', $exception->getError());
+            $this->assertSame('The code passed is incorrect or expired.', $exception->getErrorDescription());
+        }
+    }
+
+    public function testProviderErrorWithInvalidUtf8(): void
+    {
+        $github = $this->createGithub(
+            'error=bad_verification_code&error_description=Invalid+byte%3A+%FF',
+            'expired-code',
+        );
+
+        try {
+            $github->getAccessToken('expired-code');
+            $this->fail('Expected the GitHub OAuth2 provider error with invalid UTF-8 to be thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(AppwriteException::USER_OAUTH2_BAD_REQUEST, $exception->getType());
+            $this->assertSame('bad_verification_code', $exception->getError());
+            $this->assertSame('Invalid byte: �', $exception->getErrorDescription());
+        }
+    }
+
     public function testMissingAccessToken(): void
     {
         $github = $this->createGithub('{}');

--- a/tests/unit/Auth/OAuth2/GithubTest.php
+++ b/tests/unit/Auth/OAuth2/GithubTest.php
@@ -149,12 +149,14 @@ final class GithubTest extends TestCase
 
                     \parse_str($payload, $params);
 
-                    return $params === [
+                    $this->assertSame([
                         'client_id' => 'client-id',
                         'redirect_uri' => 'https://example.com/callback',
                         'client_secret' => 'client-secret',
                         'code' => $code,
-                    ];
+                    ], $params);
+
+                    return true;
                 }),
             )
             ->willReturn($response);

--- a/tests/unit/Auth/OAuth2/GithubTest.php
+++ b/tests/unit/Auth/OAuth2/GithubTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth\OAuth2;
+
+use Appwrite\Auth\OAuth2\Exception;
+use Appwrite\Auth\OAuth2\Github;
+use Appwrite\Extend\Exception as AppwriteException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class GithubTest extends TestCase
+{
+    public function testAccessToken(): void
+    {
+        $github = $this->createGithub(\json_encode([
+            'access_token' => 'access-token',
+            'scope' => 'user:email',
+            'token_type' => 'bearer',
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertSame('access-token', $github->getAccessToken('authorization-code'));
+    }
+
+    public function testProviderError(): void
+    {
+        $github = $this->createGithub(\json_encode([
+            'error' => 'bad_verification_code',
+            'error_description' => 'The code passed is incorrect or expired.',
+        ], JSON_THROW_ON_ERROR), 'expired-code');
+
+        try {
+            $github->getAccessToken('expired-code');
+            $this->fail('Expected the GitHub OAuth2 provider error to be thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(AppwriteException::USER_OAUTH2_BAD_REQUEST, $exception->getType());
+            $this->assertSame('bad_verification_code', $exception->getError());
+            $this->assertSame('The code passed is incorrect or expired.', $exception->getErrorDescription());
+        }
+    }
+
+    public function testMissingAccessToken(): void
+    {
+        $github = $this->createGithub('{}');
+
+        try {
+            $github->getAccessToken('authorization-code');
+            $this->fail('Expected a missing access token error to be thrown.');
+        } catch (Exception $exception) {
+            $this->assertSame(AppwriteException::USER_OAUTH2_BAD_REQUEST, $exception->getType());
+            $this->assertSame('access_token_missing', $exception->getError());
+            $this->assertSame('GitHub did not return an access token.', $exception->getErrorDescription());
+        }
+    }
+
+    public function testProviderFailure(): void
+    {
+        $previous = new Exception(\json_encode([
+            'error' => 'bad_verification_code',
+            'error_description' => 'The code passed is incorrect or expired.',
+        ], JSON_THROW_ON_ERROR), 400);
+
+        $exception = new AppwriteException(
+            AppwriteException::USER_OAUTH2_PROVIDER_FAILURE,
+            previous: $previous,
+            params: ['GitHub', $previous->getError()],
+        );
+
+        $this->assertSame(AppwriteException::USER_OAUTH2_PROVIDER_FAILURE, $exception->getType());
+        $this->assertSame(424, $exception->getCode());
+        $this->assertSame(
+            'GitHub couldn\'t complete sign-in (bad_verification_code). Please try again.',
+            $exception->getMessage(),
+        );
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    private function createGithub(string $response, string $code = 'authorization-code'): Github&MockObject
+    {
+        $github = $this->getMockBuilder(Github::class)
+            ->setConstructorArgs(['client-id', 'client-secret', 'https://example.com/callback'])
+            ->onlyMethods(['request'])
+            ->getMock();
+
+        $github
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'https://github.com/login/oauth/access_token',
+                ['Accept: application/json'],
+                $this->callback(function (mixed $payload) use ($code): bool {
+                    if (!\is_string($payload)) {
+                        return false;
+                    }
+
+                    \parse_str($payload, $params);
+
+                    return $params === [
+                        'client_id' => 'client-id',
+                        'redirect_uri' => 'https://example.com/callback',
+                        'client_secret' => 'client-secret',
+                        'code' => $code,
+                    ];
+                }),
+            )
+            ->willReturn($response);
+
+        return $github;
+    }
+}

--- a/tests/unit/Auth/OAuth2/GithubTest.php
+++ b/tests/unit/Auth/OAuth2/GithubTest.php
@@ -110,6 +110,24 @@ final class GithubTest extends TestCase
         $this->assertSame($previous, $exception->getPrevious());
     }
 
+    public function testPlainTextProviderFailure(): void
+    {
+        $previous = new Exception('Invalid secret');
+        $providerError = $previous->getError() ?: $previous->getMessage();
+
+        $exception = new AppwriteException(
+            AppwriteException::USER_OAUTH2_PROVIDER_FAILURE,
+            previous: $previous,
+            params: ['Apple', $providerError],
+        );
+
+        $this->assertSame(
+            'Apple couldn\'t complete sign-in (Invalid secret). Please try again.',
+            $exception->getMessage(),
+        );
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
     private function createGithub(string $response, string $code = 'authorization-code'): Github&MockObject
     {
         $github = $this->getMockBuilder(Github::class)


### PR DESCRIPTION
## What does this PR do?

Detects GitHub OAuth token exchange errors before attempting to fetch the user profile. This prevents missing or rejected access tokens from being reported as the misleading `Bad credentials: No description` error.

The OAuth callback now returns a dedicated `user_oauth2_provider_failure` response that names the provider, preserves its error code, and asks the user to retry. The original provider exception remains chained for diagnostics.

### Before

![OAuth error before](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/oauth-error-before-3f2009e8.png)

### After

![OAuth error after](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/oauth-error-after-8a11f89e.png)

## Test Plan

- `php vendor/bin/phpunit --display-phpunit-deprecations tests/unit/Auth/OAuth2/GithubTest.php`
- `composer lint src/Appwrite/Auth/OAuth2/Github.php src/Appwrite/Extend/Exception.php app/config/errors.php app/controllers/api/account.php tests/unit/Auth/OAuth2/GithubTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G src/Appwrite/Auth/OAuth2/Github.php src/Appwrite/Extend/Exception.php app/config/errors.php tests/unit/Auth/OAuth2/GithubTest.php`
- Rendered both error states with the live local Appwrite error template and captured them at 1890×1342 in dark mode.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
