### PR TITLE
fix(vcs): skip unnecessary personal OAuth2 refresh for GitHub installations

### DIFF
--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -17,13 +17,9 @@ class InstallationTokens
     {
         $provider = $installation->getAttribute('provider', 'github');
 
-        // GitHub Apps authenticate via a JWT-derived installation access token
-        // (see GitHub::initializeVariables()), which is generated independently
-        // of personalAccessToken/personalRefreshToken. Refreshing those here is
-        // both unnecessary and unsafe: GitHub rotates OAuth refresh tokens on
-        // every use, so a concurrent refresh call fails the other with
-        // "Failed to refresh OAuth2 access token" even though the installation
-        // itself is perfectly functional.
+        // GitHub uses a JWT-derived installation token (GitHub::initializeVariables()),
+        // not personalAccessToken/personalRefreshToken -- refreshing those here only
+        // risks a token-rotation race against concurrent requests, for no benefit.
         if ($provider === 'github') {
             return $installation;
         }

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -17,6 +17,17 @@ class InstallationTokens
     {
         $provider = $installation->getAttribute('provider', 'github');
 
+        // GitHub Apps authenticate via a JWT-derived installation access token
+        // (see GitHub::initializeVariables()), which is generated independently
+        // of personalAccessToken/personalRefreshToken. Refreshing those here is
+        // both unnecessary and unsafe: GitHub rotates OAuth refresh tokens on
+        // every use, so a concurrent refresh call fails the other with
+        // "Failed to refresh OAuth2 access token" even though the installation
+        // itself is perfectly functional.
+        if ($provider === 'github') {
+            return $installation;
+        }
+
         return $this->refresh($installation, $dbForPlatform, $vcsFactory->oauth2FromProvider($provider));
     }
 

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -6,8 +6,10 @@ namespace Tests\Unit\Vcs;
 
 use Appwrite\Auth\OAuth2;
 use Appwrite\Extend\Exception;
+use Appwrite\Vcs\Factory;
 use Appwrite\Vcs\InstallationTokens;
 use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Cache;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -211,6 +213,52 @@ final class InstallationTokensTest extends TestCase
         $result = (new InstallationTokens())->refresh($installation, $db, $oauth2);
 
         $this->assertSame('already-refreshed-token', $result->getAttribute('personalAccessToken'));
+    }
+
+    public function testGithubProviderSkipsPersonalTokenRefresh(): void
+    {
+        $installation = new Document([
+            '$id' => 'installation1',
+            'provider' => 'github',
+            'personalAccessToken' => 'stale-token',
+            'personalRefreshToken' => 'stale-refresh',
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), -3600),
+        ]);
+
+        // Empty registry: oauth2FromProvider('github') would throw if it were
+        // ever called, proving GitHub never reaches the OAuth2 refresh path.
+        $vcsFactory = new Factory($this->createStub(Cache::class), []);
+
+        $result = (new InstallationTokens())->refreshForInstallation($installation, $this->db(), $vcsFactory);
+
+        $this->assertSame('stale-token', $result->getAttribute('personalAccessToken'));
+    }
+
+    public function testNonGithubProviderStillRefreshesPersonalToken(): void
+    {
+        $oauth2 = $this->fakeOAuth2();
+        $vcsFactory = new Factory($this->createStub(Cache::class), [
+            'gitlab' => [
+                'oauth2' => fn () => $oauth2,
+                'variables' => [],
+            ],
+        ]);
+
+        $db = $this->createMock(Database::class);
+        $db->expects($this->once())->method('updateDocument');
+
+        $installation = new Document([
+            '$id' => 'installation1',
+            'provider' => 'gitlab',
+            'personalAccessToken' => 'stale-token',
+            'personalRefreshToken' => 'stale-refresh',
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), -3600),
+        ]);
+
+        $result = (new InstallationTokens())->refreshForInstallation($installation, $db, $vcsFactory);
+
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
     }
 
     protected function fakeOAuth2(bool $emptyUserId = false, bool $throwOnRefresh = false)


### PR DESCRIPTION
## Summary
- GitHub App installations authenticate via a JWT-derived installation access token (`GitHub::initializeVariables()` in `vendor/utopia-php/vcs`), generated independently of `personalAccessToken`/`personalRefreshToken`. Every GitHub API call in the adapter (`listBranches`, `getOwnerName`, `getRepositoryName`, etc.) uses that JWT-derived token exclusively — never the personal OAuth token.
- `InstallationTokens::refreshForInstallation()` was unconditionally refreshing the personal OAuth2 token before every GitHub-scoped read operation (branch listing, repository listing/detection, file contents), even though nothing downstream consumes it for GitHub.
- GitHub rotates OAuth refresh tokens on every use. Two concurrent refresh calls sharing the same stored refresh token cause the second to fail with `"Failed to refresh OAuth2 access token. Please reconnect the installation."`, even though the installation itself is fully functional. This is a real, race-triggered failure mode — not tied to any actual installation corruption.
- Root-caused from a customer report of intermittent "branches don't appear in Console" and confirmed via code trace, not guesswork: see [GitHub.php:68-86](https://github.com/appwrite/appwrite/blob/main/vendor/utopia-php/vcs/src/VCS/Adapter/Git/GitHub.php) for the JWT-only token flow, and [Branches/XList.php:87](https://github.com/appwrite/appwrite/blob/main/src/Appwrite/Platform/Modules/VCS/Http/Installations/Repositories/Branches/XList.php) for the unconditional refresh call site.

## Fix
`InstallationTokens::refreshForInstallation()` now returns the installation unchanged for `provider === 'github'`, skipping the OAuth2 refresh entirely. Other providers (GitLab, Gitea) are unaffected — they genuinely use OAuth2 access tokens for API calls and still refresh normally.

Repository creation under a personal namespace (the one legitimate use of the personal token — GitHub App tokens can't create personal-account repos, so this needs user-scoped OAuth) is unaffected: it calls `InstallationTokens::refresh()` directly with its own guard in `Repositories/Create.php`, not through `refreshForInstallation()`.

## Test plan
- [x] Added `testGithubProviderSkipsPersonalTokenRefresh` — proves GitHub never reaches the OAuth2 client (empty provider registry would throw if it did)
- [x] Added `testNonGithubProviderStillRefreshesPersonalToken` — proves GitLab/Gitea still refresh correctly
- [x] All 11 tests in `tests/unit/Vcs/InstallationTokensTest.php` pass
- [ ] Deploy and confirm branch listing no longer intermittently fails for GitHub installations under concurrent load