### PR TITLE
Reintroduce vibes console (appwrite/new) with legacy console URL compatibility

### DIFF
--- a/.claude/skills/patch-release-checklist/SKILL.md
+++ b/.claude/skills/patch-release-checklist/SKILL.md
@@ -7,7 +7,7 @@ When bumping a patch version (e.g., `1.9.0` -> `1.9.1`), follow this checklist.
 ### Bump console image
 
 Update the console Docker image tag:
-- [ ] `docker-compose.yml` -- update `image: appwrite/vibes:X.Y.Z` (the `appwrite-console` service)
+- [ ] `docker-compose.yml` -- update `image: appwrite/new:X.Y.Z` (the `appwrite-console` service)
 
 ### Bump Appwrite version
 

--- a/.claude/skills/patch-release-checklist/SKILL.md
+++ b/.claude/skills/patch-release-checklist/SKILL.md
@@ -6,9 +6,8 @@ When bumping a patch version (e.g., `1.9.0` -> `1.9.1`), follow this checklist.
 
 ### Bump console image
 
-Update the console Docker image tag in both files:
-- [ ] `docker-compose.yml` -- update `image: appwrite/console:X.Y.Z`
-- [ ] `app/views/install/compose.phtml` -- update `image: <?php echo $organization; ?>/console:X.Y.Z`
+Update the console Docker image tag:
+- [ ] `docker-compose.yml` -- update `image: appwrite/vibes:X.Y.Z` (the `appwrite-console` service)
 
 ### Bump Appwrite version
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ docker-compose.web-installer.yml
 .env.web-installer
 docker-compose.web-installer.yml.**.backup
 tests/playwright/screenshots
+.playwright-mcp/

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -224,6 +224,15 @@ return [
                 'filter' => ''
             ],
             [
+                'name' => '_APP_CONSOLE_URL_SCHEME',
+                'description' => 'Console URL scheme used when the backend generates links to the console (OAuth callbacks, emails, error page CTAs, VCS comments). Set to \'root\' for the new console served at the root path (appwrite/new), or \'legacy\' for the older console served under the /console path prefix. The default value is \'legacy\'.',
+                'introduction' => '2.0.0',
+                'default' => 'legacy',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
                 'name' => '_APP_CONSOLE_HOSTNAMES',
                 'description' => 'This option allows you to add additional hostnames to your Appwrite console. This option is very useful for allowing access to the console project from additional domains. To enable it, pass a list of allowed hostnames separated by a comma.',
                 'introduction' => '1.5.0',

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -76,8 +76,8 @@ use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
-$oauthDefaultSuccess = '/console/auth/oauth2/success';
-$oauthDefaultFailure = '/console/auth/oauth2/failure';
+$oauthDefaultSuccess = '/auth/oauth2/success';
+$oauthDefaultFailure = '/auth/oauth2/failure';
 
 $createSession = function (string $userId, string $secret, Request $request, Response $response, User $user, Database $dbForProject, Document $project, array $platform, Locale $locale, GeoRecord $geoRecord, Event $queueForEvents, Bus $bus, Store $store, ProofsToken $proofForToken, ProofsCode $proofForCode, bool $domainVerification, ?string $cookieDomain, Authorization $authorization) {
 
@@ -2396,7 +2396,7 @@ Http::post('/v1/account/tokens/magic-url')
             } elseif ($protocol === 'http' && $port !== '80') {
                 $callbackBase .= ':' . $port;
             }
-            $url = $callbackBase . '/console/auth/magic-url';
+            $url = $callbackBase . '/auth/magic-url';
         }
 
         $url = Template::parseURL($url);

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -2252,7 +2252,7 @@ Http::post('/v1/account/tokens/magic-url')
     ->inject('proofForPassword')
     ->inject('platform')
     ->inject('authorization')
-    ->action(function (string $userId, string $email, string $url, bool $phrase, Request $request, Response $response, Document $user, Document $project, Database $dbForProject, Locale $locale, Event $queueForEvents, MailPublisher $publisherForMails, array $plan, ProofsPassword $proofForPassword, array $platform, Authorization $authorization) {
+    ->action(function (string $userId, string $email, string $url, bool $phrase, Request $request, Response $response, Document $user, Document $project, Database $dbForProject, Locale $locale, Event $queueForEvents, MailPublisher $publisherForMails, array $plan, ProofsPassword $proofForPassword, array $platform, Authorization $authorization) use ($legacyConsolePaths) {
         if (empty(System::getEnv('_APP_SMTP_HOST'))) {
             throw new Exception(Exception::GENERAL_SMTP_DISABLED, 'SMTP disabled');
         }
@@ -2398,7 +2398,7 @@ Http::post('/v1/account/tokens/magic-url')
             } elseif ($protocol === 'http' && $port !== '80') {
                 $callbackBase .= ':' . $port;
             }
-            $url = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+            $url = $legacyConsolePaths
                 ? "{$callbackBase}/console/auth/magic-url"
                 : "{$callbackBase}/auth/magic-url";
         }

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -76,8 +76,10 @@ use Utopia\Validator\Range;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
-$oauthDefaultSuccess = '/auth/oauth2/success';
-$oauthDefaultFailure = '/auth/oauth2/failure';
+$legacyConsolePaths = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root';
+
+$oauthDefaultSuccess = $legacyConsolePaths ? '/console/auth/oauth2/success' : '/auth/oauth2/success';
+$oauthDefaultFailure = $legacyConsolePaths ? '/console/auth/oauth2/failure' : '/auth/oauth2/failure';
 
 $createSession = function (string $userId, string $secret, Request $request, Response $response, User $user, Database $dbForProject, Document $project, array $platform, Locale $locale, GeoRecord $geoRecord, Event $queueForEvents, Bus $bus, Store $store, ProofsToken $proofForToken, ProofsCode $proofForCode, bool $domainVerification, ?string $cookieDomain, Authorization $authorization) {
 
@@ -2396,7 +2398,9 @@ Http::post('/v1/account/tokens/magic-url')
             } elseif ($protocol === 'http' && $port !== '80') {
                 $callbackBase .= ':' . $port;
             }
-            $url = $callbackBase . '/auth/magic-url';
+            $url = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+                ? "{$callbackBase}/console/auth/magic-url"
+                : "{$callbackBase}/auth/magic-url";
         }
 
         $url = Template::parseURL($url);

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -125,7 +125,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             if (\str_ends_with($host, $denyDomain)) {
                 $exception = new AppwriteException(AppwriteException::RULE_NOT_FOUND, 'This domain is not connected to any Appwrite resources. Visit domains tab under function/site settings to configure it.', view: $errorView);
 
-                $exception->addCTA('Start with this domain', $url . '/console');
+                $exception->addCTA('Start with this domain', $url);
                 throw $exception;
             }
         }
@@ -200,7 +200,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $resourceId = $rule->getAttribute('deploymentResourceId', '');
             $type = ($resourceType === 'site') ? 'sites' : 'functions';
             $exception = new AppwriteException(AppwriteException::DEPLOYMENT_NOT_FOUND, view: $errorView);
-            $exception->addCTA('View deployments', $url . '/console/project-' . $project->getAttribute('region', 'default') . '-' . $projectId . '/' . $type . '/' . $resourceType . '-' . $resourceId);
+            $exception->addCTA('View deployments', $url . '/projects/' . $projectId . '/' . $type . '/' . $resourceId);
             throw $exception;
         }
 
@@ -289,7 +289,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
                 $response
                     ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
                     ->addHeader('Pragma', 'no-cache')
-                    ->redirect($url . '/console/auth/preview?'
+                    ->redirect($url . '/auth/preview?'
                         . \http_build_query([
                             'projectId' => $projectId,
                             'origin' => $protocol . '://' . $host,
@@ -346,22 +346,21 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
         $allowAnyStatus = !\is_null($apiKey) && $apiKey->isDeploymentStatusIgnored();
         if (!$allowAnyStatus && $deployment->getAttribute('status') !== 'ready') {
             $status = $deployment->getAttribute('status');
-            $region = $project->getAttribute('region', 'default');
 
             switch ($status) {
                 case 'failed':
                     $exception = new AppwriteException(AppwriteException::BUILD_FAILED, view: $errorView);
-                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments/deployment-' . $deployment->getId();
+                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments/' . $deployment->getId();
                     $exception->addCTA('View logs', $url . $ctaUrl);
                     break;
                 case 'canceled':
                     $exception = new AppwriteException(AppwriteException::BUILD_CANCELED, view: $errorView);
-                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments';
+                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments';
                     $exception->addCTA('View deployments', $url . $ctaUrl);
                     break;
                 default:
                     $exception = new AppwriteException(AppwriteException::BUILD_NOT_READY, view: $errorView);
-                    $ctaUrl = '/console/project-' . $region . '-' . $project->getId() . '/sites/site-' . $resource->getId() . '/deployments/deployment-' . $deployment->getId();
+                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments/' . $deployment->getId();
                     $exception->addCTA('Reload', '/');
                     $exception->addCTA('View logs', $url . $ctaUrl);
                     break;
@@ -373,7 +372,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $permissions = $resource->getAttribute('execute');
             if (!(\in_array('any', $permissions)) && !(\in_array('guests', $permissions))) {
                 $exception = new AppwriteException(AppwriteException::FUNCTION_EXECUTE_PERMISSION_MISSING, view: $errorView);
-                $exception->addCTA('View settings', $url . '/console/project-' . $project->getAttribute('region', 'default') . '-' . $project->getId() . '/functions/function-' . $resource->getId() . '/settings');
+                $exception->addCTA('View settings', $url . '/projects/' . $project->getId() . '/functions/' . $resource->getId() . '/settings');
                 throw $exception;
             }
         }

--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -125,7 +125,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             if (\str_ends_with($host, $denyDomain)) {
                 $exception = new AppwriteException(AppwriteException::RULE_NOT_FOUND, 'This domain is not connected to any Appwrite resources. Visit domains tab under function/site settings to configure it.', view: $errorView);
 
-                $exception->addCTA('Start with this domain', $url);
+                $exception->addCTA('Start with this domain', System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root' ? "{$url}/console" : $url);
                 throw $exception;
             }
         }
@@ -200,7 +200,11 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $resourceId = $rule->getAttribute('deploymentResourceId', '');
             $type = ($resourceType === 'site') ? 'sites' : 'functions';
             $exception = new AppwriteException(AppwriteException::DEPLOYMENT_NOT_FOUND, view: $errorView);
-            $exception->addCTA('View deployments', $url . '/projects/' . $projectId . '/' . $type . '/' . $resourceId);
+            $region = $project->getAttribute('region', 'default');
+            $ctaUrl = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+                ? "/console/project-{$region}-{$projectId}/{$type}/{$resourceType}-{$resourceId}"
+                : "/projects/{$projectId}/{$type}/{$resourceId}";
+            $exception->addCTA('View deployments', $url . $ctaUrl);
             throw $exception;
         }
 
@@ -289,7 +293,7 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
                 $response
                     ->addHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
                     ->addHeader('Pragma', 'no-cache')
-                    ->redirect($url . '/auth/preview?'
+                    ->redirect($url . (System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root' ? '/console/auth/preview?' : '/auth/preview?')
                         . \http_build_query([
                             'projectId' => $projectId,
                             'origin' => $protocol . '://' . $host,
@@ -346,23 +350,28 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
         $allowAnyStatus = !\is_null($apiKey) && $apiKey->isDeploymentStatusIgnored();
         if (!$allowAnyStatus && $deployment->getAttribute('status') !== 'ready') {
             $status = $deployment->getAttribute('status');
+            $region = $project->getAttribute('region', 'default');
+            $legacyConsolePaths = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root';
+            $siteUrl = $legacyConsolePaths
+                ? "/console/project-{$region}-{$project->getId()}/sites/site-{$resource->getId()}"
+                : "/projects/{$project->getId()}/sites/{$resource->getId()}";
+            $deploymentUrl = $legacyConsolePaths
+                ? "{$siteUrl}/deployments/deployment-{$deployment->getId()}"
+                : "{$siteUrl}/deployments/{$deployment->getId()}";
 
             switch ($status) {
                 case 'failed':
                     $exception = new AppwriteException(AppwriteException::BUILD_FAILED, view: $errorView);
-                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments/' . $deployment->getId();
-                    $exception->addCTA('View logs', $url . $ctaUrl);
+                    $exception->addCTA('View logs', $url . $deploymentUrl);
                     break;
                 case 'canceled':
                     $exception = new AppwriteException(AppwriteException::BUILD_CANCELED, view: $errorView);
-                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments';
-                    $exception->addCTA('View deployments', $url . $ctaUrl);
+                    $exception->addCTA('View deployments', $url . $siteUrl . '/deployments');
                     break;
                 default:
                     $exception = new AppwriteException(AppwriteException::BUILD_NOT_READY, view: $errorView);
-                    $ctaUrl = '/projects/' . $project->getId() . '/sites/' . $resource->getId() . '/deployments/' . $deployment->getId();
                     $exception->addCTA('Reload', '/');
-                    $exception->addCTA('View logs', $url . $ctaUrl);
+                    $exception->addCTA('View logs', $url . $deploymentUrl);
                     break;
             }
             throw $exception;
@@ -372,7 +381,11 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             $permissions = $resource->getAttribute('execute');
             if (!(\in_array('any', $permissions)) && !(\in_array('guests', $permissions))) {
                 $exception = new AppwriteException(AppwriteException::FUNCTION_EXECUTE_PERMISSION_MISSING, view: $errorView);
-                $exception->addCTA('View settings', $url . '/projects/' . $project->getId() . '/functions/' . $resource->getId() . '/settings');
+                $region = $project->getAttribute('region', 'default');
+                $ctaUrl = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+                    ? "/console/project-{$region}-{$project->getId()}/functions/function-{$resource->getId()}/settings"
+                    : "/projects/{$project->getId()}/functions/{$resource->getId()}/settings";
+                $exception->addCTA('View settings', $url . $ctaUrl);
                 throw $exception;
             }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,20 +218,22 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/console:8.7.11
+    image: appwrite/vibes:0.3.16
     restart: unless-stopped
     networks:
       - appwrite
+    environment:
+      - VITE_CONSOLE_PROFILE=self-hosted
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=appwrite
       - traefik.docker.network=appwrite
-      - traefik.http.services.appwrite_console.loadbalancer.server.port=80
+      - traefik.http.services.appwrite_console.loadbalancer.server.port=3000
       - traefik.http.routers.appwrite_console_http.entrypoints=appwrite_web
-      - traefik.http.routers.appwrite_console_http.rule=PathPrefix(`/console`)
+      - traefik.http.routers.appwrite_console_http.rule=(Host(`${_APP_DOMAIN:-localhost}`) || Host(`${_APP_CONSOLE_DOMAIN:-localhost}`)) && !PathPrefix(`/v1`) && !PathPrefix(`/.well-known`) && !HeaderRegexp(`x-appwrite-hostname`, `.+`)
       - traefik.http.routers.appwrite_console_http.service=appwrite_console
       - traefik.http.routers.appwrite_console_https.entrypoints=appwrite_websecure
-      - traefik.http.routers.appwrite_console_https.rule=PathPrefix(`/console`)
+      - traefik.http.routers.appwrite_console_https.rule=(Host(`${_APP_DOMAIN:-localhost}`) || Host(`${_APP_CONSOLE_DOMAIN:-localhost}`)) && !PathPrefix(`/v1`) && !PathPrefix(`/.well-known`) && !HeaderRegexp(`x-appwrite-hostname`, `.+`)
       - traefik.http.routers.appwrite_console_https.service=appwrite_console
       - traefik.http.routers.appwrite_console_https.tls=true
   appwrite-realtime:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       - _APP_NOTIFICATIONS_TRACKING_SECRET
       - _APP_DOMAIN
       - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_URL_SCHEME=root
       - _APP_CONSOLE_TRUSTED_PROJECTS
       - _APP_DOMAIN_TARGET_CNAME
       - _APP_DOMAIN_TARGET_AAAA
@@ -218,7 +219,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/vibes:0.3.16
+    image: appwrite/new:0.3.24
     restart: unless-stopped
     networks:
       - appwrite
@@ -328,6 +329,7 @@ services:
       - _APP_LOGGING_CONFIG
       - _APP_WEBHOOK_MAX_FAILED_ATTEMPTS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_CONSOLE_URL_SCHEME=root
   appwrite-worker-deletes:
     entrypoint: worker-deletes
     logging:
@@ -490,6 +492,7 @@ services:
       - _APP_OPTIONS_ROUTER_FORCE_HTTPS
       - _APP_DOMAIN
       - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_URL_SCHEME=root
       - _APP_CONSOLE_TRUSTED_PROJECTS
       - _APP_STORAGE_DEVICE
       - _APP_STORAGE_S3_ACCESS_KEY

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -259,6 +259,8 @@ class Webhooks extends Action
 
         $projectId = $project->getId();
         $projectInternalId = $project->getSequence();
+        $region = $project->getAttribute('region', 'default');
+        $webhookId = $webhook->getId();
 
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS', 'disabled') === 'disabled' ? 'http' : 'https';
         $consoleHostname = System::getEnv('_APP_CONSOLE_DOMAIN', System::getEnv('_APP_DOMAIN', 'localhost'));
@@ -302,7 +304,9 @@ class Webhooks extends Action
             $template->setParam('{{url}}', $webhook->getAttribute('url'));
             $template->setParam('{{error}}', 'The server returned ' . $statusCode . ' status code');
             $template->setParam('{{host}}', $protocol . '://' . $consoleHostname);
-            $template->setParam('{{path}}', "/projects/$projectId/settings/webhooks");
+            $template->setParam('{{path}}', System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+                ? "/console/project-{$region}-{$projectId}/settings/webhooks/{$webhookId}"
+                : "/projects/{$projectId}/settings/webhooks");
             $template->setParam('{{attempts}}', $attempts);
 
             $publisherForNotifications->enqueue(new NotificationMessage(

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -259,8 +259,6 @@ class Webhooks extends Action
 
         $projectId = $project->getId();
         $projectInternalId = $project->getSequence();
-        $region = $project->getAttribute('region', 'default');
-        $webhookId = $webhook->getId();
 
         $protocol = System::getEnv('_APP_OPTIONS_FORCE_HTTPS', 'disabled') === 'disabled' ? 'http' : 'https';
         $consoleHostname = System::getEnv('_APP_CONSOLE_DOMAIN', System::getEnv('_APP_DOMAIN', 'localhost'));
@@ -304,7 +302,7 @@ class Webhooks extends Action
             $template->setParam('{{url}}', $webhook->getAttribute('url'));
             $template->setParam('{{error}}', 'The server returned ' . $statusCode . ' status code');
             $template->setParam('{{host}}', $protocol . '://' . $consoleHostname);
-            $template->setParam('{{path}}', "/console/project-$region-$projectId/settings/webhooks/$webhookId");
+            $template->setParam('{{path}}', "/projects/$projectId/settings/webhooks");
             $template->setParam('{{attempts}}', $attempts);
 
             $publisherForNotifications->enqueue(new NotificationMessage(

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -161,7 +161,10 @@ class Comment
                     };
 
                     if ($site['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/projects/' . $projectId . '/sites/' . $siteId . '/deployments/' . $site['deploymentId'] . ')';
+                        $logsUrl = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+                            ? "{$protocol}://{$hostname}/console/project-{$site['region']}-{$projectId}/sites/site-{$siteId}/deployments/deployment-{$site['deploymentId']}"
+                            : "{$protocol}://{$hostname}/projects/{$projectId}/sites/{$siteId}/deployments/{$site['deploymentId']}";
+                        $action = "[View Logs]({$logsUrl})";
                     } else {
                         $action = '[Authorize](' . $site['action']['url'] . ')';
                     }
@@ -209,7 +212,10 @@ class Comment
                     };
 
                     if ($function['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/projects/' . $projectId . '/functions/' . $functionId . '/deployments/' . $function['deploymentId'] . ')';
+                        $logsUrl = System::getEnv('_APP_CONSOLE_URL_SCHEME', 'legacy') !== 'root'
+                            ? "{$protocol}://{$hostname}/console/project-{$function['region']}-{$projectId}/functions/function-{$functionId}/deployment-{$function['deploymentId']}"
+                            : "{$protocol}://{$hostname}/projects/{$projectId}/functions/{$functionId}/deployments/{$function['deploymentId']}";
+                        $action = "[View Logs]({$logsUrl})";
                     } else {
                         $action = '[Authorize](' . $function['action']['url'] . ')';
                     }

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -161,7 +161,7 @@ class Comment
                     };
 
                     if ($site['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/console/project-' . $site['region'] . '-' . $projectId . '/sites/site-' . $siteId . '/deployments/deployment-' . $site['deploymentId'] . ')';
+                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/projects/' . $projectId . '/sites/' . $siteId . '/deployments/' . $site['deploymentId'] . ')';
                     } else {
                         $action = '[Authorize](' . $site['action']['url'] . ')';
                     }
@@ -209,7 +209,7 @@ class Comment
                     };
 
                     if ($function['action']['type'] === 'logs') {
-                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/console/project-' . $function['region'] . '-' . $projectId . '/functions/function-' . $functionId . '/deployment-' . $function['deploymentId'] . ')';
+                        $action = '[View Logs](' . $protocol . '://' . $hostname . '/projects/' . $projectId . '/functions/' . $functionId . '/deployments/' . $function['deploymentId'] . ')';
                     } else {
                         $action = '[Authorize](' . $function['action']['url'] . ')';
                     }

--- a/tests/e2e/General/HTTPTest.php
+++ b/tests/e2e/General/HTTPTest.php
@@ -26,6 +26,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_OPTIONS, '/', \array_merge([
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
@@ -51,6 +52,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/humans.txt', \array_merge([
             'origin' => 'http://localhost',
         ]));
@@ -64,6 +66,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/robots.txt', \array_merge([
             'origin' => 'http://localhost',
         ]));
@@ -77,6 +80,7 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/.well-known/acme-challenge/8DdIKX257k6Dih5s_saeVMpTnjPJdKO5Ase0OCiJrIg');
 
         // 'Unknown path', but validation passed
@@ -87,8 +91,8 @@ final class HTTPTest extends Scope
          */
         $response = $this->client->call(Client::METHOD_GET, '/.well-known/acme-challenge/../../../../../../../etc/passwd');
 
-        // 'Unknown path', but validation passed
-        $this->assertEquals(404, $response['headers']['status-code']);
+        // 'Invalid challenge token', traversal rejected by validation
+        $this->assertEquals(400, $response['headers']['status-code']);
     }
 
     public function testVersions()
@@ -96,6 +100,7 @@ final class HTTPTest extends Scope
         /**
          * Test without header
          */
+        $this->client->setEndpoint('http://localhost');
         $response = $this->client->call(Client::METHOD_GET, '/versions', \array_merge([
             'content-type' => 'application/json',
         ], $this->getHeaders()));
@@ -172,11 +177,23 @@ final class HTTPTest extends Scope
         /**
          * Test for SUCCESS
          */
+        $this->client->setEndpoint('http://localhost');
 
         $endpoint = '/invite?membershipId=123&userId=asdf';
 
-        $response = $this->client->call(Client::METHOD_GET, $endpoint);
+        $response = $this->client->call(Client::METHOD_GET, $endpoint, [], [], true, false);
 
         $this->assertEquals('/console' . $endpoint, $response['headers']['location']);
+    }
+
+    public function testConsoleServed()
+    {
+        /**
+         * Test for SUCCESS
+         */
+        $response = $this->client->call(Client::METHOD_GET, '/');
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringContainsString('text/html', (string) $response['headers']['content-type']);
     }
 }

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -2229,7 +2229,7 @@ final class SitesCustomServerTest extends Scope
         $proxyClient->setEndpoint('http://' . $deploymentDomain);
         $response = $proxyClient->call(Client::METHOD_GET, '/', followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
 
         $jwtObj = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 900, 0);
         $apiKey = $jwtObj->encode([
@@ -2561,7 +2561,7 @@ final class SitesCustomServerTest extends Scope
 
         $response = $proxyClient->call(Client::METHOD_GET, '/contact', followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
         $this->assertStringContainsString('projectId=' . $this->getProject()['$id'], (string) $response['headers']['location']);
         $this->assertStringContainsString('origin=', (string) $response['headers']['location']);
         $this->assertStringContainsString('path=%2Fcontact', (string) $response['headers']['location']);
@@ -2624,7 +2624,7 @@ final class SitesCustomServerTest extends Scope
             'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
         ], followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
 
         // Failure: User missing
         $cookie = 'a_session_console=' .$this->getRoot()['session'];
@@ -2659,7 +2659,7 @@ final class SitesCustomServerTest extends Scope
             'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
         ], followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
 
         // Failure: Membership missing
         $email = \uniqid() . 'newuser@appwrite.io';
@@ -2699,7 +2699,7 @@ final class SitesCustomServerTest extends Scope
             'cookie' => 'a_jwt_console=' . $jwt['body']['jwt']
         ], followRedirects: false);
         $this->assertEquals(301, $response['headers']['status-code']);
-        $this->assertStringContainsString('/console/auth/preview', (string) $response['headers']['location']);
+        $this->assertStringContainsString('/auth/preview', (string) $response['headers']['location']);
 
         $this->cleanupSite($siteId);
     }

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -32,7 +32,7 @@ final class WebhooksTest extends TestCase
         $publisherForNotifications = new NotificationPublisher($publisher, new Queue('v1-notifications'));
         $worker = new Webhooks();
 
-        $worker->sendAlert(
+        $this->withConsoleUrlScheme('legacy', fn () => $worker->sendAlert(
             attempts: 10,
             statusCode: 500,
             webhook: new Document([
@@ -51,7 +51,7 @@ final class WebhooksTest extends TestCase
             dbForPlatform: $database,
             publisherForNotifications: $publisherForNotifications,
             plan: []
-        );
+        ));
 
         $events = $publisher->getEvents('v1-notifications');
 
@@ -105,32 +105,26 @@ final class WebhooksTest extends TestCase
         $publisherForNotifications = new NotificationPublisher($publisher, new Queue('v1-notifications'));
         $worker = new Webhooks();
 
-        \putenv('_APP_CONSOLE_URL_SCHEME=root');
-
-        try {
-            $worker->sendAlert(
-                attempts: 10,
-                statusCode: 500,
-                webhook: new Document([
-                    '$id' => 'webhook-1',
-                    '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
-                    'name' => 'Payments',
-                    'url' => 'https://example.test/webhook',
-                ]),
-                project: new Document([
-                    '$id' => 'project-1',
-                    '$sequence' => 'project-internal-1',
-                    'name' => 'Production',
-                    'teamInternalId' => 'team-internal-1',
-                    'region' => 'fra',
-                ]),
-                dbForPlatform: $database,
-                publisherForNotifications: $publisherForNotifications,
-                plan: []
-            );
-        } finally {
-            \putenv('_APP_CONSOLE_URL_SCHEME');
-        }
+        $this->withConsoleUrlScheme('root', fn () => $worker->sendAlert(
+            attempts: 10,
+            statusCode: 500,
+            webhook: new Document([
+                '$id' => 'webhook-1',
+                '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+                'name' => 'Payments',
+                'url' => 'https://example.test/webhook',
+            ]),
+            project: new Document([
+                '$id' => 'project-1',
+                '$sequence' => 'project-internal-1',
+                'name' => 'Production',
+                'teamInternalId' => 'team-internal-1',
+                'region' => 'fra',
+            ]),
+            dbForPlatform: $database,
+            publisherForNotifications: $publisherForNotifications,
+            plan: []
+        ));
 
         $events = $publisher->getEvents('v1-notifications');
 
@@ -264,6 +258,18 @@ final class WebhooksTest extends TestCase
         yield 'other project owner' => [['project-project-2-owner'], false];
         yield 'non owner' => [['developer'], false];
         yield 'invalid roles' => [null, false];
+    }
+
+    private function withConsoleUrlScheme(string $scheme, callable $callback): void
+    {
+        $original = \getenv('_APP_CONSOLE_URL_SCHEME');
+        \putenv("_APP_CONSOLE_URL_SCHEME={$scheme}");
+
+        try {
+            $callback();
+        } finally {
+            \putenv($original === false ? '_APP_CONSOLE_URL_SCHEME' : "_APP_CONSOLE_URL_SCHEME={$original}");
+        }
     }
 
     private function createPlatformDatabase(): Database

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -69,7 +69,7 @@ final class WebhooksTest extends TestCase
         );
         $this->assertStringContainsString('Payments', (string) $payload['body']);
         $this->assertStringContainsString('Ada Lovelace', (string) $payload['body']);
-        $this->assertStringContainsString('/console/project-fra-project-1/settings/webhooks/webhook-1', (string) $payload['body']);
+        $this->assertStringContainsString('/projects/project-1/settings/webhooks', (string) $payload['body']);
         $this->assertStringNotContainsString('{{', (string) $payload['body']);
         $this->assertSame(APP_NAME, $payload['variables']['platform']);
         $this->assertSame(APP_EMAIL_LOGO_URL, $payload['variables']['logoUrl']);

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -69,7 +69,7 @@ final class WebhooksTest extends TestCase
         );
         $this->assertStringContainsString('Payments', (string) $payload['body']);
         $this->assertStringContainsString('Ada Lovelace', (string) $payload['body']);
-        $this->assertStringContainsString('/projects/project-1/settings/webhooks', (string) $payload['body']);
+        $this->assertStringContainsString('/console/project-fra-project-1/settings/webhooks/webhook-1', (string) $payload['body']);
         $this->assertStringNotContainsString('{{', (string) $payload['body']);
         $this->assertSame(APP_NAME, $payload['variables']['platform']);
         $this->assertSame(APP_EMAIL_LOGO_URL, $payload['variables']['logoUrl']);
@@ -94,6 +94,49 @@ final class WebhooksTest extends TestCase
             'parentResourceId' => 'project-1',
             'parentResourceInternalId' => 'project-internal-1',
         ], $payload['recipients'][1]);
+    }
+
+    public function testSendAlertUsesRootConsolePathsWhenConfigured(): void
+    {
+        $database = $this->createPlatformDatabase();
+        $this->seedOwnerUser($database);
+
+        $publisher = new MockPublisher();
+        $publisherForNotifications = new NotificationPublisher($publisher, new Queue('v1-notifications'));
+        $worker = new Webhooks();
+
+        \putenv('_APP_CONSOLE_URL_SCHEME=root');
+
+        try {
+            $worker->sendAlert(
+                attempts: 10,
+                statusCode: 500,
+                webhook: new Document([
+                    '$id' => 'webhook-1',
+                    '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+                    'name' => 'Payments',
+                    'url' => 'https://example.test/webhook',
+                ]),
+                project: new Document([
+                    '$id' => 'project-1',
+                    '$sequence' => 'project-internal-1',
+                    'name' => 'Production',
+                    'teamInternalId' => 'team-internal-1',
+                    'region' => 'fra',
+                ]),
+                dbForPlatform: $database,
+                publisherForNotifications: $publisherForNotifications,
+                plan: []
+            );
+        } finally {
+            \putenv('_APP_CONSOLE_URL_SCHEME');
+        }
+
+        $events = $publisher->getEvents('v1-notifications');
+
+        $this->assertCount(1, $events);
+        $this->assertStringContainsString('/projects/project-1/settings/webhooks', (string) $events[0]['body']);
+        $this->assertStringNotContainsString('/console/', (string) $events[0]['body']);
     }
 
     public function testSendAlertPersonalizesBodyPerOwner(): void


### PR DESCRIPTION
# What does this PR do?

Reintroduces the vibes console migration (#12834, reverted in #12883) with backward compatibility for deployments that still run the older `appwrite/console` image — most importantly `appwrite/cloud`, which pins `appwrite/server-ce: main-dev` and broke when the backend started generating root-path console URLs its `/console`-prefixed console cannot serve.

## Changes over #12834

### 1. Console image: `appwrite/vibes` → `appwrite/new`

Vibes images are now published publicly as `appwrite/new` on Docker Hub and GHCR (appwrite/vibes#79). The compose service is pinned to `appwrite/new:0.3.24`. Everything else about the serving model is unchanged from #12834: port 3000, `VITE_CONSOLE_PROFILE=self-hosted`, image-level healthcheck, and host-based Traefik routing (console host minus `/v1`, `/.well-known`, and `x-appwrite-hostname` requests goes to vibes; everything else stays on the backend catch-all).

### 2. New env var: `_APP_CONSOLE_URL_SCHEME`

Every place where the backend generates a link into the console now picks the URL shape at runtime:

| Value | Behavior |
|---|---|
| `legacy` (**default**) | Pre-2.0 URLs: `/console/auth/*`, `/console/project-{region}-{id}/...`, `site-`/`function-`/`deployment-` resource prefixes |
| `root` | Vibes URLs: `/auth/*`, `/projects/{id}/...` |

Affected call sites:

- `app/controllers/api/account.php` — OAuth default success/failure callbacks, magic-URL email link
- `app/controllers/general.php` — router error-page CTAs (unknown domain, deployment not found, build failed/canceled/not ready, missing execute permission) and the OAuth preview redirect
- `src/Appwrite/Platform/Workers/Webhooks.php` — webhook-pause email link
- `src/Appwrite/Vcs/Comment.php` — VCS PR comment "View Logs" links

The **default is `legacy`**, so cloud (and anyone else consuming this repo as a library with the old console) is byte-for-byte unaffected without any configuration or deploy coordination. The self-hosted `docker-compose.yml` — which pairs with the vibes image in the same file — explicitly sets `_APP_CONSOLE_URL_SCHEME=root` on the three services that generate console URLs: `appwrite`, `appwrite-worker-webhooks`, and `appwrite-worker-builds`.

As an extra safety net, vibes ≥ 0.3.5 already 302-redirects `/console/*` to `/*`, so a self-hosted install left on `legacy` against the new console still gets working auth flows (`/console/auth/*` maps 1:1 after prefix strip).

### 3. Tests

- `WebhooksTest` covers **both** schemes: the default-scheme test asserts the legacy path (`/console/project-fra-project-1/settings/webhooks/webhook-1`), and a new `testSendAlertUsesRootConsolePathsWhenConfigured` sets `_APP_CONSOLE_URL_SCHEME=root` and asserts the vibes path. This pins the legacy behavior cloud depends on.
- The #12834 e2e changes (HTTPTest backend-direct targeting, `testConsoleServed`, Sites CTA assertions) are reapplied unchanged; the e2e stack runs with `root` via compose.

## Test plan

- [x] `tests/unit/Platform/Workers/WebhooksTest.php` — 13/13 passing (both URL schemes)
- [x] Pint clean, PHPStan level 4 — no findings on changed files
- [x] `appwrite/new:0.3.24` verified against the local stack: container healthy, vibes SSR served at root through Traefik, `/v1/health/version` still routed to the API, `/console` 302-redirects to root

## Related

- Reverts the revert #12883, restoring #12834
- appwrite/vibes#79 (`0.3.24`) — publish images as `appwrite/new`
