### PR TITLE
Expose database pool selection

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Create.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\Databases\Http\Databases;
 
 use Appwrite\Event\Event;
 use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Databases\Pool;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Deprecated;
@@ -19,9 +20,7 @@ use Utopia\Database\Exception\Index as IndexException;
 use Utopia\Database\Exception\Limit as LimitException;
 use Utopia\Database\Exception\Structure as StructureException;
 use Utopia\Database\Helpers\ID;
-use Utopia\DSN\DSN;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
-use Utopia\System\System;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Text;
 
@@ -36,96 +35,7 @@ class Create extends Action
     {
         // TODO: use database worker for for creating the v2 schema if not present
         // it is considered that the v2 metadata schema is already created during server start in the http.php
-        return $this->constructDatabaseDSNFromProjectDatabase($this->getDatabaseType(), $project->getAttribute('region'), $project->getAttribute('database'));
-    }
-
-    private function constructDatabaseDSNFromProjectDatabase(string $databasetype, $region, ?string $dsn = null): string
-    {
-        $databases = [];
-        $databaseKeys = [];
-        /**
-         * @var string|null $databaseOverride
-        */
-        $databaseOverride = '';
-        $dbScheme = '';
-        $databaseSharedTables = [];
-
-        switch ($databasetype) {
-            case DOCUMENTSDB:
-                $databases = Config::getParam('pools-documentsdb', []);
-                $databaseKeys = System::getEnv('_APP_DATABASE_DOCUMENTSDB_KEYS', '');
-                $databaseOverride = System::getEnv('_APP_DATABASE_DOCUMENTSDB_OVERRIDE');
-                $dbScheme = System::getEnv('_APP_DB_HOST_DOCUMENTSDB', 'mongodb');
-                $databaseSharedTables = \array_filter(\explode(',', System::getEnv('_APP_DATABASE_DOCUMENTSDB_SHARED_TABLES', '')));
-                break;
-            case VECTORSDB:
-                $databases = Config::getParam('pools-vectorsdb', []);
-                $databaseKeys = System::getEnv('_APP_DATABASE_VECTORSDB_KEYS', '');
-                $databaseOverride = System::getEnv('_APP_DATABASE_VECTORSDB_OVERRIDE');
-                $dbScheme = System::getEnv('_APP_DB_HOST_VECTORSDB', 'postgresql');
-                $databaseSharedTables = \array_filter(\explode(',', System::getEnv('_APP_DATABASE_VECTORSDB_SHARED_TABLES', '')));
-                break;
-            default:
-                // legacy/tablesdb
-                // it is already created during create project
-                return $dsn;
-        }
-
-        $isSharedTables = false;
-
-        if (!empty($dsn)) {
-            try {
-                $parsedDsn = new DSN($dsn);
-                $dsnHost = $parsedDsn->getHost();
-            } catch (\InvalidArgumentException) {
-                $dsnHost = $dsn;
-            }
-
-            $projectSharedTables = \explode(',', System::getEnv('_APP_DATABASE_SHARED_TABLES', ''));
-            $isSharedTables = \in_array($dsnHost, $projectSharedTables);
-        }
-
-        if ($region !== 'default') {
-            $keys = explode(',', $databaseKeys);
-            $databases = array_filter($keys, function ($value) use ($region) {
-                return str_contains($value, $region);
-            });
-        }
-
-        $index = \array_search($databaseOverride, $databases);
-        if ($index !== false) {
-            $selectedDsn = $databases[$index];
-        } else {
-            if (!empty($dsn) && !empty($databaseSharedTables)) {
-                if ($isSharedTables) {
-                    $databases = array_filter($databases, fn ($value) => \in_array($value, $databaseSharedTables));
-                } else {
-                    $databases = array_filter($databases, fn ($value) => !\in_array($value, $databaseSharedTables));
-                }
-            }
-            if (empty($databases)) {
-                throw new Exception(Exception::GENERAL_SERVER_ERROR, "No {$databasetype} database pool available for the current shared-tables mode");
-            }
-            $selectedDsn = $databases[array_rand($databases)];
-        }
-
-        if (\in_array($selectedDsn, $databaseSharedTables)) {
-            $schema = 'appwrite';
-            $database = 'appwrite';
-            $namespace = System::getEnv('_APP_DATABASE_SHARED_NAMESPACE', '');
-            $selectedDsn = $schema . '://' . $selectedDsn . '?database=' . $database;
-
-            if (!empty($namespace)) {
-                $selectedDsn .= '&namespace=' . $namespace;
-            }
-        }
-        try {
-            new DSN($selectedDsn);
-        } catch (\InvalidArgumentException) {
-            $selectedDsn = $dbScheme.'://' . $selectedDsn;
-        }
-
-        return $selectedDsn;
+        return Pool::dsn($this->getDatabaseType(), (string) $project->getAttribute('region', 'default'), $project->getAttribute('database'));
     }
 
     protected function getDatabaseCollection()

--- a/src/Appwrite/Platform/Modules/Databases/Pool.php
+++ b/src/Appwrite/Platform/Modules/Databases/Pool.php
@@ -33,7 +33,11 @@ final class Pool
                 $sharedTables = \array_filter(\explode(',', System::getEnv('_APP_DATABASE_VECTORSDB_SHARED_TABLES', '')));
                 break;
             default:
-                return $projectDsn ?? '';
+                if (empty($projectDsn)) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, "Project database DSN is required for {$type} databases");
+                }
+
+                return $projectDsn;
         }
 
         $projectUsesSharedTables = false;

--- a/src/Appwrite/Platform/Modules/Databases/Pool.php
+++ b/src/Appwrite/Platform/Modules/Databases/Pool.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Appwrite\Platform\Modules\Databases;
+
+use Appwrite\Extend\Exception;
+use Utopia\Config\Config;
+use Utopia\DSN\DSN;
+use Utopia\System\System;
+
+final class Pool
+{
+    public static function dsn(string $type, string $region, ?string $projectDsn): string
+    {
+        $databases = [];
+        $keys = '';
+        $override = null;
+        $scheme = '';
+        $sharedTables = [];
+
+        switch ($type) {
+            case DATABASE_TYPE_DOCUMENTSDB:
+                $databases = Config::getParam('pools-documentsdb', []);
+                $keys = System::getEnv('_APP_DATABASE_DOCUMENTSDB_KEYS', '');
+                $override = System::getEnv('_APP_DATABASE_DOCUMENTSDB_OVERRIDE');
+                $scheme = System::getEnv('_APP_DB_HOST_DOCUMENTSDB', 'mongodb');
+                $sharedTables = \array_filter(\explode(',', System::getEnv('_APP_DATABASE_DOCUMENTSDB_SHARED_TABLES', '')));
+                break;
+            case DATABASE_TYPE_VECTORSDB:
+                $databases = Config::getParam('pools-vectorsdb', []);
+                $keys = System::getEnv('_APP_DATABASE_VECTORSDB_KEYS', '');
+                $override = System::getEnv('_APP_DATABASE_VECTORSDB_OVERRIDE');
+                $scheme = System::getEnv('_APP_DB_HOST_VECTORSDB', 'postgresql');
+                $sharedTables = \array_filter(\explode(',', System::getEnv('_APP_DATABASE_VECTORSDB_SHARED_TABLES', '')));
+                break;
+            default:
+                return $projectDsn ?? '';
+        }
+
+        $projectUsesSharedTables = false;
+
+        if (!empty($projectDsn)) {
+            try {
+                $parsedDsn = new DSN($projectDsn);
+                $projectHost = $parsedDsn->getHost();
+            } catch (\InvalidArgumentException) {
+                $projectHost = $projectDsn;
+            }
+
+            $projectSharedTables = \explode(',', System::getEnv('_APP_DATABASE_SHARED_TABLES', ''));
+            $projectUsesSharedTables = \in_array($projectHost, $projectSharedTables);
+        }
+
+        if ($region !== 'default') {
+            $databases = \array_filter(
+                \explode(',', $keys),
+                fn (string $value): bool => \str_contains($value, $region)
+            );
+        }
+
+        $index = \array_search($override, $databases);
+        if ($index !== false) {
+            $selectedDsn = $databases[$index];
+        } else {
+            if (!empty($projectDsn) && !empty($sharedTables)) {
+                if ($projectUsesSharedTables) {
+                    $databases = \array_filter($databases, fn (string $value): bool => \in_array($value, $sharedTables));
+                } else {
+                    $databases = \array_filter($databases, fn (string $value): bool => !\in_array($value, $sharedTables));
+                }
+            }
+
+            if (empty($databases)) {
+                throw new Exception(Exception::GENERAL_SERVER_ERROR, "No {$type} database pool available for the current shared-tables mode");
+            }
+
+            $selectedDsn = $databases[\array_rand($databases)];
+        }
+
+        if (\in_array($selectedDsn, $sharedTables)) {
+            $namespace = System::getEnv('_APP_DATABASE_SHARED_NAMESPACE', '');
+            $selectedDsn = 'appwrite://' . $selectedDsn . '?database=appwrite';
+
+            if (!empty($namespace)) {
+                $selectedDsn .= '&namespace=' . $namespace;
+            }
+        }
+
+        try {
+            new DSN($selectedDsn);
+        } catch (\InvalidArgumentException) {
+            $selectedDsn = $scheme . '://' . $selectedDsn;
+        }
+
+        return $selectedDsn;
+    }
+}

--- a/tests/unit/Platform/Modules/Databases/PoolTest.php
+++ b/tests/unit/Platform/Modules/Databases/PoolTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Databases;
+
+use Appwrite\Platform\Modules\Databases\Pool;
+use PHPUnit\Framework\TestCase;
+use Utopia\Config\Config;
+
+final class PoolTest extends TestCase
+{
+    private const array VARIABLES = [
+        '_APP_DATABASE_DOCUMENTSDB_KEYS',
+        '_APP_DATABASE_DOCUMENTSDB_OVERRIDE',
+        '_APP_DATABASE_DOCUMENTSDB_SHARED_TABLES',
+        '_APP_DATABASE_SHARED_NAMESPACE',
+        '_APP_DATABASE_SHARED_TABLES',
+        '_APP_DATABASE_VECTORSDB_KEYS',
+        '_APP_DATABASE_VECTORSDB_OVERRIDE',
+        '_APP_DATABASE_VECTORSDB_SHARED_TABLES',
+        '_APP_DB_HOST_DOCUMENTSDB',
+        '_APP_DB_HOST_VECTORSDB',
+    ];
+
+    /** @var array<string, mixed> */
+    private array $params;
+
+    /** @var array<string, string|false> */
+    private array $variables = [];
+
+    protected function setUp(): void
+    {
+        $this->params = Config::$params;
+
+        foreach (self::VARIABLES as $variable) {
+            $this->variables[$variable] = \getenv($variable);
+            \putenv($variable);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        Config::$params = $this->params;
+
+        foreach ($this->variables as $variable => $value) {
+            \putenv($value === false ? $variable : $variable . '=' . $value);
+        }
+    }
+
+    public function testReturnsProjectDatabaseForTablesDB(): void
+    {
+        $dsn = 'mysql://project?database=appwrite';
+
+        $this->assertSame($dsn, Pool::dsn('tablesdb', 'default', $dsn));
+    }
+
+    public function testSelectsDocumentsDatabasePool(): void
+    {
+        Config::setParam('pools-documentsdb', ['documents']);
+
+        $this->assertSame('mongodb://documents', Pool::dsn('documentsdb', 'default', null));
+    }
+
+    public function testSelectsVectorsDatabasePool(): void
+    {
+        Config::setParam('pools-vectorsdb', ['vectors']);
+
+        $this->assertSame('postgresql://vectors', Pool::dsn('vectorsdb', 'default', null));
+    }
+
+    public function testSelectsSharedPoolForSharedProject(): void
+    {
+        Config::setParam('pools-documentsdb', ['documents-dedicated', 'documents-shared']);
+        \putenv('_APP_DATABASE_SHARED_TABLES=projects-shared');
+        \putenv('_APP_DATABASE_DOCUMENTSDB_SHARED_TABLES=documents-shared');
+        \putenv('_APP_DATABASE_SHARED_NAMESPACE=tenant');
+
+        $this->assertSame(
+            'appwrite://documents-shared?database=appwrite&namespace=tenant',
+            Pool::dsn('documentsdb', 'default', 'mysql://projects-shared')
+        );
+    }
+
+    public function testSelectsDedicatedPoolForDedicatedProject(): void
+    {
+        Config::setParam('pools-documentsdb', ['documents-dedicated', 'documents-shared']);
+        \putenv('_APP_DATABASE_SHARED_TABLES=projects-shared');
+        \putenv('_APP_DATABASE_DOCUMENTSDB_SHARED_TABLES=documents-shared');
+
+        $this->assertSame(
+            'mongodb://documents-dedicated',
+            Pool::dsn('documentsdb', 'default', 'mysql://projects-dedicated')
+        );
+    }
+
+    public function testSelectsPoolForRegion(): void
+    {
+        Config::setParam('pools-documentsdb', ['default-documents']);
+        \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=fra-documents,nyc-documents');
+
+        $this->assertSame(
+            'mongodb://fra-documents',
+            Pool::dsn('documentsdb', 'fra', null)
+        );
+    }
+
+    public function testOverrideTakesPrecedence(): void
+    {
+        Config::setParam('pools-documentsdb', ['documents-default', 'documents-override']);
+        \putenv('_APP_DATABASE_DOCUMENTSDB_OVERRIDE=documents-override');
+
+        $this->assertSame(
+            'mongodb://documents-override',
+            Pool::dsn('documentsdb', 'default', null)
+        );
+    }
+}

--- a/tests/unit/Platform/Modules/Databases/PoolTest.php
+++ b/tests/unit/Platform/Modules/Databases/PoolTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Platform\Modules\Databases;
 
+use Appwrite\Extend\Exception;
 use Appwrite\Platform\Modules\Databases\Pool;
 use PHPUnit\Framework\TestCase;
 use Utopia\Config\Config;
@@ -53,6 +54,14 @@ final class PoolTest extends TestCase
         $dsn = 'mysql://project?database=appwrite';
 
         $this->assertSame($dsn, Pool::dsn('tablesdb', 'default', $dsn));
+    }
+
+    public function testRejectsEmptyProjectDatabaseForTablesDB(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Project database DSN is required for tablesdb databases');
+
+        Pool::dsn('tablesdb', 'default', null);
     }
 
     public function testSelectsDocumentsDatabasePool(): void


### PR DESCRIPTION
## What does this PR do?

Extracts the existing DocumentsDB and VectorsDB pool selection from the database create action into the reusable `Appwrite\Platform\Modules\Databases\Pool::dsn()` API.

Database creation continues to use the same selector. Other Appwrite consumers can now select the correct product pool without duplicating region, override, or shared-table routing rules. Missing legacy or TablesDB project DSNs fail immediately with a clear domain error instead of returning an invalid empty DSN.

## Test Plan

- `php vendor/bin/phpunit tests/unit/Platform/Modules/Databases/PoolTest.php` (8 tests, 9 assertions)
- `composer lint`
- focused PHPStan analysis for the changed files
- focused Rector dry-run for the changed files

The unit suite covers TablesDB passthrough and missing-DSN validation, DocumentsDB and VectorsDB schemes, shared and dedicated routing, regional keys, and override precedence.

## Related PRs and Issues

- appwrite-labs/cloud#4851

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to API metadata (desc, label, params, etc.), does it also include updated API specs and example docs? Not applicable; no API metadata changed.