### PR TITLE
fix: mark migrations failed when MIGRATION_HOST is unset

### DIFF
--- a/src/Appwrite/Platform/Workers/Migrations.php
+++ b/src/Appwrite/Platform/Workers/Migrations.php
@@ -496,14 +496,14 @@ class Migrations extends Action
         $transfer = $source = $destination = null;
         $caughtError = null;
 
-        $host = System::getEnv('_APP_MIGRATION_HOST');
-        if (empty($host)) {
-            throw new \Exception('_APP_MIGRATION_HOST is not set');
-        }
-
-        $endpoint = 'http://' . $host . '/v1';
-
         try {
+            $host = System::getEnv('_APP_MIGRATION_HOST');
+            if (empty($host)) {
+                throw new \Exception('_APP_MIGRATION_HOST is not set');
+            }
+
+            $endpoint = 'http://' . $host . '/v1';
+
             $credentials = $migration->getAttribute('credentials', []);
 
             if ($migration->getAttribute('source') === SourceAppwrite::getName()) {


### PR DESCRIPTION
## What does this PR do?

When `_APP_MIGRATION_HOST` is missing from the migrations worker env, the worker threw **before** the `try/catch` that marks the migration `status=failed`. CSV imports (and other migrations) stayed `pending` forever, so the console import box kept reloading them after refresh.

This moves the host check inside the existing try/catch so failures are persisted as `failed` / `finished` and surface through the normal error path.

## Test Plan

1. Temporarily unset `_APP_MIGRATION_HOST` on `appwrite-worker-migrations`.
2. Start a CSV import from the console.
3. Confirm the migration document ends as `status=failed` (not stuck `pending`).
4. Restore `_APP_MIGRATION_HOST=appwrite` and confirm a normal import still completes.

## Related PRs and Issues

- Discord: https://appwrite.io/threads/1528763052218912840

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
