### PR TITLE
Feat 12964 self hosted multi regions support

### DIFF
--- a/.env
+++ b/.env
@@ -153,10 +153,10 @@ _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET=
 _APP_PROJECT_REGIONS=default
 _APP_REGION=default
 # Self-hosted multi-region (optional). Leave unset for monolith.
-# _APP_REGIONS={"default":{"$id":"default","name":"Default","disabled":true,"default":false},"france":{"$id":"france","name":"France","disabled":false,"default":true},"japan":{"$id":"japan","name":"Japan","disabled":false,"default":false}}
-# _APP_PROJECT_REGIONS=france,japan
-# _APP_CONNECTIONS_DATABASE=db_france_main=mariadb://user:password@mariadb-france:3306/appwrite,db_japan_main=mariadb://user:password@mariadb-japan:3306/appwrite
-# _APP_DATABASE_KEYS=database_db_france_main,database_db_japan_main
+# _APP_REGIONS={"default":{"$id":"default","name":"Default","disabled":true,"default":false},"fra":{"$id":"fra","name":"Frankfurt","disabled":false,"default":true},"nyc":{"$id":"nyc","name":"New York","disabled":false,"default":false}}
+# _APP_PROJECT_REGIONS=fra,nyc
+# _APP_CONNECTIONS_DATABASE=db_fra_main=mariadb://user:password@mariadb-fra:3306/appwrite,db_nyc_main=mariadb://user:password@mariadb-nyc:3306/appwrite
+# _APP_DATABASE_KEYS=database_db_fra_main,database_db_nyc_main
 _APP_GEO_SECRET=your-secret-key
 _APP_GEO_ENDPOINT=http://appwrite-geo/v1
 _APP_VCS_GITHUB_APP_ID=

--- a/.env
+++ b/.env
@@ -151,6 +151,12 @@ _APP_MIGRATION_HOST=appwrite
 _APP_MIGRATIONS_FIREBASE_CLIENT_ID=
 _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET=
 _APP_PROJECT_REGIONS=default
+_APP_REGION=default
+# Self-hosted multi-region (optional). Leave unset for monolith.
+# _APP_REGIONS={"default":{"$id":"default","name":"Default","disabled":true,"default":false},"france":{"$id":"france","name":"France","disabled":false,"default":true},"japan":{"$id":"japan","name":"Japan","disabled":false,"default":false}}
+# _APP_PROJECT_REGIONS=france,japan
+# _APP_CONNECTIONS_DATABASE=db_france_main=mariadb://user:password@mariadb-france:3306/appwrite,db_japan_main=mariadb://user:password@mariadb-japan:3306/appwrite
+# _APP_DATABASE_KEYS=database_db_france_main,database_db_japan_main
 _APP_GEO_SECRET=your-secret-key
 _APP_GEO_ENDPOINT=http://appwrite-geo/v1
 _APP_VCS_GITHUB_APP_ID=

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1193,7 +1193,7 @@ return [
     ],
     Exception::PROJECT_REGION_UNSUPPORTED => [
         'name' => Exception::PROJECT_REGION_UNSUPPORTED,
-        'description' => 'The requested region is either inactive or unsupported. Please check the value of the _APP_REGIONS environment variable.',
+        'description' => 'The requested region is either inactive or unsupported. Check _APP_REGIONS and _APP_PROJECT_REGIONS.',
         'code' => 400,
     ],
     Exception::WEBHOOK_NOT_FOUND => [

--- a/app/config/regions.php
+++ b/app/config/regions.php
@@ -1,5 +1,14 @@
 <?php
 
+use Appwrite\Config\Regions;
+use Utopia\System\System;
+
+$regions = System::getEnv('_APP_REGIONS', '');
+
+if (!empty($regions)) {
+    return Regions::parse($regions);
+}
+
 return [
     'default' => [
         '$id' => 'default',

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -472,6 +472,51 @@ return [
                 'question' => '',
                 'filter' => 'password'
             ],
+            [
+                'name' => '_APP_CONNECTIONS_DATABASE',
+                'description' => 'Comma-separated project database DSNs for the Utopia database pool. Console/platform still uses _APP_DB_*. Format: db_<regionId>_main=mariadb://user:pass@host:3306/appwrite. Leave empty to reuse _APP_DB_*.',
+                'introduction' => '1.9.6',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_DATABASE_KEYS',
+                'description' => 'Comma-separated Utopia pool names for non-default region project create. Example: database_db_france_main,database_db_japan_main.',
+                'introduction' => '1.9.6',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_REGION',
+                'description' => 'Region id of this Appwrite process. Default value is: \'default\'.',
+                'introduction' => '1.9.6',
+                'default' => 'default',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_REGIONS',
+                'description' => 'Optional JSON region catalog overriding app/config/regions.php. Each entry: $id, name, disabled, default. Exactly one entry must set default to true. Leave empty for the stock default region.',
+                'introduction' => '1.9.6',
+                'default' => '',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
+                'name' => '_APP_PROJECT_REGIONS',
+                'description' => 'Optional comma-separated allowlist of region ids allowed when creating projects. Default value is: \'default\'.',
+                'introduction' => '1.9.6',
+                'default' => 'default',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -483,7 +483,7 @@ return [
             ],
             [
                 'name' => '_APP_DATABASE_KEYS',
-                'description' => 'Comma-separated Utopia pool names for non-default region project create. Example: database_db_france_main,database_db_japan_main.',
+                'description' => 'Comma-separated Utopia pool names for non-default region project create. Example: database_db_fra_main,database_db_nyc_main.',
                 'introduction' => '1.9.6',
                 'default' => '',
                 'required' => false,

--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -192,7 +192,7 @@ $register->set('pools', function () {
         ],
         'database' => [
             'type' => 'database',
-            'dsns' => $fallbackForDB,
+            'dsns' => System::getEnv('_APP_CONNECTIONS_DATABASE', $fallbackForDB),
             'multiple' => true,
             'schemes' => ['mongodb','mariadb', 'mysql','postgresql'],
         ],

--- a/app/init/registers.php
+++ b/app/init/registers.php
@@ -262,11 +262,12 @@ $register->set('pools', function () {
             $dsn = explode('=', $dsn);
             $name = ($multiple) ? $key . '_' . $dsn[0] : $key;
             $dsn = $dsn[1] ?? '';
-            $config[] = $name;
             if (empty($dsn)) {
+                // Skip empty DSNs entirely — do not record a phantom name in pools-*.
                 //throw new Exception(Exception::GENERAL_SERVER_ERROR, "Missing value for DSN connection in {$key}");
                 continue;
             }
+            $config[] = $name;
 
             $dsn = new DSN($dsn);
             $dsnHost = $dsn->getHost();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,11 @@ services:
       - _APP_EXPERIMENT_LOGGING_PROVIDER
       - _APP_EXPERIMENT_LOGGING_CONFIG
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_DATABASE_SHARED_NAMESPACE
       - _APP_FUNCTIONS_CREATION_ABUSE_LIMIT
       - _APP_CUSTOM_DOMAIN_DENY_LIST
@@ -304,6 +309,11 @@ services:
       - _APP_LOGGING_FORMAT
       - _APP_LOGGING_CONFIG_REALTIME
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_POOL_ADAPTER=swoole
 
   appwrite-worker-webhooks:
@@ -343,6 +353,11 @@ services:
       - _APP_LOGGING_FORMAT
       - _APP_WEBHOOK_MAX_FAILED_ATTEMPTS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_CONSOLE_URL_SCHEME=root
   appwrite-worker-deletes:
     entrypoint: worker-deletes
@@ -410,6 +425,11 @@ services:
       - _APP_EXECUTOR_SECRET
       - _APP_EXECUTOR_HOST
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_EMAIL_CERTIFICATES
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
@@ -455,6 +475,11 @@ services:
       - _APP_LOGGING_FORMAT
       - _APP_QUEUE_NAME
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-worker-builds:
     entrypoint: worker-builds
     logging:
@@ -543,6 +568,11 @@ services:
       - _APP_STORAGE_WASABI_REGION
       - _APP_STORAGE_WASABI_BUCKET
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_DOMAIN_SITES
       - _APP_BUILDS_VOLUME
       - _APP_JOBS_HOST
@@ -589,6 +619,11 @@ services:
       - _APP_LOGGING_CONFIG
       - _APP_LOGGING_FORMAT
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
     extra_hosts:
       - host.docker.internal:host-gateway
 
@@ -631,6 +666,11 @@ services:
       - _APP_DB_USER
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_STORAGE_DEVICE
       - _APP_STORAGE_S3_ACCESS_KEY
       - _APP_STORAGE_S3_SECRET
@@ -702,6 +742,11 @@ services:
       - _APP_LOGGING_CONFIG
       - _APP_LOGGING_FORMAT
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
 
   appwrite-worker-functions:
     entrypoint: worker-functions
@@ -749,6 +794,11 @@ services:
       - _APP_LOGGING_FORMAT
       - _APP_LOGGING_PROVIDER
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-worker-mails:
     entrypoint: worker-mails
     logging:
@@ -793,6 +843,11 @@ services:
       - _APP_DOMAIN
       - _APP_OPTIONS_FORCE_HTTPS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
 
   appwrite-worker-notifications:
     entrypoint: worker-notifications
@@ -837,6 +892,11 @@ services:
       - _APP_DOMAIN
       - _APP_OPTIONS_FORCE_HTTPS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-worker-messaging:
     entrypoint: worker-messaging
     logging:
@@ -898,6 +958,11 @@ services:
       - _APP_STORAGE_WASABI_REGION
       - _APP_STORAGE_WASABI_BUCKET
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-worker-migrations:
     entrypoint: worker-migrations
     logging:
@@ -944,6 +1009,11 @@ services:
       - _APP_MIGRATIONS_FIREBASE_CLIENT_ID
       - _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_OPTIONS_FORCE_HTTPS
       - _APP_MIGRATION_HOST
   appwrite-task-maintenance:
@@ -996,6 +1066,11 @@ services:
       - _APP_MAINTENANCE_RETENTION_SCHEDULES
       - _APP_MAINTENANCE_START_TIME
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-task-interval:
     entrypoint: interval
     restart: unless-stopped
@@ -1036,6 +1111,11 @@ services:
       - _APP_DB_USER
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
       - _APP_INTERVAL_DOMAIN_VERIFICATION
       - _APP_INTERVAL_CLEANUP_STALE_EXECUTIONS
 
@@ -1080,6 +1160,11 @@ services:
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
       - _APP_FUNCTIONS_SCHEDULE_SPREAD
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-task-scheduler-executions:
     entrypoint: schedule-executions
     restart: unless-stopped
@@ -1120,6 +1205,11 @@ services:
       - _APP_DB_USER
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-task-scheduler-messages:
     entrypoint: schedule-messages
     restart: unless-stopped
@@ -1153,6 +1243,11 @@ services:
       - _APP_DB_USER
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_REGION
+      - _APP_REGIONS
+      - _APP_PROJECT_REGIONS
+      - _APP_CONNECTIONS_DATABASE
+      - _APP_DATABASE_KEYS
   appwrite-assistant:
     container_name: appwrite-assistant
     image: appwrite/assistant:0.8.4

--- a/docs/tutorials/self-hosted-multi-region.md
+++ b/docs/tutorials/self-hosted-multi-region.md
@@ -1,0 +1,74 @@
+# Self-hosted multi-region
+
+This document is part of the Appwrite contributors' guide. Before you continue reading this document, make sure you have read the [Code of Conduct](https://github.com/appwrite/.github/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guide](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md).
+
+## Getting Started
+
+### Agenda
+
+Self-hosted Appwrite can run a meta control plane plus regional API stacks. Region ids are arbitrary DNS labels (for example `france` or `eu-west-1`), not limited to Cloud city codes.
+
+### Topology
+
+| Role | `_APP_REGION` | `_APP_DB_*` | `_APP_CONNECTIONS_DATABASE` |
+|------|---------------|-------------|-----------------------------|
+| Meta | `default` | Local platform DB | All regional DSNs |
+| Regional | e.g. `france` | Meta DB host | This region only |
+
+### Environment variables
+
+- `_APP_REGIONS` — JSON catalog overriding `app/config/regions.php`. Leave empty for monolith.
+- `_APP_PROJECT_REGIONS` — Optional create allowlist.
+- `_APP_REGION` — Region id of this process.
+- `_APP_CONNECTIONS_DATABASE` — Project DB DSNs (`db_<regionId>_main=...`). Console still uses `_APP_DB_*`.
+- `_APP_DATABASE_KEYS` — Utopia pool names (`database_db_<regionId>_main`).
+- `_APP_DOMAIN_TARGET_CNAME` — Must be non-empty.
+
+### `_APP_REGIONS` example
+
+```json
+{
+  "default": { "$id": "default", "name": "Default", "disabled": true, "default": false },
+  "france": { "$id": "france", "name": "France", "disabled": false, "default": true },
+  "japan": { "$id": "japan", "name": "Japan", "disabled": false, "default": false }
+}
+```
+
+Exactly one entry must set `"default": true`. `$id` must be a lowercase DNS label.
+
+### Pool naming
+
+1. DSN id: `db_<regionId>_main=mariadb://user:pass@host:3306/appwrite`
+2. Pool name: `database_db_<regionId>_main`
+3. Add that name to `_APP_DATABASE_KEYS`
+
+Matching uses a `_db_<regionId>_` token so short ids (e.g. `us`) do not match longer ones (e.g. `australia`).
+
+### Meta example
+
+```bash
+_APP_REGION=default
+_APP_REGIONS={"default":{"$id":"default","name":"Default","disabled":true,"default":false},"france":{"$id":"france","name":"France","disabled":false,"default":true},"japan":{"$id":"japan","name":"Japan","disabled":false,"default":false}}
+_APP_PROJECT_REGIONS=france,japan
+_APP_CONNECTIONS_DATABASE=db_france_main=mariadb://user:password@mariadb-france:3306/appwrite,db_japan_main=mariadb://user:password@mariadb-japan:3306/appwrite
+_APP_DATABASE_KEYS=database_db_france_main,database_db_japan_main
+_APP_DOMAIN_TARGET_CNAME=appwrite.example.com
+```
+
+### Regional example (`france`)
+
+```bash
+_APP_REGION=france
+_APP_DB_HOST=mariadb-meta
+_APP_CONNECTIONS_DATABASE=db_france_main=mariadb://user:password@mariadb-france:3306/appwrite
+_APP_DATABASE_KEYS=database_db_france_main
+_APP_DOMAIN=france.example.com
+```
+
+Use sibling DNS hosts (`appwrite.example.com` → `france.example.com`), not Cloud `{region}.cloud…` prefixes.
+
+### Monolith
+
+Leave `_APP_REGIONS`, `_APP_CONNECTIONS_DATABASE`, and `_APP_DATABASE_KEYS` unset. Keep `_APP_REGION=default`.
+
+Related issue: [appwrite/appwrite#12964](https://github.com/appwrite/appwrite/issues/12964).

--- a/docs/tutorials/self-hosted-multi-region.md
+++ b/docs/tutorials/self-hosted-multi-region.md
@@ -6,14 +6,14 @@ This document is part of the Appwrite contributors' guide. Before you continue r
 
 ### Agenda
 
-Self-hosted Appwrite can run a meta control plane plus regional API stacks. Region ids are arbitrary DNS labels (for example `france` or `eu-west-1`), not limited to Cloud city codes.
+Self-hosted Appwrite can run a meta control plane plus regional API stacks. Examples use Cloud-style ids (`fra`, `nyc`, `sfo`); custom DNS-label ids (e.g. `france`) are also supported.
 
 ### Topology
 
 | Role | `_APP_REGION` | `_APP_DB_*` | `_APP_CONNECTIONS_DATABASE` |
 |------|---------------|-------------|-----------------------------|
 | Meta | `default` | Local platform DB | All regional DSNs |
-| Regional | e.g. `france` | Meta DB host | This region only |
+| Regional | e.g. `fra` | Meta DB host | This region only |
 
 ### Environment variables
 
@@ -29,8 +29,8 @@ Self-hosted Appwrite can run a meta control plane plus regional API stacks. Regi
 ```json
 {
   "default": { "$id": "default", "name": "Default", "disabled": true, "default": false },
-  "france": { "$id": "france", "name": "France", "disabled": false, "default": true },
-  "japan": { "$id": "japan", "name": "Japan", "disabled": false, "default": false }
+  "fra": { "$id": "fra", "name": "Frankfurt", "disabled": false, "default": true },
+  "nyc": { "$id": "nyc", "name": "New York", "disabled": false, "default": false }
 }
 ```
 
@@ -48,24 +48,24 @@ Matching uses a `_db_<regionId>_` token so short ids (e.g. `us`) do not match lo
 
 ```bash
 _APP_REGION=default
-_APP_REGIONS={"default":{"$id":"default","name":"Default","disabled":true,"default":false},"france":{"$id":"france","name":"France","disabled":false,"default":true},"japan":{"$id":"japan","name":"Japan","disabled":false,"default":false}}
-_APP_PROJECT_REGIONS=france,japan
-_APP_CONNECTIONS_DATABASE=db_france_main=mariadb://user:password@mariadb-france:3306/appwrite,db_japan_main=mariadb://user:password@mariadb-japan:3306/appwrite
-_APP_DATABASE_KEYS=database_db_france_main,database_db_japan_main
+_APP_REGIONS={"default":{"$id":"default","name":"Default","disabled":true,"default":false},"fra":{"$id":"fra","name":"Frankfurt","disabled":false,"default":true},"nyc":{"$id":"nyc","name":"New York","disabled":false,"default":false}}
+_APP_PROJECT_REGIONS=fra,nyc
+_APP_CONNECTIONS_DATABASE=db_fra_main=mariadb://user:password@mariadb-fra:3306/appwrite,db_nyc_main=mariadb://user:password@mariadb-nyc:3306/appwrite
+_APP_DATABASE_KEYS=database_db_fra_main,database_db_nyc_main
 _APP_DOMAIN_TARGET_CNAME=appwrite.example.com
 ```
 
-### Regional example (`france`)
+### Regional example (`fra`)
 
 ```bash
-_APP_REGION=france
+_APP_REGION=fra
 _APP_DB_HOST=mariadb-meta
-_APP_CONNECTIONS_DATABASE=db_france_main=mariadb://user:password@mariadb-france:3306/appwrite
-_APP_DATABASE_KEYS=database_db_france_main
-_APP_DOMAIN=france.example.com
+_APP_CONNECTIONS_DATABASE=db_fra_main=mariadb://user:password@mariadb-fra:3306/appwrite
+_APP_DATABASE_KEYS=database_db_fra_main
+_APP_DOMAIN=fra.example.com
 ```
 
-Use sibling DNS hosts (`appwrite.example.com` → `france.example.com`), not Cloud `{region}.cloud…` prefixes.
+Use sibling DNS hosts (`appwrite.example.com` → `fra.example.com`), not Cloud `{region}.cloud…` prefixes.
 
 ### Monolith
 

--- a/src/Appwrite/Config/Regions.php
+++ b/src/Appwrite/Config/Regions.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Appwrite\Config;
+
+final class Regions
+{
+    public const ID_PATTERN = '/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/';
+
+    /**
+     * Parse `_APP_REGIONS` JSON into the regions config shape.
+     *
+     * @param string $json
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public static function parse(string $json): array
+    {
+        $decoded = \json_decode($json, true);
+
+        if (!\is_array($decoded) || empty($decoded)) {
+            throw new \InvalidArgumentException('Invalid _APP_REGIONS value. Must be a non-empty JSON object or array.');
+        }
+
+        $isList = \array_is_list($decoded);
+        $catalog = [];
+
+        foreach ($decoded as $key => $entry) {
+            if (!\is_array($entry)) {
+                throw new \InvalidArgumentException('Invalid _APP_REGIONS value. Each entry must be an object.');
+            }
+
+            $id = $entry['$id'] ?? ($isList ? null : $key);
+
+            if (!\is_string($id) || empty($id)) {
+                throw new \InvalidArgumentException('Invalid _APP_REGIONS value. Each region must include a non-empty "$id".');
+            }
+
+            if (\preg_match(self::ID_PATTERN, $id) !== 1) {
+                throw new \InvalidArgumentException('Invalid region id "' . $id . '". Use a lowercase DNS label (a-z, 0-9, hyphen).');
+            }
+
+            if (!$isList && $key !== $id) {
+                throw new \InvalidArgumentException('Invalid _APP_REGIONS value. Object key must match "$id".');
+            }
+
+            if (isset($catalog[$id])) {
+                throw new \InvalidArgumentException('Duplicate region id "' . $id . '" in _APP_REGIONS.');
+            }
+
+            $name = $entry['name'] ?? $id;
+
+            if (!\is_string($name) || empty($name)) {
+                throw new \InvalidArgumentException('Invalid _APP_REGIONS value. Region "' . $id . '" must include a non-empty "name".');
+            }
+
+            $catalog[$id] = [
+                '$id' => $id,
+                'name' => $name,
+                'disabled' => (bool) ($entry['disabled'] ?? false),
+                'default' => (bool) ($entry['default'] ?? false),
+            ];
+        }
+
+        $defaults = \array_filter($catalog, fn (array $region) => $region['default'] === true);
+
+        if (\count($defaults) !== 1) {
+            throw new \InvalidArgumentException('Invalid _APP_REGIONS value. Exactly one region must have "default": true.');
+        }
+
+        return $catalog;
+    }
+
+    /**
+     * Match pool/DSN keys to a region using `_db_<region>_` token boundaries.
+     *
+     * @param string $poolKey
+     * @param string $region
+     * @return bool
+     */
+    public static function poolKeyMatchesRegion(string $poolKey, string $region): bool
+    {
+        if (empty($poolKey) || empty($region)) {
+            return false;
+        }
+
+        return \preg_match('/(^|_)db_' . \preg_quote($region, '/') . '(_|$)/', $poolKey) === 1;
+    }
+
+    /**
+     * @param array $keys
+     * @param string $region
+     * @return array
+     */
+    public static function filterPoolKeysForRegion(array $keys, string $region): array
+    {
+        return \array_values(\array_filter($keys, function ($value) use ($region) {
+            return \is_string($value) && self::poolKeyMatchesRegion($value, $region);
+        }));
+    }
+}

--- a/src/Appwrite/Config/Regions.php
+++ b/src/Appwrite/Config/Regions.php
@@ -97,4 +97,34 @@ final class Regions
             return \is_string($value) && self::poolKeyMatchesRegion($value, $region);
         }));
     }
+
+    /**
+     * Prefer the catalog entry marked default (and enabled); otherwise first enabled id.
+     *
+     * @param array $catalog
+     * @param string $fallback
+     * @return string
+     */
+    public static function getDefaultRegionId(array $catalog, string $fallback = 'default'): string
+    {
+        foreach ($catalog as $id => $config) {
+            if (!\is_array($config)) {
+                continue;
+            }
+            if (!empty($config['default']) && empty($config['disabled'])) {
+                return (string) ($config['$id'] ?? $id);
+            }
+        }
+
+        foreach ($catalog as $id => $config) {
+            if (!\is_array($config)) {
+                continue;
+            }
+            if (empty($config['disabled'])) {
+                return (string) ($config['$id'] ?? $id);
+            }
+        }
+
+        return $fallback;
+    }
 }

--- a/src/Appwrite/Platform/Modules/Databases/Pool.php
+++ b/src/Appwrite/Platform/Modules/Databases/Pool.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Databases;
 
+use Appwrite\Config\Regions;
 use Appwrite\Extend\Exception;
 use Utopia\Config\Config;
 use Utopia\DSN\DSN;
@@ -55,10 +56,7 @@ final class Pool
         }
 
         if ($region !== 'default') {
-            $databases = \array_filter(
-                \explode(',', $keys),
-                fn (string $value): bool => \str_contains($value, $region)
-            );
+            $databases = Regions::filterPoolKeysForRegion(\explode(',', $keys), $region);
         }
 
         $index = \array_search($override, $databases);

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Organization\Http\Projects;
 
+use Appwrite\Config\Regions;
 use Appwrite\Extend\Exception;
 use Appwrite\Hooks\Hooks;
 use Appwrite\SDK\AuthType;
@@ -119,10 +120,8 @@ class Create extends Action
 
         if ($region !== 'default') {
             $databaseKeys = System::getEnv('_APP_DATABASE_KEYS', '');
-            $keys = explode(',', $databaseKeys);
-            $databases = array_filter($keys, function ($value) use ($region) {
-                return str_contains($value, $region);
-            });
+            $keys = \explode(',', $databaseKeys);
+            $databases = Regions::filterPoolKeysForRegion($keys, $region);
         }
 
         $databaseOverride = System::getEnv('_APP_DATABASE_OVERRIDE');

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
@@ -116,18 +116,22 @@ class Create extends Action
             throw new Exception(Exception::PROJECT_RESERVED_PROJECT, "'console' is a reserved project.");
         }
 
-        $databases = Config::getParam('pools-database', []);
+        $registeredPools = Config::getParam('pools-database', []);
 
         if ($region !== 'default') {
             $databaseKeys = System::getEnv('_APP_DATABASE_KEYS', '');
-            $keys = \explode(',', $databaseKeys);
-            $databases = Regions::filterPoolKeysForRegion($keys, $region);
+            $keys = \array_values(\array_filter(\array_map('trim', \explode(',', $databaseKeys))));
+            $candidateKeys = Regions::filterPoolKeysForRegion($keys, $region);
+            // Only persist pool names that are actually registered from _APP_CONNECTIONS_DATABASE.
+            $databases = \array_values(\array_intersect($candidateKeys, $registeredPools));
+        } else {
+            $databases = $registeredPools;
         }
 
         if (empty($databases)) {
             throw new Exception(
                 Exception::PROJECT_REGION_UNSUPPORTED,
-                'No database pool configured for region "' . $region . '". Check _APP_DATABASE_KEYS.'
+                'No registered database pool for region "' . $region . '". Check _APP_DATABASE_KEYS and _APP_CONNECTIONS_DATABASE.'
             );
         }
 

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
@@ -66,7 +66,7 @@ class Create extends Action
             ))
             ->param('projectId', '', new ProjectId(), 'Unique Id. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, and hyphen. Can\'t start with a special char. Max length is 36 chars.')
             ->param('name', null, new Text(128), 'Project name. Max length: 128 chars.')
-            ->param('region', System::getEnv('_APP_REGION', 'default'), new WhiteList(array_keys(array_filter(Config::getParam('regions'), fn ($config) => !$config['disabled']))), 'Project Region.', true, enum: new Enum(name: 'Region'))
+            ->param('region', Regions::getDefaultRegionId(Config::getParam('regions', []), System::getEnv('_APP_REGION', 'default')), new WhiteList(array_keys(array_filter(Config::getParam('regions'), fn ($config) => !$config['disabled']))), 'Project Region.', true, enum: new Enum(name: 'Region'))
             ->inject('response')
             ->inject('dbForPlatform')
             ->inject('cache')
@@ -124,12 +124,19 @@ class Create extends Action
             $databases = Regions::filterPoolKeysForRegion($keys, $region);
         }
 
+        if (empty($databases)) {
+            throw new Exception(
+                Exception::PROJECT_REGION_UNSUPPORTED,
+                'No database pool configured for region "' . $region . '". Check _APP_DATABASE_KEYS.'
+            );
+        }
+
         $databaseOverride = System::getEnv('_APP_DATABASE_OVERRIDE');
         $index = \array_search($databaseOverride, $databases);
         if ($index !== false) {
             $dsn = $databases[$index];
         } else {
-            $dsn = $databases[array_rand($databases)];
+            $dsn = $databases[\array_rand($databases)];
         }
 
         // TODO: Temporary until all projects are using shared tables.

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Projects\Http\Projects;
 
+use Appwrite\Config\Regions;
 use Appwrite\Extend\Exception;
 use Appwrite\Hooks\Hooks;
 use Appwrite\Utopia\Database\Validator\ProjectId;
@@ -122,10 +123,8 @@ class Create extends Action
 
         if ($region !== 'default') {
             $databaseKeys = System::getEnv('_APP_DATABASE_KEYS', '');
-            $keys = explode(',', $databaseKeys);
-            $databases = array_filter($keys, function ($value) use ($region) {
-                return str_contains($value, $region);
-            });
+            $keys = \explode(',', $databaseKeys);
+            $databases = Regions::filterPoolKeysForRegion($keys, $region);
         }
 
         $databaseOverride = System::getEnv('_APP_DATABASE_OVERRIDE');

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
@@ -119,18 +119,22 @@ class Create extends Action
             throw new Exception(Exception::PROJECT_RESERVED_PROJECT, "'console' is a reserved project.");
         }
 
-        $databases = Config::getParam('pools-database', []);
+        $registeredPools = Config::getParam('pools-database', []);
 
         if ($region !== 'default') {
             $databaseKeys = System::getEnv('_APP_DATABASE_KEYS', '');
-            $keys = \explode(',', $databaseKeys);
-            $databases = Regions::filterPoolKeysForRegion($keys, $region);
+            $keys = \array_values(\array_filter(\array_map('trim', \explode(',', $databaseKeys))));
+            $candidateKeys = Regions::filterPoolKeysForRegion($keys, $region);
+            // Only persist pool names that are actually registered from _APP_CONNECTIONS_DATABASE.
+            $databases = \array_values(\array_intersect($candidateKeys, $registeredPools));
+        } else {
+            $databases = $registeredPools;
         }
 
         if (empty($databases)) {
             throw new Exception(
                 Exception::PROJECT_REGION_UNSUPPORTED,
-                'No database pool configured for region "' . $region . '". Check _APP_DATABASE_KEYS.'
+                'No registered database pool for region "' . $region . '". Check _APP_DATABASE_KEYS and _APP_CONNECTIONS_DATABASE.'
             );
         }
 

--- a/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Projects/Http/Projects/Create.php
@@ -56,7 +56,7 @@ class Create extends Action
             ->param('projectId', '', new ProjectId(), 'Unique Id. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, and hyphen. Can\'t start with a special char. Max length is 36 chars.')
             ->param('name', null, new Text(128), 'Project name. Max length: 128 chars.')
             ->param('teamId', '', new UID(), 'Team unique ID.')
-            ->param('region', System::getEnv('_APP_REGION', 'default'), new WhiteList(array_keys(array_filter(Config::getParam('regions'), fn ($config) => !$config['disabled']))), 'Project Region.', true, enum: new Enum(name: 'Region'))
+            ->param('region', Regions::getDefaultRegionId(Config::getParam('regions', []), System::getEnv('_APP_REGION', 'default')), new WhiteList(array_keys(array_filter(Config::getParam('regions'), fn ($config) => !$config['disabled']))), 'Project Region.', true, enum: new Enum(name: 'Region'))
             ->inject('request')
             ->inject('response')
             ->inject('dbForPlatform')
@@ -127,12 +127,19 @@ class Create extends Action
             $databases = Regions::filterPoolKeysForRegion($keys, $region);
         }
 
+        if (empty($databases)) {
+            throw new Exception(
+                Exception::PROJECT_REGION_UNSUPPORTED,
+                'No database pool configured for region "' . $region . '". Check _APP_DATABASE_KEYS.'
+            );
+        }
+
         $databaseOverride = System::getEnv('_APP_DATABASE_OVERRIDE');
         $index = \array_search($databaseOverride, $databases);
         if ($index !== false) {
             $dsn = $databases[$index];
         } else {
-            $dsn = $databases[array_rand($databases)];
+            $dsn = $databases[\array_rand($databases)];
         }
 
         // TODO: Temporary until all projects are using shared tables.

--- a/tests/unit/Config/RegionsTest.php
+++ b/tests/unit/Config/RegionsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use Appwrite\Config\Regions;
+use PHPUnit\Framework\TestCase;
+
+final class RegionsTest extends TestCase
+{
+    public function testParseCatalog(): void
+    {
+        $catalog = Regions::parse(\json_encode([
+            'default' => [
+                '$id' => 'default',
+                'name' => 'Default',
+                'disabled' => true,
+                'default' => false,
+            ],
+            'france' => [
+                '$id' => 'france',
+                'name' => 'France',
+                'disabled' => false,
+                'default' => true,
+            ],
+            'japan' => [
+                '$id' => 'japan',
+                'name' => 'Japan',
+                'disabled' => false,
+                'default' => false,
+            ],
+        ]));
+
+        $this->assertEquals(['default', 'france', 'japan'], \array_keys($catalog));
+        $this->assertTrue($catalog['france']['default']);
+        $this->assertTrue($catalog['default']['disabled']);
+        $this->assertEquals('Japan', $catalog['japan']['name']);
+    }
+
+    public function testParseListCatalog(): void
+    {
+        $catalog = Regions::parse(\json_encode([
+            [
+                '$id' => 'eu-west-1',
+                'name' => 'EU West',
+                'disabled' => false,
+                'default' => true,
+            ],
+        ]));
+
+        $this->assertArrayHasKey('eu-west-1', $catalog);
+        $this->assertTrue($catalog['eu-west-1']['default']);
+    }
+
+    public function testParseRejectsInvalidJson(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Regions::parse('not-json');
+    }
+
+    public function testParseRejectsInvalidRegionId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Regions::parse(\json_encode([
+            'France' => [
+                '$id' => 'France',
+                'name' => 'France',
+                'default' => true,
+            ],
+        ]));
+    }
+
+    public function testParseRejectsMultipleDefaults(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Regions::parse(\json_encode([
+            'france' => [
+                '$id' => 'france',
+                'name' => 'France',
+                'default' => true,
+            ],
+            'japan' => [
+                '$id' => 'japan',
+                'name' => 'Japan',
+                'default' => true,
+            ],
+        ]));
+    }
+
+    public function testPoolKeyMatchesRegion(): void
+    {
+        $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_france_main', 'france'));
+        $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_eu-west-1_main', 'eu-west-1'));
+        $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_franceville_main', 'france'));
+        $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_australia_main', 'us'));
+        $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_france_main', 'fra'));
+    }
+
+    public function testFilterPoolKeysForRegion(): void
+    {
+        $keys = [
+            'database_db_france_main',
+            'database_db_japan_main',
+            'database_db_franceville_main',
+        ];
+
+        $this->assertEquals(
+            ['database_db_france_main'],
+            Regions::filterPoolKeysForRegion($keys, 'france')
+        );
+    }
+}

--- a/tests/unit/Config/RegionsTest.php
+++ b/tests/unit/Config/RegionsTest.php
@@ -9,7 +9,36 @@ use PHPUnit\Framework\TestCase;
 
 final class RegionsTest extends TestCase
 {
-    public function testParseCatalog(): void
+    public function testParseAppwriteRegionsCatalog(): void
+    {
+        $catalog = Regions::parse(\json_encode([
+            'default' => [
+                '$id' => 'default',
+                'name' => 'Default',
+                'disabled' => true,
+                'default' => false,
+            ],
+            'fra' => [
+                '$id' => 'fra',
+                'name' => 'Frankfurt',
+                'disabled' => false,
+                'default' => true,
+            ],
+            'nyc' => [
+                '$id' => 'nyc',
+                'name' => 'New York',
+                'disabled' => false,
+                'default' => false,
+            ],
+        ]));
+
+        $this->assertEquals(['default', 'fra', 'nyc'], \array_keys($catalog));
+        $this->assertTrue($catalog['fra']['default']);
+        $this->assertTrue($catalog['default']['disabled']);
+        $this->assertEquals('New York', $catalog['nyc']['name']);
+    }
+
+    public function testParseCustomRegionsCatalog(): void
     {
         $catalog = Regions::parse(\json_encode([
             'default' => [
@@ -34,7 +63,6 @@ final class RegionsTest extends TestCase
 
         $this->assertEquals(['default', 'france', 'japan'], \array_keys($catalog));
         $this->assertTrue($catalog['france']['default']);
-        $this->assertTrue($catalog['default']['disabled']);
         $this->assertEquals('Japan', $catalog['japan']['name']);
     }
 
@@ -42,15 +70,15 @@ final class RegionsTest extends TestCase
     {
         $catalog = Regions::parse(\json_encode([
             [
-                '$id' => 'eu-west-1',
-                'name' => 'EU West',
+                '$id' => 'sfo',
+                'name' => 'San Francisco',
                 'disabled' => false,
                 'default' => true,
             ],
         ]));
 
-        $this->assertArrayHasKey('eu-west-1', $catalog);
-        $this->assertTrue($catalog['eu-west-1']['default']);
+        $this->assertArrayHasKey('sfo', $catalog);
+        $this->assertTrue($catalog['sfo']['default']);
     }
 
     public function testParseRejectsInvalidJson(): void
@@ -63,9 +91,9 @@ final class RegionsTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         Regions::parse(\json_encode([
-            'France' => [
-                '$id' => 'France',
-                'name' => 'France',
+            'FRA' => [
+                '$id' => 'FRA',
+                'name' => 'Frankfurt',
                 'default' => true,
             ],
         ]));
@@ -75,36 +103,51 @@ final class RegionsTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         Regions::parse(\json_encode([
-            'france' => [
-                '$id' => 'france',
-                'name' => 'France',
+            'fra' => [
+                '$id' => 'fra',
+                'name' => 'Frankfurt',
                 'default' => true,
             ],
-            'japan' => [
-                '$id' => 'japan',
-                'name' => 'Japan',
+            'nyc' => [
+                '$id' => 'nyc',
+                'name' => 'New York',
                 'default' => true,
             ],
         ]));
     }
 
-    public function testPoolKeyMatchesRegion(): void
+    public function testPoolKeyMatchesAppwriteRegions(): void
+    {
+        $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_fra_main', 'fra'));
+        $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_nyc_main', 'nyc'));
+        $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_frankfurt_main', 'fra'));
+        $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_nyc_main', 'fra'));
+    }
+
+    public function testPoolKeyMatchesCustomRegions(): void
     {
         $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_france_main', 'france'));
+        $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_japan_main', 'japan'));
         $this->assertTrue(Regions::poolKeyMatchesRegion('database_db_eu-west-1_main', 'eu-west-1'));
         $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_franceville_main', 'france'));
         $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_australia_main', 'us'));
         $this->assertFalse(Regions::poolKeyMatchesRegion('database_db_france_main', 'fra'));
     }
 
-    public function testFilterPoolKeysForRegion(): void
+    public function testFilterPoolKeysForAppwriteAndCustomRegions(): void
     {
         $keys = [
+            'database_db_fra_main',
+            'database_db_nyc_main',
             'database_db_france_main',
             'database_db_japan_main',
-            'database_db_franceville_main',
+            'database_db_frankfurt_main',
         ];
 
+        $this->assertEquals(
+            ['database_db_fra_main'],
+            Regions::filterPoolKeysForRegion($keys, 'fra')
+        );
         $this->assertEquals(
             ['database_db_france_main'],
             Regions::filterPoolKeysForRegion($keys, 'france')

--- a/tests/unit/Config/RegionsTest.php
+++ b/tests/unit/Config/RegionsTest.php
@@ -153,4 +153,50 @@ final class RegionsTest extends TestCase
             Regions::filterPoolKeysForRegion($keys, 'france')
         );
     }
+
+    public function testGetDefaultRegionIdPrefersEnabledCatalogDefault(): void
+    {
+        $catalog = [
+            'default' => [
+                '$id' => 'default',
+                'name' => 'Default',
+                'disabled' => true,
+                'default' => false,
+            ],
+            'fra' => [
+                '$id' => 'fra',
+                'name' => 'Frankfurt',
+                'disabled' => false,
+                'default' => true,
+            ],
+            'nyc' => [
+                '$id' => 'nyc',
+                'name' => 'New York',
+                'disabled' => false,
+                'default' => false,
+            ],
+        ];
+
+        $this->assertEquals('fra', Regions::getDefaultRegionId($catalog, 'default'));
+    }
+
+    public function testGetDefaultRegionIdFallsBackToFirstEnabled(): void
+    {
+        $catalog = [
+            'default' => [
+                '$id' => 'default',
+                'name' => 'Default',
+                'disabled' => true,
+                'default' => false,
+            ],
+            'nyc' => [
+                '$id' => 'nyc',
+                'name' => 'New York',
+                'disabled' => false,
+                'default' => false,
+            ],
+        ];
+
+        $this->assertEquals('nyc', Regions::getDefaultRegionId($catalog, 'default'));
+    }
 }

--- a/tests/unit/Platform/Modules/Databases/PoolTest.php
+++ b/tests/unit/Platform/Modules/Databases/PoolTest.php
@@ -103,7 +103,7 @@ final class PoolTest extends TestCase
         );
     }
 
-    public function testSelectsPoolForRegion(): void
+    public function testSelectsPoolForAppwriteRegion(): void
     {
         Config::setParam('pools-documentsdb', ['default-documents']);
         \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=database_db_fra_documents,database_db_nyc_documents');
@@ -114,7 +114,7 @@ final class PoolTest extends TestCase
         );
     }
 
-    public function testSelectsPoolForArbitraryRegionId(): void
+    public function testSelectsPoolForCustomRegion(): void
     {
         Config::setParam('pools-documentsdb', ['default-documents']);
         \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=database_db_france_documents,database_db_japan_documents,database_db_franceville_documents');
@@ -122,6 +122,17 @@ final class PoolTest extends TestCase
         $this->assertSame(
             'mongodb://database_db_france_documents',
             Pool::dsn('documentsdb', 'france', null)
+        );
+    }
+
+    public function testSelectsPoolForRegionTokenBoundaries(): void
+    {
+        Config::setParam('pools-documentsdb', ['default-documents']);
+        \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=database_db_fra_documents,database_db_nyc_documents,database_db_frankfurt_documents');
+
+        $this->assertSame(
+            'mongodb://database_db_fra_documents',
+            Pool::dsn('documentsdb', 'fra', null)
         );
     }
 

--- a/tests/unit/Platform/Modules/Databases/PoolTest.php
+++ b/tests/unit/Platform/Modules/Databases/PoolTest.php
@@ -106,11 +106,22 @@ final class PoolTest extends TestCase
     public function testSelectsPoolForRegion(): void
     {
         Config::setParam('pools-documentsdb', ['default-documents']);
-        \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=fra-documents,nyc-documents');
+        \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=database_db_fra_documents,database_db_nyc_documents');
 
         $this->assertSame(
-            'mongodb://fra-documents',
+            'mongodb://database_db_fra_documents',
             Pool::dsn('documentsdb', 'fra', null)
+        );
+    }
+
+    public function testSelectsPoolForArbitraryRegionId(): void
+    {
+        Config::setParam('pools-documentsdb', ['default-documents']);
+        \putenv('_APP_DATABASE_DOCUMENTSDB_KEYS=database_db_france_documents,database_db_japan_documents,database_db_franceville_documents');
+
+        $this->assertSame(
+            'mongodb://database_db_france_documents',
+            Pool::dsn('documentsdb', 'france', null)
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds first-class self-hosted multi-region configuration so operators can run a meta control plane plus regional API stacks without patching the image.

- **Configurable region catalog** via `_APP_REGIONS` (JSON) overriding `app/config/regions.php`, with validation in `Appwrite\Config\Regions` (DNS-label ids, exactly one `default: true`, object/list shapes).
- **Project create allowlist** via `_APP_PROJECT_REGIONS`; unsupported regions raise `PROJECT_REGION_UNSUPPORTED` with clearer guidance.
- **Regional DB pool selection** on project create and DocumentsDB/VectorsDB pool resolution using `_APP_DATABASE_KEYS` / region-scoped keys (`database_db_<regionId>_…`), matched with `_db_<region>_` token boundaries so short ids (e.g. `us`) do not collide with longer ones (e.g. `australia`).
- **Env + compose wiring** for `_APP_REGION`, `_APP_REGIONS`, `_APP_PROJECT_REGIONS`, `_APP_CONNECTIONS_DATABASE`, and `_APP_DATABASE_KEYS`.
- **Docs:** `docs/tutorials/self-hosted-multi-region.md` (meta vs regional topology, pool naming, monolith fallback).
- **Unit tests:** `tests/unit/Config/RegionsTest.php` covering parse + pool key matching for Cloud-style and custom region ids.

Monolith installs stay unchanged when multi-region env vars are left empty / default.

## Test Plan

- [x] `composer format` / `composer lint` on touched PHP files
- [x] `docker compose exec appwrite test tests/unit/Config/RegionsTest.php`
- [x] Monolith smoke: unset `_APP_REGIONS` / `_APP_CONNECTIONS_DATABASE` / `_APP_DATABASE_KEYS`, keep `_APP_REGION=default` — create project succeeds
- [x] Multi-region catalog: set `_APP_REGIONS` with `default` + `fra`/`nyc` (exactly one `"default": true`) — regions load; invalid JSON / multiple defaults fail at boot
- [x] Project create allowlist: `_APP_PROJECT_REGIONS=fra,nyc` — create in `fra` OK, create in unsupported id → `PROJECT_REGION_UNSUPPORTED`
- [x] Meta pool routing: `_APP_CONNECTIONS_DATABASE` + `_APP_DATABASE_KEYS` for `fra`/`nyc` — create project in `fra` binds to `database_db_fra_main` (not `nyc`)
- [x] Confirm short region ids do not false-match longer pool names (e.g. `us` vs `australia`)

## Related PRs and Issues

- Closes https://github.com/appwrite/appwrite/issues/12964
- Related console work (region picker / sibling hosts) tracked separately in appwrite/console

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?