### PR TITLE
Support Cloud sidecar squashfs+lz4 builds (SDK 0.7 + compression-agnostic test)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "league/csv": "9.14.*",
         "enshrined/svg-sanitize": "0.22.*",
         "utopia-php/client": "^0.2.2",
-        "open-runtimes/sdk-for-php": "0.6.*"
+        "open-runtimes/sdk-for-php": "0.6.* || 0.7.*"
     },
     "require-dev": {
         "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f007708a2c4301c72ae22feadcad6c8f",
+    "content-hash": "f1d913d8ccc683139c24d76d7d697e97",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1147,16 +1147,16 @@
         },
         {
             "name": "open-runtimes/sdk-for-php",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/open-runtimes/sdk-for-php.git",
-                "reference": "17776aeee6321a05e83ab2704e410f8fd8ffd9cf"
+                "reference": "ad80f366bdb0ec79ff22a58efc657d8f1a4154a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/17776aeee6321a05e83ab2704e410f8fd8ffd9cf",
-                "reference": "17776aeee6321a05e83ab2704e410f8fd8ffd9cf",
+                "url": "https://api.github.com/repos/open-runtimes/sdk-for-php/zipball/ad80f366bdb0ec79ff22a58efc657d8f1a4154a2",
+                "reference": "ad80f366bdb0ec79ff22a58efc657d8f1a4154a2",
                 "shasum": ""
             },
             "require": {
@@ -1184,9 +1184,9 @@
             "description": "PHP SDK for the Open Runtimes orchestrator Jobs API.",
             "support": {
                 "issues": "https://github.com/open-runtimes/sdk-for-php/issues",
-                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.6.0"
+                "source": "https://github.com/open-runtimes/sdk-for-php/tree/0.7.0"
             },
-            "time": "2026-07-17T09:11:17+00:00"
+            "time": "2026-07-20T14:46:08+00:00"
         },
         {
             "name": "open-telemetry/api",

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1027,7 +1027,7 @@ final class FunctionsCustomServerTest extends Scope
                 'entrypoint' => 'index.js',
                 'code' => $curlFile,
                 'activate' => true,
-                'commands' => 'cp blue.mp4 copy.mp4 && ls -al' // +7MB buildSize
+                'commands' => 'head -c 12582912 /dev/urandom > random.bin && ls -al' // +12MB unique, incompressible: survives squashfs dedup and any compressor
             ]);
             $counter++;
             $id = $largeTag['body']['$id'];
@@ -1050,7 +1050,7 @@ final class FunctionsCustomServerTest extends Scope
             $this->assertEquals(200, $deployment['headers']['status-code']);
             $this->assertEquals('ready', $deployment['body']['status']);
             $this->assertEquals($deploymentSize, $deployment['body']['sourceSize']);
-            $this->assertGreaterThan(1024 * 1024 * 10, $deployment['body']['buildSize']); // ~7MB video file + 10MB sample file
+            $this->assertGreaterThan(1024 * 1024 * 10, $deployment['body']['buildSize']); // ~7MB video + 12MB incompressible sample; compression/dedup-agnostic
         }, 120000, 500);
     }
 


### PR DESCRIPTION
Two prerequisites for Appwrite Cloud packing build output as lz4 squashfs in the jobs sidecar.

### 1. Allow `open-runtimes/sdk-for-php` 0.7.x
Widens `0.6.*` → `0.6.* || 0.7.*` (lock bumped to 0.7.0). [0.7.0 is purely additive](https://github.com/open-runtimes/sdk-for-php/compare/0.6.0...0.7.0) over 0.6.0 — an `Lz4` case on `ArchiveCompression` and a `blockSize` field on `ArchiveArtifact` — so server-ce is unaffected. Cloud needs these to request `Archive(format: squashfs, compression: lz4)`.

### 2. Make `testCreateDeploymentLarge` compression-agnostic
The test asserted `buildSize > 10 MB` by copying an identical video (`cp blue.mp4 copy.mp4`). That holds for gzip-of-tar but **not** for squashfs, which deduplicates the two identical copies down to ~6.85 MB. Generate a unique, incompressible 12 MB file (`head -c … /dev/urandom`) instead, so the assertion holds under gzip, zstd, and squashfs+lz4 alike.

Supersedes #12922 (SDK bump folded in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)