### PR TITLE
chore(storage): update utopia-php/storage to 3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "utopia-php/queue": "^0.22",
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
-        "utopia-php/storage": "3.*",
+        "utopia-php/storage": "^3.1",
         "utopia-php/system": "0.10.*",
         "utopia-php/telemetry": "^0.4",
         "utopia-php/user-agent": "0.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a2821539fc6e6063587e38e3eca19c4",
+    "content-hash": "45a96f275db3fcab689375890cd5b41d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4931,16 +4931,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "171746978543323c2536edacd8ad8e8d3fde401c"
+                "reference": "38bfc0c14a16a7de2a86b3331865dad1230ed739"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/171746978543323c2536edacd8ad8e8d3fde401c",
-                "reference": "171746978543323c2536edacd8ad8e8d3fde401c",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/38bfc0c14a16a7de2a86b3331865dad1230ed739",
+                "reference": "38bfc0c14a16a7de2a86b3331865dad1230ed739",
                 "shasum": ""
             },
             "require": {
@@ -4975,9 +4975,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/3.0.0"
+                "source": "https://github.com/utopia-php/storage/tree/3.1.0"
             },
-            "time": "2026-07-20T13:15:54+00:00"
+            "time": "2026-07-22T15:57:57+00:00"
         },
         {
             "name": "utopia-php/system",


### PR DESCRIPTION
## What does this PR do?

- Updates `utopia-php/storage` from 3.0.0 to 3.1.0.
- Tightens the Composer constraint from `3.*` to `^3.1`.
- Pulls in the 3.1 storage reliability fixes for S3 transfers and local storage handling.

## Test Plan

- `composer validate --strict --no-check-publish`
- `composer install --dry-run --no-interaction --ignore-platform-req=ext-scrypt --ignore-platform-req=ext-mongodb`
- `git diff --check`

The two platform requirements were ignored only for the local dry-run because the host is missing `ext-scrypt` and has MongoDB extension 2.3 instead of the locked 2.1 line. Composer resolved storage 3.1.0 successfully and reported no security advisories.

## Related PRs and Issues

- None

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] API metadata is unchanged, so specs and example docs do not require updates.