### PR TITLE
fix: add .gitattributes rule to force LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@ public/scripts/** linguist-detectable=false
 public/dist/scripts/** linguist-detectable=false
 
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+
+# Force LF so Docker images built from Windows (autocrlf) checkouts don't break
+bin/*  text eol=lf
+*.sh   text eol=lf


### PR DESCRIPTION
Replacement for #12841 by @dobbydobap.

Rebased on latest 1.9.x. No functional changes.