### PR TITLE
Preserve runtime specification on function update when omitted

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -99,12 +99,12 @@ class Update extends Base
                 System::getEnv('_APP_COMPUTE_MEMORY', 0),
                 'buildSpecifications'
             )), 'Build specification for the function deployments.', true, ['plan'])
-            ->param('runtimeSpecification', fn (array $plan) => $this->getDefaultSpecification($plan), fn (array $plan) => new Specification(
+            ->param('runtimeSpecification', null, fn (array $plan) => new Nullable(new Specification(
                 $plan,
                 Config::getParam('specifications', []),
                 System::getEnv('_APP_COMPUTE_CPUS', 0),
                 System::getEnv('_APP_COMPUTE_MEMORY', 0)
-            ), 'Runtime specification for the function executions.', true, ['plan'])
+            )), 'Runtime specification for the function executions.', true, ['plan'])
             ->param('deploymentRetention', 0, new Range(0, APP_COMPUTE_DEPLOYMENT_MAX_RETENTION), 'Days to keep non-active deployments before deletion. Value 0 means all deployments will be kept.', true)
             ->inject('request')
             ->inject('response')
@@ -142,7 +142,7 @@ class Update extends Base
         ?array $providerBranches,
         ?array $providerPaths,
         ?string $buildSpecification,
-        string $runtimeSpecification,
+        ?string $runtimeSpecification,
         int $deploymentRetention,
         Request $request,
         Response $response,
@@ -179,6 +179,7 @@ class Update extends Base
         }
 
         $buildSpecification ??= $function->getAttribute('buildSpecification', APP_COMPUTE_SPECIFICATION_DEFAULT);
+        $runtimeSpecification ??= $function->getAttribute('runtimeSpecification', APP_COMPUTE_SPECIFICATION_DEFAULT);
 
         $repositoryId = $function->getAttribute('repositoryId', '');
         $repositoryInternalId = $function->getAttribute('repositoryInternalId', '');


### PR DESCRIPTION
## Summary
- Updating a function's `schedule` (or any field) via `PUT /v1/functions/:functionId` without also sending `runtimeSpecification` silently overwrote it with a computed default, collapsing the CPU/RAM tier to the plan's smallest allowed spec and forcing an unwanted cold start (`$executor->deleteRuntime`) on every such update.
- `runtimeSpecification` now falls back to the function's existing value when the request omits it, mirroring the pattern already used for `buildSpecification`.
- Reported by a Cloud customer whose functions repeatedly reset to 0.5 CPU / 512MB after cron schedule changes, intermittently causing scheduled executions to fail while the runtime was being torn down/rebuilt.

## Root cause
`runtimeSpecification`'s param default was a closure (`getDefaultSpecification($plan)`) that always resolves to a real spec value — the framework has no way to distinguish "omitted" from "explicitly requested this value," so every update that didn't set `runtimeSpecification` got the plan's lowest tier written over the customer's real setting.

## Verification
- Reproduced locally: set `runtimeSpecification` to `s-4vcpu-4gb`, then sent an update with only `schedule` — value reset to the default tier.
- Reproduced against Cloud staging on a real multi-tier plan: same 4 vCPU/4GB -> 0.5 CPU/512MB collapse, matching the customer report exactly.
- After the fix, the same before/after sequence preserves `s-4vcpu-4gb` across the schedule-only update.
- `composer lint` and `composer analyze` pass on the changed file (pre-existing unrelated PHPStan errors in `Orchestrator.php` confirmed present on `main` too).

## Test plan
- [x] Local repro before/after the fix
- [x] Staging repro on a multi-tier plan
- [x] `composer lint src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php`
- [x] `composer analyze`
- [x] `tests/e2e/Services/Functions` `testUpdateFunction`/`testCreateFunction` pass