### PR TITLE
fix: make SDK and specs release git flow conflict-free and non-interactive safe

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -112,17 +112,14 @@ class SDKs extends Action
             throw new \Exception('Cannot use --release=yes with --mode=examples');
         }
 
+        $prUrls = [];
+        $failedPushes = [];
+
         if (! $createRelease && ! $examplesOnly) {
             $git ??= Console::confirm('Should we use git push? (yes/no)');
             $git = ($git === 'yes');
-
-            $prUrls = [];
-            $failedPushes = [];
-
         } elseif ($examplesOnly) {
             $git = false;
-            $prUrls = [];
-            $failedPushes = [];
         }
 
         if (! $createRelease) {

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -628,30 +628,20 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             $repo->execute('config', 'advice.defaultBranchName', 'false');
             $repo->addRemote('origin', $gitUrl);
 
-            // Fetch and checkout the target branch (e.g. dev) if it exists on remote,
-            // otherwise create it from the base branch (e.g. main).
-            // We build on top of the existing remote branch so a regular push
-            // works without force-pushing against protected branches.
-            $hasBranch = false;
+            // Rebuild the release branch (e.g. dev) from the base branch
+            // (e.g. main) on every run. Release PRs are squash/merge-committed
+            // into the base branch, which orphans the release branch's own
+            // history — committing on top of the stale branch makes every
+            // subsequent PR conflict with the base branch. The branch holds
+            // only generated output, so rewriting it loses nothing.
             try {
-                $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $gitBranch);
-                $hasBranch = true;
+                $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $repoBranch);
+                $repo->execute('checkout', '-f', 'FETCH_HEAD');
             } catch (\Throwable) {
-                // Branch doesn't exist on remote yet
+                // Empty repository — start the base branch from scratch
+                $repo->execute('checkout', '-b', $repoBranch);
             }
-
-            if ($hasBranch) {
-                $repo->execute('checkout', '-f', $gitBranch);
-            } else {
-                // Fetch base branch to create the target branch from it
-                try {
-                    $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $repoBranch);
-                    $repo->execute('checkout', '-f', $repoBranch);
-                } catch (\Throwable) {
-                    $repo->execute('checkout', '-b', $repoBranch);
-                }
-                $repo->execute('checkout', '-b', $gitBranch);
-            }
+            $repo->execute('checkout', '-B', $gitBranch);
 
             // Backup .github before cleaning working tree
             $githubDir = $target . '/.github';
@@ -685,12 +675,15 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             try {
                 $repo->commit($commitMessage);
             } catch (\Throwable $e) {
-                // Exit code 1 (256 in PHP) = nothing to commit
+                // Exit code 1 (256 in PHP) = nothing to commit.
+                // Still push below so a stale remote release branch is
+                // synced back to the base branch.
                 Console::log('  No changes to commit, SDK is up to date');
-                return true;
             }
 
-            $repo->execute('push', '-u', 'origin', $gitBranch, '--quiet');
+            // Force push: the branch is regenerated from the base branch each
+            // run, so its remote history is intentionally rewritten.
+            $repo->execute('push', '-u', 'origin', $gitBranch, '--force', '--quiet');
         } catch (\Throwable $e) {
             Console::warning("  Git push failed: " . $e->getMessage());
             return false;
@@ -1163,13 +1156,25 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         }
 
         $apiPath = "/repos/{$repoName}/pulls/{$prNumber}";
+
+        // Preserve a manually curated PR description: only overwrite the body
+        // when the existing one is empty or still the generated default.
+        $existingBody = '';
+        $bodyOutput = [];
+        \exec('gh api ' . \escapeshellarg($apiPath) . ' --jq .body 2>/dev/null', $bodyOutput);
+        if (! empty($bodyOutput)) {
+            $existingBody = trim(implode("\n", $bodyOutput));
+        }
+        $isDefaultBody = $existingBody === ''
+            || \str_starts_with($existingBody, 'This PR contains updates to the');
+
         $updateCommand = 'gh api'
             . ' --method PATCH'
             . ' -H "Accept: application/vnd.github+json"'
             . ' -H "X-GitHub-Api-Version: 2022-11-28"'
             . ' ' . \escapeshellarg($apiPath)
             . ' -f title=' . \escapeshellarg($prTitle)
-            . ' -f body=' . \escapeshellarg($prBody)
+            . ($isDefaultBody ? ' -f body=' . \escapeshellarg($prBody) : '')
             . ' 2>&1';
 
         $updateOutput = [];

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -117,10 +117,12 @@ class SDKs extends Action
             $git = ($git === 'yes');
 
             $prUrls = [];
+            $failedPushes = [];
 
         } elseif ($examplesOnly) {
             $git = false;
             $prUrls = [];
+            $failedPushes = [];
         }
 
         if (! $createRelease) {
@@ -572,8 +574,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
                 $repoBranch = $language['repoBranch'] ?? 'main';
                 if ($git && !empty($gitUrl)) {
-                    $prUrls = [];
-
                     // Generate commit message: use provided message, AI changelog, or fallback
                     if (! empty($message)) {
                         $commitMessage = $message;
@@ -587,6 +587,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
                     if ($pushSuccess) {
                         $this->createPullRequest($language, $platform['name'], $target, $gitBranch, $repoBranch, $aiChangelog, $prUrls);
+                    } else {
+                        $failedPushes[] = "{$platform['name']}/{$language['name']}";
                     }
 
                     \exec('chmod -R u+w ' . $target . ' && rm -rf ' . $target);
@@ -608,6 +610,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                 }
             }
             Console::log('');
+        }
+
+        // Fail the task when any SDK could not be published so release
+        // automation does not report success for an incomplete release.
+        if (! empty($failedPushes)) {
+            Console::error('Failed to publish: ' . \implode(', ', $failedPushes));
+            Console::exit(1);
         }
     }
 

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -637,8 +637,15 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             try {
                 $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $repoBranch);
                 $repo->execute('checkout', '-f', 'FETCH_HEAD');
-            } catch (\Throwable) {
-                // Empty repository — start the base branch from scratch
+            } catch (\Throwable $e) {
+                // Only start from scratch when the remote is genuinely empty.
+                // Any other failure (network, auth, missing branch) must abort:
+                // force-pushing a branch built without the real base would
+                // truncate files inherited from it.
+                $remoteRefs = $repo->execute('ls-remote', '--heads', 'origin');
+                if (! empty(\trim(\implode("\n", (array) $remoteRefs)))) {
+                    throw $e;
+                }
                 $repo->execute('checkout', '-b', $repoBranch);
             }
             $repo->execute('checkout', '-B', $gitBranch);
@@ -1161,10 +1168,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         $apiPath = "/repos/{$repoName}/pulls/{$prNumber}";
 
         // Preserve a manually curated PR description: only overwrite the body
-        // when the existing one is empty or still entirely generated — the
-        // default one-liner, optionally followed by the generated
-        // "## Changes" changelog section. A prefix match is not enough:
-        // maintainers may append notes below the generated sentence.
+        // when the existing one is empty or is exactly the generated default
+        // one-liner. Anything beyond that single sentence — an AI changelog,
+        // appended notes, links, or extra sections — cannot be reliably told
+        // apart from curated content, so it is always preserved.
         $existingBody = '';
         $bodyOutput = [];
         \exec('gh api ' . \escapeshellarg($apiPath) . ' --jq .body 2>/dev/null', $bodyOutput);
@@ -1173,7 +1180,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         }
         $isDefaultBody = $existingBody === ''
             || (bool) \preg_match(
-                '/^This PR contains updates to the .+ SDK for version \S+\.(\s*## Changes\s[\s\S]*)?$/',
+                '/^This PR contains updates to the .+ SDK for version \S+\.$/',
                 $existingBody
             );
 

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -640,6 +640,17 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             // history — committing on top of the stale branch makes every
             // subsequent PR conflict with the base branch. The branch holds
             // only generated output, so rewriting it loses nothing.
+            // Record the remote release-branch tip before doing any work, so
+            // the final push can be fenced with --force-with-lease: if a
+            // concurrent release run moves the branch in the meantime, the
+            // push is rejected instead of silently discarding its output.
+            $expectedTip = '';
+            $lsRemote = $repo->execute('ls-remote', 'origin', 'refs/heads/' . $gitBranch);
+            $lsRemoteLine = \trim(\implode("\n", (array) $lsRemote));
+            if ($lsRemoteLine !== '') {
+                $expectedTip = \explode("\t", $lsRemoteLine)[0];
+            }
+
             try {
                 $repo->execute('fetch', 'origin', '--quiet', '--no-tags', '--depth', '1', $repoBranch);
                 $repo->execute('checkout', '-f', 'FETCH_HEAD');
@@ -697,9 +708,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                 $repo->commit($commitMessage);
             }
 
-            // Force push: the branch is regenerated from the base branch each
-            // run, so its remote history is intentionally rewritten.
-            $repo->execute('push', '-u', 'origin', $gitBranch, '--force', '--quiet');
+            // Forced push fenced by the tip recorded above: the branch is
+            // regenerated from the base branch each run, so rewriting it is
+            // intentional — but only if no concurrent run moved it since.
+            // An empty expected tip means the branch must still be absent.
+            $repo->execute('push', '-u', 'origin', $gitBranch, '--force-with-lease=' . $gitBranch . ':' . $expectedTip, '--quiet');
         } catch (\Throwable $e) {
             Console::warning("  Git push failed: " . $e->getMessage());
             return false;

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -672,13 +672,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             // Stage, commit, push
             $repo->addAllChanges();
 
-            try {
-                $repo->commit($commitMessage);
-            } catch (\Throwable $e) {
-                // Exit code 1 (256 in PHP) = nothing to commit.
-                // Still push below so a stale remote release branch is
-                // synced back to the base branch.
+            $statusOutput = $repo->execute('status', '--porcelain');
+            if (empty(\trim(\implode("\n", (array) $statusOutput)))) {
+                // Nothing to commit — still push below so a stale remote
+                // release branch is synced back to the base branch.
                 Console::log('  No changes to commit, SDK is up to date');
+            } else {
+                // Any commit failure here is a real error: let it propagate
+                // to the outer catch instead of force-pushing a base-derived
+                // HEAD without the generated changes.
+                $repo->commit($commitMessage);
             }
 
             // Force push: the branch is regenerated from the base branch each
@@ -1158,7 +1161,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         $apiPath = "/repos/{$repoName}/pulls/{$prNumber}";
 
         // Preserve a manually curated PR description: only overwrite the body
-        // when the existing one is empty or still the generated default.
+        // when the existing one is empty or still entirely generated — the
+        // default one-liner, optionally followed by the generated
+        // "## Changes" changelog section. A prefix match is not enough:
+        // maintainers may append notes below the generated sentence.
         $existingBody = '';
         $bodyOutput = [];
         \exec('gh api ' . \escapeshellarg($apiPath) . ' --jq .body 2>/dev/null', $bodyOutput);
@@ -1166,7 +1172,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             $existingBody = trim(implode("\n", $bodyOutput));
         }
         $isDefaultBody = $existingBody === ''
-            || \str_starts_with($existingBody, 'This PR contains updates to the');
+            || (bool) \preg_match(
+                '/^This PR contains updates to the .+ SDK for version \S+\.(\s*## Changes\s[\s\S]*)?$/',
+                $existingBody
+            );
 
         $updateCommand = 'gh api'
             . ' --method PATCH'

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -1172,17 +1172,22 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         // one-liner. Anything beyond that single sentence — an AI changelog,
         // appended notes, links, or extra sections — cannot be reliably told
         // apart from curated content, so it is always preserved.
-        $existingBody = '';
         $bodyOutput = [];
-        \exec('gh api ' . \escapeshellarg($apiPath) . ' --jq .body 2>/dev/null', $bodyOutput);
-        if (! empty($bodyOutput)) {
+        $bodyReturnCode = 0;
+        \exec('gh api ' . \escapeshellarg($apiPath) . ' --jq .body 2>&1', $bodyOutput, $bodyReturnCode);
+
+        if ($bodyReturnCode !== 0) {
+            // Could not read the current body (API, auth, network, rate
+            // limit). Assume it is curated and never overwrite it blindly.
+            $isDefaultBody = false;
+        } else {
             $existingBody = trim(implode("\n", $bodyOutput));
+            $isDefaultBody = $existingBody === ''
+                || (bool) \preg_match(
+                    '/^This PR contains updates to the .+ SDK for version \S+\.$/',
+                    $existingBody
+                );
         }
-        $isDefaultBody = $existingBody === ''
-            || (bool) \preg_match(
-                '/^This PR contains updates to the .+ SDK for version \S+\.$/',
-                $existingBody
-            );
 
         $updateCommand = 'gh api'
             . ' --method PATCH'

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -887,7 +887,13 @@ class Specs extends Action
             // must happen even with nothing to commit, so a stale remote
             // branch is synced back to the base branch.
             $statusOutput = [];
-            \exec('cd ' . $target . ' && git add -A && git status --porcelain', $statusOutput);
+            $statusReturnCode = 0;
+            \exec('cd ' . $target . ' && git add -A && git status --porcelain 2>&1', $statusOutput, $statusReturnCode);
+
+            if ($statusReturnCode !== 0) {
+                Console::error("Failed to stage specs for {$gitRepoName}: " . \implode("\n", $statusOutput));
+                return;
+            }
 
             if (empty($statusOutput)) {
                 Console::log("No spec changes to commit for {$gitRepoName}, syncing branch");

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -811,7 +811,10 @@ class Specs extends Action
             // Building on top of the previously pushed branch makes the PR
             // conflict with the base branch as soon as another specs update
             // lands there first — the branch is fully generated, so it is
-            // safe to rewrite.
+            // safe to rewrite. The whole chain must succeed: force-pushing
+            // from a partially initialized clone would truncate the branch.
+            $cloneOutput = [];
+            $cloneReturnCode = 0;
             \exec('rm -rf ' . $target . ' && \
                 mkdir -p ' . $target . ' && \
                 cd ' . $target . ' && \
@@ -820,10 +823,15 @@ class Specs extends Action
                 git config pull.rebase false && \
                 git remote add origin ' . $gitUrl . ' && \
                 git fetch origin && \
-                (git checkout -f ' . $repoBranch . ' 2>/dev/null || git checkout -b ' . $repoBranch . ') && \
-                git pull origin ' . $repoBranch . ' 2>/dev/null; \
-                git checkout -B ' . $gitBranch . '
-            ');
+                git checkout -f ' . $repoBranch . ' && \
+                git pull origin ' . $repoBranch . ' && \
+                git checkout -B ' . $gitBranch . ' 2>&1
+            ', $cloneOutput, $cloneReturnCode);
+
+            if ($cloneReturnCode !== 0) {
+                Console::error("Failed to prepare {$gitRepoName} clone from branch {$repoBranch}: " . \implode("\n", $cloneOutput));
+                return;
+            }
 
             // Copy generated spec files into specs/{version}/ subdirectory
             $prPlatforms = static::getPlatformsForPR();

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -830,7 +830,7 @@ class Specs extends Action
 
             if ($cloneReturnCode !== 0) {
                 Console::error("Failed to prepare {$gitRepoName} clone from branch {$repoBranch}: " . \implode("\n", $cloneOutput));
-                return;
+                Console::exit(1);
             }
 
             // Copy generated spec files into specs/{version}/ subdirectory
@@ -892,7 +892,7 @@ class Specs extends Action
 
             if ($statusReturnCode !== 0) {
                 Console::error("Failed to stage specs for {$gitRepoName}: " . \implode("\n", $statusOutput));
-                return;
+                Console::exit(1);
             }
 
             if (empty($statusOutput)) {
@@ -904,7 +904,7 @@ class Specs extends Action
 
                 if ($commitReturnCode !== 0) {
                     Console::error("Failed to commit specs for {$gitRepoName}: " . \implode("\n", $commitOutput));
-                    return;
+                    Console::exit(1);
                 }
             }
 
@@ -914,7 +914,7 @@ class Specs extends Action
 
             if ($pushReturnCode !== 0) {
                 Console::error("Failed to push specs to {$gitRepoName}: " . \implode("\n", $pushOutput));
-                return;
+                Console::exit(1);
             }
 
             Console::success("Pushed specs to {$gitRepoName} on branch {$gitBranch}");

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -900,7 +900,7 @@ class Specs extends Action
             } else {
                 $commitOutput = [];
                 $commitReturnCode = 0;
-                \exec('cd ' . $target . ' && git commit -m "' . \addslashes($message) . '" 2>&1', $commitOutput, $commitReturnCode);
+                \exec('cd ' . $target . ' && git commit -m ' . \escapeshellarg($message) . ' 2>&1', $commitOutput, $commitReturnCode);
 
                 if ($commitReturnCode !== 0) {
                     Console::error("Failed to commit specs for {$gitRepoName}: " . \implode("\n", $commitOutput));

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -575,6 +575,12 @@ class Specs extends Action
             $message = Console::confirm('Please enter your commit message:');
         }
 
+        // Non-interactive runs get an empty confirm answer; without a message
+        // `git commit` aborts silently while the task still reports success.
+        if ($git === 'yes' && empty(\trim((string) $message))) {
+            $message = "feat: update {$version} API specifications";
+        }
+
         if (\is_null($branch)) {
             $branch = 'main';
         }
@@ -801,6 +807,11 @@ class Specs extends Action
 
             Console::info("Cloning {$gitRepoName} into {$target}...");
 
+            // Rebuild the working branch from the base branch on every run.
+            // Building on top of the previously pushed branch makes the PR
+            // conflict with the base branch as soon as another specs update
+            // lands there first — the branch is fully generated, so it is
+            // safe to rewrite.
             \exec('rm -rf ' . $target . ' && \
                 mkdir -p ' . $target . ' && \
                 cd ' . $target . ' && \
@@ -810,10 +821,8 @@ class Specs extends Action
                 git remote add origin ' . $gitUrl . ' && \
                 git fetch origin && \
                 (git checkout -f ' . $repoBranch . ' 2>/dev/null || git checkout -b ' . $repoBranch . ') && \
-                git pull origin ' . $repoBranch . ' && \
-                (git checkout -f ' . $gitBranch . ' 2>/dev/null || git checkout -b ' . $gitBranch . ') && \
-                (git fetch origin ' . $gitBranch . ' 2>/dev/null || git push -u origin ' . $gitBranch . ') && \
-                git reset --hard origin/' . $gitBranch . ' 2>/dev/null || true
+                git pull origin ' . $repoBranch . ' 2>/dev/null; \
+                git checkout -B ' . $gitBranch . '
             ');
 
             // Copy generated spec files into specs/{version}/ subdirectory
@@ -865,14 +874,28 @@ class Specs extends Action
                 Console::warning("No SDK examples found at: {$examplesDir}. Skipping examples copy.");
             }
 
-            // Git add, commit, and push
-            \exec('cd ' . $target . ' && \
-                git add -A && \
-                git commit -m "' . \addslashes($message) . '" && \
-                git push -u origin ' . $gitBranch . '
-            ');
+            // Git add, commit, and push. Force push is required because the
+            // branch is rebuilt from the base branch on every run.
+            $statusOutput = [];
+            \exec('cd ' . $target . ' && git add -A && git status --porcelain', $statusOutput);
 
-            Console::success("Pushed specs to {$gitRepoName} on branch {$gitBranch}");
+            if (empty($statusOutput)) {
+                Console::log("No spec changes to push to {$gitRepoName}, already up to date");
+            } else {
+                $pushOutput = [];
+                $pushReturnCode = 0;
+                \exec('cd ' . $target . ' && \
+                    git commit -m "' . \addslashes($message) . '" && \
+                    git push -u origin ' . $gitBranch . ' --force 2>&1
+                ', $pushOutput, $pushReturnCode);
+
+                if ($pushReturnCode !== 0) {
+                    Console::error("Failed to push specs to {$gitRepoName}: " . \implode("\n", $pushOutput));
+                    return;
+                }
+
+                Console::success("Pushed specs to {$gitRepoName} on branch {$gitBranch}");
+            }
 
             // Create or update PR
             $prTitle = "feat: API specs update for version {$version}";

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -883,27 +883,35 @@ class Specs extends Action
             }
 
             // Git add, commit, and push. Force push is required because the
-            // branch is rebuilt from the base branch on every run.
+            // branch is rebuilt from the base branch on every run — and it
+            // must happen even with nothing to commit, so a stale remote
+            // branch is synced back to the base branch.
             $statusOutput = [];
             \exec('cd ' . $target . ' && git add -A && git status --porcelain', $statusOutput);
 
             if (empty($statusOutput)) {
-                Console::log("No spec changes to push to {$gitRepoName}, already up to date");
+                Console::log("No spec changes to commit for {$gitRepoName}, syncing branch");
             } else {
-                $pushOutput = [];
-                $pushReturnCode = 0;
-                \exec('cd ' . $target . ' && \
-                    git commit -m "' . \addslashes($message) . '" && \
-                    git push -u origin ' . $gitBranch . ' --force 2>&1
-                ', $pushOutput, $pushReturnCode);
+                $commitOutput = [];
+                $commitReturnCode = 0;
+                \exec('cd ' . $target . ' && git commit -m "' . \addslashes($message) . '" 2>&1', $commitOutput, $commitReturnCode);
 
-                if ($pushReturnCode !== 0) {
-                    Console::error("Failed to push specs to {$gitRepoName}: " . \implode("\n", $pushOutput));
+                if ($commitReturnCode !== 0) {
+                    Console::error("Failed to commit specs for {$gitRepoName}: " . \implode("\n", $commitOutput));
                     return;
                 }
-
-                Console::success("Pushed specs to {$gitRepoName} on branch {$gitBranch}");
             }
+
+            $pushOutput = [];
+            $pushReturnCode = 0;
+            \exec('cd ' . $target . ' && git push -u origin ' . $gitBranch . ' --force 2>&1', $pushOutput, $pushReturnCode);
+
+            if ($pushReturnCode !== 0) {
+                Console::error("Failed to push specs to {$gitRepoName}: " . \implode("\n", $pushOutput));
+                return;
+            }
+
+            Console::success("Pushed specs to {$gitRepoName} on branch {$gitBranch}");
 
             // Create or update PR
             $prTitle = "feat: API specs update for version {$version}";

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -833,6 +833,15 @@ class Specs extends Action
                 Console::exit(1);
             }
 
+            // Record the remote working-branch tip so the final push can be
+            // fenced with --force-with-lease against concurrent release runs.
+            $leaseOutput = [];
+            \exec('cd ' . $target . ' && git ls-remote origin ' . \escapeshellarg('refs/heads/' . $gitBranch), $leaseOutput);
+            $expectedTip = '';
+            if (! empty($leaseOutput[0])) {
+                $expectedTip = \explode("\t", \trim($leaseOutput[0]))[0];
+            }
+
             // Copy generated spec files into specs/{version}/ subdirectory
             $prPlatforms = static::getPlatformsForPR();
             $prFiles = \array_filter(
@@ -910,7 +919,7 @@ class Specs extends Action
 
             $pushOutput = [];
             $pushReturnCode = 0;
-            \exec('cd ' . $target . ' && git push -u origin ' . $gitBranch . ' --force 2>&1', $pushOutput, $pushReturnCode);
+            \exec('cd ' . $target . ' && git push -u origin ' . $gitBranch . ' --force-with-lease=' . \escapeshellarg($gitBranch . ':' . $expectedTip) . ' 2>&1', $pushOutput, $pushReturnCode);
 
             if ($pushReturnCode !== 0) {
                 Console::error("Failed to push specs to {$gitRepoName}: " . \implode("\n", $pushOutput));


### PR DESCRIPTION
Fixes three issues in the SDK/specs release tasks that surfaced during the 1.9.x cloud SDK release (11 SDK PRs + specs PR all required manual conflict resolution).

## 1. Every release PR conflicted with the base branch (`SDKs.php`)

`pushToGit` checked out the existing remote release branch (e.g. `dev`) and committed generated output on top. But release PRs are squash/merge-committed into the base branch, which orphans the release branch's own history — so `main` and `dev` end up with identical content on unrelated commits, and the *next* release PR conflicts on essentially every file. All 11 SDK PRs in the last release cycle hit this and needed manual `-s ours` merges.

The branch now gets rebuilt from the base branch (`checkout -B` on top of the fetched base) on every run and force-pushed. The branch holds only generated output, so rewriting it loses nothing, and the PR diff is always exactly "generated output vs base branch". When there is nothing to commit, the branch is still pushed so a stale remote branch gets synced back to base.

## 2. PR updates clobbered curated descriptions (`SDKs.php`)

`updateExistingPr` unconditionally PATCHed both title and body, wiping any manually written changelog description each time the SDK was regenerated. The body is now only overwritten when the existing one is empty or still the generated default (`This PR contains updates to the …`).

## 3. Specs push silently did nothing on non-interactive runs (`Specs.php`)

- With no `--message`, `Console::confirm` returns empty on non-interactive runs, `git commit` aborts ("Aborting commit due to empty commit message") — yet the task still printed `Pushed specs to appwrite/specs`. A default message is now used, and the push result is actually checked before reporting success (or logging "already up to date" when there are no changes).
- The `feat-{version}-specs` branch had the same divergence problem as #1 (it reset to its own stale remote state instead of building on the base branch) — appwrite/specs#88 needed manual conflict resolution because of this. It is now rebuilt from the base branch and force-pushed.

## Validation

- `php -l` and Pint pass on both files.
- The flow changes mirror exactly the manual recovery that fixed the conflicting PRs across the 12 SDK repos and appwrite/specs during the last release.