### PR TITLE
Strip the git-forge wrapper when extracting remote build sources on the orchestrator backend

### DIFF
--- a/src/Appwrite/Deployment/Backend/Orchestrator.php
+++ b/src/Appwrite/Deployment/Backend/Orchestrator.php
@@ -135,16 +135,17 @@ readonly class Orchestrator extends Backend
 
         // Source artifacts, both ending in /mnt/code/source:
         //  - remote tarball ($source): templates (public codeload URL) and VCS
-        //    (a short-lived presigned URL). The unarchive auto-strips the
-        //    "{repo}-{ref}/" wrapper and, via subdir, extracts just the
-        //    rootDirectory.
+        //    (a short-lived presigned URL). Git-forge archives wrap the tree in
+        //    a "{repo}-{ref}/" root the caller can't predict, so strip drops it
+        //    and subdir then extracts just the rootDirectory from the unwrapped
+        //    tree. Uploaded tarballs (the else branch) are flat — no strip.
         //  - otherwise: the deployment's uploaded tarball, fetched from Appwrite
         //    over a presigned GET (manual upload / duplicate).
         if ($source !== null) {
             $subdir = \trim($source['subdir'] ?? '', '/');
             $sourceArtifacts = [
                 new DownloadArtifact(id: 'source', in: $source['url'], out: 'source.tar.gz'),
-                new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', subdir: $subdir !== '' ? $subdir : null),
+                new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', subdir: $subdir !== '' ? $subdir : null, strip: true),
                 // Appwrite never sees the remote source (the sidecar fetches it),
                 // so unlike the uploaded-tarball path it can't size it. Stat the
                 // downloaded archive so the orchestrator reports its byte size in


### PR DESCRIPTION
## What does this PR do?

Passes `strip: true` on the remote-source unarchive artifact in `Deployment\Backend\Orchestrator`, so the sidecar drops the git-forge `{repo}-{ref}/` wrapper directory and `subdir` resolves against the unwrapped tree.

## Why

The jobs-service sidecar never auto-strips the wrapper (strip is opt-in), so on the orchestrator backend:

- **VCS deployments with no rootDirectory** extracted the wrapper intact — the build ran against an empty `/usr/local/build` and failed with `npm error ENOENT ... package.json`.
- **Template/VCS deployments with rootDirectory `./`** cleaned the subdir to empty and hit the same failure.
- Deployments with a real rootDirectory (e.g. `node/starter`) only worked by falling into the sidecar's legacy no-strip path, which prepends the detected archive root to the subdir.

Verified live on Appwrite Cloud staging (fra1): before the fix, sites+functions VCS creates and a site template create all failed with exit 254 / empty workspace; the function template create (real rootDirectory) passed via the legacy path.

## Test Plan

Existing e2e deployment tests; verified the four remote-source flows (function/site × VCS/template) against a staging deployment of this commit.

## Related PRs and Issues

- Cloud follow-up: bump `appwrite/server-ce` lock after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTKgotgUqcAq3WhddVoXX8