### PR TITLE
Fix Doctor false DB and queue disconnect reports

### DIFF
--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -8,6 +8,7 @@ use Utopia\Cache\Adapter\Pool as CachePool;
 use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Database\Adapter\Pool as DatabasePool;
+use Utopia\Database\Validator\Authorization;
 use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
@@ -17,6 +18,7 @@ use Utopia\Messaging\Messages\Email as EmailMessage;
 use Utopia\Platform\Action;
 use Utopia\Pools\Group;
 use Utopia\Queue\Broker\Pool as BrokerPool;
+use Utopia\Queue\Queue;
 use Utopia\Registry\Registry;
 use Utopia\Storage\Device\Local;
 use Utopia\Storage\Storage;
@@ -35,10 +37,11 @@ class Doctor extends Action
         $this
             ->desc('Validate server health')
             ->inject('register')
+            ->inject('authorization')
             ->callback($this->action(...));
     }
 
-    public function action(Registry $register): void
+    public function action(Registry $register, Authorization $authorization): void
     {
         Console::log("  __   ____  ____  _  _  ____  __  ____  ____     __  __  
  / _\ (  _ \(  _ \/ )( \(  _ \(  )(_  _)(  __)   (  )/  \ 
@@ -154,6 +157,7 @@ class Doctor extends Action
             foreach ($config as $database) {
                 try {
                     $adapter = new DatabasePool($pools->get($database));
+                    $adapter->setAuthorization($authorization);
 
                     if ($adapter->ping()) {
                         Console::success('🟢 ' . str_pad("{$key}({$database})", 50, '.') . 'connected');
@@ -161,7 +165,7 @@ class Doctor extends Action
                         Console::error('🔴 ' . str_pad("{$key}({$database})", 47, '.') . 'disconnected');
                     }
                 } catch (\Throwable) {
-                    Console::error('🔴 ' . str_pad("{$key}.({$database})", 47, '.') . 'disconnected');
+                    Console::error('🔴 ' . str_pad("{$key}({$database})", 47, '.') . 'disconnected');
                 }
             }
         }
@@ -171,20 +175,21 @@ class Doctor extends Action
 
         $configs = [
             'Cache' => Config::getParam('pools-cache'),
-            'Queue' => Config::getParam('pools-queue'),
+            'Queue' => Config::getParam('pools-publisher'),
             'PubSub' => Config::getParam('pools-pubsub'),
         ];
 
         foreach ($configs as $key => $config) {
-            foreach ($config as $pool) {
+            foreach ($config ?? [] as $pool) {
                 try {
-                    $adapter = match($key) {
-                        'Cache' => new CachePool($pools->get($pool)),
-                        'Queue' => new BrokerPool($pools->get($pool)),
-                        'PubSub' => new PubSubPool($pools->get($pool)),
+                    $connected = match ($key) {
+                        'Cache' => (new CachePool($pools->get($pool)))->ping(),
+                        'Queue' => (new BrokerPool(publisher: $pools->get($pool)))
+                            ->getQueueSize(new Queue('_doctor')) >= 0,
+                        'PubSub' => (new PubSubPool($pools->get($pool)))->ping(),
                     };
 
-                    if ($adapter->ping()) {
+                    if ($connected) {
                         Console::success('🟢 ' . str_pad("{$key}({$pool})", 50, '.') . 'connected');
                     } else {
                         Console::error('🔴 ' . str_pad("{$key}({$pool})", 47, '.') . 'disconnected');

--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -180,7 +180,12 @@ class Doctor extends Action
         ];
 
         foreach ($configs as $key => $config) {
-            foreach ($config ?? [] as $pool) {
+            if (!\is_array($config) || $config === []) {
+                Console::error('🔴 ' . str_pad($key, 47, '.') . 'disconnected');
+                continue;
+            }
+
+            foreach ($config as $pool) {
                 try {
                     $connected = match ($key) {
                         'Cache' => (new CachePool($pools->get($pool)))->ping(),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the `doctor` CLI task reporting false disconnects for Console.DB / Projects.DB and Queue.

- Call `DatabasePool::setAuthorization()` before `ping()` so DB connectivity checks succeed when authorization is required.
- Point the Queue check at `pools-publisher` (replacing stale `pools-queue`) and use `BrokerPool::getQueueSize()` because BrokerPool has no `ping()`.
- Fix catch-path label typo (`{$key}.({$database})` → `{$key}({$database})`).
- Null-safe `foreach` over pool configs (`$config ?? []`).

## Test Plan

- [ ] Run `doctor` against a healthy self-hosted stack and confirm Console.DB / Projects.DB report connected.
- [ ] Confirm Cache, Queue, and PubSub connectivity lines report correctly (no fatal / false disconnect for Queue).
- [ ] Temporarily break DB or publisher connectivity and confirm doctor reports disconnected without crashing.
- [ ] Spot-check catch-path labels still format as `Key(poolName)` without an extra `.`.

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

Made with [Cursor](https://cursor.com)