### PR TITLE
fix(users): reject empty password and block session creation for blocked users

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -251,6 +251,11 @@ return [
         'description' => 'Passwords do not match. Please check the password and confirm password.',
         'code' => 400,
     ],
+    Exception::USER_PASSWORD_EMPTY => [
+        'name' => Exception::USER_PASSWORD_EMPTY,
+        'description' => 'Password cannot be empty. Please provide a valid password.',
+        'code' => 400,
+    ],
     Exception::USER_PASSWORD_RECENTLY_USED => [
         'name' => Exception::USER_PASSWORD_RECENTLY_USED,
         'description' => 'The password you are trying to use is similar to your previous password. For your security, please choose a different password and try again.',

--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1461,16 +1461,7 @@ Http::patch('/v1/users/:userId/password')
         }
 
         if (\strlen($password) === 0) {
-            $user
-                ->setAttribute('password', '')
-                ->setAttribute('passwordUpdate', DateTime::now());
-
-            $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
-                'password' => $user->getAttribute('password'),
-                'passwordUpdate' => $user->getAttribute('passwordUpdate'),
-            ]));
-            $queueForEvents->setParam('userId', $user->getId());
-            $response->dynamic($user, Response::MODEL_USER);
+            throw new Exception(Exception::USER_PASSWORD_EMPTY);
         }
 
         $hooks->trigger('passwordValidator', [$dbForProject, $project, $password, &$user, true]);
@@ -2391,6 +2382,10 @@ Http::post('/v1/users/:userId/sessions')
         $user = $dbForProject->getDocument('users', $userId);
         if ($user->isEmpty()) {
             throw new Exception(Exception::USER_NOT_FOUND);
+        }
+
+        if (false === $user->getAttribute('status')) { // Account is blocked
+            throw new Exception(Exception::USER_BLOCKED);
         }
 
         $secret = $proofForToken->generate();

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -87,6 +87,7 @@ class Exception extends \Exception
     public const string USER_EMAIL_NOT_CORPORATE = 'user_email_not_corporate';
     public const string USER_EMAIL_NOT_CANONICAL = 'user_email_not_canonical';
     public const string USER_PASSWORD_MISMATCH = 'user_password_mismatch';
+    public const string USER_PASSWORD_EMPTY = 'user_password_empty';
     public const string USER_SESSION_NOT_FOUND = 'user_session_not_found';
     public const string USER_IDENTITY_NOT_FOUND = 'user_identity_not_found';
     public const string USER_UNAUTHORIZED = 'user_unauthorized';


### PR DESCRIPTION
Replacement for #12926 by @TechGenius-Karan.

Rebased on latest 1.9.x. No functional changes.