### PR TITLE
fix: resolve synchronous execution timeout on manual site uploads

### DIFF
--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -60,7 +60,7 @@ class Create extends Action
                 group: 'deployments',
                 name: 'createDeployment',
                 description: <<<EOT
-                Create a new site code deployment. Use this endpoint to upload a new version of your site code. To activate your newly uploaded code, you'll need to update the site's deployment to use your new deployment ID.
+                Create a new site code deployment. Use this endpoint to upload a new version of your site code. Deployments activate automatically by default, and you can disable that by setting activate to false.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
                 responses: [
@@ -78,7 +78,7 @@ class Create extends Action
             ->param('buildCommand', null, new Nullable(new Text(8192, 0)), 'Build Commands.', true)
             ->param('outputDirectory', null, new Nullable(new Text(8192, 0)), 'Output Directory.', true)
             ->param('code', [], new File(), 'Gzip file with your code package. When used with the Appwrite CLI, pass the path to your code directory, and the CLI will automatically package your code. Use a path that is within the current directory.', skipValidation: true)
-            ->param('activate', false, new Boolean(true), 'Automatically activate the deployment when it is finished building.', true)
+            ->param('activate', true, new Boolean(true), 'Automatically activate the deployment when it is finished building.', true)
             ->inject('request')
             ->inject('response')
             ->inject('dbForProject')

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -1314,8 +1314,29 @@ final class SitesCustomServerTest extends Scope
         $this->assertEquals($deploymentIdActive, $site['body']['deploymentId']);
         $this->assertNotEquals($deploymentIdInactive, $site['body']['deploymentId']);
 
+        $deployment = $this->createDeployment($siteId, [
+            'code' => $this->packageSite('static-single-file'),
+        ]);
+
+        $this->assertEquals(202, $deployment['headers']['status-code']);
+        $deploymentIdDefaultActive = $deployment['body']['$id'] ?? '';
+        $this->assertNotEmpty($deploymentIdDefaultActive);
+
+        $this->assertEventually(function () use ($siteId, $deploymentIdDefaultActive) {
+            $deployment = $this->getDeployment($siteId, $deploymentIdDefaultActive);
+
+            $this->assertEquals('ready', $deployment['body']['status']);
+        }, 120000, 500);
+
+        $this->assertEventually(function () use ($siteId, $deploymentIdDefaultActive) {
+            $site = $this->getSite($siteId);
+
+            $this->assertEquals($deploymentIdDefaultActive, $site['body']['deploymentId'], 'Deployment is not activated by default, deployment: ' . json_encode($site['body'], JSON_PRETTY_PRINT));
+        }, 120000, 500);
+
         $this->cleanupDeployment($siteId, $deploymentIdActive);
         $this->cleanupDeployment($siteId, $deploymentIdInactive);
+        $this->cleanupDeployment($siteId, $deploymentIdDefaultActive);
         $this->cleanupSite($siteId);
     }
 


### PR DESCRIPTION
Replacement for #12845 by @Youcef3939.

Rebased on latest 1.9.x. Squashed commits. No functional changes.