### PR TITLE
fix: spatial isNull/isNotNull query support

### DIFF
--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -8730,6 +8730,28 @@ trait DatabasesBase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(2, $response['body'][$this->getRecordResource()]);
 
+        // Test 4.0a: isNotNull on spatial attribute (regression: MariaDB::handleSpatialQueries threw "Unknown spatial query method: isNotNull")
+        $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $collectionId), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [Query::isNotNull('pointAttr')->toString()]
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(3, $response['body']['total']);
+
+        // Test 4.0b: isNull on spatial attribute (regression: MariaDB::handleSpatialQueries threw "Unknown spatial query method: isNull")
+        $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $collectionId), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [Query::isNull('pointAttr')->toString()]
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(0, $response['body']['total']);
+
         // Test 4.1: contains on line (point on line)
         $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $collectionId), array_merge([
             'content-type' => 'application/json',

--- a/tests/unit/Messaging/MessagingFanoutTest.php
+++ b/tests/unit/Messaging/MessagingFanoutTest.php
@@ -383,7 +383,7 @@ final class MessagingFanoutTest extends TestCase
      * Build a topic-backed dataset: $count subscribers, each pointing at one email target. A single identifier
      * is duplicated so per-page dedup is exercised when the dataset fits in one page.
      *
-     * @return array{subscribers: array<Document>, targets: array<int|string, Document>}
+     * @return array{subscribers: array<Document>, targets: array<int, Document>}
      */
     private function topicDataset(int $count): array
     {


### PR DESCRIPTION
Replacement PR for #12901. Same fix, rebased on latest main.\n\n- Adds e2e coverage for isNull/isNotNull on spatial attributes\n- Fixes MessagingFanoutTest docblock type annotation\n\nNote: composer.lock changes omitted (database already at 6.4.4 on main).