### PR TITLE
Accept providerNamespace on createRepository to create in a GitLab group

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Gitea.php
+++ b/src/Appwrite/Auth/OAuth2/Gitea.php
@@ -137,7 +137,7 @@ class Gitea extends OAuth2
         return $this->user;
     }
 
-    public function createRepository(string $accessToken, string $repositoryName, bool $private): array
+    public function createRepository(string $accessToken, string $repositoryName, bool $private, string $namespaceId = ''): array
     {
         $repository = $this->request('POST', $this->endpoint . '/api/v1/user/repos', ['Authorization: token ' . $accessToken, 'Content-Type: application/json'], \json_encode([
             'name' => $repositoryName,

--- a/src/Appwrite/Auth/OAuth2/Github.php
+++ b/src/Appwrite/Auth/OAuth2/Github.php
@@ -235,7 +235,7 @@ class Github extends OAuth2
         return $this->user;
     }
 
-    public function createRepository(string $accessToken, string $repositoryName, bool $private): array
+    public function createRepository(string $accessToken, string $repositoryName, bool $private, string $namespaceId = ''): array
     {
         $repository = $this->request('POST', 'https://api.github.com/user/repos', ['Authorization: token ' . \urlencode($accessToken)], \json_encode([
             'name' => $repositoryName,

--- a/src/Appwrite/Auth/OAuth2/Gitlab.php
+++ b/src/Appwrite/Auth/OAuth2/Gitlab.php
@@ -183,12 +183,18 @@ class Gitlab extends OAuth2
      *
      * @return array
      */
-    public function createRepository(string $accessToken, string $repositoryName, bool $private): array
+    public function createRepository(string $accessToken, string $repositoryName, bool $private, string $namespaceId = ''): array
     {
-        $repository = $this->request('POST', $this->getEndpoint() . '/api/v4/projects', ['Authorization: Bearer ' . $accessToken, 'Content-Type: application/json'], \json_encode([
+        $payload = [
             'name' => $repositoryName,
             'visibility' => $private ? 'private' : 'public',
-        ]));
+        ];
+
+        if (!empty($namespaceId)) {
+            $payload['namespace_id'] = (int) $namespaceId;
+        }
+
+        $repository = $this->request('POST', $this->getEndpoint() . '/api/v4/projects', ['Authorization: Bearer ' . $accessToken, 'Content-Type: application/json'], \json_encode($payload));
 
         $repository = \json_decode($repository, true) ?? [];
 

--- a/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Create.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Create.php
@@ -51,6 +51,7 @@ class Create extends Action
             ->param('installationId', '', new Text(256), 'Installation Id')
             ->param('name', '', new Text(256), 'Repository name (slug)')
             ->param('private', '', new Boolean(false), 'Mark repository public or private')
+            ->param('providerNamespace', '', new Text(256), 'Namespace of the git repository. Defaults to the installation\'s own namespace.', true)
             ->inject('vcsFactory')
             ->inject('installationTokens')
             ->inject('user')
@@ -63,6 +64,7 @@ class Create extends Action
         string $installationId,
         string $name,
         bool $private,
+        string $providerNamespace,
         VcsFactory $vcsFactory,
         InstallationTokens $installationTokens,
         Document $user,
@@ -99,14 +101,18 @@ class Create extends Action
             $accessToken = $installation->getAttribute('personalAccessToken');
 
             try {
-                $repository = $oauth2->createRepository($accessToken, $name, $private);
+                if (!empty($providerNamespace)) {
+                    $repository = $oauth2->createRepository($accessToken, $name, $private, $providerNamespace);
+                } else {
+                    $repository = $oauth2->createRepository($accessToken, $name, $private);
+                }
             } catch (\Throwable $exception) {
                 throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, "VCS provider failed to process the request: " . $exception->getMessage());
             }
         } else {
             $providerInstallationId = $installation->getAttribute('providerInstallationId');
             $vcs = $vcsFactory->fromInstallation($installation);
-            $owner = $vcs->getOwnerName($providerInstallationId);
+            $owner = !empty($providerNamespace) ? $providerNamespace : $vcs->getOwnerName($providerInstallationId);
 
             try {
                 $repository = $vcs->createRepository($owner, $name, $private);


### PR DESCRIPTION
## Summary
The namespaces endpoint and `listRepositories` namespace support (merged in #12951) let you browse a GitLab group's repos, but `createRepository` still always resolved the owner from the installation itself -- so a GitLab user with groups had no way to create a new repo inside a group, only in their personal namespace.

This mirrors the `listRepositories` fix: adds an optional `providerNamespace` param to `createRepository`, threaded through to `OAuth2Gitlab::createRepository()` as GitLab's `namespace_id`. Also widens `Github`/`Gitea` OAuth2 `createRepository()` signatures with the same optional (no-op) param so the call site doesn't need a provider-specific branch.

## Test plan
- [ ] `composer format && composer analyze` (done locally, clean)
- [ ] E2E: create a repo with `providerNamespace` set to a GitLab group, verify it lands in the group not the personal namespace
- [ ] E2E: create a repo without `providerNamespace`, verify unchanged personal-namespace behavior for GitHub/Gitea/GitLab