### PR TITLE
chore: bump utopia-php/mongo to 1.3.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4492,16 +4492,16 @@
         },
         {
             "name": "utopia-php/mongo",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/mongo.git",
-                "reference": "44eeb4db9bfcfddccd6e757668a519d9541e65c9"
+                "reference": "f6ef5f1cecf80fb0378eda13250d6c14096d7620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/44eeb4db9bfcfddccd6e757668a519d9541e65c9",
-                "reference": "44eeb4db9bfcfddccd6e757668a519d9541e65c9",
+                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/f6ef5f1cecf80fb0378eda13250d6c14096d7620",
+                "reference": "f6ef5f1cecf80fb0378eda13250d6c14096d7620",
                 "shasum": ""
             },
             "require": {
@@ -4547,9 +4547,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/mongo/issues",
-                "source": "https://github.com/utopia-php/mongo/tree/1.3.0"
+                "source": "https://github.com/utopia-php/mongo/tree/1.3.1"
             },
-            "time": "2026-07-08T04:09:01+00:00"
+            "time": "2026-07-14T15:22:52+00:00"
         },
         {
             "name": "utopia-php/platform",


### PR DESCRIPTION
## What does this PR do?

Bumps `utopia-php/mongo` from **1.3.0** → **1.3.1** so Appwrite picks up the receive fail-fast fix from https://github.com/utopia-php/mongo/pull/42 / https://github.com/utopia-php/mongo/releases/tag/1.3.1.

Previously, `Client::receive()` could retry a timed-out `recv()` up to 10 000 times, turning a ~30s socket idle timeout into multi-minute hangs. Under load that showed up as Appwrite create requests never responding until the e2e client's 120s curl timeout:

```text
Exception: Operation timed out after 12000x milliseconds with 0 bytes received
```

with Appwrite logs:

```text
Utopia\Mongo\Exception: Receive timeout: no data received within reasonable time
Swoole\Client::send(): ... Broken pipe
```

**1.3.1** fails fast on socket idle timeouts (idle deadline, configurable `$timeout` constructor arg, Mongo codes `11601`/`9001` for classification) instead of spinning in the receive loop.

`composer.lock` only — mongo is already constrained as `1.*` via `utopia-php/database`.

## Test Plan

- [ ] CI green on this PR
- [x] `composer update utopia-php/mongo` → lock shows `1.3.1` / `f6ef5f1`
- [ ] Optional: under CPU-capped concurrent large document creates, Appwrite should surface Mongo receive timeouts within ~idle timeout instead of hanging past 120s

## Related PRs and Issues

- https://github.com/utopia-php/mongo/pull/42
- https://github.com/utopia-php/mongo/releases/tag/1.3.1

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?