### PR TITLE
(ci): drop php-retry, run tests directly without retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,6 @@ jobs:
     needs: build
     permissions:
       contents: read
-      pull-requests: write
       packages: read
     steps:
       - name: checkout
@@ -341,18 +340,10 @@ jobs:
 
       - name: Run Unit Tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
-        with:
-          max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
-          retry_wait_seconds: 60
-          timeout_minutes: 5
-          job_id: ${{ job.check_run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_dir: tests/unit
-          command: >-
-            docker compose exec
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-            appwrite test /usr/src/code/tests/unit
+        run: >-
+          docker compose exec
+          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+          appwrite test /usr/src/code/tests/unit
 
   e2e_general:
     name: Tests / E2E / General
@@ -361,7 +352,6 @@ jobs:
     needs: build
     permissions:
       contents: read
-      pull-requests: write
       packages: read
     steps:
       - name: checkout
@@ -411,18 +401,10 @@ jobs:
 
       - name: Run General Tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
-        with:
-          max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
-          retry_wait_seconds: 60
-          timeout_minutes: 5
-          job_id: ${{ job.check_run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_dir: tests/e2e/General
-          command: >-
-            docker compose exec -T
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-            appwrite test /usr/src/code/tests/e2e/General
+        run: >-
+          docker compose exec -T
+          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+          appwrite test /usr/src/code/tests/e2e/General
 
       - name: Failure Logs
         if: failure()
@@ -437,7 +419,6 @@ jobs:
     needs: [build, matrix]
     permissions:
       contents: read
-      pull-requests: write
       packages: read
     strategy:
       fail-fast: false
@@ -518,33 +499,25 @@ jobs:
           done
 
       - name: Run tests
-        timeout-minutes: 15
-        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
-        with:
-          max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
-          retry_wait_seconds: 60
-          timeout_minutes: ${{ matrix.service.timeout }}
-          job_id: ${{ job.check_run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_dir: tests/e2e/Services/${{ matrix.service.name }}
-          command: |
-            SERVICE_PATH="/usr/src/code/tests/e2e/Services/${{ matrix.service.name }}"
+        timeout-minutes: ${{ matrix.service.timeout }}
+        run: |
+          SERVICE_PATH="/usr/src/code/tests/e2e/Services/${{ matrix.service.name }}"
 
-            FUNCTIONAL_FLAG=""
-            if [ "${{ matrix.service.functional }}" = "true" ]; then
-              FUNCTIONAL_FLAG="--functional"
-            fi
+          FUNCTIONAL_FLAG=""
+          if [ "${{ matrix.service.functional }}" = "true" ]; then
+            FUNCTIONAL_FLAG="--functional"
+          fi
 
-            PARATEST_PROCESSES="${{ matrix.service.processes }}"
-            if [ -z "$PARATEST_PROCESSES" ]; then
-              PARATEST_PROCESSES="$(nproc)"
-            fi
+          PARATEST_PROCESSES="${{ matrix.service.processes }}"
+          if [ -z "$PARATEST_PROCESSES" ]; then
+            PARATEST_PROCESSES="$(nproc)"
+          fi
 
-            docker compose exec -T \
-              -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
-              -e _TESTS_OAUTH2_GITHUB_CLIENT_ID="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_ID }}" \
-              -e _TESTS_OAUTH2_GITHUB_CLIENT_SECRET="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_SECRET }}" \
-              appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service.name }}/junit.xml
+          docker compose exec -T \
+            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
+            -e _TESTS_OAUTH2_GITHUB_CLIENT_ID="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_ID }}" \
+            -e _TESTS_OAUTH2_GITHUB_CLIENT_SECRET="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_SECRET }}" \
+            appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service.name }}/junit.xml
 
       - name: Failure Logs
         if: failure()
@@ -559,7 +532,6 @@ jobs:
     needs: [build, matrix]
     permissions:
       contents: read
-      pull-requests: write
       packages: read
     strategy:
       fail-fast: false
@@ -612,18 +584,10 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
-        with:
-          max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
-          retry_wait_seconds: 60
-          timeout_minutes: 5
-          job_id: ${{ job.check_run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_dir: tests/e2e
-          command: >-
-            docker compose exec -T
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-            appwrite test /usr/src/code/tests/e2e --group=abuseEnabled
+        run: >-
+          docker compose exec -T
+          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+          appwrite test /usr/src/code/tests/e2e --group=abuseEnabled
 
       - name: Failure Logs
         if: failure()
@@ -638,7 +602,6 @@ jobs:
     needs: [build, matrix]
     permissions:
       contents: read
-      pull-requests: write
       packages: read
     strategy:
       fail-fast: false
@@ -696,18 +659,10 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        uses: itznotabug/php-retry@60547503cb2126eddaa082d0999e99cfca2b3856 # v4
-        with:
-          max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}
-          retry_wait_seconds: 60
-          timeout_minutes: 5
-          job_id: ${{ job.check_run_id }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          test_dir: tests/e2e/Services/Sites
-          command: >-
-            docker compose exec -T
-            -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-            appwrite test /usr/src/code/tests/e2e/Services/Sites --group=screenshots
+        run: >-
+          docker compose exec -T
+          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
+          appwrite test /usr/src/code/tests/e2e/Services/Sites --group=screenshots
 
       - name: Failure Logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,33 +193,33 @@ jobs:
             const runner8 = `runs-on=${context.runId}/runner=8cpu-linux-x64/volume=60g/spot=price-capacity-optimized/retry=when-interrupted/extras=otel+ecr-cache`;
 
             const services = [
-              { name: 'Account',           runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Avatars',           runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Console',           runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Databases',         runner: runner8, functional: false, processes: 3,    timeout: 8 },
-              { name: 'TablesDB',          runner: runner8, functional: false, processes: 3,    timeout: 8 },
-              { name: 'Functions',         runner: runner4, functional: false, processes: null, timeout: 8 },
-              { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'GraphQL',           runner: runner4, functional: false, processes: null, timeout: 8 },
-              { name: 'Health',            runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Advisor',           runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Locale',            runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Projects',          runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Realtime',          runner: runner4, functional: false, processes: null, timeout: 8 },
-              { name: 'Sites',             runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Proxy',             runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Storage',           runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Tokens',            runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Teams',             runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Users',             runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'ProjectWebhooks',   runner: runner4, functional: false, processes: null, timeout: 8 },
-              { name: 'Webhooks',          runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'VCS',               runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Messaging',         runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Notifications',     runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1,    timeout: 8 },
-              { name: 'Project',           runner: runner4, functional: true,  processes: null, timeout: 8 },
-              { name: 'Presences',         runner: runner4, functional: true,  processes: null, timeout: 8 },
+              { name: 'Account',           runner: runner4, functional: true,  processes: null },
+              { name: 'Avatars',           runner: runner4, functional: true,  processes: null },
+              { name: 'Console',           runner: runner4, functional: true,  processes: null },
+              { name: 'Databases',         runner: runner8, functional: false, processes: 3 },
+              { name: 'TablesDB',          runner: runner8, functional: false, processes: 3 },
+              { name: 'Functions',         runner: runner4, functional: false, processes: null },
+              { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null },
+              { name: 'GraphQL',           runner: runner4, functional: false, processes: null },
+              { name: 'Health',            runner: runner4, functional: true,  processes: null },
+              { name: 'Advisor',           runner: runner4, functional: true,  processes: null },
+              { name: 'Locale',            runner: runner4, functional: true,  processes: null },
+              { name: 'Projects',          runner: runner4, functional: true,  processes: null },
+              { name: 'Realtime',          runner: runner4, functional: false, processes: null },
+              { name: 'Sites',             runner: runner4, functional: true,  processes: null },
+              { name: 'Proxy',             runner: runner4, functional: true,  processes: null },
+              { name: 'Storage',           runner: runner4, functional: true,  processes: null },
+              { name: 'Tokens',            runner: runner4, functional: true,  processes: null },
+              { name: 'Teams',             runner: runner4, functional: true,  processes: null },
+              { name: 'Users',             runner: runner4, functional: true,  processes: null },
+              { name: 'ProjectWebhooks',   runner: runner4, functional: false, processes: null },
+              { name: 'Webhooks',          runner: runner4, functional: true,  processes: null },
+              { name: 'VCS',               runner: runner4, functional: true,  processes: null },
+              { name: 'Messaging',         runner: runner4, functional: true,  processes: null },
+              { name: 'Notifications',     runner: runner4, functional: true,  processes: null },
+              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1 },
+              { name: 'Project',           runner: runner4, functional: true,  processes: null },
+              { name: 'Presences',         runner: runner4, functional: true,  processes: null },
             ];
             core.setOutput('services', JSON.stringify(services));
 
@@ -499,7 +499,7 @@ jobs:
           done
 
       - name: Run tests
-        timeout-minutes: ${{ matrix.service.timeout }}
+        timeout-minutes: 15
         run: |
           SERVICE_PATH="/usr/src/code/tests/e2e/Services/${{ matrix.service.name }}"
 


### PR DESCRIPTION
## What

Removes `itznotabug/php-retry` from CI entirely. All 5 test steps that used it now run their command directly via a plain `run:` step.

## Changes

- Replaced all 5 `itznotabug/php-retry` steps (Unit, E2E General, E2E per-service matrix, Abuse, Screenshots) with direct `docker compose exec ... test` / paratest runs.
- Dropped the `max_attempts: ${{ github.event_name == 'pull_request' && 2 || 1 }}` retry conditional along with the action's `retry_wait_seconds`, `timeout_minutes`, `job_id`, `github_token`, and `test_dir` inputs.
- The per-service matrix step now uses `timeout-minutes: ${{ matrix.service.timeout }}` at the step level, preserving the per-service timeout previously passed to the action.
- Removed `pull-requests: write` from the 5 test jobs where php-retry was the only consumer of that permission. The `benchmark` job keeps it — it posts its own PR comments.

Tests now fail fast on the first attempt instead of retrying on PRs.

Cloud counterpart: appwrite-labs/cloud#4843