### PR TITLE
Sync 1.9.6 self-hosted fixes to main

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1141,7 +1141,7 @@ services:
       - _APP_ASSISTANT_OPENAI_API_KEY
   appwrite-browser:
     container_name: appwrite-browser
-    image: appwrite/browser:0.3.2
+    image: appwrite/browser:0.3.3
     networks:
       - appwrite
 
@@ -1174,7 +1174,7 @@ services:
         max-file: "5"
         max-size: 10m
     stop_signal: SIGINT
-    image: openruntimes/executor:0.25.2
+    image: openruntimes/executor:0.25.4
     restart: unless-stopped
     networks:
       - appwrite

--- a/src/Appwrite/Migration/Version/V25.php
+++ b/src/Appwrite/Migration/Version/V25.php
@@ -109,6 +109,21 @@ class V25 extends Migration
                     }
                     break;
 
+                case 'functions':
+                case 'sites':
+                    if ($collectionType === 'projects') {
+                        $attributes = ['providerBranches', 'providerPaths'];
+                        try {
+                            $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
+                        } catch (Throwable $th) {
+                            Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
+                        }
+
+                        $this->dbForProject->purgeCachedCollection($id);
+                        $this->dbForProject->purgeCachedDocument(Database::METADATA, $id);
+                    }
+                    break;
+
                 case 'migrations':
                     if ($collectionType === 'projects') {
                         $attributes = [

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -153,7 +153,7 @@ class Create extends Base
 
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
 
-        if (!empty($allowList) && !\in_array($buildRuntime, $allowList, true)) {
+        if (!empty($allowList) && !empty($buildRuntime) && !\in_array($buildRuntime, $allowList, true)) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
         }
 

--- a/tests/unit/Migration/MigrationVersionsTest.php
+++ b/tests/unit/Migration/MigrationVersionsTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Migration;
 
 use Appwrite\Migration\Migration;
 use Appwrite\Migration\Version\V24;
+use Appwrite\Migration\Version\V25;
 use PHPUnit\Framework\TestCase;
 use Utopia\Cache\Adapter\None as NoCache;
 use Utopia\Cache\Cache;
@@ -181,6 +182,51 @@ final class MigrationVersionsTest extends TestCase
 
         foreach ([...$existing, ...$new] as $id) {
             $this->assertContains($id, $attributes);
+        }
+    }
+
+    public function testV25RepairsProviderAttributesIdempotently(): void
+    {
+        require_once __DIR__ . '/../../../app/init.php';
+
+        $authorization = new Authorization();
+        $database = new Database(new Memory(), new Cache(new NoCache()));
+        $database
+            ->setAuthorization($authorization)
+            ->setDatabase('migrationV25ProviderAttributes')
+            ->setNamespace('migration_provider_attributes_' . \uniqid());
+        $database->create();
+        $database->createCollection('databases');
+        $database->createCollection('functions');
+        $database->createCollection('sites');
+
+        $migration = new V25();
+        $migration->setProject(
+            new Document(['$id' => 'project', '$sequence' => '1']),
+            $database,
+            $database,
+            $authorization,
+        );
+
+        $migration->createAttributesFromCollection($database, 'functions', ['providerBranches']);
+
+        $migrateCollections = new \ReflectionMethod($migration, 'migrateCollections');
+        \ob_start();
+        try {
+            $migrateCollections->invoke($migration);
+            $migrateCollections->invoke($migration);
+        } finally {
+            \ob_end_clean();
+        }
+
+        foreach (['functions', 'sites'] as $collectionId) {
+            $attributes = [];
+            foreach ($database->getCollection($collectionId)->getAttribute('attributes', []) as $attribute) {
+                $attributes[] = $attribute instanceof Document ? $attribute->getAttribute('$id') : ($attribute['$id'] ?? '');
+            }
+
+            $this->assertContains('providerBranches', $attributes);
+            $this->assertContains('providerPaths', $attributes);
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Syncs the remaining self-hosted fixes prepared for 1.9.6 back into `main` without bringing release-only metadata into the 2.0 development line.

- folds the 1.9.6 `providerBranches` and `providerPaths` repair into the existing 2.0 V25 migration, including mixed-schema and repeated-run handling
- allows Sites with an intentionally empty build runtime when `_APP_SITES_RUNTIMES` is configured
- updates the Browser service to 0.3.3 for configurable internal Appwrite origins
- updates Open Runtimes Executor to 0.25.4

The Console 8.7.30 image bump is intentionally excluded because `main` uses the new Vibes-based Console. The healthcheck, MongoDB primary readiness, Doctor connectivity, migration helper idempotency, and Sites allowlist changes from 1.9.x already have equivalent implementations on `main`.

## Test Plan

- `composer format src/Appwrite/Migration/Version/V25.php src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php tests/unit/Migration/MigrationVersionsTest.php`
- `composer lint src/Appwrite/Migration/Version/V25.php src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php tests/unit/Migration/MigrationVersionsTest.php`
- `vendor/bin/phpunit tests/unit/Migration/MigrationVersionsTest.php tests/unit/Migration/Version/V25Test.php` (8 tests, 106 assertions)
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G src/Appwrite/Migration/Version/V25.php src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php tests/unit/Migration/MigrationVersionsTest.php`
- `composer refactor:check`
- `docker compose config --quiet`
- Browser 0.3.3 screenshot requests were exercised in the 1.9.6 stack against a custom internal host, both without and with `X-Appwrite-Internal-Origin`; the header-enabled request returned a PNG successfully.
- The 1.9.6 release branch passed a clean isolated installer smoke test with these Browser and Executor image versions.

## Related PRs and Issues

- #12937
- #12938
- [docker-browser 0.3.3](https://github.com/appwrite/docker-browser/releases/tag/0.3.3)
- [open-runtimes/executor 0.25.4](https://github.com/open-runtimes/executor/releases/tag/0.25.4)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (Not applicable; no API metadata changed.)
