### PR TITLE
feat(locale): add Sign Language (sgn) to languages list (#8201)

### DIFF
--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -719,6 +719,11 @@ return [
         "nativeName" => "Sängö"
     ],
     [
+        "code" => "sgn",
+        "name" => "Sign Language",
+        "nativeName" => "Sign Language"
+    ],
+    [
         "code" => "sh",
         "name" => "Serbo-Croatian",
         "nativeName" => "Srpskohrvatski / Српскохрватски"
@@ -762,11 +767,6 @@ return [
         "code" => "sr",
         "name" => "Serbian",
         "nativeName" => "Српски"
-    ],
-    [
-        "code" => "sgn",
-        "name" => "Sign Language",
-        "nativeName" => "Sign Language"
     ],
     [
         "code" => "ss",

--- a/app/config/locale/languages.php
+++ b/app/config/locale/languages.php
@@ -764,6 +764,11 @@ return [
         "nativeName" => "Српски"
     ],
     [
+        "code" => "sgn",
+        "name" => "Sign Language",
+        "nativeName" => "Sign Language"
+    ],
+    [
         "code" => "ss",
         "name" => "Swati",
         "nativeName" => "SiSwati"

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -211,9 +211,9 @@ trait LocaleBase
         $this->assertEquals($response['body']['languages'][0]['name'], 'Afar');
         $this->assertEquals($response['body']['languages'][0]['nativeName'], 'Afar');
 
-        $this->assertEquals($response['body']['languages'][125]['code'], 'sgn');
-        $this->assertEquals($response['body']['languages'][125]['name'], 'Sign Language');
-        $this->assertEquals($response['body']['languages'][125]['nativeName'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][142]['code'], 'sgn');
+        $this->assertEquals($response['body']['languages'][142]['name'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][142]['nativeName'], 'Sign Language');
 
         $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
         $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -215,9 +215,9 @@ trait LocaleBase
         $this->assertEquals($response['body']['languages'][125]['name'], 'Sign Language');
         $this->assertEquals($response['body']['languages'][125]['nativeName'], 'Sign Language');
 
-        $this->assertEquals($response['body']['languages'][187]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][187]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][187]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -205,15 +205,19 @@ trait LocaleBase
 
         $this->assertEquals($response['headers']['status-code'], 200);
         $this->assertIsArray($response['body']);
-        $this->assertEquals(186, $response['body']['total']);
+        $this->assertEquals(187, $response['body']['total']);
 
         $this->assertEquals($response['body']['languages'][0]['code'], 'aa');
         $this->assertEquals($response['body']['languages'][0]['name'], 'Afar');
         $this->assertEquals($response['body']['languages'][0]['nativeName'], 'Afar');
 
-        $this->assertEquals($response['body']['languages'][185]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][185]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][185]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][126]['code'], 'sgn');
+        $this->assertEquals($response['body']['languages'][126]['name'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][126]['nativeName'], 'Sign Language');
+
+        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE

--- a/tests/e2e/Services/Locale/LocaleBase.php
+++ b/tests/e2e/Services/Locale/LocaleBase.php
@@ -211,13 +211,13 @@ trait LocaleBase
         $this->assertEquals($response['body']['languages'][0]['name'], 'Afar');
         $this->assertEquals($response['body']['languages'][0]['nativeName'], 'Afar');
 
-        $this->assertEquals($response['body']['languages'][126]['code'], 'sgn');
-        $this->assertEquals($response['body']['languages'][126]['name'], 'Sign Language');
-        $this->assertEquals($response['body']['languages'][126]['nativeName'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][125]['code'], 'sgn');
+        $this->assertEquals($response['body']['languages'][125]['name'], 'Sign Language');
+        $this->assertEquals($response['body']['languages'][125]['nativeName'], 'Sign Language');
 
-        $this->assertEquals($response['body']['languages'][186]['code'], 'zu');
-        $this->assertEquals($response['body']['languages'][186]['name'], 'Zulu');
-        $this->assertEquals($response['body']['languages'][186]['nativeName'], 'isiZulu');
+        $this->assertEquals($response['body']['languages'][187]['code'], 'zu');
+        $this->assertEquals($response['body']['languages'][187]['name'], 'Zulu');
+        $this->assertEquals($response['body']['languages'][187]['nativeName'], 'isiZulu');
 
         /**
          * Test for FAILURE


### PR DESCRIPTION
## Summary
Adds Sign Language (`sgn`) to the locale API language list, resolving https://github.com/appwrite/appwrite/issues/8201.

## Changes
- Added `sgn` / `Sign Language` (native name `Sign Language`) to `app/config/locale/languages.php`, placed alphabetically by language code between `sg` (Sango) and `sh` (Serbo-Croatian).
- Updated the locale e2e test in `tests/e2e/Services/Locale/LocaleBase.php`:
  - Bumped the total language count assertion from `186` to `187`.
  - Added a direct index assertion for `sgn` at 0-based position `142` (the 143rd entry; the locale API returns the config array in file order, no sort).
  - Adjusted the trailing `zu` assertion to index `186` (last entry).

## Verification
- `app/config/locale/languages.php` now contains exactly `187` entries.
- `sgn` is the 143rd code in file order (0-based index `142`), confirmed between `sg` (index 141) and `sh` (index 143); `zu` remains last at index `186`.
- Test assertions in `LocaleBase.php` match these exact indices and the new total.
- Note: PHP/Docker are not available on this worker, so upstream CI on appwrite/appwrite runs the full e2e locale suite. The change is data-only and aligned with existing locale-data conventions.

## Links
- Upstream issue: https://github.com/appwrite/appwrite/issues/8201
- OpenJobs: openjobs.bot | https://openjobs.bot/jobs/cc566267-28cf-4785-bdce-9329c92e31b3 | cc566267-28cf-4785-bdce-9329c92e31b3