### PR TITLE
fix(install): stop sending admin name/email in self-hosted telemetry, add opt-out

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -44,6 +44,15 @@ return [
                 'filter' => ''
             ],
             [
+                'name' => '_APP_TELEMETRY',
+                'description' => 'Controls the one-time anonymous install/upgrade ping the self-hosted setup sends to Appwrite. By default, set to \'enabled\'. To opt out, set to \'disabled\' (the cross-vendor \'DO_NOT_TRACK\' standard is honored as well). The ping is anonymous and never includes the administrator\'s name or email.',
+                'introduction' => '1.9.6',
+                'default' => 'enabled',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
                 'name' => '_APP_LOCKING_ENABLED',
                 'description' => 'Enable distributed locking for platform writes. Locks coordinate concurrent updates across API pods so read-modify-write operations on shared documents do not lose updates. By default, set to \'enabled\'. Set to \'disabled\' as an emergency kill switch; locks become no-ops and concurrent writes will race.',
                 'introduction' => '1.9.3',

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -15,6 +15,7 @@ use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Fetch\Client;
 use Utopia\Platform\Action;
+use Utopia\System\System;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
@@ -697,11 +698,11 @@ class Install extends Action
                 // Run tracking in a coroutine when inside a Swoole
                 // request so it doesn't block the worker.
                 if (Coroutine::getCid() !== -1) {
-                    go(function () use ($input, $isUpgrade, $version, $account) {
-                        $this->trackSelfHostedInstall($input, $isUpgrade, $version, $account);
+                    go(function () use ($input, $isUpgrade, $version) {
+                        $this->trackSelfHostedInstall($input, $isUpgrade, $version);
                     });
                 } else {
-                    $this->trackSelfHostedInstall($input, $isUpgrade, $version, $account);
+                    $this->trackSelfHostedInstall($input, $isUpgrade, $version);
                 }
 
                 if ($isCLI) {
@@ -851,54 +852,17 @@ class Install extends Action
         );
     }
 
-    private function trackSelfHostedInstall(array $input, bool $isUpgrade, string $version, array $account): void
+    private function trackSelfHostedInstall(array $input, bool $isUpgrade, string $version): void
     {
         if ($this->isLocalInstall()) {
             return;
         }
 
-        $appEnv = $input['_APP_ENV'] ?? 'development';
-        $domain = $input['_APP_DOMAIN'] ?? 'localhost';
+        $payload = $this->buildSelfHostedInstallPayload($input, $isUpgrade, $version);
 
-        /* local or test instance */
-        if ($appEnv !== 'production') {
+        if ($payload === null) {
             return;
         }
-
-        /* prod but local or test instance */
-        if ($domain === 'localhost'
-            || str_starts_with($domain, '127.')
-            || str_starts_with($domain, '0.0.0.0')
-        ) {
-            return;
-        }
-
-        $type = $isUpgrade ? 'upgrade' : 'install';
-        $database = $input['_APP_DB_ADAPTER'] ?? 'postgresql';
-        $name = $account['name'] ?? 'Admin';
-        $email = $account['email'] ?? 'admin@selfhosted.local';
-
-        $hostIp = @gethostbyname($domain);
-
-        $payload = [
-            'action' => $type,
-            'account' => 'self-hosted',
-            'url' => 'https://' . $domain,
-            'category' => 'self_hosted',
-            'label' => 'self_hosted_' . $type,
-            'version' => $version,
-            'data' => json_encode([
-                'name' => $name,
-                'email' => $email,
-                'domain' => $domain,
-                'database' => $database,
-                'ip' => ($hostIp !== $domain) ? $hostIp : null,
-                'os' => php_uname('s') . ' ' . php_uname('r'),
-                'arch' => php_uname('m'),
-                'cpus' => ((int) trim((string) \shell_exec('nproc'))) ?: null,
-                'ram' => (int) round(((float) trim((string) \shell_exec('grep MemTotal /proc/meminfo | awk \'{print $2}\''))) / 1024),
-            ]),
-        ];
 
         try {
             $client = new Client();
@@ -910,6 +874,79 @@ class Install extends Action
         } catch (\Throwable) {
             // tracking shouldn't block installation
         }
+    }
+
+    /**
+     * Build the anonymous self-hosted install/upgrade analytics payload.
+     *
+     * Returns null when tracking must not happen: the operator has opted out,
+     * or the instance is a local/non-production one. The payload is intentionally
+     * anonymous — it never includes the administrator's name or email (see #12863).
+     *
+     * @param array<string, mixed> $input Resolved environment variables
+     * @return array<string, mixed>|null The payload to send, or null to skip tracking
+     */
+    public function buildSelfHostedInstallPayload(array $input, bool $isUpgrade, string $version): ?array
+    {
+        /* operator opted out of telemetry */
+        if ($this->isTelemetryDisabled()) {
+            return null;
+        }
+
+        $appEnv = $input['_APP_ENV'] ?? 'development';
+        $domain = $input['_APP_DOMAIN'] ?? 'localhost';
+
+        /* local or test instance */
+        if ($appEnv !== 'production') {
+            return null;
+        }
+
+        /* prod but local or test instance */
+        if ($domain === 'localhost'
+            || str_starts_with($domain, '127.')
+            || str_starts_with($domain, '0.0.0.0')
+        ) {
+            return null;
+        }
+
+        $type = $isUpgrade ? 'upgrade' : 'install';
+        $database = $input['_APP_DB_ADAPTER'] ?? 'postgresql';
+
+        $hostIp = @gethostbyname($domain);
+
+        return [
+            'action' => $type,
+            'account' => 'self-hosted',
+            'url' => 'https://' . $domain,
+            'category' => 'self_hosted',
+            'label' => 'self_hosted_' . $type,
+            'version' => $version,
+            'data' => json_encode([
+                'domain' => $domain,
+                'database' => $database,
+                'ip' => ($hostIp !== $domain) ? $hostIp : null,
+                'os' => php_uname('s') . ' ' . php_uname('r'),
+                'arch' => php_uname('m'),
+                'cpus' => ((int) trim((string) \shell_exec('nproc'))) ?: null,
+                'ram' => (int) round(((float) trim((string) \shell_exec('grep MemTotal /proc/meminfo | awk \'{print $2}\''))) / 1024),
+            ]),
+        ];
+    }
+
+    /**
+     * Whether the operator has opted out of anonymous install/upgrade telemetry.
+     *
+     * Honors the cross-vendor `DO_NOT_TRACK` standard (https://consoledonottrack.com)
+     * as well as Appwrite's own `_APP_TELEMETRY=disabled` switch.
+     */
+    public function isTelemetryDisabled(): bool
+    {
+        $doNotTrack = \strtolower((string) System::getEnv('DO_NOT_TRACK', ''));
+        if ($doNotTrack === '1' || $doNotTrack === 'true') {
+            return true;
+        }
+
+        return \strtolower((string) System::getEnv('_APP_TELEMETRY', '')) === 'disabled';
     }
 
     /**

--- a/tests/unit/Platform/Tasks/InstallTest.php
+++ b/tests/unit/Platform/Tasks/InstallTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Tasks;
+
+use Appwrite\Platform\Tasks\Install;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../../app/init.php';
+
+final class InstallTest extends TestCase
+{
+    private Install $install;
+
+    protected function setUp(): void
+    {
+        // Ensure a deterministic, opted-in environment for each test.
+        \putenv('DO_NOT_TRACK');
+        \putenv('_APP_TELEMETRY');
+
+        $this->install = new Install();
+    }
+
+    protected function tearDown(): void
+    {
+        \putenv('DO_NOT_TRACK');
+        \putenv('_APP_TELEMETRY');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function productionInput(): array
+    {
+        return [
+            '_APP_ENV' => 'production',
+            '_APP_DOMAIN' => 'example.com',
+            '_APP_DB_ADAPTER' => 'mariadb',
+        ];
+    }
+
+    public function testPayloadIsAnonymousAndOmitsAdminNameAndEmail(): void
+    {
+        $payload = $this->install->buildSelfHostedInstallPayload($this->productionInput(), false, '1.9.6');
+
+        $this->assertIsArray($payload);
+        $this->assertSame('install', $payload['action']);
+        $this->assertSame('self-hosted', $payload['account']);
+        $this->assertSame('1.9.6', $payload['version']);
+
+        $data = \json_decode($payload['data'], true);
+        $this->assertIsArray($data);
+
+        // The whole point of #12863: no administrator PII in the ping.
+        $this->assertArrayNotHasKey('name', $data);
+        $this->assertArrayNotHasKey('email', $data);
+
+        // Anonymous host/instance fields are still reported.
+        $this->assertSame('example.com', $data['domain']);
+        $this->assertSame('mariadb', $data['database']);
+        $this->assertArrayHasKey('os', $data);
+        $this->assertArrayHasKey('arch', $data);
+    }
+
+    public function testUpgradeActionIsReported(): void
+    {
+        $payload = $this->install->buildSelfHostedInstallPayload($this->productionInput(), true, '1.9.6');
+
+        $this->assertIsArray($payload);
+        $this->assertSame('upgrade', $payload['action']);
+        $this->assertSame('self_hosted_upgrade', $payload['label']);
+    }
+
+    public function testDoNotTrackDisablesTelemetry(): void
+    {
+        \putenv('DO_NOT_TRACK=1');
+
+        $this->assertTrue($this->install->isTelemetryDisabled());
+        $this->assertNull($this->install->buildSelfHostedInstallPayload($this->productionInput(), false, '1.9.6'));
+    }
+
+    public function testDoNotTrackTrueValueDisablesTelemetry(): void
+    {
+        \putenv('DO_NOT_TRACK=true');
+
+        $this->assertTrue($this->install->isTelemetryDisabled());
+    }
+
+    public function testAppTelemetryDisabledDisablesTelemetry(): void
+    {
+        \putenv('_APP_TELEMETRY=disabled');
+
+        $this->assertTrue($this->install->isTelemetryDisabled());
+        $this->assertNull($this->install->buildSelfHostedInstallPayload($this->productionInput(), false, '1.9.6'));
+    }
+
+    public function testTelemetryEnabledByDefault(): void
+    {
+        $this->assertFalse($this->install->isTelemetryDisabled());
+    }
+
+    public function testNonProductionEnvironmentIsNotTracked(): void
+    {
+        $input = $this->productionInput();
+        $input['_APP_ENV'] = 'development';
+
+        $this->assertNull($this->install->buildSelfHostedInstallPayload($input, false, '1.9.6'));
+    }
+
+    public function testLocalhostDomainIsNotTracked(): void
+    {
+        $input = $this->productionInput();
+        $input['_APP_DOMAIN'] = 'localhost';
+
+        $this->assertNull($this->install->buildSelfHostedInstallPayload($input, false, '1.9.6'));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

The self-hosted installer sends a one-time analytics ping to
`growth.appwrite.io` on install/upgrade. Today that payload includes the
**administrator's name and email in plaintext**, and there is no way to opt
out. This addresses #12863 and finally delivers the opt-out env var promised
in #2772.

Changes:

- **Remove PII from the ping.** `name` and `email` are no longer collected;
  the payload is now anonymous (domain + host stats only — os/arch/cpus/ram/ip).
- **Add an opt-out.** Tracking is skipped when the operator sets the
  cross-vendor [`DO_NOT_TRACK`](https://consoledonottrack.com) standard, or
  Appwrite's own `_APP_TELEMETRY=disabled`. `_APP_TELEMETRY` is documented in
  `app/config/variables.php`.
- **Make it testable.** Extracted `buildSelfHostedInstallPayload()` and
  `isTelemetryDisabled()` from `trackSelfHostedInstall()` so the behavior can
  be unit-tested without network calls.

The existing guards (skip local installs, non-production `_APP_ENV`, and
localhost/loopback domains) are unchanged.

## Test Plan

New unit test `tests/unit/Platform/Tasks/InstallTest.php` (8 tests, 22 assertions):

- payload omits `name`/`email` and still reports anonymous host fields;
- `install` vs `upgrade` action is reported correctly;
- `DO_NOT_TRACK=1` / `DO_NOT_TRACK=true` and `_APP_TELEMETRY=disabled` each
  short-circuit tracking (payload is `null`);
- telemetry is enabled by default;
- non-production env and localhost domain are not tracked.

Verified locally in the dev container:

- `vendor/bin/phpunit tests/unit/Platform/Tasks/InstallTest.php` → OK (8 tests, 22 assertions)
- `vendor/bin/pint --test` (PSR-12) → PASS
- `vendor/bin/phpstan analyse` (level 4) → No errors

## Related PRs and Issues

- Fixes #12863
- Follow-up to #2772 (opt-out env var that was promised but never shipped)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — N/A (no API surface change; CLI install task + config only)

