### PR TITLE
Fix duplicate webhook paused alerts

### DIFF
--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -162,10 +162,6 @@ class Webhooks extends Action
         $error = null;
 
         if (!empty($curlError) || $statusCode >= 400) {
-            $dbForPlatform->increaseDocumentAttribute('webhooks', $webhook->getId(), 'attempts', 1);
-            $webhook = $dbForPlatform->getDocument('webhooks', $webhook->getId());
-            $attempts = $webhook->getAttribute('attempts');
-
             $logs = '';
             $logs .= 'URL: ' . $webhook->getAttribute('url') . "\n";
             $logs .= 'Method: ' . 'POST' . "\n";
@@ -178,17 +174,33 @@ class Webhooks extends Action
                 $logs .= 'Body: ' . "\n" . \mb_strcut($responseBody, 0, 10000) . "\n"; // Limit to 10kb
             }
 
-            $webhook->setAttribute('logs', $logs);
+            $shouldAlert = false;
+            $dbForPlatform->withTransaction(function () use ($dbForPlatform, &$webhook, $logs, &$shouldAlert): void {
+                $shouldAlert = false;
+                $webhook = $dbForPlatform->getDocument('webhooks', $webhook->getId(), forUpdate: true);
+                $dbForPlatform->increaseDocumentAttribute('webhooks', $webhook->getId(), 'attempts', 1);
+                $webhook = $dbForPlatform->getDocument('webhooks', $webhook->getId());
+                $attempts = $webhook->getAttribute('attempts');
 
-            $updatePayload = ['logs' => $logs];
+                $webhook->setAttribute('logs', $logs);
+                $updatePayload = ['logs' => $logs];
 
-            if ($attempts >= \intval(System::getEnv('_APP_WEBHOOK_MAX_FAILED_ATTEMPTS', '10'))) {
-                $webhook->setAttribute('enabled', false);
-                $updatePayload['enabled'] = false;
-                $this->sendAlert($attempts, $statusCode, $webhook, $project, $dbForPlatform, $publisherForNotifications, $plan);
+                if (
+                    $webhook->getAttribute('enabled', true)
+                    && $attempts >= \intval(System::getEnv('_APP_WEBHOOK_MAX_FAILED_ATTEMPTS', '10'))
+                ) {
+                    $webhook->setAttribute('enabled', false);
+                    $updatePayload['enabled'] = false;
+                    $shouldAlert = true;
+                }
+
+                $dbForPlatform->updateDocument('webhooks', $webhook->getId(), new Document($updatePayload));
+            });
+
+            if ($shouldAlert) {
+                $this->sendAlert($webhook->getAttribute('attempts'), $statusCode, $webhook, $project, $dbForPlatform, $publisherForNotifications, $plan);
             }
 
-            $dbForPlatform->updateDocument('webhooks', $webhook->getId(), new Document($updatePayload));
             $dbForPlatform->purgeCachedDocument('projects', $project->getId());
 
             $error = $logs;

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -174,10 +174,17 @@ class Webhooks extends Action
                 $logs .= 'Body: ' . "\n" . \mb_strcut($responseBody, 0, 10000) . "\n"; // Limit to 10kb
             }
 
-            $shouldAlert = false;
-            $dbForPlatform->withTransaction(function () use ($dbForPlatform, &$webhook, $logs, &$shouldAlert): void {
-                $shouldAlert = false;
+            $dbForPlatform->withTransaction(function () use (
+                $dbForPlatform,
+                &$webhook,
+                $logs,
+                $statusCode,
+                $project,
+                $publisherForNotifications,
+                $plan
+            ): void {
                 $webhook = $dbForPlatform->getDocument('webhooks', $webhook->getId(), forUpdate: true);
+                $pauseCycle = $webhook->getUpdatedAt();
                 $dbForPlatform->increaseDocumentAttribute('webhooks', $webhook->getId(), 'attempts', 1);
                 $webhook = $dbForPlatform->getDocument('webhooks', $webhook->getId());
                 $attempts = $webhook->getAttribute('attempts');
@@ -189,17 +196,27 @@ class Webhooks extends Action
                     $webhook->getAttribute('enabled', true)
                     && $attempts >= \intval(System::getEnv('_APP_WEBHOOK_MAX_FAILED_ATTEMPTS', '10'))
                 ) {
+                    $queued = $this->sendAlert(
+                        $attempts,
+                        $statusCode,
+                        $webhook,
+                        $project,
+                        $dbForPlatform,
+                        $publisherForNotifications,
+                        $plan,
+                        $pauseCycle
+                    );
+
+                    if (!$queued) {
+                        throw new \RuntimeException('Failed to enqueue webhook paused notification.');
+                    }
+
                     $webhook->setAttribute('enabled', false);
                     $updatePayload['enabled'] = false;
-                    $shouldAlert = true;
                 }
 
                 $dbForPlatform->updateDocument('webhooks', $webhook->getId(), new Document($updatePayload));
             });
-
-            if ($shouldAlert) {
-                $this->sendAlert($webhook->getAttribute('attempts'), $statusCode, $webhook, $project, $dbForPlatform, $publisherForNotifications, $plan);
-            }
 
             $dbForPlatform->purgeCachedDocument('projects', $project->getId());
 
@@ -239,9 +256,10 @@ class Webhooks extends Action
      * @param Database $dbForPlatform
      * @param NotificationPublisher $publisherForNotifications
      * @param array $plan
-     * @return void
+     * @param string|null $pauseCycle
+     * @return bool
      */
-    public function sendAlert(int $attempts, mixed $statusCode, Document $webhook, Document $project, Database $dbForPlatform, NotificationPublisher $publisherForNotifications, array $plan): void
+    public function sendAlert(int $attempts, mixed $statusCode, Document $webhook, Document $project, Database $dbForPlatform, NotificationPublisher $publisherForNotifications, array $plan, ?string $pauseCycle = null): bool
     {
         $memberships = $dbForPlatform->find('memberships', [
             Query::equal('teamInternalId', [$project->getAttribute('teamInternalId')]),
@@ -254,7 +272,7 @@ class Webhooks extends Action
         );
 
         if (empty($ownerMemberships)) {
-            return;
+            return true;
         }
 
         $userIds = \array_values(\array_unique(\array_filter(\array_map(
@@ -263,7 +281,7 @@ class Webhooks extends Action
         ))));
 
         if (empty($userIds)) {
-            return;
+            return true;
         }
 
         $users = $dbForPlatform->find('users', [
@@ -272,7 +290,7 @@ class Webhooks extends Action
         ]);
 
         if (empty($users)) {
-            return;
+            return true;
         }
 
         $projectId = $project->getId();
@@ -327,10 +345,10 @@ class Webhooks extends Action
                 : "/projects/{$projectId}/settings/webhooks");
             $template->setParam('{{attempts}}', $attempts);
 
-            $publisherForNotifications->enqueue(new NotificationMessage(
+            $queued = $publisherForNotifications->enqueue(new NotificationMessage(
                 project: $project,
                 recipients: $recipients,
-                deduplicationKey: 'webhook:' . $webhook->getId() . ':paused:' . $webhook->getUpdatedAt(),
+                deduplicationKey: 'webhook:' . $webhook->getId() . ':paused:' . ($pauseCycle ?? $webhook->getUpdatedAt()),
                 subject: $subject,
                 bodyTemplate: __DIR__ . '/../../../../app/config/locale/templates/email-base-styled.tpl',
                 body: $template->render(),
@@ -346,7 +364,13 @@ class Webhooks extends Action
                     'platform' => $plan['platformName'] ?? APP_NAME,
                 ],
             ));
+
+            if ($queued === false) {
+                return false;
+            }
         }
+
+        return true;
     }
 
     private static function hasOwnerRole(Document $membership): bool

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Platform\Workers;
 
 use Appwrite\Event\Publisher\Notification as NotificationPublisher;
+use Appwrite\Event\Publisher\Usage as UsagePublisher;
 use Appwrite\Platform\Workers\Webhooks;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -17,12 +18,87 @@ use Utopia\Database\Document;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\Authorization;
+use Utopia\Logger\Log;
+use Utopia\Queue\Message;
 use Utopia\Queue\Queue;
 
 require_once __DIR__ . '/../../../../app/init.php';
 
 final class WebhooksTest extends TestCase
 {
+    public function testFailureThresholdSendsOneAlertForStaleConcurrentMessages(): void
+    {
+        $database = $this->createPlatformDatabase();
+        $this->seedOwnerUser($database);
+        $database->createCollection('webhooks', [], [], [
+            Permission::create(Role::any()),
+            Permission::read(Role::any()),
+            Permission::update(Role::any()),
+            Permission::delete(Role::any()),
+        ], false);
+        $database->createAttribute('webhooks', 'attempts', Database::VAR_INTEGER, 0, true);
+        $database->createAttribute('webhooks', 'enabled', Database::VAR_BOOLEAN, 0, true);
+        $database->createAttribute('webhooks', 'logs', Database::VAR_STRING, 20000, false);
+
+        $webhook = new Document([
+            '$id' => 'webhook-1',
+            '$sequence' => 201,
+            'attempts' => 9,
+            'enabled' => true,
+            'events' => ['documents.create'],
+            'name' => 'Payments',
+            'url' => 'http://127.0.0.1:1',
+            'signatureKey' => 'secret',
+            'httpUser' => '',
+            'httpPass' => '',
+            'security' => false,
+        ]);
+        $database->createDocument('webhooks', $webhook);
+
+        $project = new Document([
+            '$id' => 'project-1',
+            '$sequence' => 1,
+            'name' => 'Production',
+            'teamInternalId' => 'team-internal-1',
+            'region' => 'fra',
+            'webhooks' => [$webhook],
+        ]);
+        $message = new Message([
+            'pid' => 'pid',
+            'queue' => 'v1-webhooks',
+            'timestamp' => \time(),
+            'payload' => [
+                'events' => ['documents.create'],
+                'payload' => [],
+                'user' => [],
+            ],
+        ]);
+        $publisher = new MockPublisher();
+        $publisherForNotifications = new NotificationPublisher($publisher, new Queue('v1-notifications'));
+        $publisherForUsage = new UsagePublisher($publisher, new Queue('v1-usage'));
+        $worker = new Webhooks();
+
+        for ($i = 0; $i < 2; $i++) {
+            try {
+                $worker->action(
+                    $message,
+                    $project,
+                    $database,
+                    $publisherForNotifications,
+                    $publisherForUsage,
+                    new Log(),
+                    []
+                );
+            } catch (\Exception) {
+                // Delivery failure is expected; both messages started with the same stale enabled webhook.
+            }
+        }
+
+        $this->assertCount(1, $publisher->getEvents('v1-notifications'));
+        $this->assertFalse($database->getDocument('webhooks', 'webhook-1')->getAttribute('enabled'));
+        $this->assertSame(11, $database->getDocument('webhooks', 'webhook-1')->getAttribute('attempts'));
+    }
+
     public function testSendAlertPublishesNotificationMessage(): void
     {
         $database = $this->createPlatformDatabase();

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -26,9 +26,10 @@ require_once __DIR__ . '/../../../../app/init.php';
 
 final class WebhooksTest extends TestCase
 {
-    public function testFailureThresholdSendsOneAlertForStaleConcurrentMessages(): void
+    public function testFailureThresholdUsesLockAndSendsOneAlertForStaleMessages(): void
     {
-        $database = $this->createPlatformDatabase();
+        $adapter = new LockTrackingMemory();
+        $database = $this->createPlatformDatabase($adapter);
         $this->seedOwnerUser($database);
         $database->createCollection('webhooks', [], [], [
             Permission::create(Role::any()),
@@ -96,8 +97,106 @@ final class WebhooksTest extends TestCase
         }
 
         $this->assertCount(1, $publisher->getEvents('v1-notifications'));
+        $this->assertSame(2, $adapter->getWebhookLockingReads());
         $this->assertFalse($database->getDocument('webhooks', 'webhook-1')->getAttribute('enabled'));
         $this->assertSame(11, $database->getDocument('webhooks', 'webhook-1')->getAttribute('attempts'));
+    }
+
+    public function testFailedAlertEnqueueRollsBackPauseForRetry(): void
+    {
+        $database = $this->createPlatformDatabase();
+        $this->seedOwnerUser($database);
+        $database->createCollection('webhooks', [], [], [
+            Permission::create(Role::any()),
+            Permission::read(Role::any()),
+            Permission::update(Role::any()),
+            Permission::delete(Role::any()),
+        ], false);
+        $database->createAttribute('webhooks', 'attempts', Database::VAR_INTEGER, 0, true);
+        $database->createAttribute('webhooks', 'enabled', Database::VAR_BOOLEAN, 0, true);
+        $database->createAttribute('webhooks', 'events', Database::VAR_STRING, Database::LENGTH_KEY, true, null, true, true);
+        $database->createAttribute('webhooks', 'logs', Database::VAR_STRING, 20000, false);
+
+        $webhook = new Document([
+            '$id' => 'webhook-1',
+            '$sequence' => 201,
+            'attempts' => 9,
+            'enabled' => true,
+            'events' => ['documents.create'],
+            'name' => 'Payments',
+            'url' => 'http://127.0.0.1:1',
+            'signatureKey' => 'secret',
+            'httpUser' => '',
+            'httpPass' => '',
+            'security' => false,
+        ]);
+        $database->createDocument('webhooks', $webhook);
+
+        $project = new Document([
+            '$id' => 'project-1',
+            '$sequence' => 1,
+            'name' => 'Production',
+            'teamInternalId' => 'team-internal-1',
+            'region' => 'fra',
+            'webhooks' => [$webhook],
+        ]);
+        $message = new Message([
+            'pid' => 'pid',
+            'queue' => 'v1-webhooks',
+            'timestamp' => \time(),
+            'payload' => [
+                'events' => ['documents.create'],
+                'payload' => [],
+                'user' => [],
+            ],
+        ]);
+        $publisher = new class () extends MockPublisher {
+            private int $attempts = 0;
+            private array $deduplicationKeys = [];
+
+            public function enqueue(Queue $queue, array $payload, bool $priority = false): bool
+            {
+                if ($queue->name === 'v1-notifications') {
+                    $this->attempts++;
+                    $this->deduplicationKeys[] = $payload['deduplicationKey'];
+                    return false;
+                }
+
+                return parent::enqueue($queue, $payload, $priority);
+            }
+
+            public function getAttempts(): int
+            {
+                return $this->attempts;
+            }
+
+            public function getDeduplicationKeys(): array
+            {
+                return $this->deduplicationKeys;
+            }
+        };
+        $worker = new Webhooks();
+
+        try {
+            $worker->action(
+                $message,
+                $project,
+                $database,
+                new NotificationPublisher($publisher, new Queue('v1-notifications')),
+                new UsagePublisher($publisher, new Queue('v1-usage')),
+                new Log(),
+                []
+            );
+            $this->fail('Expected notification enqueue failure.');
+        } catch (\RuntimeException $error) {
+            $this->assertSame('Failed to enqueue webhook paused notification.', $error->getMessage());
+        }
+
+        $stored = $database->getDocument('webhooks', 'webhook-1');
+        $this->assertTrue($stored->getAttribute('enabled'));
+        $this->assertSame(9, $stored->getAttribute('attempts'));
+        $this->assertSame(3, $publisher->getAttempts());
+        $this->assertCount(1, \array_unique($publisher->getDeduplicationKeys()));
     }
 
     public function testSendAlertPublishesNotificationMessage(): void
@@ -349,12 +448,12 @@ final class WebhooksTest extends TestCase
         }
     }
 
-    private function createPlatformDatabase(): Database
+    private function createPlatformDatabase(?Memory $adapter = null): Database
     {
         $authorization = new Authorization();
         $authorization->addRole(Role::any()->toString());
 
-        $database = new Database(new Memory(), new Cache(new NoCache()));
+        $database = new Database($adapter ?? new Memory(), new Cache(new NoCache()));
         $database
             ->setAuthorization($authorization)
             ->setDatabase('webhookTests')
@@ -405,5 +504,24 @@ final class WebhooksTest extends TestCase
             'email' => 'developer@example.test',
             'name' => 'Developer User',
         ]));
+    }
+}
+
+final class LockTrackingMemory extends Memory
+{
+    private int $webhookLockingReads = 0;
+
+    public function getDocument(Document $collection, string $id, array $queries = [], bool $forUpdate = false): Document
+    {
+        if ($collection->getId() === 'webhooks' && $forUpdate) {
+            $this->webhookLockingReads++;
+        }
+
+        return parent::getDocument($collection, $id, $queries, $forUpdate);
+    }
+
+    public function getWebhookLockingReads(): int
+    {
+        return $this->webhookLockingReads;
     }
 }

--- a/tests/unit/Platform/Workers/WebhooksTest.php
+++ b/tests/unit/Platform/Workers/WebhooksTest.php
@@ -38,6 +38,7 @@ final class WebhooksTest extends TestCase
         ], false);
         $database->createAttribute('webhooks', 'attempts', Database::VAR_INTEGER, 0, true);
         $database->createAttribute('webhooks', 'enabled', Database::VAR_BOOLEAN, 0, true);
+        $database->createAttribute('webhooks', 'events', Database::VAR_STRING, Database::LENGTH_KEY, true, null, true, true);
         $database->createAttribute('webhooks', 'logs', Database::VAR_STRING, 20000, false);
 
         $webhook = new Document([


### PR DESCRIPTION
## Summary

Prevents concurrent failed webhook deliveries from sending duplicate paused notifications without losing the alert when notification enqueueing fails.

## Root cause

Each worker incremented attempts and checked a stale webhook document independently, so multiple workers could cross the threshold and send the same alert. The pause state was then committed before notification enqueueing, and the enqueue result was ignored, which could permanently suppress a failed alert.

## Changes

- Lock the webhook row while incrementing attempts and deciding the enabled-to-disabled transition.
- Enqueue the paused notification before committing `enabled: false`; a rejected enqueue rolls the transaction back for retry.
- Reuse a stable pause-cycle deduplication key across transaction retries.
- Verify every failure transition requests a row lock, stale messages produce one alert, and enqueue failure preserves the enabled state and attempt count.

## Verification

- `git diff --check` passes.
- Targeted PHPUnit execution is locally blocked: PHP is unavailable, and Docker Desktop became unresponsive while building the repository's official test image, including after one restart.

Fixes #12944
