### PR TITLE
Fix MongoDB healthcheck false-positive before replica-set primary

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1301,9 +1301,6 @@ services:
       - /bin/bash
       - /mongo-entrypoint.sh
     healthcheck:
-      # Require replica-set primary (setName === 'rs0'). Docker's first-boot
-      # temporary mongod is a writable standalone; treating that as healthy lets
-      # CI start tests before rs0 has a primary (NotPrimaryNoSecondaryOk flakes).
       test: |
         bash -c "
           mongosh -u root -p ${_APP_DB_ROOT_PASS} --authenticationDatabase admin --quiet --eval \"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1301,6 +1301,7 @@ services:
       - /bin/bash
       - /mongo-entrypoint.sh
     healthcheck:
+      # replica set 0
       test: |
         bash -c "
           mongosh -u root -p ${_APP_DB_ROOT_PASS} --authenticationDatabase admin --quiet --eval \"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1301,12 +1301,15 @@ services:
       - /bin/bash
       - /mongo-entrypoint.sh
     healthcheck:
+      # Require replica-set primary (setName === 'rs0'). Docker's first-boot
+      # temporary mongod is a writable standalone; treating that as healthy lets
+      # CI start tests before rs0 has a primary (NotPrimaryNoSecondaryOk flakes).
       test: |
         bash -c "
           mongosh -u root -p ${_APP_DB_ROOT_PASS} --authenticationDatabase admin --quiet --eval \"
             try {
               const hello = db.adminCommand({hello: 1});
-              if (hello.isWritablePrimary) {
+              if (hello.isWritablePrimary && hello.setName === 'rs0') {
                 quit(0);
               }
             } catch (e) {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1301,7 +1301,6 @@ services:
       - /bin/bash
       - /mongo-entrypoint.sh
     healthcheck:
-      # replica set 0
       test: |
         bash -c "
           mongosh -u root -p ${_APP_DB_ROOT_PASS} --authenticationDatabase admin --quiet --eval \"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Tightens the `mongodb` Docker healthcheck so it only succeeds when MongoDB is a **writable replica-set primary** (`hello.isWritablePrimary && hello.setName === 'rs0'`).

Previously the check accepted any writable primary. On first boot, Docker’s temporary init `mongod` is a writable standalone, so Compose could mark Mongo healthy before `rs0` elected a primary. CI then started E2E tests early and documentsdb writes failed with:

```text
Utopia\Mongo\Exception: E13435 NotPrimaryNoSecondaryOk: not master and slaveOk=false
```

That showed up as a flaky failure in `ProjectsConsoleClientTest::testDeleteProjectWithMultiDB` (documentsdb collection create expected `201`, got `500`) on `Tests / E2E / PostgreSQL (dedicated) / Projects` — documentsdb still uses Mongo even when the main adapter is PostgreSQL.

Observed race from [CI job 88192218508](https://github.com/appwrite/appwrite/actions/runs/29686547188/job/88192218508):

1. Temporary init mongod becomes writable → healthcheck passes
2. Real `--replSet rs0` mongod starts (not primary yet)
3. Tests hit documentsdb → `NotPrimaryNoSecondaryOk`
4. ~10s later healthcheck runs `rs.initiate` and elects PRIMARY

## Test Plan

- Confirmed root cause from CI logs (NotPrimary + mongo PRIMARY election after test failure)
- Healthcheck now requires `setName === 'rs0'` so standalone init mongod cannot mark the service healthy
- Prior CI on this PR: Projects E2E passed with no `NotPrimary` errors (original flake fixed)
- Remaining CI failures on that run were unrelated flakes (`DocumentsDBCustomServerTest::testTimeout` client hang; `SitesCustomServerTest::testUpdateDeployment` multipart EOF)

## Related PRs and Issues

- Flake seen on https://github.com/appwrite/appwrite/actions/runs/29686547188/job/88192218508?pr=12912 (unrelated to that PR’s VCS changes)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (Not applicable.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-842ae216-8e66-49f0-98b7-df346769c625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-842ae216-8e66-49f0-98b7-df346769c625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

