### PR TITLE
Scope GitHub App installation queries by provider

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Callback/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Callback/Get.php
@@ -111,7 +111,8 @@ class Get extends Action
 
             $installation = $dbForPlatform->findOne('installations', [
                 Query::equal('providerInstallationId', [$providerInstallationId]),
-                Query::equal('projectInternalId', [$projectInternalId])
+                Query::equal('projectInternalId', [$projectInternalId]),
+                Query::equal('provider', ['github'])
             ]);
 
             $personal = false;

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Events/Create.php
@@ -113,6 +113,7 @@ class Create extends Action
         do {
             $installationQueries = [
                 Query::equal('providerInstallationId', [$providerInstallationId]),
+                Query::equal('provider', ['github']),
                 Query::limit(1000),
             ];
             if ($installationCursor !== null) {


### PR DESCRIPTION
## Summary
- Fixes a real finding from Greptile's review of #12820: `GitHub/Callback/Get.php`'s installation lookup was missing a `provider` filter, so a numeric `providerInstallationId` collision between a GitHub App installation and a Gitea installation (same project) could silently overwrite the Gitea installation document with GitHub data.
- Found and fixed the same root cause in a second, more severe spot while auditing: `GitHub/Events/Create.php::handleInstallationEvent()` (the `installation.deleted` webhook handler) queries `installations` unscoped by project *and* without a provider filter — a collision there would disconnect a Gitea installation's functions/sites and delete its repositories/installation document entirely.
- `Callback/Base.php` (Gitea's own OAuth2 callback) already scopes correctly by `provider` — this brings the GitHub-specific paths in line with that.

## Test plan
- [x] `tests/unit/Vcs/GitHubInstallationEventTest.php` — all 3 tests still pass
- [x] `composer analyze` — clean
- [x] `composer format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)