### PR TITLE
fix(deps): move utopia-php/auth to 0.10.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3212,16 +3212,16 @@
         },
         {
             "name": "utopia-php/auth",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/auth.git",
-                "reference": "fc6e7861a0428415a7454ba808a511cc01bf8db4"
+                "reference": "0f1a342bceebc2659736e52a4496daf24ca4954c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/auth/zipball/fc6e7861a0428415a7454ba808a511cc01bf8db4",
-                "reference": "fc6e7861a0428415a7454ba808a511cc01bf8db4",
+                "url": "https://api.github.com/repos/utopia-php/auth/zipball/0f1a342bceebc2659736e52a4496daf24ca4954c",
+                "reference": "0f1a342bceebc2659736e52a4496daf24ca4954c",
                 "shasum": ""
             },
             "require": {
@@ -3264,10 +3264,10 @@
                 "security"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/auth/tree/0.10.0",
+                "source": "https://github.com/utopia-php/auth/tree/0.10.1",
                 "issues": "https://github.com/utopia-php/auth/issues"
             },
-            "time": "2026-07-15T15:52:58+00:00"
+            "time": "2026-07-23T07:34:27+00:00"
         },
         {
             "name": "utopia-php/cache",


### PR DESCRIPTION
Lockfile-only, one package, six lines.

## What broke

GitHub serves a **truncated zip** for `utopia-php/auth` 0.10.0's commit (`fc6e786`) — a complete 75,406-byte body with no end-of-central-directory record. That is the dist URL Packagist hands Composer, so any `--prefer-dist` install of 0.10.0 dies as soon as it hits that archive:

```
In ZipDownloader.php line 255:
  '.../tmp-275211cab8164dce5f308210711774fe.zip' is not a valid zip archive, got error code: 35
```

Error 35 is libzip's truncated-archive code, not a curl/network error. `unzip` reports `cannot find zipfile directory`.

This already took down three consecutive Appwrite Cloud production deploy builds. This repo locks the same sha, so it is exposed the moment a build misses its Composer cache.

## Why it appeared without warning

The archive was fine earlier the same day — a build downloaded *and extracted* it at 03:28:52Z, and by 06:50:28Z it was failing, with no push to the repo since 2026-07-15. A cached archive was regenerated badly on GitHub's side inside that window.

Nothing warns you either: Packagist publishes no checksums for GitHub zipball dists (`"shasum": ""` on every package), so Composer has no integrity check and corruption only surfaces as a cryptic unzip failure.

## Why a version bump

Archives are keyed by commit sha and there is no self-service purge — query-string busting, `Cache-Control: no-cache`, `Pragma: no-cache`, `no-store`, pushing to the repo, and warming the healthy ref spellings all leave the corrupt object in place. `^0.10` had no other release to fall back to, so [utopia-php/monorepo#86](https://github.com/utopia-php/monorepo/pull/86) released 0.10.1: same library, new commit, freshly generated archive.

## Verification

- New dist `zipball/0f1a342b` returns 87,301 bytes and extracts cleanly on repeat fetches, with a valid EOCD.
- `docker build --target composer --no-cache` completes against this lock.
- `utopia-php/auth 0.10.1` confirmed in the built image via `vendor/composer/installed.json`.
- Re-locked with Composer 2.9.8 to match the lock's existing `plugin-api-version`, so the diff is only the package entry — no unrelated churn.

Cloud's matching re-lock is [appwrite-labs/cloud#4944](https://github.com/appwrite-labs/cloud/pull/4944).

🤖 Generated with [Claude Code](https://claude.com/claude-code)