### PR TITLE
fix: remove stale audit/usage worker stubs from compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -50,18 +50,6 @@ services:
       - ./src:/usr/src/code/src
     ports:
       - 9502:80
-  appwrite-worker-audits:
-    build:
-      context: .
-      target: development
-      args:
-        DEBUG: false
-        TESTING: true
-        VERSION: dev
-    image: appwrite-dev
-    volumes:
-      - ./app:/usr/src/code/app
-      - ./src:/usr/src/code/src
   appwrite-worker-webhooks:
     build:
       context: .
@@ -138,18 +126,6 @@ services:
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
   appwrite-worker-certificates:
-    build:
-      context: .
-      target: development
-      args:
-        DEBUG: false
-        TESTING: true
-        VERSION: dev
-    image: appwrite-dev
-    volumes:
-      - ./app:/usr/src/code/app
-      - ./src:/usr/src/code/src
-  appwrite-worker-executions:
     build:
       context: .
       target: development
@@ -239,42 +215,6 @@ services:
       - ./app:/usr/src/code/app
       - ./src:/usr/src/code/src
   appwrite-task-interval:
-    build:
-      context: .
-      target: development
-      args:
-        DEBUG: false
-        TESTING: true
-        VERSION: dev
-    image: appwrite-dev
-    volumes:
-      - ./app:/usr/src/code/app
-      - ./src:/usr/src/code/src
-  appwrite-task-stats-resources:
-    build:
-      context: .
-      target: development
-      args:
-        DEBUG: false
-        TESTING: true
-        VERSION: dev
-    image: appwrite-dev
-    volumes:
-      - ./app:/usr/src/code/app
-      - ./src:/usr/src/code/src
-  appwrite-worker-stats-resources:
-    build:
-      context: .
-      target: development
-      args:
-        DEBUG: false
-        TESTING: true
-        VERSION: dev
-    image: appwrite-dev
-    volumes:
-      - ./app:/usr/src/code/app
-      - ./src:/usr/src/code/src
-  appwrite-worker-stats-usage:
     build:
       context: .
       target: development


### PR DESCRIPTION
## What does this PR do?

Removes leftover local-dev stubs from `docker-compose.override.yml` for services that were already dropped from CE `docker-compose.yml` (audit/usage/stats workers and the stats-resources task).

Those override-only services had no entrypoint or `appwrite` network, so Compose started them with the Dockerfile default (`php app/http.php`) on `appwrite_default`. They could not reach Redis and crashed with misleading `Pool 'cache_redis_main' is empty` errors.

## Test Plan

- Confirmed Redis and the main stack were healthy while only these five containers were exited
- Removed the stubs and deleted the exited containers
- Verified `docker compose config` no longer lists the stale services, no exited containers remain, Redis `PONG`, and `/v1/health/version` returns 200

## Related PRs and Issues

- Follow-up to CE removal of audit/usage consumer infra (`d2bbbbb7`, `1724985c`, `70666dc2`)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
