### PR TITLE
fix(sites): route domain traffic to the active deployment instead of pinning to the first

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
@@ -114,7 +114,6 @@ class Update extends Base
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceType', ['function']),
             Query::equal('deploymentResourceInternalId', [$function->getSequence()]),
-            Query::equal('deploymentVcsProviderBranch', ['']),
             Query::equal('projectInternalId', [$project->getSequence()])
         ];
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -982,7 +982,6 @@ class Builds extends Action
                             Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
                             Query::equal('deploymentResourceType', ['function']),
                             Query::equal('trigger', ['manual']),
-                            Query::equal('deploymentVcsProviderBranch', ['']),
                         ];
 
                         $rulesUpdated = false;
@@ -1007,7 +1006,6 @@ class Builds extends Action
                             Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
                             Query::equal('deploymentResourceType', ['site']),
                             Query::equal('trigger', ['manual']),
-                            Query::equal('deploymentVcsProviderBranch', ['']),
                         ];
 
                         $dbForPlatform->forEach('rules', function (Document $rule) use ($dbForPlatform, $deployment) {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -102,7 +102,6 @@ class Update extends Base
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceType', ['site']),
             Query::equal('deploymentResourceInternalId', [$site->getSequence()]),
-            Query::equal('deploymentVcsProviderBranch', ['']),
             Query::equal('projectInternalId', [$project->getSequence()])
         ];
 


### PR DESCRIPTION
Replacement for #12855 by @Srujanreddy1234.

Rebased on 1.9.x with no conflicts. Note: Jobs.php not present in current 1.9.x, skipped that hunk.