### PR TITLE
Fix VCS webhook deployment database context

### DIFF
--- a/src/Appwrite/Deployment/Backend.php
+++ b/src/Appwrite/Deployment/Backend.php
@@ -24,6 +24,11 @@ abstract readonly class Backend
     }
 
     /**
+     * Return a backend bound to a project resolved after request initialization.
+     */
+    abstract public function forProject(Database $dbForProject, Document $project): static;
+
+    /**
      * Saves chunked-upload progress onto the deployment — source path/size,
      * chunk counters, metadata. Never triggers a build; call createFromUpload()
      * once the upload is complete. Pass a single `Document` carrying every field

--- a/src/Appwrite/Deployment/Backend/Executor.php
+++ b/src/Appwrite/Deployment/Backend/Executor.php
@@ -11,7 +11,7 @@ use Utopia\Database\Document;
 
 readonly class Executor extends Backend
 {
-    public function __construct(
+    final public function __construct(
         private BuildPublisher $publisherForBuilds,
         Database $dbForProject,
         Document $project,
@@ -19,6 +19,11 @@ readonly class Executor extends Backend
         private array $platform,
     ) {
         parent::__construct($dbForProject, $project);
+    }
+
+    public function forProject(Database $dbForProject, Document $project): static
+    {
+        return new static($this->publisherForBuilds, $dbForProject, $project, $this->executor, $this->platform);
     }
 
     public function createFromUpload(Document $resource, Document $deployment): Document

--- a/src/Appwrite/Deployment/Backend/Orchestrator.php
+++ b/src/Appwrite/Deployment/Backend/Orchestrator.php
@@ -37,13 +37,18 @@ use Utopia\System\System;
  */
 readonly class Orchestrator extends Backend
 {
-    public function __construct(
+    final public function __construct(
         private Jobs $jobs,
         Database $dbForProject,
         Document $project,
         private array $platform,
     ) {
         parent::__construct($dbForProject, $project);
+    }
+
+    public function forProject(Database $dbForProject, Document $project): static
+    {
+        return new static($this->jobs, $dbForProject, $project, $this->platform);
     }
 
     public function createFromUpload(Document $resource, Document $deployment): Document

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -397,12 +397,14 @@ trait Deployment
                 // or jobs-service, decided by _APP_BUILDS_BACKEND) when the
                 // caller opts in. Sites always stay on the executor.
                 if ($deployments !== null && $resourceCollection === 'functions') {
-                    $deployment = $authorization->skip(fn () => $deployments->createFromUrl(
-                        $resource,
-                        $deployment,
-                        $vcs->getRepositoryPresignedUrl($providerRepositoryOwner, $providerRepositoryName, $providerCommitHash),
-                        $resource->getAttribute('providerRootDirectory', ''),
-                    ));
+                    $deployment = $authorization->skip(fn () => $deployments
+                        ->forProject($dbForProject, $project)
+                        ->createFromUrl(
+                            $resource,
+                            $deployment,
+                            $vcs->getRepositoryPresignedUrl($providerRepositoryOwner, $providerRepositoryName, $providerCommitHash),
+                            $resource->getAttribute('providerRootDirectory', ''),
+                        ));
                 } else {
                     $deployment = $authorization->skip(fn () => $dbForProject->createDocument('deployments', new Document([
                         '$permissions' => [

--- a/tests/e2e/Services/VCS/VCSConsoleClientTest.php
+++ b/tests/e2e/Services/VCS/VCSConsoleClientTest.php
@@ -621,6 +621,82 @@ final class VCSConsoleClientTest extends Scope
         $this->assertEquals('main', $function['body']['providerBranch']);
     }
 
+    public function testGitHubPushCreatesFunctionDeploymentWithoutProjectHeader(): void
+    {
+        $data = $this->setupFunctionUsingVCS();
+        $github = new GitHub(new Cache(new None()));
+        $github->initializeVariables(
+            $this->providerInstallationId,
+            System::getEnv('_APP_VCS_GITHUB_PRIVATE_KEY'),
+            System::getEnv('_APP_VCS_GITHUB_APP_ID'),
+        );
+        $commit = $github->getLatestCommit('appwrite-test', 'ruby-starter', 'main');
+        $payload = [
+            'created' => false,
+            'deleted' => false,
+            'ref' => 'refs/heads/main',
+            'before' => $commit['commitHash'],
+            'after' => $commit['commitHash'],
+            'repository' => [
+                'id' => (int) $this->providerRepositoryId,
+                'name' => 'ruby-starter',
+                'full_name' => 'appwrite-test/ruby-starter',
+                'private' => false,
+                'html_url' => 'https://github.com/appwrite-test/ruby-starter',
+                'owner' => ['name' => 'appwrite-test'],
+            ],
+            'installation' => ['id' => (int) $this->providerInstallationId],
+            'head_commit' => [
+                'author' => [
+                    'name' => $commit['commitAuthor'],
+                    'email' => 'vcs-e2e@appwrite.io',
+                ],
+                'message' => $commit['commitMessage'],
+                'url' => $commit['commitUrl'],
+            ],
+            'commits' => [[
+                'id' => $commit['commitHash'],
+                'added' => [],
+                'removed' => [],
+                'modified' => ['main.rb'],
+            ]],
+            'sender' => [
+                'html_url' => $commit['commitAuthorUrl'],
+                'avatar_url' => $commit['commitAuthorAvatar'],
+            ],
+        ];
+        $headers = [
+            'content-type' => 'application/json',
+            'x-github-event' => 'push',
+        ];
+        $secret = System::getEnv('_APP_VCS_GITHUB_WEBHOOK_SECRET', '');
+        if (!empty($secret)) {
+            $headers['x-hub-signature-256'] = 'sha256=' . \hash_hmac(
+                'sha256',
+                \json_encode($payload, JSON_THROW_ON_ERROR),
+                $secret,
+            );
+        }
+
+        // GitHub webhooks are public and intentionally have no x-appwrite-project header.
+        $event = $this->client->call(Client::METHOD_POST, '/vcs/github/events', $headers, $payload);
+
+        $this->assertEquals(200, $event['headers']['status-code']);
+
+        $deployments = $this->client->call(Client::METHOD_GET, '/functions/' . $data['functionId'] . '/deployments', array_merge([
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [
+                Query::equal('providerCommitHash', [$commit['commitHash']])->toString(),
+                Query::equal('type', ['vcs'])->toString(),
+            ],
+        ]);
+
+        $this->assertEquals(200, $deployments['headers']['status-code']);
+        $this->assertGreaterThanOrEqual(1, $deployments['body']['total']);
+        $this->assertSame($data['functionId'], $deployments['body']['deployments'][0]['resourceId']);
+    }
+
     public function testUpdateFunctionUsingVCS(): void
     {
         $data = $this->setupFunctionUsingVCS();


### PR DESCRIPTION
## What does this PR do?

GitHub webhooks have no `x-appwrite-project` header, so the deployment backend starts with the console database.

Before:

```php
$deployments->createFromUrl(...); // writes through console DB
```

After resolving the project from the webhook:

```php
$deployments
    ->forProject($dbForProject, $project)
    ->createFromUrl(...); // writes through tenant DB
```

Flow change:

```text
webhook -> console lookup -> resolve project -> tenant DB -> create deployment
```

Adds an E2E push webhook test with no project header and asserts the deployment exists under the tenant function.

## Test Plan

- `composer lint`
- Targeted PHPStan: passed
- Local Docker stack: 49 containers, API healthy
- Local VCS E2E: skipped because GitHub App credentials are disabled
- Credentialed CI VCS E2E: passed

## Related PRs and Issues

- Regression introduced by #12865

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (Not applicable.)
