### PR TITLE
chore(builds): bump orchestrator to 0.13.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1239,7 +1239,7 @@ services:
       options:
         max-file: "5"
         max-size: 10m
-    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.8.0
+    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.13.0
     restart: unless-stopped
     user: root
     networks:
@@ -1250,7 +1250,7 @@ services:
       - ORCHESTRATOR_BACKEND=docker
       - ORCHESTRATOR_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator-jobs:8080
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.8.0
+      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.13.0
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
## What

Bumps the orchestrator `jobs-service` and `job-sidecar` images from 0.8.0 to 0.13.0.

All intermediate releases are additive — no integration changes required:
- 0.9.0: lz4 compression for tar/squashfs artifacts
- 0.10.0: erofs support for archive/unarchive/mount artifacts
- 0.11.0: settable workspace path for deployments
- 0.12.0: activator honors client invocation id, echoes request in async callback
- 0.13.0: k8s lifecycle callbacks for fast jobs first seen terminal

## Testing

Verified end-to-end on a local stack with `_APP_BUILDS_BACKEND=orchestrator`: uploaded a deployment whose build command allocates memory until killed. The build ran on 0.13.0, was OOM-killed at its spec limit, and the deployment correctly finalized as `failed`.

Notes from the OOM run (groundwork for follow-ups on this branch):
- User-facing build logs end with a raw shell line (`build.sh: line 44: 17 Killed bash -c "$1"`) followed by the generic `Build failed with exit code 137.` — no "out of memory" message.
- The exit callback carries only the exit code; the docker backend never inspects `State.OOMKilled`, so Appwrite can't distinguish OOM from timeout/cancel kills (all 137). Fixing that needs a `reason` field on the orchestrator's exit event first.
- The docker backend sets only `Resources.Memory`, so Docker defaults `MemorySwap` to 2× — builds can swap up to double their spec before the kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)