### PR TITLE
fix: change GitHub OAuth label from App ID to Client ID (issue #11875)

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Facebook/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Facebook/Update.php
@@ -35,7 +35,7 @@ class Update extends Base
 
     public static function getClientIdParamName(): string
     {
-        return 'appId';
+        return 'Client ID';
     }
 
     public static function getClientSecretParamName(): string
@@ -45,7 +45,7 @@ class Update extends Base
 
     public static function getClientIdName(): string
     {
-        return 'Client ID';
+        return 'App ID';
     }
 
     public static function getClientIdExample(): string

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Facebook/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Facebook/Update.php
@@ -45,7 +45,7 @@ class Update extends Base
 
     public static function getClientIdName(): string
     {
-        return 'App ID';
+        return 'Client ID';
     }
 
     public static function getClientIdExample(): string

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Facebook/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Facebook/Update.php
@@ -35,7 +35,7 @@ class Update extends Base
 
     public static function getClientIdParamName(): string
     {
-        return 'Client ID';
+        return 'appId';
     }
 
     public static function getClientSecretParamName(): string

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/GitHub/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/GitHub/Update.php
@@ -35,7 +35,7 @@ class Update extends Base
 
     public static function getClientIdName(): string
     {
-        return 'OAuth2 app Client ID, or App ID';
+        return 'Client ID';
     }
 
     public static function getClientIdExample(): string

--- a/tests/e2e/Services/Console/ConsoleConsoleClientTest.php
+++ b/tests/e2e/Services/Console/ConsoleConsoleClientTest.php
@@ -103,7 +103,7 @@ final class ConsoleConsoleClientTest extends Scope
         $this->assertCount(2, $github['parameters']);
         $clientId = $github['parameters'][0];
         $this->assertEquals('clientId', $clientId['$id']);
-        $this->assertEquals('OAuth2 app Client ID, or App ID', $clientId['name']);
+        $this->assertEquals('Client ID', $clientId['name']);
         $this->assertEquals('e4d87900000000540733', $clientId['example']);
         $this->assertEquals('Example of wrong value: 370006', $clientId['hint']);
         $clientSecret = $github['parameters'][1];


### PR DESCRIPTION
## What changed
Changed the GitHub OAuth2 settings label from "App ID" to "Client ID" in the console UI.

## Why
GitHub calls this field "Client ID" in their own settings. The previous label "App ID" was inconsistent with GitHub's terminology and caused confusion for developers setting up OAuth.

## Related issue
Fixes #11875 

## How tested
Verified the label change visually in the console UI.