### PR TITLE
fix(users): reject empty password and block session creation for blocked users

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -251,6 +251,11 @@ return [
         'description' => 'Passwords do not match. Please check the password and confirm password.',
         'code' => 400,
     ],
+    Exception::USER_PASSWORD_EMPTY => [
+        'name' => Exception::USER_PASSWORD_EMPTY,
+        'description' => 'Password cannot be empty. Please provide a valid password.',
+        'code' => 400,
+    ],
     Exception::USER_PASSWORD_RECENTLY_USED => [
         'name' => Exception::USER_PASSWORD_RECENTLY_USED,
         'description' => 'The password you are trying to use is similar to your previous password. For your security, please choose a different password and try again.',

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1461,16 +1461,7 @@ Http::patch('/v1/users/:userId/password')
         }
 
         if (\strlen($password) === 0) {
-            $user
-                ->setAttribute('password', '')
-                ->setAttribute('passwordUpdate', DateTime::now());
-
-            $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
-                'password' => $user->getAttribute('password'),
-                'passwordUpdate' => $user->getAttribute('passwordUpdate'),
-            ]));
-            $queueForEvents->setParam('userId', $user->getId());
-            $response->dynamic($user, Response::MODEL_USER);
+            throw new Exception(Exception::USER_PASSWORD_EMPTY);
         }
 
         $hooks->trigger('passwordValidator', [$dbForProject, $project, $password, &$user, true]);
@@ -2391,6 +2382,10 @@ Http::post('/v1/users/:userId/sessions')
         $user = $dbForProject->getDocument('users', $userId);
         if ($user->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
+        }
+
+        if (false === $user->getAttribute('status')) { // Account is blocked
+            throw new Exception(Exception::USER_BLOCKED);
         }
 
         $secret = $proofForToken->generate();

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -87,6 +87,7 @@ class Exception extends \Exception
     public const string USER_EMAIL_NOT_CORPORATE = 'user_email_not_corporate';
     public const string USER_EMAIL_NOT_CANONICAL = 'user_email_not_canonical';
     public const string USER_PASSWORD_MISMATCH = 'user_password_mismatch';
+    public const string USER_PASSWORD_EMPTY = 'user_password_empty';
     public const string USER_SESSION_NOT_FOUND = 'user_session_not_found';
     public const string USER_IDENTITY_NOT_FOUND = 'user_identity_not_found';
     public const string USER_UNAUTHORIZED = 'user_unauthorized';


### PR DESCRIPTION
## What does this PR do?

Fixes #12797 — two edge cases in the admin Users API:

**Bug 1 — `PATCH /v1/users/:userId/password` accepts empty string**

The empty-string branch at line 1463 stored `''` as the password but had no `return`, so execution fell through and also hashed `""` with Argon2 — leaving the user with a hash of an empty string as a valid credential. Fixed by rejecting empty passwords with a new `USER_PASSWORD_EMPTY` (400) exception, consistent with how other password-policy errors are handled (`USER_PASSWORD_MISMATCH`, `USER_PASSWORD_RECENTLY_USED`, etc.).

Changes:
- Added `Exception::USER_PASSWORD_EMPTY` constant to `Exception.php`
- Registered the error (HTTP 400) in `app/config/errors.php`
- Replaced the broken empty-password block in `users.php` with a throw

**Bug 2 — `POST /v1/users/:userId/sessions` creates a session for a blocked user**

The action only checked for `USER_NOT_FOUND`, not for `status === false`. A blocked user could have a new server session created via the admin API. Fixed by adding a blocked-user check immediately after the not-found check, using the same pattern as `account.php` (line 938).

## Test Plan

**Bug 1:**
1. Create a user via `POST /v1/users`
2. `PATCH /v1/users/{userId}/password` with `{ "password": "" }`
3. Before: returns 200, stores Argon2 hash of empty string
4. After: returns 400 `user_password_empty`

**Bug 2:**
1. Create a user, then block them via `PATCH /v1/users/{userId}/status` with `{ "status": false }`
2. `POST /v1/users/{userId}/sessions`
3. Before: returns 201, session persisted in DB
4. After: returns 403 `user_blocked`

## Related PRs and Issues

- Fixes #12797

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — N/A (no API metadata change, only validation behaviour and a new error code)