### PR TITLE
Fix unbranded team invite email and HTML-encoded subject

### DIFF
--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -35,6 +35,7 @@ use Utopia\Emails\Validator\Email as EmailValidator;
 use Utopia\Locale\Locale;
 use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\Storage\Validator\FileName;
 use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Text;
@@ -326,6 +327,15 @@ class Create extends Action
             $url = Template::unParseURL($url);
             if (! empty($email)) {
                 $projectName = $project->isEmpty() ? 'Console' : $project->getAttribute('name', '[APP-NAME]');
+                if ($project->getId() === 'console') {
+                    $projectName = $platform['platformName'];
+                }
+
+                $smtpBaseTemplate = $project->getAttribute('smtpBaseTemplate', 'email-base');
+                if (! (new FileName())->isValid($smtpBaseTemplate)) {
+                    throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Invalid template path');
+                }
+                $bodyTemplate = APP_CE_CONFIG_DIR . '/locale/templates/' . $smtpBaseTemplate . '.tpl';
 
                 $body = $locale->getText('emails.invitation.body');
                 $preview = $locale->getText('emails.invitation.preview');
@@ -412,16 +422,32 @@ class Create extends Action
                     'project' => $projectName,
                 ];
 
+                if ($smtpBaseTemplate === APP_BRANDED_EMAIL_BASE_TEMPLATE) {
+                    $emailVariables = [
+                        ...$emailVariables,
+                        'accentColor' => $platform['accentColor'],
+                        'logoUrl' => $platform['logoUrl'],
+                        'twitter' => $platform['twitterUrl'],
+                        'discord' => $platform['discordUrl'],
+                        'github' => $platform['githubUrl'],
+                        'terms' => $platform['termsUrl'],
+                        'privacy' => $platform['privacyUrl'],
+                        'platform' => $platform['platformName'],
+                    ];
+                }
+
                 $publisherForMails->enqueue(new MailMessage(
                     project: $project,
                     recipient: $invitee->getAttribute('email'),
                     name: $invitee->getAttribute('name', ''),
                     subject: $subject,
                     template: MAIL_TEMPLATE_INVITATION,
+                    bodyTemplate: $bodyTemplate,
                     body: $body,
                     preview: $preview,
                     smtp: $smtpConfig,
                     variables: $emailVariables,
+                    customMailOptions: $smtpBaseTemplate === APP_BRANDED_EMAIL_BASE_TEMPLATE ? ['senderName' => $platform['emailSenderName']] : [],
                     platform: $platform,
                 ));
             } elseif (! empty($phone)) {

--- a/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
+++ b/src/Appwrite/Platform/Modules/Teams/Http/Memberships/Create.php
@@ -336,6 +336,10 @@ class Create extends Action
                     throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Invalid template path');
                 }
                 $bodyTemplate = APP_CE_CONFIG_DIR . '/locale/templates/' . $smtpBaseTemplate . '.tpl';
+                if (! \is_readable($bodyTemplate)) {
+                    $smtpBaseTemplate = 'email-base';
+                    $bodyTemplate = APP_CE_CONFIG_DIR . '/locale/templates/email-base.tpl';
+                }
 
                 $body = $locale->getText('emails.invitation.body');
                 $preview = $locale->getText('emails.invitation.preview');

--- a/src/Appwrite/Platform/Workers/Mails.php
+++ b/src/Appwrite/Platform/Workers/Mails.php
@@ -121,7 +121,7 @@ class Mails extends Action
         if (!empty($preview)) {
             $previewTemplate = Template::fromString($preview);
             foreach ($variables as $key => $value) {
-                $previewTemplate->setParam('{{' . $key . '}}', $value);
+                $previewTemplate->setParam('{{' . $key . '}}', $value, escapeHtml: false);
             }
             // render() will return the subject in <p> tags, so use strip_tags() to remove them
             $preview = \strip_tags($previewTemplate->render());
@@ -140,7 +140,7 @@ class Mails extends Action
 
         $subjectTemplate = Template::fromString($subject);
         foreach ($variables as $key => $value) {
-            $subjectTemplate->setParam('{{' . $key . '}}', $value);
+            $subjectTemplate->setParam('{{' . $key . '}}', $value, escapeHtml: false);
         }
         // render() will return the subject in <p> tags, so use strip_tags() to remove them
         $subject = \strip_tags($subjectTemplate->render());


### PR DESCRIPTION
# What does this PR do?

Fixes two issues with team invitation emails, most visible on official Console invites:

1. **HTML entities in the subject line** — inviting someone to a team with an apostrophe in its name (e.g. `Chirag's Organization`) produced the subject `Invitation to Chirag&#039;s Organization Team at Appwrite`. The mails worker substituted subject and preview variables with HTML escaping enabled, but email subjects are plain text and `strip_tags()` does not decode entities. Subject and preview variable substitution now skips HTML escaping. This also fixes the preview text, which was being escaped twice (once during substitution and again when inserted into the HTML body).

2. **Unbranded invitation email** — the team membership invite never passed a `bodyTemplate`, so every invite fell back to the plain `email-base.tpl`, including Console invites which are configured to use the branded `email-base-styled.tpl`. The endpoint now follows the same branding pattern as the MFA challenge and session alert emails: it resolves the project's `smtpBaseTemplate`, passes the branded platform variables (logo, accent color, social links, terms/privacy) and sender name when the branded template is active, and uses the platform name as the project name for Console invites.

Projects using custom SMTP with the default `email-base` template keep exactly the same output as before — the branded path only activates when the project's `smtpBaseTemplate` is the styled template, matching the existing behavior of other branded emails.

## Before

![invite-before](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/invite-before-296c5c92.png)

## After

![invite-after](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/invite-after-c40d7fc1.png)

## Test Plan

- Reproduced the exact worker rendering pipeline (real `Template` class and `.tpl` files) for old vs new code and rendered both with Playwright — screenshots above.
- `composer format` (Pint) and `composer analyze` (PHPStan level 4) pass on the changed files.

## Related PRs and Issues

None.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
