### PR TITLE
fix: pass providerRepositoryId to getOwnerName in Builds worker

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -414,7 +414,7 @@ class Builds extends Action
                 $rootDirectory = \ltrim($rootDirectory, '.');
                 $rootDirectory = \ltrim($rootDirectory, '/');
 
-                $owner = $providerAdapter->getOwnerName($providerInstallationId);
+                $owner = $providerAdapter->getOwnerName($providerInstallationId, (int) $providerRepositoryId);
                 $repositoryName = $providerAdapter->getRepositoryName($providerRepositoryId);
 
                 $cloneOwner = $deployment->getAttribute('providerRepositoryOwner', $owner);


### PR DESCRIPTION
Deployment.php already passes `(int) $providerRepositoryId` as the second argument to `getOwnerName()` (applied in commit 9dedf391). The same fix was missed in Builds.php at line 417.

Without this, Gitea org-owned repo deployments resolve the wrong owner (falls back to authenticated user login) and fail to clone silently. Personal repos are unaffected.

Found during QA of PR #12833.