### PR TITLE
fix: spatial isNull/isNotNull query support (widen database constraint, add e2e)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "6.0.*",
+        "utopia-php/database": "^6.0.0",
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -8621,6 +8621,28 @@ trait DatabasesBase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertCount(2, $response['body'][$this->getRecordResource()]);
 
+        // Test 4.0a: isNotNull on spatial attribute (regression: MariaDB::handleSpatialQueries threw "Unknown spatial query method: isNotNull")
+        $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $collectionId), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [Query::isNotNull('pointAttr')->toString()]
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(3, $response['body']['total']);
+
+        // Test 4.0b: isNull on spatial attribute (regression: MariaDB::handleSpatialQueries threw "Unknown spatial query method: isNull")
+        $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $collectionId), array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => [Query::isNull('pointAttr')->toString()]
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(0, $response['body']['total']);
+
         // Test 4.1: contains on line (point on line)
         $response = $this->client->call(Client::METHOD_GET, $this->getRecordUrl($databaseId, $collectionId), array_merge([
             'content-type' => 'application/json',


### PR DESCRIPTION
Replacement for #12947 (closed).

Changes:
- Widen utopia-php/database constraint from \6.0.*\ to \^6.0.0\ to allow 6.4.x which includes the spatial isNull/isNotNull fix (utopia-php/database#922)
- Add E2E tests for isNull/isNotNull on spatial attributes

Note: composer.lock should be updated by running \composer update utopia-php/database\ to lock to 6.4.4.