### PR TITLE
Stabilize storage preview cache hit test

### DIFF
--- a/tests/e2e/Services/Storage/StorageBase.php
+++ b/tests/e2e/Services/Storage/StorageBase.php
@@ -1065,7 +1065,8 @@ trait StorageBase
         $this->assertNotEmpty($preview['body']);
 
         $cachedPreview = [];
-        $this->assertEventually(function () use (&$cachedPreview, $bucketId, $fileId, $headers, $params) {
+        $cachedPreviewAgain = [];
+        $this->assertEventually(function () use (&$cachedPreview, &$cachedPreviewAgain, $bucketId, $fileId, $headers, $params) {
             $cachedPreview = $this->client->call(
                 Client::METHOD_GET,
                 '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
@@ -1073,20 +1074,22 @@ trait StorageBase
                 $params
             );
 
-            $this->assertEquals('hit', $cachedPreview['headers']['x-appwrite-cache']);
+            $cachedPreviewAgain = $this->client->call(
+                Client::METHOD_GET,
+                '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
+                $headers,
+                $params
+            );
+
+            $this->assertSame('hit', $cachedPreview['headers']['x-appwrite-cache']);
+            $this->assertSame('hit', $cachedPreviewAgain['headers']['x-appwrite-cache']);
+            $this->assertSame($cachedPreview['body'], $cachedPreviewAgain['body']);
         });
 
         $this->assertEquals(200, $cachedPreview['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreview['headers']['content-type']);
         $this->assertStringStartsWith('private, max-age=', $cachedPreview['headers']['cache-control']);
         $this->assertNotEmpty($cachedPreview['body']);
-
-        $cachedPreviewAgain = $this->client->call(
-            Client::METHOD_GET,
-            '/storage/buckets/' . $bucketId . '/files/' . $fileId . '/preview',
-            $headers,
-            $params
-        );
 
         $this->assertEquals(200, $cachedPreviewAgain['headers']['status-code']);
         $this->assertEquals('image/png', $cachedPreviewAgain['headers']['content-type']);


### PR DESCRIPTION
## Problem

`testFilePreviewCacheControlOnCacheHit` can still compare preview bodies across the cache shutdown-persistence boundary after #12501. The first confirmed cache hit and a later request were made outside a single retry attempt, so late persistence from an earlier preview response could replace the cached PNG between them. Imagick timestamp metadata can then differ even though the rendered image and cache behavior are correct.

This surfaced in the Cloud migration integration matrix as intermittent byte-for-byte preview mismatches.

## Fix

Treat two consecutive cache-hit requests as one retry unit:

- issue both preview requests inside the same `assertEventually` callback;
- require both responses to report `x-appwrite-cache: hit`;
- compare the two bodies within that same callback attempt;
- retry the complete pair if either request is not a hit or the bodies differ;
- retain the existing status, content type, cache control, and non-empty body assertions.

## Validation

- Targeted Pint formatting/check: passed
- `composer lint`: passed
- `composer refactor:check`: passed
- `composer analyze`: 1,614 files, no errors
- `composer audit --locked`: no advisories
- `php -l tests/e2e/Services/Storage/StorageBase.php`: passed
- `git diff --check`: passed
- Full CI [run 29614310201](https://github.com/appwrite/appwrite/actions/runs/29614310201): 37/37 jobs passed at exact head `ae071aed8fe243b9a5d02370f567b9f1bd15af9d`

The focused E2E requires the Appwrite Docker stack; the local stack is not running, so the exact regression will be exercised by the Storage jobs in CI.

## Related

- Follow-up to #12501
- Supports [appwrite-labs/cloud#3920](https://github.com/appwrite-labs/cloud/pull/3920)
