### PR TITLE
Wait for function domain activation in tests

### DIFF
--- a/tests/e2e/Services/Functions/FunctionsBase.php
+++ b/tests/e2e/Services/Functions/FunctionsBase.php
@@ -119,6 +119,24 @@ trait FunctionsBase
                 }
 
                 $this->assertEquals($deploymentId, $function['body']['deploymentId'] ?? '', 'Deployment is not activated, deployment: ' . json_encode($function['body'], JSON_PRETTY_PRINT));
+
+                $rules = $this->client->call(Client::METHOD_GET, '/proxy/rules', [
+                    'content-type' => 'application/json',
+                    'x-appwrite-project' => $this->getProject()['$id'],
+                    'x-appwrite-key' => $this->getProject()['apiKey'],
+                ], [
+                    'queries' => [
+                        Query::equal('deploymentResourceId', [$functionId])->toString(),
+                        Query::equal('trigger', ['manual'])->toString(),
+                        Query::equal('type', ['deployment'])->toString(),
+                        Query::equal('deploymentVcsProviderBranch', [''])->toString(),
+                    ],
+                ]);
+
+                $this->assertSame(200, $rules['headers']['status-code'], 'Failed to list function domains: ' . json_encode($rules['body'], JSON_PRETTY_PRINT));
+                foreach ($rules['body']['rules'] as $rule) {
+                    $this->assertSame($deploymentId, $rule['deploymentId'] ?? '', 'Function domain is not activated, rule: ' . json_encode($rule, JSON_PRETTY_PRINT));
+                }
             }, 120000, 500);
         }
 


### PR DESCRIPTION
## Summary

- wait for every manual function-domain rule to reference the activated deployment before `setupDeployment()` returns
- authenticate the internal rules lookup with the project API key
- keep the readiness barrier in the existing activation retry loop so all custom-domain E2E tests share it
- include the rule payload in timeout failures for actionable diagnostics

## Context

The dedicated Functions suite on appwrite-labs/cloud#4851 failed twice on the same head at two custom-domain assertions:

- `testFunctionsDomain`: 404 instead of 200 ([job](https://github.com/appwrite-labs/cloud/actions/runs/29615073627/job/87998550659))
- `testErrorPagesPermissions`: 404 instead of 401 on retry ([job](https://github.com/appwrite-labs/cloud/actions/runs/29615073627/job/88001209004))

Function activation updates the project function document before the matching platform rules. The helper previously waited only for the document update, leaving a short interval where the function appeared active through the API while its domain still resolved to an empty deployment.

## Implementation

The readiness lookup filters `/proxy/rules` by the complete identity of the relevant domain rules:

- `deploymentResourceId` equals the function ID
- `trigger` equals `manual`
- `type` equals `deployment`
- `deploymentVcsProviderBranch` equals the empty string

The helper returns only after every matching rule has the new deployment ID.

## Validation

Exact head: `8b43bdac6bfd53197d7250bb7bda7d58c3abc210`

- `php -l tests/e2e/Services/Functions/FunctionsBase.php`
- targeted and full Pint checks
- Rector: 344/344 files
- PHPStan: 1,614/1,614 files
- `git diff --check`
- [CI run 29617369070](https://github.com/appwrite/appwrite/actions/runs/29617369070): 37/37 jobs green after the unit job was rerun from an unhealthy MongoDB startup
- dedicated MongoDB Functions job passed on the first attempt ([job 88005600250](https://github.com/appwrite/appwrite/actions/runs/29617369070/job/88005600250))
- [Greptile review](https://github.com/appwrite/appwrite/pull/12908#issuecomment-5007955997): confidence 5/5, no blocking issues
- 0 unresolved review threads
