### PR TITLE
fix(install): preserve custom _APP_DB_HOST/_APP_DB_PORT during upgrade

### DIFF
--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -308,16 +308,7 @@ class Install extends Action
         }
         $userInput['_APP_DB_ADAPTER'] = $userInput['_APP_DB_ADAPTER'] ?? $database;
         $database = $userInput['_APP_DB_ADAPTER'];
-        if ($database === 'postgresql') {
-            $userInput['_APP_DB_HOST'] = 'postgresql';
-            $userInput['_APP_DB_PORT'] = 5432;
-        } elseif ($database === 'mongodb') {
-            $userInput['_APP_DB_HOST'] = 'mongodb';
-            $userInput['_APP_DB_PORT'] = 27017;
-        } elseif ($database === 'mariadb') {
-            $userInput['_APP_DB_HOST'] = 'mariadb';
-            $userInput['_APP_DB_PORT'] = 3306;
-        }
+        $this->applyContainerDatabaseHost($userInput, $database, $vars['_APP_DB_HOST']['default'] ?? null);
 
         $shouldGenerateSecrets = !$existingInstallation && !$isUpgrade;
         $input = $this->prepareEnvironmentVariables($userInput, $vars, $shouldGenerateSecrets);
@@ -437,18 +428,32 @@ class Install extends Action
 
         // Set database-specific connection details
         $database = $input['_APP_DB_ADAPTER'] ?? 'postgresql';
-        if ($database === 'mongodb') {
-            $input['_APP_DB_HOST'] = 'mongodb';
-            $input['_APP_DB_PORT'] = 27017;
-        } elseif ($database === 'mariadb') {
-            $input['_APP_DB_HOST'] = 'mariadb';
-            $input['_APP_DB_PORT'] = 3306;
-        } elseif ($database === 'postgresql') {
-            $input['_APP_DB_HOST'] = 'postgresql';
-            $input['_APP_DB_PORT'] = 5432;
-        }
+        $this->applyContainerDatabaseHost($input, $database, $input['_APP_DB_HOST'] ?? null);
 
         return $input;
+    }
+
+    /**
+     * Point _APP_DB_HOST/_APP_DB_PORT at the bundled database container for
+     * the given adapter, unless the current host is already a custom value
+     * (e.g. an external database preserved from an existing installation).
+     */
+    private function applyContainerDatabaseHost(array &$input, string $database, ?string $currentHost): void
+    {
+        $containerHosts = [
+            'postgresql' => 5432,
+            'mongodb' => 27017,
+            'mariadb' => 3306,
+        ];
+
+        if (!empty($currentHost) && !array_key_exists($currentHost, $containerHosts)) {
+            return;
+        }
+
+        if (isset($containerHosts[$database])) {
+            $input['_APP_DB_HOST'] = $database;
+            $input['_APP_DB_PORT'] = $containerHosts[$database];
+        }
     }
 
     public function hasExistingConfig(): bool

--- a/tests/unit/Platform/Tasks/InstallTest.php
+++ b/tests/unit/Platform/Tasks/InstallTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Tasks;
+
+use Appwrite\Platform\Tasks\Install;
+use PHPUnit\Framework\TestCase;
+
+final class InstallTest extends TestCase
+{
+    protected ?Install $install = null;
+
+    protected function setUp(): void
+    {
+        $this->install = new Install();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->install = null;
+    }
+
+    private function makeVar(string $name, ?string $default, string $filter = '', bool $required = false): array
+    {
+        return [
+            'name' => $name,
+            'default' => $default,
+            'required' => $required,
+            'question' => '',
+            'filter' => $filter,
+        ];
+    }
+
+    private function baseVars(?string $dbHostDefault, ?string $dbPortDefault, string $dbAdapterDefault = 'postgresql'): array
+    {
+        return [
+            '_APP_DB_ADAPTER' => $this->makeVar('_APP_DB_ADAPTER', $dbAdapterDefault, required: true),
+            '_APP_DB_HOST' => $this->makeVar('_APP_DB_HOST', $dbHostDefault),
+            '_APP_DB_PORT' => $this->makeVar('_APP_DB_PORT', $dbPortDefault),
+        ];
+    }
+
+    public function testPreservesCustomDatabaseHostOnUpgrade(): void
+    {
+        // Simulates an upgrade where the user has _APP_DB_HOST pointing at an
+        // external database (preserved into the vars default by the existing
+        // installation detection logic in action()).
+        $vars = $this->baseVars('my-remote-db.example.com', '5433');
+
+        $input = $this->install->prepareEnvironmentVariables(
+            ['_APP_DB_ADAPTER' => 'postgresql'],
+            $vars,
+            false
+        );
+
+        $this->assertSame('my-remote-db.example.com', $input['_APP_DB_HOST']);
+        $this->assertSame('5433', $input['_APP_DB_PORT']);
+    }
+
+    public function testAppliesContainerHostForFreshInstall(): void
+    {
+        // Fresh install: no existing installation, so the default is still
+        // the config's own known container hostname for the chosen adapter.
+        $vars = $this->baseVars('postgresql', '5432');
+
+        $input = $this->install->prepareEnvironmentVariables(
+            ['_APP_DB_ADAPTER' => 'mongodb'],
+            $vars,
+            true
+        );
+
+        $this->assertSame('mongodb', $input['_APP_DB_HOST']);
+        $this->assertSame(27017, $input['_APP_DB_PORT']);
+    }
+
+    public function testKeepsContainerHostInSyncWhenAlreadyUsingDefaultContainer(): void
+    {
+        // Upgrade where the previous install used the bundled mariadb
+        // container; switching adapter should still follow the container.
+        $vars = $this->baseVars('mariadb', '3306', 'mariadb');
+
+        $input = $this->install->prepareEnvironmentVariables(
+            ['_APP_DB_ADAPTER' => 'mariadb'],
+            $vars,
+            false
+        );
+
+        $this->assertSame('mariadb', $input['_APP_DB_HOST']);
+        $this->assertSame(3306, $input['_APP_DB_PORT']);
+    }
+}


### PR DESCRIPTION
## What does this PR do?
The upgrade script unconditionally overwrote _APP_DB_HOST/_APP_DB_PORT with the bundled container hostname (postgresql/mariadb/mongodb), even when a user had configured an external database host in their .env. This silently pointed the migration at the wrong database.

Now the container default is only applied when the current host is empty or already one of the known container service names, so a custom external host is preserved across upgrades.
  
## Test Plan  
- Added `tests/unit/Platform/Tasks/InstallTest.php` covering: preserving a custom external host on upgrade, applying the container default on a fresh install, and keeping the container host in sync when already using the bundled container.
- `docker compose exec appwrite test tests/unit/Platform/Tasks/InstallTest.php` — new tests pass.
- `docker compose exec appwrite test tests/unit/` — full unit suite (936 tests) passes, no regressions.
- `vendor/bin/phpstan analyse` on the changed file — no errors.
- Manually verified the actual upgrade flow described in the docs (`docker run --entrypoint="upgrade" appwrite/appwrite:<VERSION>`), using a local build of this branch's image:
    1. Ran `--entrypoint="install"` to generate a fresh `.env`/`docker-compose.yml` (simulating an existing installation).
    2. Edited `.env` to set `_APP_DB_HOST`/`_APP_DB_PORT` to a custom external database (e.g. `my-remote-db.example.com:5433`), simulating the scenario from the issue.
    3. Ran `--entrypoint="upgrade"` against that installation and confirmed `_APP_DB_HOST`/`_APP_DB_PORT` remained unchanged in the resulting `.env`.
    4. Repeated the same steps against an image built from `main` (without this fix) and confirmed the values were indeed reset to the bundled container hostname (`mariadb`/`3306`), reproducing the reported bug.

## Related PRs and Issues
- Fixes #11902

## Checklist
- [x] Have you read the [Contributing Guidelines on issues (https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?