### PR TITLE
feat(locale): add Sign Language (sgn) to languages list

### DIFF
--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -719,6 +719,11 @@ return [
         "nativeName" => "Sängö"
     ],
     [
+        "code" => "sgn",
+        "name" => "Sign Language",
+        "nativeName" => "Sign Language"
+    ],
+    [
         "code" => "sh",
         "name" => "Serbo-Croatian",
         "nativeName" => "Srpskohrvatski / Српскохрватски"
@@ -762,11 +767,6 @@ return [
         "code" => "sr",
         "name" => "Serbian",
         "nativeName" => "Српски"
-    ],
-    [
-        "code" => "sgn",
-        "name" => "Sign Language",
-        "nativeName" => "Sign Language"
     ],
     [
         "code" => "ss",

--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -764,6 +764,11 @@ return [
         "nativeName" => "Српски"
     ],
     [
+        "code" => "sgn",
+        "name" => "Sign Language",
+        "nativeName" => "Sign Language"
+    ],
+    [
         "code" => "ss",
         "name" => "Swati",
         "nativeName" => "SiSwati"

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -215,9 +215,9 @@ trait LocaleBase
         $this->assertEquals($response['body']['languages'][125]['name'], 'Sign Language');
         $this->assertEquals($response['body']['languages'][125]['nativeName'], 'Sign Language');
 
-        $this->assertEquals($response['body']['languages'][187]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][187]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][187]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -205,15 +205,19 @@ trait LocaleBase
 
         $this->assertEquals($response['headers']['status-code'], 200);
         $this->assertIsArray($response['body']);
-        $this->assertEquals(186, $response['body']['total']);
+        $this->assertEquals(187, $response['body']['total']);
 
         $this->assertEquals($response['body']['languages'][0]['code'], 'aa');
         $this->assertEquals($response['body']['languages'][0]['name'], 'Afar');
         $this->assertEquals($response['body']['languages'][0]['nativeName'], 'Afar');
 
-        $this->assertEquals($response['body']['languages'][185]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][185]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][185]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][126]['code'], 'sgn');
+        $this->assertEquals($response['body']['languages'][126]['name'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][126]['nativeName'], 'Sign Language');
+
+        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -211,13 +211,13 @@ trait LocaleBase
         $this->assertEquals($response['body']['languages'][0]['name'], 'Afar');
         $this->assertEquals($response['body']['languages'][0]['nativeName'], 'Afar');
 
-        $this->assertEquals($response['body']['languages'][126]['code'], 'sgn');
-        $this->assertEquals($response['body']['languages'][126]['name'], 'Sign Language');
-        $this->assertEquals($response['body']['languages'][126]['nativeName'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][125]['code'], 'sgn');
+        $this->assertEquals($response['body']['languages'][125]['name'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][125]['nativeName'], 'Sign Language');
 
-        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][187]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][187]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][187]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE


### PR DESCRIPTION
## Summary
Adds Sign Language (`sgn`) to the locale API language list.

Fixes appwrite/appwrite#8201.

## Changes
- Added `sgn` / `Sign Language` to `app/config/locale/languages.php`.
- Updated locale e2e expectations to include the new language count and direct `sgn` assertions.

## Testing
- Static verification on this worker: confirmed `sgn` is present in the language config and locale e2e test assertions were updated.
- Local PHP/Appwrite e2e execution was blocked because `php` is not installed on this Windows worker; upstream CI should run the full locale suite.

OpenJobs: openjobs.bot | https://openjobs.bot/jobs/cc566267-28cf-4785-bdce-9329c92e31b3 | cc566267-28cf-4785-bdce-9329c92e31b3