### PR TITLE
Update utopia-php/storage to 3.0.0

### DIFF
--- a/app/init/resources.php
+++ b/app/init/resources.php
@@ -48,7 +48,7 @@ use Utopia\Storage\Device\Linode;
 use Utopia\Storage\Device\Local;
 use Utopia\Storage\Device\S3;
 use Utopia\Storage\Device\Wasabi;
-use Utopia\Storage\Storage;
+use Utopia\Storage\DeviceType;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
@@ -260,18 +260,16 @@ function getDevice(string $root, string $connection = ''): Device
 {
     $connection = ! empty($connection) ? $connection : System::getEnv('_APP_CONNECTIONS_STORAGE', '');
 
-    if (! empty($connection)) {
-        $acl = 'private';
-        $device = Storage::DEVICE_LOCAL;
-        $accessKey = '';
-        $accessSecret = '';
-        $bucket = '';
-        $region = '';
-        $url = System::getEnv('_APP_STORAGE_S3_ENDPOINT', '');
+    $device = DeviceType::Local;
+    $accessKey = '';
+    $accessSecret = '';
+    $bucket = '';
+    $region = '';
 
+    if (! empty($connection)) {
         try {
             $dsn = new DSN($connection);
-            $device = $dsn->getScheme();
+            $device = DeviceType::tryFrom($dsn->getScheme()) ?? DeviceType::Local;
             $accessKey = $dsn->getUser() ?? '';
             $accessSecret = $dsn->getPassword() ?? '';
             $bucket = $dsn->getPath() ?? '';
@@ -279,87 +277,45 @@ function getDevice(string $root, string $connection = ''): Device
         } catch (\Throwable $e) {
             Console::warning($e->getMessage() . 'Invalid DSN. Defaulting to Local device.');
         }
-
-        switch ($device) {
-            case Storage::DEVICE_S3:
-                if (! empty($url)) {
-                    $bucketRoot = (! empty($bucket) ? "{$bucket}/" : '') . \ltrim($root, '/');
-
-                    return new S3($bucketRoot, $accessKey, $accessSecret, $url, $region, $acl);
-                } else {
-                    return new AWS($root, $accessKey, $accessSecret, $bucket, $region, $acl);
-                }
-                // no break
-            case Storage::DEVICE_DO_SPACES:
-                $device = new DOSpaces($root, $accessKey, $accessSecret, $bucket, $region, $acl);
-                $device->setHttpVersion(S3::HTTP_VERSION_1_1);
-
-                return $device;
-            case Storage::DEVICE_BACKBLAZE:
-                return new Backblaze($root, $accessKey, $accessSecret, $bucket, $region, $acl);
-            case Storage::DEVICE_LINODE:
-                return new Linode($root, $accessKey, $accessSecret, $bucket, $region, $acl);
-            case Storage::DEVICE_WASABI:
-                return new Wasabi($root, $accessKey, $accessSecret, $bucket, $region, $acl);
-            case Storage::DEVICE_LOCAL:
-            default:
-                return new Local($root);
-        }
     } else {
-        switch (strtolower(System::getEnv('_APP_STORAGE_DEVICE', Storage::DEVICE_LOCAL))) {
-            case Storage::DEVICE_S3:
-                $s3AccessKey = System::getEnv('_APP_STORAGE_S3_ACCESS_KEY', '');
-                $s3SecretKey = System::getEnv('_APP_STORAGE_S3_SECRET', '');
-                $s3Region = System::getEnv('_APP_STORAGE_S3_REGION', '');
-                $s3Bucket = System::getEnv('_APP_STORAGE_S3_BUCKET', '');
-                $s3Acl = 'private';
-                $s3EndpointUrl = System::getEnv('_APP_STORAGE_S3_ENDPOINT', '');
-                if (! empty($s3EndpointUrl)) {
-                    $bucketRoot = (! empty($s3Bucket) ? "{$s3Bucket}/" : '') . \ltrim($root, '/');
-
-                    return new S3($bucketRoot, $s3AccessKey, $s3SecretKey, $s3EndpointUrl, $s3Region, $s3Acl);
-                } else {
-                    return new AWS($root, $s3AccessKey, $s3SecretKey, $s3Bucket, $s3Region, $s3Acl);
-                }
-                // no break
-            case Storage::DEVICE_DO_SPACES:
-                $doSpacesAccessKey = System::getEnv('_APP_STORAGE_DO_SPACES_ACCESS_KEY', '');
-                $doSpacesSecretKey = System::getEnv('_APP_STORAGE_DO_SPACES_SECRET', '');
-                $doSpacesRegion = System::getEnv('_APP_STORAGE_DO_SPACES_REGION', '');
-                $doSpacesBucket = System::getEnv('_APP_STORAGE_DO_SPACES_BUCKET', '');
-                $doSpacesAcl = 'private';
-                $device = new DOSpaces($root, $doSpacesAccessKey, $doSpacesSecretKey, $doSpacesBucket, $doSpacesRegion, $doSpacesAcl);
-                $device->setHttpVersion(S3::HTTP_VERSION_1_1);
-
-                return $device;
-            case Storage::DEVICE_BACKBLAZE:
-                $backblazeAccessKey = System::getEnv('_APP_STORAGE_BACKBLAZE_ACCESS_KEY', '');
-                $backblazeSecretKey = System::getEnv('_APP_STORAGE_BACKBLAZE_SECRET', '');
-                $backblazeRegion = System::getEnv('_APP_STORAGE_BACKBLAZE_REGION', '');
-                $backblazeBucket = System::getEnv('_APP_STORAGE_BACKBLAZE_BUCKET', '');
-                $backblazeAcl = 'private';
-
-                return new Backblaze($root, $backblazeAccessKey, $backblazeSecretKey, $backblazeBucket, $backblazeRegion, $backblazeAcl);
-            case Storage::DEVICE_LINODE:
-                $linodeAccessKey = System::getEnv('_APP_STORAGE_LINODE_ACCESS_KEY', '');
-                $linodeSecretKey = System::getEnv('_APP_STORAGE_LINODE_SECRET', '');
-                $linodeRegion = System::getEnv('_APP_STORAGE_LINODE_REGION', '');
-                $linodeBucket = System::getEnv('_APP_STORAGE_LINODE_BUCKET', '');
-                $linodeAcl = 'private';
-
-                return new Linode($root, $linodeAccessKey, $linodeSecretKey, $linodeBucket, $linodeRegion, $linodeAcl);
-            case Storage::DEVICE_WASABI:
-                $wasabiAccessKey = System::getEnv('_APP_STORAGE_WASABI_ACCESS_KEY', '');
-                $wasabiSecretKey = System::getEnv('_APP_STORAGE_WASABI_SECRET', '');
-                $wasabiRegion = System::getEnv('_APP_STORAGE_WASABI_REGION', '');
-                $wasabiBucket = System::getEnv('_APP_STORAGE_WASABI_BUCKET', '');
-                $wasabiAcl = 'private';
-
-                return new Wasabi($root, $wasabiAccessKey, $wasabiSecretKey, $wasabiBucket, $wasabiRegion, $wasabiAcl);
-            case Storage::DEVICE_LOCAL:
-            default:
-                return new Local($root);
+        $device = DeviceType::tryFrom(strtolower(System::getEnv('_APP_STORAGE_DEVICE', DeviceType::Local->value))) ?? DeviceType::Local;
+        $prefix = match ($device) {
+            DeviceType::S3, DeviceType::AwsS3 => 'S3',
+            DeviceType::DoSpaces => 'DO_SPACES',
+            DeviceType::Backblaze => 'BACKBLAZE',
+            DeviceType::Linode => 'LINODE',
+            DeviceType::Wasabi => 'WASABI',
+            DeviceType::Local => null,
+        };
+        if ($prefix !== null) {
+            $accessKey = System::getEnv("_APP_STORAGE_{$prefix}_ACCESS_KEY", '');
+            $accessSecret = System::getEnv("_APP_STORAGE_{$prefix}_SECRET", '');
+            $region = System::getEnv("_APP_STORAGE_{$prefix}_REGION", '');
+            $bucket = System::getEnv("_APP_STORAGE_{$prefix}_BUCKET", '');
         }
+    }
+
+    switch ($device) {
+        case DeviceType::S3:
+        case DeviceType::AwsS3:
+            $endpoint = System::getEnv('_APP_STORAGE_S3_ENDPOINT', '');
+            if (! empty($endpoint)) {
+                $bucketRoot = (! empty($bucket) ? "{$bucket}/" : '') . \ltrim($root, '/');
+
+                return new S3($bucketRoot, $accessKey, $accessSecret, $endpoint, $region);
+            }
+
+            return new AWS($root, $accessKey, $accessSecret, $bucket, $region);
+        case DeviceType::DoSpaces:
+            return new DOSpaces($root, $accessKey, $accessSecret, $bucket, $region);
+        case DeviceType::Backblaze:
+            return new Backblaze($root, $accessKey, $accessSecret, $bucket, $region);
+        case DeviceType::Linode:
+            return new Linode($root, $accessKey, $accessSecret, $bucket, $region);
+        case DeviceType::Wasabi:
+            return new Wasabi($root, $accessKey, $accessSecret, $bucket, $region);
+        case DeviceType::Local:
+            return new Local($root);
     }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "utopia-php/queue": "^0.22",
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
-        "utopia-php/storage": "2.*",
+        "utopia-php/storage": "3.*",
         "utopia-php/system": "0.10.*",
         "utopia-php/telemetry": "^0.4",
         "utopia-php/user-agent": "0.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9e477526d52de114f4bc6b07ebd21ea",
+    "content-hash": "7a2821539fc6e6063587e38e3eca19c4",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4363,16 +4363,16 @@
         },
         {
             "name": "utopia-php/migration",
-            "version": "1.18.0",
+            "version": "1.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/migration.git",
-                "reference": "b531ea43293fde5ceb72c29d312489aa0ded0c83"
+                "reference": "9dc829536b545d548e1cd4a924776c625c3edab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/migration/zipball/b531ea43293fde5ceb72c29d312489aa0ded0c83",
-                "reference": "b531ea43293fde5ceb72c29d312489aa0ded0c83",
+                "url": "https://api.github.com/repos/utopia-php/migration/zipball/9dc829536b545d548e1cd4a924776c625c3edab8",
+                "reference": "9dc829536b545d548e1cd4a924776c625c3edab8",
                 "shasum": ""
             },
             "require": {
@@ -4380,10 +4380,10 @@
                 "ext-curl": "*",
                 "ext-openssl": "*",
                 "halaxa/json-machine": "^1.2",
-                "php": ">=8.2",
+                "php": ">=8.5",
                 "utopia-php/database": "^6.0.0",
                 "utopia-php/dsn": "0.2.*",
-                "utopia-php/storage": "2.*"
+                "utopia-php/storage": "3.*"
             },
             "require-dev": {
                 "ext-pdo": "*",
@@ -4412,9 +4412,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/migration/issues",
-                "source": "https://github.com/utopia-php/migration/tree/1.18.0"
+                "source": "https://github.com/utopia-php/migration/tree/1.20.1"
             },
-            "time": "2026-07-20T10:00:12+00:00"
+            "time": "2026-07-22T04:10:07+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -4931,25 +4931,27 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "2.0.7",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "c56687a1ca2a97ba17feb467b68d767a970c6668"
+                "reference": "171746978543323c2536edacd8ad8e8d3fde401c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/c56687a1ca2a97ba17feb467b68d767a970c6668",
-                "reference": "c56687a1ca2a97ba17feb467b68d767a970c6668",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/171746978543323c2536edacd8ad8e8d3fde401c",
+                "reference": "171746978543323c2536edacd8ad8e8d3fde401c",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-fileinfo": "*",
                 "ext-simplexml": "*",
-                "ext-zlib": "*",
                 "php": ">=8.5",
-                "utopia-php/system": "0.*.*",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "utopia-php/client": "0.2.*",
+                "utopia-php/psr7": "0.2.*",
                 "utopia-php/telemetry": "^0.4",
                 "utopia-php/validators": "0.3.*"
             },
@@ -4973,9 +4975,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/2.0.7"
+                "source": "https://github.com/utopia-php/storage/tree/3.0.0"
             },
-            "time": "2026-07-14T09:36:25+00:00"
+            "time": "2026-07-20T13:15:54+00:00"
         },
         {
             "name": "utopia-php/system",

--- a/src/Appwrite/GraphQL/Types/Mapper.php
+++ b/src/Appwrite/GraphQL/Types/Mapper.php
@@ -351,7 +351,7 @@ class Mapper
             case \Utopia\Validator\JSON::class:
                 $type = Types::json();
                 break;
-            case \Utopia\Storage\Validator\File::class:
+            case \Appwrite\Utopia\Request\Validator\File::class:
                 $type = Types::inputFile();
                 break;
         }

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Utopia\Request\Validator\File;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -21,7 +22,6 @@ use Utopia\Lock\Exception\Contention as LockContention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
-use Utopia\Storage\Validator\File;
 use Utopia\Storage\Validator\FileExt;
 use Utopia\Storage\Validator\FileSize;
 use Utopia\Storage\Validator\Upload;
@@ -266,7 +266,7 @@ class Create extends Action
             return;
         }
 
-        $chunksUploaded = $deviceForFunctions->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
+        $chunksUploaded = $deviceForFunctions->uploadChunk($deviceForLocal->read($fileTmpName), $path, $chunk, $chunks, $metadata);
 
         if (empty($chunksUploaded)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -385,9 +385,9 @@ class Builds extends Action
                         throw new \Exception('Unable to move file');
                     }
 
-                    Console::execute('rm -rf ' . \escapeshellarg($tmpTemplateDirectory), '', $stdout, $stderr);
+                    $directorySize = $localDevice->getFileSize($tmpPathFile);
 
-                    $directorySize = $device->getFileSize($source);
+                    Console::execute('rm -rf ' . \escapeshellarg($tmpTemplateDirectory), '', $stdout, $stderr);
                     $deployment
                         ->setAttribute('sourcePath', $source)
                         ->setAttribute('sourceSize', $directorySize)
@@ -572,9 +572,9 @@ class Builds extends Action
                     throw new \Exception('Unable to move file');
                 }
 
-                Console::execute('rm -rf ' . \escapeshellarg($tmpPath), '', $stdout, $stderr);
+                $directorySize = $localDevice->getFileSize($tmpPathFile);
 
-                $directorySize = $device->getFileSize($source);
+                Console::execute('rm -rf ' . \escapeshellarg($tmpPath), '', $stdout, $stderr);
 
                 $deployment
                     ->setAttribute('sourcePath', $source)

--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Stats/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Stats/Get.php
@@ -2,12 +2,14 @@
 
 namespace Appwrite\Platform\Modules\Health\Http\Health\Stats;
 
+use Appwrite\Storage\Bytes;
 use Appwrite\Utopia\Response;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Registry\Registry;
 use Utopia\Storage\Device;
-use Utopia\Storage\Storage;
+use Utopia\Storage\Device\Local;
+use Utopia\Storage\Device\Telemetry;
 
 class Get extends Action
 {
@@ -39,11 +41,14 @@ class Get extends Action
 
         $cacheStats = $cache->info();
 
+        $device = $deviceForFiles instanceof Telemetry ? $deviceForFiles->getDevice() : $deviceForFiles;
+        $local = $device instanceof Local ? $device : new Local($device->getRoot());
+
         $response->json([
             'storage' => [
-                'used' => Storage::human($deviceForFiles->getDirectorySize($deviceForFiles->getRoot() . '/')),
-                'partitionTotal' => Storage::human($deviceForFiles->getPartitionTotalSpace()),
-                'partitionFree' => Storage::human($deviceForFiles->getPartitionFreeSpace()),
+                'used' => Bytes::human($local->getDirectorySize($local->getRoot() . '/')),
+                'partitionTotal' => Bytes::human($local->getPartitionTotalSpace()),
+                'partitionFree' => Bytes::human($local->getPartitionFreeSpace()),
             ],
             'cache' => [
                 'uptime' => $cacheStats['uptime_in_seconds'] ?? 0,

--- a/src/Appwrite/Platform/Modules/Health/Http/Health/Stats/Get.php
+++ b/src/Appwrite/Platform/Modules/Health/Http/Health/Stats/Get.php
@@ -42,7 +42,7 @@ class Get extends Action
         $cacheStats = $cache->info();
 
         $device = $deviceForFiles instanceof Telemetry ? $deviceForFiles->getDevice() : $deviceForFiles;
-        $local = $device instanceof Local ? $device : new Local($device->getRoot());
+        $local = $device instanceof Local ? $device : new Local(APP_STORAGE_UPLOADS);
 
         $response->json([
             'storage' => [

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Utopia\Request\Validator\File;
 use Appwrite\Utopia\Response;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -21,7 +22,6 @@ use Utopia\Lock\Exception\Contention as LockContention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
-use Utopia\Storage\Validator\File;
 use Utopia\Storage\Validator\FileExt;
 use Utopia\Storage\Validator\FileSize;
 use Utopia\Storage\Validator\Upload;
@@ -306,7 +306,7 @@ class Create extends Action
             return;
         }
 
-        $chunksUploaded = $deviceForSites->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
+        $chunksUploaded = $deviceForSites->uploadChunk($deviceForLocal->read($fileTmpName), $path, $chunk, $chunks, $metadata);
 
         if (empty($chunksUploaded)) {
             throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed moving file');

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Create.php
@@ -7,6 +7,7 @@ use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Storage\Bytes;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
 use Utopia\Compression\Compression;
@@ -19,7 +20,6 @@ use Utopia\Database\Helpers\Permission;
 use Utopia\Platform\Action;
 use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Storage\Storage;
 use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Boolean;
@@ -68,11 +68,11 @@ class Create extends Action
             ->param('permissions', null, new Nullable(new \Utopia\Database\Validator\Permissions(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of permission strings. By default, no user is granted with any permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
             ->param('fileSecurity', false, new Boolean(true), 'Enables configuring permissions for individual file. A user needs one of file or bucket level permissions to access a file. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
             ->param('enabled', true, new Boolean(true), 'Is bucket enabled? When set to \'disabled\', users cannot access the files in this bucket but Server SDKs with and API key can still access the bucket. No files are lost when this is toggled.', true)
-            ->param('maximumFileSize', fn (array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn (array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Storage::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
+            ->param('maximumFileSize', fn (array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn (array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Bytes::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
             ->param('allowedFileExtensions', [], new ArrayList(new Text(64), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Allowed file extensions. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' extensions are allowed, each 64 characters long.', true)
-            ->param('compression', Compression::NONE, new WhiteList([Compression::NONE, Compression::GZIP, Compression::ZSTD], true), 'Compression algorithm chosen for compression. Can be one of ' . Compression::NONE . ',  [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd), For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' compression is skipped even if it\'s enabled', true, enum: new Enum(name: 'Compression'))
-            ->param('encryption', true, new Boolean(true), 'Is encryption enabled? For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' encryption is skipped even if it\'s enabled', true)
-            ->param('antivirus', true, new Boolean(true), 'Is virus scanning enabled? For file size above ' . Storage::human(APP_LIMIT_ANTIVIRUS, 0) . ' AntiVirus scanning is skipped even if it\'s enabled', true)
+            ->param('compression', Compression::NONE, new WhiteList([Compression::NONE, Compression::GZIP, Compression::ZSTD], true), 'Compression algorithm chosen for compression. Can be one of ' . Compression::NONE . ',  [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd), For file size above ' . Bytes::human(APP_STORAGE_READ_BUFFER, 0) . ' compression is skipped even if it\'s enabled', true, enum: new Enum(name: 'Compression'))
+            ->param('encryption', true, new Boolean(true), 'Is encryption enabled? For file size above ' . Bytes::human(APP_STORAGE_READ_BUFFER, 0) . ' encryption is skipped even if it\'s enabled', true)
+            ->param('antivirus', true, new Boolean(true), 'Is virus scanning enabled? For file size above ' . Bytes::human(APP_LIMIT_ANTIVIRUS, 0) . ' AntiVirus scanning is skipped even if it\'s enabled', true)
             ->param('transformations', true, new Boolean(true), 'Are image transformations enabled?', true)
             ->inject('response')
             ->inject('dbForProject')

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -13,6 +13,7 @@ use Appwrite\SDK\MethodType;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Database\Validator\CustomId;
+use Appwrite\Utopia\Request\Validator\File;
 use Appwrite\Utopia\Response;
 use Utopia\Compression\Algorithms\GZIP;
 use Utopia\Compression\Algorithms\Zstd;
@@ -33,8 +34,7 @@ use Utopia\Lock\Exception\Contention as LockContention;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
 use Utopia\Storage\Device;
-use Utopia\Storage\Storage;
-use Utopia\Storage\Validator\File;
+use Utopia\Storage\DeviceType;
 use Utopia\Storage\Validator\FileExt;
 use Utopia\Storage\Validator\FileSize;
 use Utopia\Storage\Validator\Upload;
@@ -354,7 +354,7 @@ class Create extends Action
             if ($chunksUploaded === $chunks && $uploaded < $chunks) {
                 $deviceForFiles->finalizeUpload($path, $chunks, $metadata);
 
-                if (System::getEnv('_APP_STORAGE_ANTIVIRUS') === 'enabled' && $bucket->getAttribute('antivirus', true) && $fileSize <= APP_LIMIT_ANTIVIRUS && $deviceForFiles->getType() === Storage::DEVICE_LOCAL) {
+                if (System::getEnv('_APP_STORAGE_ANTIVIRUS') === 'enabled' && $bucket->getAttribute('antivirus', true) && $fileSize <= APP_LIMIT_ANTIVIRUS && $deviceForFiles->getType() === DeviceType::Local) {
                     $antivirus = new Network(
                         System::getEnv('_APP_STORAGE_ANTIVIRUS_HOST', 'clamav'),
                         (int) System::getEnv('_APP_STORAGE_ANTIVIRUS_PORT', 3310)
@@ -510,7 +510,7 @@ class Create extends Action
         };
 
         try {
-            $chunksUploaded = $deviceForFiles->uploadChunk($fileTmpName, $path, $chunk, $chunks, $metadata);
+            $chunksUploaded = $deviceForFiles->uploadChunk($deviceForLocal->read($fileTmpName), $path, $chunk, $chunks, $metadata);
 
             if (empty($chunksUploaded)) {
                 throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Failed uploading file');

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Update.php
@@ -7,6 +7,7 @@ use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
+use Appwrite\Storage\Bytes;
 use Appwrite\Utopia\Response;
 use Utopia\Compression\Compression;
 use Utopia\Database\Database;
@@ -16,7 +17,6 @@ use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Enum;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Storage\Storage;
 use Utopia\System\System;
 use Utopia\Validator\ArrayList;
 use Utopia\Validator\Boolean;
@@ -65,11 +65,11 @@ class Update extends Action
             ->param('permissions', null, new Nullable(new Permissions(APP_LIMIT_ARRAY_PARAMS_SIZE)), 'An array of permission strings. By default, the current permissions are inherited. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
             ->param('fileSecurity', false, new Boolean(true), 'Enables configuring permissions for individual file. A user needs one of file or bucket level permissions to access a file. [Learn more about permissions](https://appwrite.io/docs/permissions).', true)
             ->param('enabled', true, new Boolean(true), 'Is bucket enabled? When set to \'disabled\', users cannot access the files in this bucket but Server SDKs with and API key can still access the bucket. No files are lost when this is toggled.', true)
-            ->param('maximumFileSize', fn (array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn (array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Storage::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
+            ->param('maximumFileSize', fn (array $plan) => empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000, fn (array $plan) => new Range(1, empty($plan['fileSize']) ? (int) System::getEnv('_APP_STORAGE_LIMIT', 0) : $plan['fileSize'] * 1000 * 1000), 'Maximum file size allowed in bytes. Maximum allowed value is ' . Bytes::human(System::getEnv('_APP_STORAGE_LIMIT', 0), 0) . '.', true, ['plan'])
             ->param('allowedFileExtensions', [], new ArrayList(new Text(64), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Allowed file extensions. Maximum of ' . APP_LIMIT_ARRAY_PARAMS_SIZE . ' extensions are allowed, each 64 characters long.', true)
-            ->param('compression', Compression::NONE, new WhiteList([Compression::NONE, Compression::GZIP, Compression::ZSTD], true), 'Compression algorithm chosen for compression. Can be one of ' . Compression::NONE . ', [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd), For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' compression is skipped even if it\'s enabled', true, enum: new Enum(name: 'Compression'))
-            ->param('encryption', true, new Boolean(true), 'Is encryption enabled? For file size above ' . Storage::human(APP_STORAGE_READ_BUFFER, 0) . ' encryption is skipped even if it\'s enabled', true)
-            ->param('antivirus', true, new Boolean(true), 'Is virus scanning enabled? For file size above ' . Storage::human(APP_LIMIT_ANTIVIRUS, 0) . ' AntiVirus scanning is skipped even if it\'s enabled', true)
+            ->param('compression', Compression::NONE, new WhiteList([Compression::NONE, Compression::GZIP, Compression::ZSTD], true), 'Compression algorithm chosen for compression. Can be one of ' . Compression::NONE . ', [' . Compression::GZIP . '](https://en.wikipedia.org/wiki/Gzip), or [' . Compression::ZSTD . '](https://en.wikipedia.org/wiki/Zstd), For file size above ' . Bytes::human(APP_STORAGE_READ_BUFFER, 0) . ' compression is skipped even if it\'s enabled', true, enum: new Enum(name: 'Compression'))
+            ->param('encryption', true, new Boolean(true), 'Is encryption enabled? For file size above ' . Bytes::human(APP_STORAGE_READ_BUFFER, 0) . ' encryption is skipped even if it\'s enabled', true)
+            ->param('antivirus', true, new Boolean(true), 'Is virus scanning enabled? For file size above ' . Bytes::human(APP_LIMIT_ANTIVIRUS, 0) . ' AntiVirus scanning is skipped even if it\'s enabled', true)
             ->param('transformations', true, new Boolean(true), 'Are image transformations enabled?', true)
             ->inject('response')
             ->inject('dbForProject')

--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Tasks;
 
 use Appwrite\ClamAV\Network;
 use Appwrite\PubSub\Adapter\Pool as PubSubPool;
+use Appwrite\Storage\Bytes;
 use Utopia\Cache\Adapter\Pool as CachePool;
 use Utopia\Config\Config;
 use Utopia\Console;
@@ -21,7 +22,6 @@ use Utopia\Queue\Broker\Pool as BrokerPool;
 use Utopia\Queue\Queue;
 use Utopia\Registry\Registry;
 use Utopia\Storage\Device\Local;
-use Utopia\Storage\Storage;
 use Utopia\System\System;
 use Utopia\Validator\IP;
 
@@ -286,7 +286,7 @@ class Doctor extends Action
             $percentage = (($device->getPartitionTotalSpace() - $device->getPartitionFreeSpace())
             / $device->getPartitionTotalSpace()) * 100;
 
-            $message = $key . ' Volume has ' . Storage::human($device->getPartitionFreeSpace()) . ' free space (' . \round($percentage, 2) . '% used)';
+            $message = $key . ' Volume has ' . Bytes::human($device->getPartitionFreeSpace()) . ' free space (' . \round($percentage, 2) . '% used)';
 
             if ($percentage < 80) {
                 Console::success('🟢 ' . $message);

--- a/src/Appwrite/Platform/Workers/Messaging.php
+++ b/src/Appwrite/Platform/Workers/Messaging.php
@@ -47,7 +47,7 @@ use Utopia\Queue\Message;
 use Utopia\Span\Span;
 use Utopia\Storage\Device;
 use Utopia\Storage\Device\Local;
-use Utopia\Storage\Storage;
+use Utopia\Storage\DeviceType;
 use Utopia\System\System;
 use Utopia\Telemetry\Adapter as Telemetry;
 
@@ -296,7 +296,7 @@ class Messaging extends Action
 
         // Delete any attachments that were downloaded to local storage
         if ($providerType === MESSAGE_TYPE_EMAIL) {
-            if ($deviceForFiles->getType() === Storage::DEVICE_LOCAL) {
+            if ($deviceForFiles->getType() === DeviceType::Local) {
                 return;
             }
 
@@ -1007,7 +1007,7 @@ class Messaging extends Action
                     $contentType = $file->getAttribute('mimeType');
                 }
 
-                if ($deviceForFiles->getType() !== Storage::DEVICE_LOCAL) {
+                if ($deviceForFiles->getType() !== DeviceType::Local) {
                     $deviceForFiles->transfer($path, $path, $this->getLocalDevice($project));
                 }
 

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -573,7 +573,7 @@ class OpenAPI3 extends Format
                         $node['schema']['default'] = (empty($param['default'])) ? new \stdClass() : $param['default'];
                         $node['schema']['x-example'] = ($param['example'] ?? '') ?: '{}';
                         break;
-                    case \Utopia\Storage\Validator\File::class:
+                    case \Appwrite\Utopia\Request\Validator\File::class:
                         $consumes = ['multipart/form-data'];
                         $node['schema']['type'] = $validator->getType();
                         $node['schema']['format'] = 'binary';

--- a/src/Appwrite/Storage/Bytes.php
+++ b/src/Appwrite/Storage/Bytes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Appwrite\Storage;
+
+class Bytes
+{
+    private const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+    public static function human(int|float $bytes, int $decimals = 2): string
+    {
+        $factor = (int) \floor((\strlen((string) (int) $bytes) - 1) / 3);
+
+        return \sprintf("%.{$decimals}f%s", $bytes / 1000 ** $factor, self::UNITS[$factor]);
+    }
+}

--- a/src/Appwrite/Utopia/Request/Validator/File.php
+++ b/src/Appwrite/Utopia/Request/Validator/File.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Appwrite\Utopia\Request\Validator;
+
+use Utopia\Validator;
+
+/**
+ * Placeholder for binary file parameters, used only to surface the
+ * parameter in generated SDKs and specs. Validation happens elsewhere.
+ */
+class File extends Validator
+{
+    public function getDescription(): string
+    {
+        return 'File is not valid';
+    }
+
+    public function isValid($name): bool
+    {
+        return true;
+    }
+
+    public function isArray(): bool
+    {
+        return false;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE_STRING;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Updates `utopia-php/storage` 2.0.7 → 3.0.0 and migrates all call sites across the breaking 3.0 API. Also bumps `utopia-php/migration` 1.18.0 → 1.20.1, the release that adds storage 3.0 support (it was the only other package pinning storage 2.*).

### Migration notes

- **`Storage` registry removed** → `DeviceType` enum everywhere. The `getDevice()` factory in `app/init/resources.php` collapses its two duplicated credential switches into one construction path (110 → 63 lines).
- **`uploadChunk()` now takes raw chunk data** instead of a tmp-file path — the Storage files, Functions deployments, and Sites deployments upload endpoints read the tmp file via `$deviceForLocal->read()`.
- **String ACLs → `Acl` enum**; all call sites used the default `private`, so the argument is omitted.
- **`setHttpVersion(HTTP_VERSION_1_1)` removed** — safe to drop: the new PSR-18 curl adapter pins HTTP/1.1 unconditionally, so DO Spaces keeps its required version.
- **`Storage::human()` removed** → new `Appwrite\Storage\Bytes::human()` (metric-only, matching every existing caller).
- **`Validator\File` removed** → recreated as `Appwrite\Utopia\Request\Validator\File` so the OpenAPI `format: binary` output and GraphQL type mapping stay intact for SDK generation.
- **Partition/directory-size methods are now `Local`-only** — the health stats endpoint unwraps the `Telemetry` decorator via the new `getDevice()` accessor.

### Behavior notes

- `/v1/health/stats` now reports the container's local disk partition even when files live on S3 (previously zeros through the S3 device).
- A storage DSN scheme of `awss3` now resolves to the AWS device instead of silently falling back to Local.

## Test plan

- `composer analyze` (PHPStan level 4) clean, `composer format` applied
- Unit tests: 932 passing
- E2E: `tests/e2e/Services/Storage` 77/77 (incl. chunked, out-of-order, and parallel chunk uploads — the paths affected by the `uploadChunk` change), `tests/e2e/Services/Health` 21/21

🤖 Generated with [Claude Code](https://claude.com/claude-code)