### PR TITLE
fix: prevent empty JWT session lookup

### DIFF
--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -453,9 +453,11 @@ return function (Container $context): void {
                     $user = $dbForProject->getDocument('users', $jwtUserId);
                 }
             }
+
             $jwtSessionId = $payload['sessionId'] ?? '';
-            if (! empty($jwtSessionId)) {
-                if (empty($user->find('$id', $jwtSessionId, 'sessions'))) { // Match JWT to active token
+
+            if (! empty($jwtSessionId) && ! $user->isEmpty()) {
+                if (empty($user->find('$id', $jwtSessionId, 'sessions'))) {
                     $user = new User([]);
                 }
             }


### PR DESCRIPTION
Replacement for #12844 by @Akanshagore.

Rebased on latest 1.9.x. No functional changes.