### PR TITLE
Fix self-hosted console endpoint warning

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,8 @@
 services:
+  appwrite-console:
+    environment:
+      - VITE_APPWRITE_ENDPOINT=http://localhost/v1
+
   appwrite:
     build:
       context: .

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,8 +1,4 @@
 services:
-  appwrite-console:
-    environment:
-      - VITE_APPWRITE_ENDPOINT=${VITE_APPWRITE_ENDPOINT:-http://${_APP_CONSOLE_DOMAIN:-localhost}:${_APP_HTTP_PORT:-80}/v1}
-
   appwrite:
     build:
       context: .

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,7 @@
 services:
   appwrite-console:
     environment:
-      - VITE_APPWRITE_ENDPOINT=http://localhost/v1
+      - VITE_APPWRITE_ENDPOINT=${VITE_APPWRITE_ENDPOINT:-http://${_APP_CONSOLE_DOMAIN:-localhost}:${_APP_HTTP_PORT:-80}/v1}
 
   appwrite:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,12 +225,13 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/new:0.3.24
+    image: appwrite/new:0.3.32
     restart: unless-stopped
     networks:
       - appwrite
     environment:
       - VITE_CONSOLE_PROFILE=self-hosted
+      - APPWRITE_ENDPOINT_SAME_ORIGIN=true
       - VITE_GROWTH_ENDPOINT=https://growth.appwrite.io/v1
     labels:
       - traefik.enable=true


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates the self-hosted console to `appwrite/new:0.3.32` and explicitly enables its same-origin Appwrite endpoint fallback. The console now derives `/v1` from the browser origin, preserving the active HTTP/HTTPS scheme, hostname, and port while avoiding the expected missing-endpoint startup warning.

This also removes the development-only static endpoint override, which could disagree with the browser-facing origin in HTTPS and reverse-proxy setups. Split-origin self-hosted deployments still receive the warning unless they configure an endpoint or explicitly opt into same-origin fallback.

## Test Plan

- Ran `docker compose config --quiet`.
- Verified the resolved `appwrite-console` service uses `appwrite/new:0.3.32` with `APPWRITE_ENDPOINT_SAME_ORIGIN=true` and no static endpoint override.
- Verified Docker Hub published `appwrite/new:0.3.32` at digest `sha256:e83438bbba64b5b3bea3cab51b9b37602d1396b019311fcc3e77f5957f7b7057`.
- Started the released image with the self-hosted profile and same-origin opt-in; verified the server became ready and did not log the missing-endpoint warning.
- Ran `git diff --check`.

## Related PRs and Issues

- appwrite/vibes#86
- https://github.com/appwrite/vibes/releases/tag/0.3.32

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
