### PR TITLE
Configure growth endpoint for console feedback and support forms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,6 +225,7 @@ services:
       - appwrite
     environment:
       - VITE_CONSOLE_PROFILE=self-hosted
+      - VITE_GROWTH_ENDPOINT=https://growth.appwrite.io/v1
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=appwrite


### PR DESCRIPTION
# What does this PR do?

Sets `VITE_GROWTH_ENDPOINT` on the console service in `docker-compose.yml` so the feedback and support forms in the new console keep working on self-hosted installs.

> Follow-up to #12887.

## Why

The old console had the growth endpoint **baked into the published image at build time**: `appwrite/console`'s publish workflow passed `PUBLIC_GROWTH_ENDPOINT=https://growth.appwrite.io/v1` as a Docker build arg, so compose never needed to reference it.

Vibes reads `VITE_GROWTH_ENDPOINT` at **runtime** via the same runtime-config injection as `VITE_CONSOLE_PROFILE` (`src/lib/runtime-config-shared.ts`). Nothing is baked into the image, and the feedback popover in the header renders regardless of console profile — so without this variable, a self-hosted user submitting feedback hits *"Feedback is not configured. Set VITE_GROWTH_ENDPOINT in .env to enable submission."*

This restores parity with the old console: same endpoint value (matching vibes' own `.env.example`), same submission behavior as every `appwrite/console` image ships with today — no new telemetry.

## Test plan

- [x] Recreated the console container locally with the new env var and verified the served page's runtime config now injects `growthEndpoint":"https://growth.appwrite.io/v1"`
