### PR TITLE
DISCORD-15272384: Harden flaky RealtimeCustomClientTest::testChannelExecutions

### DIFF
--- a/tests/e2e/Services/Realtime/RealtimeBase.php
+++ b/tests/e2e/Services/Realtime/RealtimeBase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\E2E\Services\Realtime;
 
+use Appwrite\Tests\Async\Exceptions\Critical;
 use WebSocket\Client as WebSocketClient;
 use WebSocket\ConnectionException;
 use WebSocket\TimeoutException;
@@ -26,28 +27,41 @@ trait RealtimeBase
         int $timeoutMs = 60000,
         int $pollMs = 50
     ): array {
-        $deadline = \microtime(true) + ($timeoutMs / 1000);
+        $matched = [];
         $lastMessage = [];
 
-        while (\microtime(true) < $deadline) {
-            try {
-                $message = \json_decode($client->receive(), true);
-            } catch (TimeoutException) {
-                \usleep($pollMs * 1000);
-                continue;
-            }
+        try {
+            $this->assertEventually(function () use ($client, $match, &$matched, &$lastMessage): void {
+                try {
+                    $frame = $client->receive();
+                } catch (TimeoutException) {
+                    // No frame arrived within the read timeout yet; keep polling.
+                    throw new \Exception('No websocket frame received within read timeout.');
+                } catch (ConnectionException $e) {
+                    // Server closed or reset the socket (e.g. idle-timeout eviction).
+                    // Retrying can never recover, so fail fast with context instead of
+                    // letting a raw stack trace bubble up.
+                    throw new Critical('WebSocket connection closed while waiting for expected frame: ' . $e->getMessage());
+                }
 
-            if (!\is_array($message)) {
-                continue;
-            }
+                $message = \json_decode($frame, true);
+                if (\is_array($message)) {
+                    $lastMessage = $message;
+                }
 
-            $lastMessage = $message;
-            if ($match($message)) {
-                return $message;
-            }
+                if (!\is_array($message) || !$match($message)) {
+                    throw new \Exception('Websocket frame did not match expected event.');
+                }
+
+                $matched = $message;
+            }, $timeoutMs, $pollMs);
+        } catch (Critical $e) {
+            $this->fail($e->getMessage() . ' Last frame: ' . \json_encode($lastMessage));
+        } catch (\Exception) {
+            $this->fail('Timed out waiting for expected websocket frame. Last frame: ' . \json_encode($lastMessage));
         }
 
-        $this->fail('Timed out waiting for expected websocket frame. Last frame: ' . \json_encode($lastMessage));
+        return $matched;
     }
 
     private function getWebsocket(

--- a/tests/e2e/Services/Realtime/RealtimeBase.php
+++ b/tests/e2e/Services/Realtime/RealtimeBase.php
@@ -4,9 +4,52 @@ namespace Tests\E2E\Services\Realtime;
 
 use WebSocket\Client as WebSocketClient;
 use WebSocket\ConnectionException;
+use WebSocket\TimeoutException;
 
 trait RealtimeBase
 {
+    /**
+     * Receive websocket frames until one matches, skipping unrelated frames.
+     *
+     * Realtime channels such as `executions` are project-scoped, so a subscriber
+     * may see intermediate or unrelated frames before the one under test. Some
+     * events (e.g. an async execution's terminal `update`) also arrive only after
+     * substantial latency (worker pickup + runtime cold start + execution timeout),
+     * well beyond a single read timeout. This polls, tolerating both, until $match
+     * returns true or the overall deadline elapses.
+     *
+     * @param callable(array): bool $match
+     */
+    private function receiveUntilEvent(
+        WebSocketClient $client,
+        callable $match,
+        int $timeoutMs = 60000,
+        int $pollMs = 50
+    ): array {
+        $deadline = \microtime(true) + ($timeoutMs / 1000);
+        $lastMessage = [];
+
+        while (\microtime(true) < $deadline) {
+            try {
+                $message = \json_decode($client->receive(), true);
+            } catch (TimeoutException) {
+                \usleep($pollMs * 1000);
+                continue;
+            }
+
+            if (!\is_array($message)) {
+                continue;
+            }
+
+            $lastMessage = $message;
+            if ($match($message)) {
+                return $message;
+            }
+        }
+
+        $this->fail('Timed out waiting for expected websocket frame. Last frame: ' . \json_encode($lastMessage));
+    }
+
     private function getWebsocket(
         array $channels = [],
         array $headers = [],

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -2457,10 +2457,23 @@ final class RealtimeCustomClientTest extends Scope
         $this->assertEquals(202, $execution['headers']['status-code']);
         $this->assertNotEmpty($execution['body']['$id']);
 
-        $response = json_decode($client->receive(), true);
-        $responseUpdate = json_decode($client->receive(), true);
-
         $executionId = $execution['body']['$id'];
+
+        // The async execution first emits a `create` event, then a terminal `update`
+        // once the runtime finishes. That `update` only arrives after worker pickup,
+        // runtime cold start, and the function's execution timeout, so it can easily
+        // exceed a single read timeout. Skip unrelated frames and wait generously for
+        // each expected event instead of assuming they are the next two frames.
+        $response = $this->receiveUntilEvent(
+            $client,
+            fn (array $message): bool => ($message['type'] ?? null) === 'event'
+                && \in_array("functions.{$functionId}.executions.{$executionId}.create", $message['data']['events'] ?? [], true)
+        );
+        $responseUpdate = $this->receiveUntilEvent(
+            $client,
+            fn (array $message): bool => ($message['type'] ?? null) === 'event'
+                && \in_array("functions.{$functionId}.executions.{$executionId}.update", $message['data']['events'] ?? [], true)
+        );
 
         $this->assertArrayHasKey('type', $response);
         $this->assertArrayHasKey('data', $response);


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky `Tests / CE / E2E / Realtime (dedicated) → RealtimeCustomClientTest::testChannelExecutions`, which intermittently fails with:

```
WebSocket\TimeoutException: Client read timeout
```

### Root cause

The test subscribes to the **project-scoped** `executions` channel and then makes two bare `receive()` calls, assuming the next two frames are exactly the execution `create` and `update` events, each bounded by a single 10s read timeout.

The async execution's terminal `update` only arrives after worker pickup, runtime cold start, and the function's execution timeout (the `timeout` fixture sleeps 60s against a 10s function timeout), so it regularly exceeds a single 10s read window → `Client read timeout`. The bare receives are also brittle to any intermediate or unrelated frames on the shared channel.

### Fix

- Add a reusable `receiveUntilEvent()` helper to the `RealtimeBase` trait (mirroring `PresenceRealtimeClientTest::receiveUntil`) that polls, tolerates per-read timeouts, skips unrelated frames, and waits generously (default 60s) for a matching frame.
- Use it in `testChannelExecutions` to wait for the specific `create` and `update` events for the execution instead of assuming they are the next two frames.

The subsequent assertions are unchanged and are satisfied by the matched frames.

## Test Plan

- Test-only change. Exercised by the existing CE realtime e2e job (`RealtimeCustomClientTest::testChannelExecutions`).

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] Test-only change; no API metadata changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)