### PR TITLE
Revert vibes console switch from #12834

### DIFF
--- a/.claude/skills/patch-release-checklist/SKILL.md
+++ b/.claude/skills/patch-release-checklist/SKILL.md
@@ -6,8 +6,9 @@ When bumping a patch version (e.g., `1.9.0` -> `1.9.1`), follow this checklist.
 
 ### Bump console image
 
-Update the console Docker image tag:
-- [ ] `docker-compose.yml` -- update `image: appwrite/vibes:X.Y.Z` (the `appwrite-console` service)
+Update the console Docker image tag in both files:
+- [ ] `docker-compose.yml` -- update `image: appwrite/console:X.Y.Z`
+- [ ] `app/views/install/compose.phtml` -- update `image: <?php echo $organization; ?>/console:X.Y.Z`
 
 ### Bump Appwrite version
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ docker-compose.web-installer.yml
 .env.web-installer
 docker-compose.web-installer.yml.**.backup
 tests/playwright/screenshots
-.playwright-mcp/

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -76,8 +76,8 @@ use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
-$oauthDefaultSuccess = '/auth/oauth2/success';
-$oauthDefaultFailure = '/auth/oauth2/failure';
+$oauthDefaultSuccess = '/console/auth/oauth2/success';
+$oauthDefaultFailure = '/console/auth/oauth2/failure';
 
 $createSession = function (string $userId, string $secret, Request $request, Response $response, User $user, Database $dbForProject, Document $project, array $platform, Locale $locale, GeoRecord $geoRecord, Event $queueForEvents, Bus $bus, Store $store, ProofsToken $proofForToken, ProofsCode $proofForCode, bool $domainVerification, ?string $cookieDomain, Authorization $authorization) {
 
@@ -2396,7 +2396,7 @@ Http::post('/v1/account/tokens/magic-url')
             } elseif ($protocol === 'http' && $port !== '80') {
                 $callbackBase .= ':' . $port;
             }
-            $url = $callbackBase . '/auth/magic-url';
+            $url = $callbackBase . '/console/auth/magic-url';
         }
 
         $url = Template::parseURL($url);

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -125,7 +125,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             if (\str_ends_with($host, $denyDomain)) {
                 $exception = new AppwriteException(AppwriteException::RULE_NOT_FOUND, 'This domain is not connected to any Appwrite resources. Visit domains tab under function/site settings to configure it.', view: $errorView);
 
-                $exception->addCTA('Start with this domain', $url);
+                $exception->addCTA('Start with this domain', $url . '/console');
                 throw $exception;
             }
         }
@@ -200,7 +200,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $resourceId = $rule->getAttribute('deploymentResourceId', '');
             $type = ($resourceType === 'site') ? 'sites' : 'functions';
             $exception = new AppwriteException(AppwriteException::DEPLOYMENT_NOT_FOUND, view: $errorView);
-            $exception->addCTA('View deployments', $url . '/projects/' . $projectId . '/' . $type . '/' . $resourceId);
+            $exception->addCTA('View deployments', $url . '/console/project-' . $project->getAttribute('region', 'default') . '-' . $projectId . '/' . $type . '/' . $resourceType . '-' . $resourceId);
             throw $exception;
         }
 
@@ -289,7 +289,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
                 $response
                     ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
                     ->addHeader('Pragma', 'no-cache')
-                    ->redirect($url . '/auth/preview?'
+                    ->redirect($url . '/console/auth/preview?'
                         . \http_build_query([
                             'projectId' => $projectId,
                             'origin' => $protocol . '://' . $host,
@@ -346,21 +346,22 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
         $allowAnyStatus = !\is_null($apiKey) && $apiKey->isDeploymentStatusIgnored();
         if (!$allowAnyStatus && $deployment->getAttribute('status') !== 'ready') {
             $status = $deployment->getAttribute('status');
+            $region = $project->getAttribute('region', 'default');
 
             switch ($status) {
                 case 'failed':
                     $exception = new AppwriteException(AppwriteException::BUILD_FAILED, view: $errorView);
-                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments/' . $deployment->getId();
+                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments/deployment-' . $deployment->getId();
                     $exception->addCTA('View logs', $url . $ctaUrl);
                     break;
                 case 'canceled':
                     $exception = new AppwriteException(AppwriteException::BUILD_CANCELED, view: $errorView);
-                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments';
+                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments';
                     $exception->addCTA('View deployments', $url . $ctaUrl);
                     break;
                 default:
                     $exception = new AppwriteException(AppwriteException::BUILD_NOT_READY, view: $errorView);
-                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments/' . $deployment->getId();
+                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments/deployment-' . $deployment->getId();
                     $exception->addCTA('Reload', '/');
                     $exception->addCTA('View logs', $url . $ctaUrl);
                     break;
@@ -372,7 +373,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $permissions = $resource->getAttribute('execute');
             if (!(\in_array('any', $permissions)) && !(\in_array('guests', $permissions))) {
                 $exception = new AppwriteException(AppwriteException::FUNCTION_EXECUTE_PERMISSION_MISSING, view: $errorView);
-                $exception->addCTA('View settings', $url . '/projects/' . $project->getId() . '/functions/' . $resource->getId() . '/settings');
+                $exception->addCTA('View settings', $url . '/console/project-' . $project->getAttribute('region', 'default') . '-' . $project->getId() . '/functions/function-' . $resource->getId() . '/settings');
                 throw $exception;
             }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,22 +218,20 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/vibes:0.3.16
+    image: appwrite/console:8.7.11
     restart: unless-stopped
     networks:
       - appwrite
-    environment:
-      - VITE_CONSOLE_PROFILE=self-hosted
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=appwrite
       - traefik.docker.network=appwrite
-      - traefik.http.services.appwrite_console.loadbalancer.server.port=3000
+      - traefik.http.services.appwrite_console.loadbalancer.server.port=80
       - traefik.http.routers.appwrite_console_http.entrypoints=appwrite_web
-      - traefik.http.routers.appwrite_console_http.rule=(Host(`${_APP_DOMAIN:-localhost}`) || Host(`${_APP_CONSOLE_DOMAIN:-localhost}`)) && !PathPrefix(`/v1`) && !PathPrefix(`/.well-known`) && !HeaderRegexp(`x-appwrite-hostname`, `.+`)
+      - traefik.http.routers.appwrite_console_http.rule=PathPrefix(`/console`)
       - traefik.http.routers.appwrite_console_http.service=appwrite_console
       - traefik.http.routers.appwrite_console_https.entrypoints=appwrite_websecure
-      - traefik.http.routers.appwrite_console_https.rule=(Host(`${_APP_DOMAIN:-localhost}`) || Host(`${_APP_CONSOLE_DOMAIN:-localhost}`)) && !PathPrefix(`/v1`) && !PathPrefix(`/.well-known`) && !HeaderRegexp(`x-appwrite-hostname`, `.+`)
+      - traefik.http.routers.appwrite_console_https.rule=PathPrefix(`/console`)
       - traefik.http.routers.appwrite_console_https.service=appwrite_console
       - traefik.http.routers.appwrite_console_https.tls=true
   appwrite-realtime:

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -259,6 +259,8 @@ class Webhooks extends Action
 
         $projectId = $project->getId();
         $projectInternalId = $project->getSequence();
+        $region = $project->getAttribute('region', 'default');
+        $webhookId = $webhook->getId();
 
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS', 'disabled') === 'disabled' ? 'http' : 'https';
         $consoleHostname = System::getEnv('_APP_CONSOLE_DOMAIN', System::getEnv('_APP_DOMAIN', 'localhost'));
@@ -302,7 +304,7 @@ class Webhooks extends Action
             $template->setParam('{{url}}', $webhook->getAttribute('url'));
             $template->setParam('{{error}}', 'The server returned ' . $statusCode . ' status code');
             $template->setParam('{{host}}', $protocol . '://' . $consoleHostname);
-            $template->setParam('{{path}}', "/projects/$projectId/settings/webhooks");
+            $template->setParam('{{path}}', "/console/project-$region-$projectId/settings/webhooks/$webhookId");
             $template->setParam('{{attempts}}', $attempts);
 
             $publisherForNotifications->enqueue(new NotificationMessage(

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -161,7 +161,7 @@ class Comment
                     };
 
                     if ($site['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/projects/' . $projectId . '/sites/' . $siteId . '/deployments/' . $site['deploymentId'] . ')';
+                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/console/project-' . $site['region'] . '-' . $projectId . '/sites/site-' . $siteId . '/deployments/deployment-' . $site['deploymentId'] . ')';
                     } else {
                         $action = '[Authorize](' . $site['action']['url'] . ')';
                     }
@@ -209,7 +209,7 @@ class Comment
                     };
 
                     if ($function['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/projects/' . $projectId . '/functions/' . $functionId . '/deployments/' . $function['deploymentId'] . ')';
+                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/console/project-' . $function['region'] . '-' . $projectId . '/functions/function-' . $functionId . '/deployment-' . $function['deploymentId'] . ')';
                     } else {
                         $action = '[Authorize](' . $function['action']['url'] . ')';
                     }

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -26,7 +26,6 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_OPTIONS, '/', \array_merge([
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
@@ -52,7 +51,6 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/humans.txt', \array_merge([
             'origin' => 'http://localhost',
         ]));
@@ -66,7 +64,6 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/robots.txt', \array_merge([
             'origin' => 'http://localhost',
         ]));
@@ -80,7 +77,6 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/.well-known/acme-challenge/8DdIKX257k6Dih5s_saeVMpTnjPJdKO5Ase0OCiJrIg');
 
         // 'Unknown path', but validation passed
@@ -91,8 +87,8 @@ final class HTTPTest extends Scope
          */
         $response = $this->client->call(Client::METHOD_GET, '/.well-known/acme-challenge/../../../../../../../etc/passwd');
 
-        // 'Invalid challenge token', traversal rejected by validation
-        $this->assertEquals(400, $response['headers']['status-code']);
+        // 'Unknown path', but validation passed
+        $this->assertEquals(404, $response['headers']['status-code']);
     }
 
     public function testVersions()
@@ -100,7 +96,6 @@ final class HTTPTest extends Scope
         /**
          * Test without header
          */
-        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/versions', \array_merge([
             'content-type' => 'application/json',
         ], $this->getHeaders()));
@@ -177,23 +172,11 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
-        $this->client->setEndpoint('http://localhost');
 
         $endpoint = '/invite?membershipId=123&userId=asdf';
 
-        $response = $this->client->call(Client::METHOD_GET, $endpoint, [], [], true, false);
+        $response = $this->client->call(Client::METHOD_GET, $endpoint);
 
         $this->assertEquals('/console' . $endpoint, $response['headers']['location']);
-    }
-
-    public function testConsoleServed()
-    {
-        /**
-         * Test for SUCCESS
-         */
-        $response = $this->client->call(Client::METHOD_GET, '/');
-
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertStringContainsString('text/html', (string) $response['headers']['content-type']);
     }
 }

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2229,7 +2229,7 @@ final class SitesCustomServerTest extends Scope
         $proxyClient->setEndpoint('http://' . $deploymentDomain);
         $response = $proxyClient->call(Client::METHOD_GET, '/', followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
 
         $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 900, 0);
         $apiKey = $jwtObj->encode([
@@ -2561,7 +2561,7 @@ final class SitesCustomServerTest extends Scope
 
         $response = $proxyClient->call(Client::METHOD_GET, '/contact', followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
         $this->assertStringContainsString('projectId=' . $this->getProject()['$id'], (string) $response['headers']['location']);
         $this->assertStringContainsString('origin=', (string) $response['headers']['location']);
         $this->assertStringContainsString('path=%2Fcontact', (string) $response['headers']['location']);
@@ -2624,7 +2624,7 @@ final class SitesCustomServerTest extends Scope
             'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
         ], followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
 
         // Failure: User missing
         $cookie = 'a_session_console=' .$this->getRoot()['session'];
@@ -2659,7 +2659,7 @@ final class SitesCustomServerTest extends Scope
             'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
         ], followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
 
         // Failure: Membership missing
         $email = \uniqid() . 'newuser@appwrite.io';
@@ -2699,7 +2699,7 @@ final class SitesCustomServerTest extends Scope
             'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
         ], followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
 
         $this->cleanupSite($siteId);
     }

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -69,7 +69,7 @@ final class WebhooksTest extends TestCase
         );
         $this->assertStringContainsString('Payments', (string) $payload['body']);
         $this->assertStringContainsString('Ada Lovelace', (string) $payload['body']);
-        $this->assertStringContainsString('/projects/project-1/settings/webhooks', (string) $payload['body']);
+        $this->assertStringContainsString('/console/project-fra-project-1/settings/webhooks/webhook-1', (string) $payload['body']);
         $this->assertStringNotContainsString('{{', (string) $payload['body']);
         $this->assertSame(APP_NAME, $payload['variables']['platform']);
         $this->assertSame(APP_EMAIL_LOGO_URL, $payload['variables']['logoUrl']);


### PR DESCRIPTION
## What does this PR do?

Reverts #12834, which replaced `appwrite/console` with `appwrite/vibes` for the 2.0.0 self-hosted release.

This restores:
- Console image `appwrite/console:8.7.11` (from `appwrite/vibes:0.3.16`)
- Traefik routing under `/console` on port 80
- Legacy `/console/...` URL generation in account, general, webhooks, and VCS comment paths
- Related e2e/unit test expectations

Note: resolving the revert conflict chose `appwrite/console:8.7.11` over the later vibes bump to `0.3.16` on main, which is required to fully undo the vibes console switch.

## Test Plan

- [ ] Confirm `docker-compose.yml` serves `appwrite/console:8.7.11` with `/console` Traefik rules
- [ ] Confirm backend-generated console URLs again use `/console/...` paths
- [ ] Smoke: `tests/e2e/General/HTTPTest.php` and webhook/comment URL unit expectations

## Related PRs and Issues

- Reverts https://github.com/appwrite/appwrite/pull/12834

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
