### PR TITLE
fix(compose): add missing _APP_DOMAIN* and _APP_OPTIONS_FORCE_HTTPS env vars to appwrite-worker-executions and appwrite-task-scheduler-messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -668,6 +668,10 @@ services:
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_DOMAIN
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
@@ -1167,6 +1171,10 @@ services:
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_DOMAIN
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER


### PR DESCRIPTION
Rebased on latest 1.9.x from original PR #12729 with conflict resolution.

Changes: Added missing _APP_DOMAIN, _APP_DOMAIN_FUNCTIONS, _APP_DOMAIN_SITES, and _APP_OPTIONS_FORCE_HTTPS env vars to appwrite-worker-executions and appwrite-task-scheduler-messages services.