### PR TITLE
Allow open-runtimes/sdk-for-php 0.7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*",
         "utopia-php/client": "^0.2.2",
-        "open-runtimes/sdk-for-php": "0.6.*"
+        "open-runtimes/sdk-for-php": "0.6.* || 0.7.*"
     },
     "require-dev": {
         "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f007708a2c4301c72ae22feadcad6c8f",
+    "content-hash": "f1d913d8ccc683139c24d76d7d697e97",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1147,16 +1147,16 @@
         },
         {
             "name": "open-runtimes/sdk-for-php",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/open-runtimes/sdk-for-php.git",
-                "reference": "17776aeee6321a05e83ab2704e410f8fd8ffd9cf"
+                "reference": "ad80f366bdb0ec79ff22a58efc657d8f1a4154a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/17776aeee6321a05e83ab2704e410f8fd8ffd9cf",
-                "reference": "17776aeee6321a05e83ab2704e410f8fd8ffd9cf",
+                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/ad80f366bdb0ec79ff22a58efc657d8f1a4154a2",
+                "reference": "ad80f366bdb0ec79ff22a58efc657d8f1a4154a2",
                 "shasum": ""
             },
             "require": {
@@ -1184,9 +1184,9 @@
             "description": "PHP SDK for the Open Runtimes orchestrator Jobs API.",
             "support": {
                 "issues": "https://github.com/open-runtimes/sdk-for-php/issues",
-                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.6.0"
+                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.7.0"
             },
-            "time": "2026-07-17T09:11:17+00:00"
+            "time": "2026-07-20T14:46:08+00:00"
         },
         {
             "name": "open-telemetry/api",


### PR DESCRIPTION
Widens the `open-runtimes/sdk-for-php` constraint from `0.6.*` to `0.6.* || 0.7.*` (and bumps the lock to 0.7.0).

### Why
0.7.0 is **purely additive** over 0.6.0 — [the only changes](https://github.com/open-runtimes/sdk-for-php/compare/0.6.0...0.7.0) are:
- an `Lz4 = 'lz4'` case on `ArchiveCompression`
- a `blockSize` field on `ArchiveArtifact` (squashfs block size, serialized as `blockSize`)

Nothing was removed or changed, so server-ce keeps working unchanged. These mirror the orchestrator's squashfs archive options and let consumers request the lz4 / 1 MiB-block squashfs artifact the jobs sidecar produces.

### Context
Appwrite Cloud wants to move build-output compression into the jobs sidecar (`ArchiveArtifact(format: squashfs, compression: lz4)`), which needs `ArchiveCompression::Lz4` from 0.7.0. The `0.6.*` pin currently blocks that bump downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)