### PR TITLE
fix(databases): route createAttribute DDL to the resolved database, not the project DB

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
+++ b/src/Appwrite/Platform/Modules/Databases/Workers/Databases.php
@@ -93,7 +93,7 @@ class Databases extends Action
         match (\strval($type)) {
             DATABASE_TYPE_DELETE_DATABASE => $this->deleteDatabase($database, $dbForProject, $dbForDatabases),
             DATABASE_TYPE_DELETE_COLLECTION => $this->deleteCollection($database, $collection, $dbForProject, $dbForDatabases),
-            DATABASE_TYPE_CREATE_ATTRIBUTE => $this->createAttribute($database, $collection, $document, $project, $dbForPlatform, $dbForProject, $queueForRealtime),
+            DATABASE_TYPE_CREATE_ATTRIBUTE => $this->createAttribute($database, $collection, $document, $project, $dbForPlatform, $dbForProject, $dbForDatabases, $queueForRealtime),
             DATABASE_TYPE_DELETE_ATTRIBUTE => $this->deleteAttribute($database, $collection, $document, $project, $dbForPlatform, $dbForProject, $dbForDatabases, $queueForRealtime),
             DATABASE_TYPE_CREATE_INDEX => $this->createIndex($database, $collection, $document, $project, $dbForPlatform, $dbForProject, $dbForDatabases, $queueForRealtime),
             DATABASE_TYPE_DELETE_INDEX => $this->deleteIndex($database, $collection, $document, $project, $dbForPlatform, $dbForProject, $dbForDatabases, $queueForRealtime),
@@ -108,6 +108,7 @@ class Databases extends Action
      * @param Document $project
      * @param Database $dbForPlatform
      * @param Database $dbForProject
+     * @param Database $dbForDatabases
      * @param Realtime $queueForRealtime
      * @return void
      * @throws Authorization
@@ -122,6 +123,7 @@ class Databases extends Action
         Document $project,
         Database $dbForPlatform,
         Database $dbForProject,
+        Database $dbForDatabases,
         Realtime $queueForRealtime
     ): void {
         if ($collection->isEmpty()) {
@@ -183,7 +185,7 @@ class Databases extends Action
                     }
 
                     if (
-                        !$dbForProject->createRelationship(
+                        !$dbForDatabases->createRelationship(
                             collection: 'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),
                             relatedCollection: 'database_' . $database->getSequence() . '_collection_' . $relatedCollection->getSequence(),
                             type: $options['relationType'],
@@ -202,7 +204,7 @@ class Databases extends Action
                     }
                     break;
                 default:
-                    if (!$dbForProject->createAttribute('database_' . $database->getSequence() . '_collection_' . $collection->getSequence(), $key, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters)) {
+                    if (!$dbForDatabases->createAttribute('database_' . $database->getSequence() . '_collection_' . $collection->getSequence(), $key, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters)) {
                         throw new Exception('Failed to create attribute/column');
                     }
             }

--- a/tests/unit/Platform/Workers/DatabasesTest.php
+++ b/tests/unit/Platform/Workers/DatabasesTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Workers;
+
+use Appwrite\Event\Realtime;
+use Appwrite\Platform\Modules\Databases\Workers\Databases;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Logger\Log;
+use Utopia\Queue\Message;
+
+require_once __DIR__ . '/../../../../app/init.php';
+
+final class DatabasesTest extends TestCase
+{
+    /**
+     * A dedicated database (tablesdb/documentsdb/vectorsdb) hosts its collections
+     * on the backing resolved by getDatabasesDB, not the shared project database.
+     * createAttribute must run its DDL on that resolved database — as its siblings
+     * createIndex/deleteAttribute already do — or, for a dedicated backing, it
+     * queries the shared pool, cannot find the collection and fails
+     * "Collection not found" (DAT-1967).
+     */
+    public function testCreateAttributeTargetsResolvedDatabaseNotProjectDb(): void
+    {
+        $attribute = new Document([
+            '$id' => 'attr1',
+            'key' => 'note',
+            'type' => Database::VAR_STRING,
+            'size' => 64,
+            'required' => false,
+            'default' => null,
+        ]);
+
+        // The shared project DB owns the `attributes` metadata but must never
+        // receive the collection DDL for a dedicated backing.
+        $dbForProject = $this->createMock(Database::class);
+        $dbForProject->method('getDocument')->willReturnCallback(
+            fn (string $collection, string $id) => $collection === 'attributes' ? $attribute : new Document()
+        );
+        $dbForProject->method('updateDocument')->willReturnArgument(2);
+        $dbForProject->expects($this->never())->method('createAttribute');
+
+        $dbForPlatform = $this->createMock(Database::class);
+        $dbForPlatform->method('getDocument')->willReturn(new Document(['$id' => 'proj1']));
+
+        // The resolved (dedicated) backing must receive the physical DDL.
+        $dbForDatabases = $this->createMock(Database::class);
+        $dbForDatabases->expects($this->once())
+            ->method('createAttribute')
+            ->willReturn(true);
+
+        $worker = new class () extends Databases {
+            protected function trigger(
+                Document $database,
+                Document $collection,
+                Document $project,
+                string $event,
+                Realtime $queueForRealtime,
+                Document|null $attribute = null,
+                Document|null $index = null,
+            ): void {
+            }
+        };
+
+        $message = new Message([
+            'pid' => 'pid',
+            'queue' => 'v1-databases',
+            'timestamp' => \time(),
+            'payload' => [
+                'type' => DATABASE_TYPE_CREATE_ATTRIBUTE,
+                'database' => ['$id' => 'db1', '$sequence' => '30360'],
+                'collection' => ['$id' => 'proof', '$sequence' => '1'],
+                'document' => ['$id' => 'attr1'],
+            ],
+        ]);
+
+        $worker->action(
+            $message,
+            new Document(['$id' => 'proj1']),
+            $dbForPlatform,
+            $dbForProject,
+            static fn () => $dbForDatabases,
+            $this->createStub(Realtime::class),
+            $this->createStub(Log::class),
+        );
+    }
+}


### PR DESCRIPTION
## What

The databases worker (`Platform/Modules/Databases/Workers/Databases`) resolves the collection's host database via `$dbForDatabases = $getDatabasesDB($database)` and passes it to `deleteAttribute`, `createIndex`, and `deleteIndex` — but **`createAttribute` was called with only `$dbForProject`**. It's the one DDL op that never received the resolved database.

For a database whose collections live on a **separate backing** (a dedicated `tablesdb`/`documentsdb`/`vectorsdb` in a multi-host setup), `createAttribute` then runs its physical DDL — and its internal collection lookup — against the shared **project** database, which doesn't hold that collection. The column creation fails with `Collection not found` and the attribute is marked `failed`.

Effect: on such a backing, tables can be created but **no columns can be added** → no typed rows → the database isn't usable.

## Fix

Thread `$dbForDatabases` into `createAttribute` and run the `createAttribute` / `createRelationship` DDL on it, exactly like `createIndex` already does. The `attributes` metadata reads/writes and cache purges stay on `$dbForProject`.

For a non-dedicated/single-host database `getDatabasesDB()` returns the project database, so this is a **no-op** there — only multi-host backings change behavior.

## Test

Adds `tests/unit/Platform/Workers/DatabasesTest` — drives the worker's `action()` with a `CREATE_ATTRIBUTE` message where `getDatabasesDB` returns a distinct database, and asserts the DDL lands on the resolved database (`->once()`) and **never** on the project DB (`->never()`). Fails without the fix ("`createAttribute(...)` on the project DB was not expected to be called"), passes with it. Pint + PHPStan clean.

> Reproduced live: a dedicated tablesdb on Appwrite Cloud provisions and creates tables on its dedicated backing, but `createAttribute` failed `Collection not found` against the shared pool until this fix.