### PR TITLE
Re-ship vibes console with legacy URL compatibility

### DIFF
--- a/.claude/skills/patch-release-checklist/SKILL.md
+++ b/.claude/skills/patch-release-checklist/SKILL.md
@@ -6,9 +6,8 @@ When bumping a patch version (e.g., `1.9.0` -> `1.9.1`), follow this checklist.
 
 ### Bump console image
 
-Update the console Docker image tag in both files:
-- [ ] `docker-compose.yml` -- update `image: appwrite/console:X.Y.Z`
-- [ ] `app/views/install/compose.phtml` -- update `image: <?php echo $organization; ?>/console:X.Y.Z`
+Update the console Docker image tag:
+- [ ] `docker-compose.yml` -- update `image: appwrite/vibes:X.Y.Z` (the `appwrite-console` service)
 
 ### Bump Appwrite version
 

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -233,6 +233,15 @@ return [
                 'filter' => ''
             ],
             [
+                'name' => '_APP_CONSOLE_URL_SCHEME',
+                'description' => 'Controls how backend-generated console deep links are formatted. Use \'legacy\' for `/console/project-{region}-{id}/...` (required while cloud still serves console-cloud). Use \'vibes\' for root-path `/projects/{id}/...` links. Defaults to legacy.',
+                'introduction' => '2.0.0',
+                'default' => 'legacy',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
                 'name' => '_APP_SYSTEM_EMAIL_NAME',
                 'description' => 'This is the sender name value that will appear on email messages sent to developers from the Appwrite console. The default value is: \'Appwrite\'. You can use url encoded strings for spaces and special chars.',
                 'introduction' => '0.7.0',

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -11,6 +11,7 @@ use Appwrite\Auth\Validator\PasswordStrength;
 use Appwrite\Auth\Validator\PersonalData;
 use Appwrite\Auth\Validator\Phone;
 use Appwrite\Bus\Events\SessionCreated;
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Detector\Detector;
 use Appwrite\Event\Event;
 use Appwrite\Event\Message\Delete as DeleteMessage;
@@ -76,8 +77,8 @@ use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
-$oauthDefaultSuccess = '/console/auth/oauth2/success';
-$oauthDefaultFailure = '/console/auth/oauth2/failure';
+$oauthDefaultSuccess = ConsoleUrl::auth('oauth2/success');
+$oauthDefaultFailure = ConsoleUrl::auth('oauth2/failure');
 
 $createSession = function (string $userId, string $secret, Request $request, Response $response, User $user, Database $dbForProject, Document $project, array $platform, Locale $locale, GeoRecord $geoRecord, Event $queueForEvents, Bus $bus, Store $store, ProofsToken $proofForToken, ProofsCode $proofForCode, bool $domainVerification, ?string $cookieDomain, Authorization $authorization) {
 
@@ -2396,7 +2397,7 @@ Http::post('/v1/account/tokens/magic-url')
             } elseif ($protocol === 'http' && $port !== '80') {
                 $callbackBase .= ':' . $port;
             }
-            $url = $callbackBase . '/console/auth/magic-url';
+            $url = $callbackBase . ConsoleUrl::auth('magic-url');
         }
 
         $url = Template::parseURL($url);

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -7,6 +7,7 @@ use Ahc\Jwt\JWTException;
 use Appwrite\Auth\Key;
 use Appwrite\Bus\Events\ExecutionCompleted;
 use Appwrite\Bus\Events\RequestCompleted;
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Event\Event;
 use Appwrite\Event\Message\Delete as DeleteMessage;
 use Appwrite\Event\Publisher\Certificate;
@@ -200,7 +201,13 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $resourceId = $rule->getAttribute('deploymentResourceId', '');
             $type = ($resourceType === 'site') ? 'sites' : 'functions';
             $exception = new AppwriteException(AppwriteException::DEPLOYMENT_NOT_FOUND, view: $errorView);
-            $exception->addCTA('View deployments', $url . '/console/project-' . $project->getAttribute('region', 'default') . '-' . $projectId . '/' . $type . '/' . $resourceType . '-' . $resourceId);
+            $exception->addCTA('View deployments', $url . ConsoleUrl::projectResource(
+                $project->getAttribute('region', 'default'),
+                $projectId,
+                $type,
+                $resourceType,
+                $resourceId,
+            ));
             throw $exception;
         }
 
@@ -289,7 +296,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
                 $response
                     ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
                     ->addHeader('Pragma', 'no-cache')
-                    ->redirect($url . '/console/auth/preview?'
+                    ->redirect($url . ConsoleUrl::auth('preview') . '?'
                         . \http_build_query([
                             'projectId' => $projectId,
                             'origin' => $protocol . '://' . $host,
@@ -351,17 +358,17 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             switch ($status) {
                 case 'failed':
                     $exception = new AppwriteException(AppwriteException::BUILD_FAILED, view: $errorView);
-                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments/deployment-' . $deployment->getId();
+                    $ctaUrl = ConsoleUrl::siteDeployment($region, $project->getId(), $resource->getId(), $deployment->getId());
                     $exception->addCTA('View logs', $url . $ctaUrl);
                     break;
                 case 'canceled':
                     $exception = new AppwriteException(AppwriteException::BUILD_CANCELED, view: $errorView);
-                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments';
+                    $ctaUrl = ConsoleUrl::siteDeployments($region, $project->getId(), $resource->getId());
                     $exception->addCTA('View deployments', $url . $ctaUrl);
                     break;
                 default:
                     $exception = new AppwriteException(AppwriteException::BUILD_NOT_READY, view: $errorView);
-                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments/deployment-' . $deployment->getId();
+                    $ctaUrl = ConsoleUrl::siteDeployment($region, $project->getId(), $resource->getId(), $deployment->getId());
                     $exception->addCTA('Reload', '/');
                     $exception->addCTA('View logs', $url . $ctaUrl);
                     break;
@@ -373,7 +380,14 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $permissions = $resource->getAttribute('execute');
             if (!(\in_array('any', $permissions)) && !(\in_array('guests', $permissions))) {
                 $exception = new AppwriteException(AppwriteException::FUNCTION_EXECUTE_PERMISSION_MISSING, view: $errorView);
-                $exception->addCTA('View settings', $url . '/console/project-' . $project->getAttribute('region', 'default') . '-' . $project->getId() . '/functions/function-' . $resource->getId() . '/settings');
+                $exception->addCTA('View settings', $url . ConsoleUrl::projectResource(
+                    $project->getAttribute('region', 'default'),
+                    $project->getId(),
+                    'functions',
+                    'function',
+                    $resource->getId(),
+                    'settings',
+                ));
                 throw $exception;
             }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,20 +218,22 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/console:8.7.11
+    image: appwrite/vibes:0.3.22
     restart: unless-stopped
     networks:
       - appwrite
+    environment:
+      - VITE_CONSOLE_PROFILE=self-hosted
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=appwrite
       - traefik.docker.network=appwrite
-      - traefik.http.services.appwrite_console.loadbalancer.server.port=80
+      - traefik.http.services.appwrite_console.loadbalancer.server.port=3000
       - traefik.http.routers.appwrite_console_http.entrypoints=appwrite_web
-      - traefik.http.routers.appwrite_console_http.rule=PathPrefix(`/console`)
+      - traefik.http.routers.appwrite_console_http.rule=(Host(`${_APP_DOMAIN:-localhost}`) || Host(`${_APP_CONSOLE_DOMAIN:-localhost}`)) && !PathPrefix(`/v1`) && !PathPrefix(`/.well-known`) && !HeaderRegexp(`x-appwrite-hostname`, `.+`)
       - traefik.http.routers.appwrite_console_http.service=appwrite_console
       - traefik.http.routers.appwrite_console_https.entrypoints=appwrite_websecure
-      - traefik.http.routers.appwrite_console_https.rule=PathPrefix(`/console`)
+      - traefik.http.routers.appwrite_console_https.rule=(Host(`${_APP_DOMAIN:-localhost}`) || Host(`${_APP_CONSOLE_DOMAIN:-localhost}`)) && !PathPrefix(`/v1`) && !PathPrefix(`/.well-known`) && !HeaderRegexp(`x-appwrite-hostname`, `.+`)
       - traefik.http.routers.appwrite_console_https.service=appwrite_console
       - traefik.http.routers.appwrite_console_https.tls=true
   appwrite-realtime:

--- a/src/Appwrite/Console/Url.php
+++ b/src/Appwrite/Console/Url.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Appwrite\Console;
+
+use Utopia\System\System;
+
+/**
+ * Builds console deep links for both the legacy `/console/...` SPA and vibes.
+ *
+ * Default scheme is `legacy` so cloud (still on console-cloud) keeps working when
+ * it consumes server-ce. Self-hosted can opt into vibes paths via
+ * `_APP_CONSOLE_URL_SCHEME=vibes`; vibes also rewrites legacy bookmarks.
+ */
+class Url
+{
+    public const SCHEME_LEGACY = 'legacy';
+    public const SCHEME_VIBES = 'vibes';
+
+    public static function scheme(): string
+    {
+        $scheme = System::getEnv('_APP_CONSOLE_URL_SCHEME', '');
+
+        if ($scheme === self::SCHEME_VIBES || $scheme === self::SCHEME_LEGACY) {
+            return $scheme;
+        }
+
+        return self::SCHEME_LEGACY;
+    }
+
+    public static function isVibes(): bool
+    {
+        return self::scheme() === self::SCHEME_VIBES;
+    }
+
+    public static function protocol(): string
+    {
+        return System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
+    }
+
+    public static function absolute(string $hostname, string $path, ?string $protocol = null): string
+    {
+        $protocol ??= self::protocol();
+        if ($path === '' || $path[0] !== '/') {
+            $path = '/' . $path;
+        }
+
+        return $protocol . '://' . $hostname . $path;
+    }
+
+    public static function auth(string $suffix): string
+    {
+        $suffix = \ltrim($suffix, '/');
+
+        return self::isVibes()
+            ? '/auth/' . $suffix
+            : '/console/auth/' . $suffix;
+    }
+
+    public static function gitAuthorizeContributor(): string
+    {
+        return self::isVibes()
+            ? '/git/authorize-contributor'
+            : '/console/git/authorize-contributor';
+    }
+
+    public static function project(string $region, string $projectId, string $suffix = ''): string
+    {
+        $suffix = \ltrim($suffix, '/');
+
+        if (self::isVibes()) {
+            $base = '/projects/' . $projectId;
+        } else {
+            $base = '/console/project-' . $region . '-' . $projectId;
+        }
+
+        return $suffix === '' ? $base : $base . '/' . $suffix;
+    }
+
+    public static function projectResource(
+        string $region,
+        string $projectId,
+        string $collection,
+        string $resourceType,
+        string $resourceId,
+        string $suffix = '',
+    ): string {
+        $suffix = \ltrim($suffix, '/');
+
+        if (self::isVibes()) {
+            $resourcePath = $collection . '/' . $resourceId;
+        } else {
+            $resourcePath = $collection . '/' . $resourceType . '-' . $resourceId;
+        }
+
+        if ($suffix !== '') {
+            $resourcePath .= '/' . $suffix;
+        }
+
+        return self::project($region, $projectId, $resourcePath);
+    }
+
+    public static function siteDeployment(
+        string $region,
+        string $projectId,
+        string $siteId,
+        string $deploymentId,
+    ): string {
+        if (self::isVibes()) {
+            return self::project($region, $projectId, "sites/{$siteId}/deployments/{$deploymentId}");
+        }
+
+        return self::project(
+            $region,
+            $projectId,
+            "sites/site-{$siteId}/deployments/deployment-{$deploymentId}",
+        );
+    }
+
+    public static function siteDeployments(
+        string $region,
+        string $projectId,
+        string $siteId,
+    ): string {
+        if (self::isVibes()) {
+            return self::project($region, $projectId, "sites/{$siteId}/deployments");
+        }
+
+        return self::project($region, $projectId, "sites/site-{$siteId}/deployments");
+    }
+
+    public static function functionDeployment(
+        string $region,
+        string $projectId,
+        string $functionId,
+        string $deploymentId,
+    ): string {
+        if (self::isVibes()) {
+            return self::project(
+                $region,
+                $projectId,
+                "functions/{$functionId}/deployments/{$deploymentId}",
+            );
+        }
+
+        // Legacy console used a sibling /deployment-{id} segment (not /deployments/).
+        return self::project(
+            $region,
+            $projectId,
+            "functions/function-{$functionId}/deployment-{$deploymentId}",
+        );
+    }
+
+    public static function webhookSettings(
+        string $region,
+        string $projectId,
+        string $webhookId,
+    ): string {
+        if (self::isVibes()) {
+            return self::project($region, $projectId, 'settings/webhooks');
+        }
+
+        return self::project($region, $projectId, 'settings/webhooks/' . $webhookId);
+    }
+
+    public static function gitInstallations(string $region, string $projectId): string
+    {
+        return self::project($region, $projectId, 'settings/git-installations');
+    }
+}

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Platform\Modules\Functions\Workers;
 
 use Ahc\Jwt\JWT;
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Deployment\Backend;
 use Appwrite\Event\Event;
 use Appwrite\Event\Message\Func as FunctionMessage;
@@ -1497,8 +1498,16 @@ class Builds extends Action
                 $region = $project->getAttribute('region', 'default');
                 $resourceId = $resource->getId();
                 $providerTargetUrl = match ($resource->getCollection()) {
-                    'functions' => "{$protocol}://{$hostname}/console/project-{$region}-{$projectId}/functions/function-{$resourceId}",
-                    'sites' => "{$protocol}://{$hostname}/console/project-{$region}-{$projectId}/sites/site-{$resourceId}",
+                    'functions' => ConsoleUrl::absolute(
+                        $hostname,
+                        ConsoleUrl::projectResource($region, $projectId, 'functions', 'function', $resourceId),
+                        $protocol,
+                    ),
+                    'sites' => ConsoleUrl::absolute(
+                        $hostname,
+                        ConsoleUrl::projectResource($region, $projectId, 'sites', 'site', $resourceId),
+                        $protocol,
+                    ),
                     default => throw new \Exception('Invalid resource type')
                 };
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Functions\Workers;
 
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Deployment\Backend\Orchestrator;
 use Appwrite\Event\Event;
 use Appwrite\Event\Message\Func as FunctionMessage;
@@ -374,7 +375,11 @@ class Jobs extends Action
             $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
             $hostname = System::getEnv('_APP_CONSOLE_DOMAIN', System::getEnv('_APP_DOMAIN', ''));
             $region = $project->getAttribute('region', 'default');
-            $targetUrl = "{$protocol}://{$hostname}/console/project-{$region}-{$project->getId()}/functions/function-{$function->getId()}";
+            $targetUrl = ConsoleUrl::absolute(
+                $hostname,
+                ConsoleUrl::projectResource($region, $project->getId(), 'functions', 'function', $function->getId()),
+                $protocol,
+            );
             $message = $state === 'success' ? 'Build succeeded.' : 'Build failed.';
             $name = $function->getAttribute('name', '') . ' (' . $project->getAttribute('name', '') . ')';
 

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Callback/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Callback/Get.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Platform\Modules\VCS\Http\GitHub\Callback;
 
 use Appwrite\Auth\OAuth2\Github as OAuth2Github;
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Permission as AppwritePermission;
 use Appwrite\Utopia\Response;
@@ -89,9 +90,14 @@ class Get extends Action
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
         $hostname = $platform['consoleHostname'] ?? '';
 
+        $gitInstallationsUrl = ConsoleUrl::absolute(
+            $hostname,
+            ConsoleUrl::gitInstallations($region, $projectId),
+            $protocol,
+        );
         $defaultState = [
-            'success' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
-            'failure' => $protocol . '://' . $hostname . "/console/project-$region-$projectId/settings/git-installations",
+            'success' => $gitInstallationsUrl,
+            'failure' => $gitInstallationsUrl,
         ];
 
         $state = \array_merge($defaultState, $state ?? []);

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\VCS\Http\GitHub;
 
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Deployment\Backend;
 use Appwrite\Event\Message\Build as BuildMessage;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
@@ -165,7 +166,11 @@ trait Deployment
                 $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS') === 'disabled' ? 'http' : 'https';
                 $hostname = $platform['consoleHostname'] ?? '';
 
-                $authorizeUrl = $protocol . '://' . $hostname . "/console/git/authorize-contributor?projectId={$projectId}&installationId={$installationId}&repositoryId={$repositoryId}&providerPullRequestId={$providerPullRequestId}";
+                $authorizeUrl = ConsoleUrl::absolute(
+                    $hostname,
+                    ConsoleUrl::gitAuthorizeContributor() . "?projectId={$projectId}&installationId={$installationId}&repositoryId={$repositoryId}&providerPullRequestId={$providerPullRequestId}",
+                    $protocol,
+                );
 
                 $action = $isAuthorized ? ['type' => 'logs'] : ['type' => 'authorize', 'url' => $authorizeUrl];
 
@@ -579,7 +584,11 @@ trait Deployment
                     }
                     $owner = $github->getOwnerName($providerInstallationId);
 
-                    $providerTargetUrl = $protocol . '://' . $hostname . "/console/project-$region-$projectId/$resourceCollection/$resourceType-$resourceId";
+                    $providerTargetUrl = ConsoleUrl::absolute(
+                        $hostname,
+                        ConsoleUrl::projectResource($region, $projectId, $resourceCollection, $resourceType, $resourceId),
+                        $protocol,
+                    );
                     $github->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', $message, $providerTargetUrl, $name);
                 }
 

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Workers;
 
+use Appwrite\Console\Url as ConsoleUrl;
 use Appwrite\Event\Message\Notification as NotificationMessage;
 use Appwrite\Event\Message\Usage as UsageMessage;
 use Appwrite\Event\Publisher\Notification as NotificationPublisher;
@@ -304,7 +305,7 @@ class Webhooks extends Action
             $template->setParam('{{url}}', $webhook->getAttribute('url'));
             $template->setParam('{{error}}', 'The server returned ' . $statusCode . ' status code');
             $template->setParam('{{host}}', $protocol . '://' . $consoleHostname);
-            $template->setParam('{{path}}', "/console/project-$region-$projectId/settings/webhooks/$webhookId");
+            $template->setParam('{{path}}', ConsoleUrl::webhookSettings($region, $projectId, $webhookId));
             $template->setParam('{{attempts}}', $attempts);
 
             $publisherForNotifications->enqueue(new NotificationMessage(

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Vcs;
 
+use Appwrite\Console\Url as ConsoleUrl;
 use Utopia\Database\Document;
 use Utopia\System\System;
 
@@ -161,7 +162,11 @@ class Comment
                     };
 
                     if ($site['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/console/project-' . $site['region'] . '-' . $projectId . '/sites/site-' . $siteId . '/deployments/deployment-' . $site['deploymentId'] . ')';
+                        $action = '[View Logs](' . ConsoleUrl::absolute(
+                            $hostname,
+                            ConsoleUrl::siteDeployment($site['region'], $projectId, $siteId, $site['deploymentId']),
+                            $protocol,
+                        ) . ')';
                     } else {
                         $action = '[Authorize](' . $site['action']['url'] . ')';
                     }
@@ -209,7 +214,11 @@ class Comment
                     };
 
                     if ($function['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/console/project-' . $function['region'] . '-' . $projectId . '/functions/function-' . $functionId . '/deployment-' . $function['deploymentId'] . ')';
+                        $action = '[View Logs](' . ConsoleUrl::absolute(
+                            $hostname,
+                            ConsoleUrl::functionDeployment($function['region'], $projectId, $functionId, $function['deploymentId']),
+                            $protocol,
+                        ) . ')';
                     } else {
                         $action = '[Authorize](' . $function['action']['url'] . ')';
                     }

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -26,6 +26,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_OPTIONS, '/', \array_merge([
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
@@ -51,6 +52,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/humans.txt', \array_merge([
             'origin' => 'http://localhost',
         ]));
@@ -64,6 +66,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/robots.txt', \array_merge([
             'origin' => 'http://localhost',
         ]));
@@ -77,6 +80,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/.well-known/acme-challenge/8DdIKX257k6Dih5s_saeVMpTnjPJdKO5Ase0OCiJrIg');
 
         // 'Unknown path', but validation passed
@@ -87,8 +91,8 @@ final class HTTPTest extends Scope
          */
         $response = $this->client->call(Client::METHOD_GET, '/.well-known/acme-challenge/../../../../../../../etc/passwd');
 
-        // 'Unknown path', but validation passed
-        $this->assertEquals(404, $response['headers']['status-code']);
+        // 'Invalid challenge token', traversal rejected by validation
+        $this->assertEquals(400, $response['headers']['status-code']);
     }
 
     public function testVersions()
@@ -96,6 +100,7 @@ final class HTTPTest extends Scope
         /**
          * Test without header
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/versions', \array_merge([
             'content-type' => 'application/json',
         ], $this->getHeaders()));
@@ -172,11 +177,23 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
 
         $endpoint = '/invite?membershipId=123&userId=asdf';
 
-        $response = $this->client->call(Client::METHOD_GET, $endpoint);
+        $response = $this->client->call(Client::METHOD_GET, $endpoint, [], [], true, false);
 
         $this->assertEquals('/console' . $endpoint, $response['headers']['location']);
+    }
+
+    public function testConsoleServed()
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $response = $this->client->call(Client::METHOD_GET, '/');
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringContainsString('text/html', $response['headers']['content-type']);
     }
 }

--- a/tests/unit/Console/UrlTest.php
+++ b/tests/unit/Console/UrlTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+use Appwrite\Console\Url;
+use PHPUnit\Framework\TestCase;
+
+final class UrlTest extends TestCase
+{
+    private array $envBackup = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->envBackup = [
+            '_APP_CONSOLE_URL_SCHEME' => \getenv('_APP_CONSOLE_URL_SCHEME'),
+            '_APP_OPTIONS_FORCE_HTTPS' => \getenv('_APP_OPTIONS_FORCE_HTTPS'),
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $key => $value) {
+            if ($value === false) {
+                \putenv($key);
+                unset($_ENV[$key], $_SERVER[$key]);
+            } else {
+                \putenv($key . '=' . $value);
+                $_ENV[$key] = $value;
+                $_SERVER[$key] = $value;
+            }
+        }
+        parent::tearDown();
+    }
+
+    private function setScheme(string $scheme): void
+    {
+        \putenv('_APP_CONSOLE_URL_SCHEME=' . $scheme);
+        $_ENV['_APP_CONSOLE_URL_SCHEME'] = $scheme;
+        $_SERVER['_APP_CONSOLE_URL_SCHEME'] = $scheme;
+    }
+
+    public function testDefaultsToLegacy(): void
+    {
+        \putenv('_APP_CONSOLE_URL_SCHEME');
+        unset($_ENV['_APP_CONSOLE_URL_SCHEME'], $_SERVER['_APP_CONSOLE_URL_SCHEME']);
+
+        $this->assertSame(Url::SCHEME_LEGACY, Url::scheme());
+        $this->assertFalse(Url::isVibes());
+        $this->assertSame(
+            '/console/project-fra-proj/sites/site-site1/deployments/deployment-dep1',
+            Url::siteDeployment('fra', 'proj', 'site1', 'dep1'),
+        );
+    }
+
+    public function testVibesProjectAndResourcePaths(): void
+    {
+        $this->setScheme(Url::SCHEME_VIBES);
+
+        $this->assertSame(
+            '/projects/proj/sites/site1/deployments/dep1',
+            Url::siteDeployment('fra', 'proj', 'site1', 'dep1'),
+        );
+        $this->assertSame(
+            '/projects/proj/functions/fn1/deployments/dep1',
+            Url::functionDeployment('fra', 'proj', 'fn1', 'dep1'),
+        );
+        $this->assertSame(
+            '/projects/proj/settings/webhooks',
+            Url::webhookSettings('fra', 'proj', 'webhook-1'),
+        );
+        $this->assertSame('/auth/magic-url', Url::auth('magic-url'));
+        $this->assertSame(
+            'https://cloud.appwrite.io/projects/proj/functions/fn1',
+            Url::absolute('cloud.appwrite.io', Url::projectResource('fra', 'proj', 'functions', 'function', 'fn1')),
+        );
+    }
+
+    public function testLegacyFunctionDeploymentSiblingSegment(): void
+    {
+        $this->setScheme(Url::SCHEME_LEGACY);
+
+        $this->assertSame(
+            '/console/project-nyc-proj/functions/function-fn1/deployment-dep1',
+            Url::functionDeployment('nyc', 'proj', 'fn1', 'dep1'),
+        );
+        $this->assertSame(
+            '/console/project-fra-proj/settings/webhooks/webhook-1',
+            Url::webhookSettings('fra', 'proj', 'webhook-1'),
+        );
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Re-ships `appwrite/vibes` as the self-hosted console for 2.0.0 **without** breaking cloud prod deep links.

Previous attempt (#12834) changed shared CE URL builders to vibes root-path routes. Cloud still serves `console-cloud` under `/console`, so PR "View Logs" links like `/projects/.../deployments/...` hit `general_route_not_found`. That was reverted in #12883.

This PR:
1. Swaps compose to `appwrite/vibes:0.3.22` with host-based Traefik rules (port 3000, exclude `/v1`, `/.well-known`, `x-appwrite-hostname`)
2. Keeps backend-generated console URLs on the **legacy** `/console/project-{region}-{id}/...` scheme by default (cloud-safe)
3. Adds `Appwrite\Console\Url` + `_APP_CONSOLE_URL_SCHEME` so self-hosted can later opt into native vibes paths
4. Relies on vibes [0.3.22](https://github.com/appwrite/vibes/releases/tag/0.3.22) / [vibes#78](https://github.com/appwrite/vibes/pull/78) to rewrite full legacy deep links (not just strip `/console`)

## Test Plan

- [x] `vendor/bin/phpunit tests/unit/Console/UrlTest.php tests/unit/Platform/Workers/WebhooksTest.php tests/unit/Vcs/CommentTest.php`
- [x] Confirmed default scheme still emits `/console/project-fra-itznotabug/sites/site-lede/deployments/deployment-...` (the cloud-breaking URL shape is **not** emitted)
- [ ] `docker compose up -d --force-recreate` with vibes `0.3.22`; verify root console HTML, `/v1` API, and legacy `/console/project-...` 302 → `/projects/...`
- [ ] Cloud server-ce bump of this commit: PR View Logs still opens `/console/project-...` on console-cloud

## Related PRs and Issues

- Re-attempt of #12834 (safer approach)
- Requires appwrite/vibes#78 / release `0.3.22`
- Cloud breakage context from #12883 revert

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
