### PR TITLE
perf(builds): measure source tarball size locally instead of S3 HEAD

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -387,9 +387,9 @@ class Builds extends Action
                         throw new \Exception('Unable to move file');
                     }
 
-                    Console::execute('rm -rf ' . \escapeshellarg($tmpTemplateDirectory), '', $stdout, $stderr);
+                    $directorySize = $localDevice->getFileSize($tmpPathFile);
 
-                    $directorySize = $device->getFileSize($source);
+                    Console::execute('rm -rf ' . \escapeshellarg($tmpTemplateDirectory), '', $stdout, $stderr);
                     $deployment
                         ->setAttribute('sourcePath', $source)
                         ->setAttribute('sourceSize', $directorySize)
@@ -575,9 +575,9 @@ class Builds extends Action
                     throw new \Exception('Unable to move file');
                 }
 
-                Console::execute('rm -rf ' . \escapeshellarg($tmpPath), '', $stdout, $stderr);
+                $directorySize = $localDevice->getFileSize($tmpPathFile);
 
-                $directorySize = $device->getFileSize($source);
+                Console::execute('rm -rf ' . \escapeshellarg($tmpPath), '', $stdout, $stderr);
 
                 $deployment
                     ->setAttribute('sourcePath', $source)


### PR DESCRIPTION
## What

After uploading the source tarball, the builds worker called `$device->getFileSize($source)` — an S3 HEAD round-trip — to learn the size of a file that is still sitting on local disk. Both call sites now read the local file size before cleanup.

## Why

Profiling Appwrite Cloud's builds worker during a backlog showed S3 operations (`S3::write` + `S3::getInfo`) as the dominant sink; the HEAD is half of the per-build S3 traffic and pays full DNS + TLS setup per call (no connection reuse in the S3 device — being addressed separately in utopia-php/storage#169). The local read returns the identical value: the tarball was just transferred byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)