### PR TITLE
chore(deps): bump utopia-php/pools to 1.1.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4595,16 +4595,16 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "1.0.9",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "13346168ca7097d9b220872a017c9ad8c5dac62f"
+                "reference": "fd5aa7e89685ffc74f9dff3d23c270ef30c7bbf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/13346168ca7097d9b220872a017c9ad8c5dac62f",
-                "reference": "13346168ca7097d9b220872a017c9ad8c5dac62f",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/fd5aa7e89685ffc74f9dff3d23c270ef30c7bbf3",
+                "reference": "fd5aa7e89685ffc74f9dff3d23c270ef30c7bbf3",
                 "shasum": ""
             },
             "require": {
@@ -4615,7 +4615,10 @@
                 "swoole/ide-helper": "6.*"
             },
             "suggest": {
-                "ext-swoole": "Required to use the Swoole pool adapter"
+                "ext-mongodb": "Needed to support MongoDB database pools",
+                "ext-pdo": "Needed to support MariaDB, MySQL or SQLite database pools",
+                "ext-redis": "Needed to support Redis cache pools",
+                "ext-swoole": "Needed to support Swoole based pool adapter"
             },
             "type": "library",
             "autoload": {
@@ -4642,9 +4645,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/1.0.9"
+                "source": "https://github.com/utopia-php/pools/tree/1.1.0"
             },
-            "time": "2026-06-26T10:48:18+00:00"
+            "time": "2026-07-17T10:19:09+00:00"
         },
         {
             "name": "utopia-php/preloader",


### PR DESCRIPTION
## What

Lock-only bump of `utopia-php/pools` to [1.1.0](https://github.com/utopia-php/pools/releases/tag/1.1.0).

## Why

1.1.0 recovers failed pool connections instead of leaving them tracked as active when destroy cleanup fails (utopia-php/monorepo#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)