### PR TITLE
fix: cache empty get document results (replacement of #12961)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "utopia-php/compression": "0.1.*",
         "utopia-php/config": "1.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/database": "6.0.*",
+"utopia-php/database": "dev-cache-empty-get-document as 6.4.4",
         "utopia-php/detector": "0.2.*",
         "utopia-php/domains": "^2.2",
         "utopia-php/emails": "0.7.*",


### PR DESCRIPTION
Replacement of #12961 by @fogelito. Original was CONFLICTING — rebased onto 1.9.x and conflict resolved in composer.json (composer.lock conflict resolved by accepting current 1.9.x version).