### PR TITLE
chore: bump openruntimes executor to 0.25.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1174,7 +1174,7 @@ services:
         max-file: "5"
         max-size: 10m
     stop_signal: SIGINT
-    image: openruntimes/executor:0.25.2
+    image: openruntimes/executor:0.25.4
     restart: unless-stopped
     networks:
       - appwrite


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Bumps the `openruntimes-executor` service image from `openruntimes/executor:0.25.2` to `openruntimes/executor:0.25.4`.

This pulls in recent executor fixes:
- **0.25.4**: Fix S3 bucket prefix omission for custom endpoints in StorageFactory
- **0.25.3**: Bump utopia-php/http dependency
- **0.25.2**: Report silent build command failures

## Test Plan

- [x] Verified `openruntimes/executor:0.25.4` exists on Docker Hub
- [x] Pulled and restarted local `openruntimes-executor` service via Docker Compose
- [x] Confirmed executor health check passes after upgrade

## Related PRs and Issues

- https://github.com/open-runtimes/executor/releases/tag/0.25.4
- https://github.com/open-runtimes/executor/pull/242

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
