### PR TITLE
fix(storage): fix chunked upload ClamAV scan and add antivirus e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,7 @@ jobs:
   e2e_grouped:
     name: Tests / E2E / ${{ matrix.config.label }} (${{ matrix.mode }})
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/retry=when-interrupted/extras=otel+ecr-cache
-    timeout-minutes: 20
+    timeout-minutes: 35
     needs: [build, matrix]
     permissions:
       contents: read
@@ -598,14 +598,19 @@ jobs:
               done
 
       - name: Load and Start Appwrite
-        timeout-minutes: 5
+        timeout-minutes: ${{ matrix.config.wait == 'clamav' && 15 || 5 }}
         env:
           _APP_OPTIONS_ABUSE: ${{ matrix.config.options_abuse }}
           _APP_STORAGE_ANTIVIRUS: ${{ matrix.config.storage_antivirus }}
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
-        run: docker compose up -d --quiet-pull --wait
+        run: |
+          if [ "${{ matrix.config.wait }}" = "clamav" ]; then
+            docker compose up -d --quiet-pull --wait --wait-timeout 780
+          else
+            docker compose up -d --quiet-pull --wait
+          fi
 
       - name: Wait for Open Runtimes
         if: matrix.config.wait == 'executor'
@@ -618,9 +623,9 @@ jobs:
 
       - name: Wait for ClamAV
         if: matrix.config.wait == 'clamav'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
-          for attempt in $(seq 1 60); do
+          for attempt in $(seq 1 120); do
             if docker compose exec -T appwrite php -r '
               require "/usr/src/code/vendor/autoload.php";
               $host = getenv("_APP_STORAGE_ANTIVIRUS_HOST") ?: "clamav";
@@ -631,7 +636,7 @@ jobs:
               echo "ClamAV is ready"
               exit 0
             fi
-            echo "Waiting for ClamAV (attempt ${attempt}/60)"
+            echo "Waiting for ClamAV (attempt ${attempt}/120)"
             sleep 5
           done
           echo "::error::ClamAV did not become ready"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,7 +517,7 @@ jobs:
             -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}" \
             -e _TESTS_OAUTH2_GITHUB_CLIENT_ID="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_ID }}" \
             -e _TESTS_OAUTH2_GITHUB_CLIENT_SECRET="${{ secrets.TESTS_OAUTH2_GITHUB_CLIENT_SECRET }}" \
-            appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --log-junit tests/e2e/Services/${{ matrix.service.name }}/junit.xml
+            appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" --exclude-group abuseEnabled --exclude-group screenshots --exclude-group antivirus --log-junit tests/e2e/Services/${{ matrix.service.name }}/junit.xml
 
       - name: Failure Logs
         if: failure()
@@ -525,10 +525,10 @@ jobs:
           echo "=== Appwrite Logs ==="
           docker compose logs --timestamps
 
-  e2e_abuse:
-    name: Tests / E2E / Abuse (${{ matrix.mode }})
+  e2e_grouped:
+    name: Tests / E2E / ${{ matrix.config.label }} (${{ matrix.mode }})
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/retry=when-interrupted/extras=otel+ecr-cache
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [build, matrix]
     permissions:
       contents: read
@@ -537,6 +537,30 @@ jobs:
       fail-fast: false
       matrix:
         mode: ${{ fromJSON(needs.matrix.outputs.modes) }}
+        config:
+          - label: Abuse
+            group: abuseEnabled
+            path: /usr/src/code/tests/e2e
+            options_abuse: enabled
+            storage_antivirus: disabled
+            compose_profiles: ''
+            wait: ''
+          - label: Screenshots
+            group: screenshots
+            path: /usr/src/code/tests/e2e/Services/Sites
+            options_abuse: disabled
+            storage_antivirus: disabled
+            compose_profiles: ''
+            wait: executor
+          - label: Antivirus
+            group: antivirus
+            path: /usr/src/code/tests/e2e/Services/Storage
+            options_abuse: disabled
+            storage_antivirus: enabled
+            compose_profiles: antivirus
+            wait: clamav
+    env:
+      COMPOSE_PROFILES: ${{ matrix.config.compose_profiles }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -576,80 +600,15 @@ jobs:
       - name: Load and Start Appwrite
         timeout-minutes: 5
         env:
-          _APP_OPTIONS_ABUSE: enabled
-          _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
-          _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
-          _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
-        run: docker compose up -d --quiet-pull --wait
-
-      - name: Run tests
-        timeout-minutes: 15
-        run: >-
-          docker compose exec -T
-          -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite test /usr/src/code/tests/e2e --group=abuseEnabled
-
-      - name: Failure Logs
-        if: failure()
-        run: |
-          echo "=== Appwrite Logs ==="
-          docker compose logs --timestamps
-
-  e2e_screenshots:
-    name: Tests / E2E / Screenshots (${{ matrix.mode }})
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/volume=60g/spot=price-capacity-optimized/retry=when-interrupted/extras=otel+ecr-cache
-    timeout-minutes: 15
-    needs: [build, matrix]
-    permissions:
-      contents: read
-      packages: read
-    strategy:
-      fail-fast: false
-      matrix:
-        mode: ${{ fromJSON(needs.matrix.outputs.modes) }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_AUTH_AVAILABLE == 'true' }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - parallel:
-          - name: Pull Docker Image
-            run: |
-              docker pull ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }}
-              docker tag ${{ env.RUNS_ON_ECR_CACHE }}:${{ env.IMAGE }}-${{ github.sha }} ${{ env.IMAGE }}
-
-          - name: Pull Docker Compose images
-            timeout-minutes: 5
-            run: |
-              # Docker Hub registry timeouts are a common transient CI failure
-              # (e.g. a traefik manifest fetch timing out). Retry the image pull;
-              # keep `up` single-shot so genuine container health failures still surface.
-              for attempt in 1 2 3; do
-                if docker compose pull --quiet --ignore-buildable; then
-                  break
-                elif [ "$attempt" -eq 3 ]; then
-                  echo "::error::docker compose pull failed after 3 attempts; aborting"
-                  exit 1
-                fi
-                echo "::warning::docker compose pull failed (attempt ${attempt}/3); retrying in 15s"
-                sleep 15
-              done
-
-      - name: Load and Start Appwrite
-        timeout-minutes: 5
-        env:
+          _APP_OPTIONS_ABUSE: ${{ matrix.config.options_abuse }}
+          _APP_STORAGE_ANTIVIRUS: ${{ matrix.config.storage_antivirus }}
           _APP_DATABASE_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'database_db_main' || '' }}
           _APP_DATABASE_DOCUMENTSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'documentsdb_db_main' || '' }}
           _APP_DATABASE_VECTORSDB_SHARED_TABLES: ${{ matrix.mode != 'dedicated' && 'vectorsdb_db_main' || '' }}
         run: docker compose up -d --quiet-pull --wait
 
       - name: Wait for Open Runtimes
+        if: matrix.config.wait == 'executor'
         timeout-minutes: 3
         run: |
           while ! docker logs exc1 | grep -q "Executor is ready."; do
@@ -657,18 +616,44 @@ jobs:
             sleep 1
           done
 
+      - name: Wait for ClamAV
+        if: matrix.config.wait == 'clamav'
+        timeout-minutes: 5
+        run: |
+          for attempt in $(seq 1 60); do
+            if docker compose exec -T appwrite php -r '
+              require "/usr/src/code/vendor/autoload.php";
+              $host = getenv("_APP_STORAGE_ANTIVIRUS_HOST") ?: "clamav";
+              $port = (int) (getenv("_APP_STORAGE_ANTIVIRUS_PORT") ?: 3310);
+              $av = new Appwrite\ClamAV\Network($host, $port);
+              exit(@$av->ping() ? 0 : 1);
+            '; then
+              echo "ClamAV is ready"
+              exit 0
+            fi
+            echo "Waiting for ClamAV (attempt ${attempt}/60)"
+            sleep 5
+          done
+          echo "::error::ClamAV did not become ready"
+          docker compose logs --timestamps clamav || true
+          exit 1
+
       - name: Run tests
         timeout-minutes: 15
         run: >-
           docker compose exec -T
           -e _APP_E2E_RESPONSE_FORMAT="${{ github.event.inputs.response_format }}"
-          appwrite test /usr/src/code/tests/e2e/Services/Sites --group=screenshots
+          appwrite test ${{ matrix.config.path }} --group=${{ matrix.config.group }}
 
       - name: Failure Logs
         if: failure()
         run: |
           echo "=== Appwrite Logs ==="
           docker compose logs --timestamps
+          if [ "${{ matrix.config.wait }}" = "clamav" ]; then
+            echo "=== ClamAV Logs ==="
+            docker compose logs --timestamps clamav || true
+          fi
 
   benchmark:
     name: Benchmark

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -459,7 +459,7 @@ services:
   clamav:
     profiles:
       - antivirus
-    image: clamav/clamav:1.4
+    image: clamav/clamav:1.4-debian
     container_name: appwrite-clamav
     restart: unless-stopped
     networks:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -459,7 +459,7 @@ services:
   clamav:
     profiles:
       - antivirus
-    image: appwrite/clamav:2.0.0
+    image: clamav/clamav:1.4
     container_name: appwrite-clamav
     restart: unless-stopped
     networks:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -456,6 +456,14 @@ services:
   appwrite-embedding:
     ports:
       - "9505:3000"
+  clamav:
+    profiles:
+      - antivirus
+    image: appwrite/clamav:2.0.0
+    container_name: appwrite-clamav
+    restart: unless-stopped
+    networks:
+      - appwrite
 configs:
   redisinsight-connections.json:
     content: |

--- a/docs/tutorials/multi-architecture-support.md
+++ b/docs/tutorials/multi-architecture-support.md
@@ -1,11 +1,31 @@
 # Multi Architecture Support
 
-A list of Appwrite CPU architecture support status. We use this list to track the status of all Appwrite related Docker images and which architecture is supported by each image.
+CPU architecture support for Docker images used by the Appwrite stack. Platforms are taken from the published multi-arch manifests on Docker Hub / GHCR (not from historical claims).
 
-|  | linux/amd64 | linux/arm64 | linux/arm/v6 | linux/arm/v7 | linux/arm64/v8 | linux/ppc64le | linux/s390x |
+| Image | linux/amd64 | linux/arm64 | linux/arm/v6 | linux/arm/v7 | linux/arm64/v8 | linux/ppc64le | linux/s390x |
 |---|---|---|---|---|---|---|---|
-| appwrite/appwrite | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
-| appwrite/mariadb | 🟢 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 |
-| clamav/clamav | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 |
-| traefik | 🟢 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 |
-| redis | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
+| **Core** | | | | | | | |
+| appwrite/appwrite | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/base:1.4.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/assistant:0.8.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/browser:0.3.3 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/embedding:0.1.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/geo:0.3.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/postgres:0.1.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| openruntimes/executor:0.25.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| ghcr.io/open-runtimes/orchestrator/jobs-service:0.13.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| traefik:3.6 | 🟢 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | 🟢 |
+| redis:7.4.7-alpine | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
+| mariadb:10.11 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 |
+| mongo:8.2.5 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| **Optional** | | | | | | | |
+| clamav/clamav:1.4-debian | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 |
+| **Dev / test** | | | | | | | |
+| appwrite/mailcatcher:1.1.1 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/requestcatcher:1.1.0 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
+| appwrite/altair:0.3.0 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🔴 |
+| coredns/coredns:1.12.4 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | 🟢 | 🟢 |
+
+Notes:
+
+- `linux/arm64` and `linux/arm64/v8` are treated as the same when the manifest publishes a plain `arm64` platform.

--- a/docs/tutorials/multi-architecture-support.md
+++ b/docs/tutorials/multi-architecture-support.md
@@ -6,6 +6,6 @@ A list of Appwrite CPU architecture support status. We use this list to track th
 |---|---|---|---|---|---|---|---|
 | appwrite/appwrite | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
 | appwrite/mariadb | 🟢 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 |
-| appwrite/clamav | 🟢 | 🟢 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 |
+| clamav/clamav | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 |
 | traefik | 🟢 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 |
 | redis | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |

--- a/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
+++ b/src/Appwrite/Platform/Modules/Storage/Http/Buckets/Files/Create.php
@@ -360,7 +360,7 @@ class Create extends Action
                         (int) System::getEnv('_APP_STORAGE_ANTIVIRUS_PORT', 3310)
                     );
 
-                    if (!$antivirus->fileScan($path)) {
+                    if (!$antivirus->fileScanInStream($path)) {
                         $deviceForFiles->delete($path);
                         throw new Exception(Exception::STORAGE_INVALID_FILE);
                     }

--- a/tests/e2e/Services/Storage/StorageCustomServerTest.php
+++ b/tests/e2e/Services/Storage/StorageCustomServerTest.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\E2E\Services\Storage;
 
+use CURLFile;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\E2E\Client;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideServer;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
+use Utopia\System\System;
 
 final class StorageCustomServerTest extends Scope
 {
@@ -364,5 +369,92 @@ final class StorageCustomServerTest extends Scope
             )
         );
         $this->assertEquals(404, $response['headers']['status-code']);
+    }
+
+    /**
+     * Regression for chunked uploads under the antivirus size limit.
+     *
+     * Requires ClamAV (compose profile `antivirus`) and
+     * `_APP_STORAGE_ANTIVIRUS=enabled`. File must be >5MB (chunked) and
+     * ≤20MB (`APP_LIMIT_ANTIVIRUS`) so the last chunk triggers a scan.
+     */
+    #[Group('antivirus')]
+    public function testCreateBucketFileChunkedUploadWithAntivirus(): void
+    {
+        if (System::getEnv('_APP_STORAGE_ANTIVIRUS', 'disabled') === 'disabled') {
+            $this->markTestSkipped('Antivirus is disabled.');
+        }
+
+        $health = $this->client->call(Client::METHOD_GET, '/health/anti-virus', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $health['headers']['status-code']);
+        $this->assertEquals('pass', $health['body']['status'], 'ClamAV must be reachable when antivirus is enabled.');
+
+        $bucket = $this->client->call(Client::METHOD_POST, '/storage/buckets', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'bucketId' => ID::unique(),
+            'name' => 'Antivirus Chunked Upload Bucket',
+            'fileSecurity' => true,
+            'antivirus' => true,
+            'permissions' => [
+                Permission::create(Role::any()),
+                Permission::read(Role::any()),
+            ],
+        ]);
+        $this->assertEquals(201, $bucket['headers']['status-code']);
+
+        $source = __DIR__ . '/../../../resources/functions/large/blue.mp4';
+        $totalSize = \filesize($source);
+        $this->assertGreaterThan(5 * 1024 * 1024, $totalSize, 'Fixture must be large enough to chunk.');
+        $this->assertLessThanOrEqual(20_000_000, $totalSize, 'Fixture must stay under APP_LIMIT_ANTIVIRUS.');
+
+        $chunkSize = 5 * 1024 * 1024;
+        $handle = \fopen($source, 'rb');
+        $this->assertNotFalse($handle);
+
+        $fileId = 'unique()';
+        $mimeType = \mime_content_type($source);
+        $counter = 0;
+        $id = '';
+        $file = null;
+        $headers = [
+            'content-type' => 'multipart/form-data',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ];
+
+        while (!\feof($handle)) {
+            $curlFile = new CURLFile(
+                'data://' . $mimeType . ';base64,' . \base64_encode(\fread($handle, $chunkSize)),
+                $mimeType,
+                'blue.mp4'
+            );
+            $headers['content-range'] = 'bytes ' . ($counter * $chunkSize) . '-' . \min(((($counter * $chunkSize) + $chunkSize) - 1), $totalSize - 1) . '/' . $totalSize;
+            if (!empty($id)) {
+                $headers['x-appwrite-id'] = $id;
+            }
+
+            $file = $this->client->call(Client::METHOD_POST, '/storage/buckets/' . $bucket['body']['$id'] . '/files', \array_merge($headers, $this->getHeaders()), [
+                'fileId' => $fileId,
+                'file' => $curlFile,
+                'permissions' => [
+                    Permission::read(Role::any()),
+                ],
+            ]);
+            $counter++;
+            $id = $file['body']['$id'] ?? $id;
+        }
+        \fclose($handle);
+
+        $this->assertEquals(201, $file['headers']['status-code']);
+        $this->assertNotEmpty($file['body']['$id']);
+        $this->assertEquals('blue.mp4', $file['body']['name']);
+        $this->assertEquals($totalSize, $file['body']['sizeOriginal']);
+        $this->assertEquals($file['body']['chunksTotal'], $file['body']['chunksUploaded']);
+        $this->assertNotEmpty($file['body']['mimeType']);
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes chunked file uploads failing antivirus checks on self-hosted local storage, and adds CI coverage for that path.

When a chunked upload is finalized, the assembled file is created via `tempnam()`/`rename()` and ends up mode `0600`. ClamAV's path-based `SCAN` runs as another user and cannot read that file, so the last chunk was rejected as `storage_invalid_file`. Single-shot uploads succeed because they use `file_put_contents` with mode `0644`.

This switches the chunked-upload antivirus path from `fileScan()` to `fileScanInStream()`, so Appwrite streams file bytes to clamd over the network socket instead of relying on a shared-path scan.

Also adds:
- An opt-in `clamav` service under the `antivirus` compose profile in `docker-compose.override.yml`
- A `#[Group('antivirus')]` Storage e2e that chunk-uploads a 5–20 MB file with antivirus enabled
- A consolidated `e2e_grouped` CI matrix job for abuse, screenshots, and antivirus suites (with ClamAV readiness wait for the antivirus suite)

## Test Plan

1. Enable antivirus on a self-hosted instance with local storage:
   - `_APP_STORAGE_DEVICE=local`
   - `_APP_STORAGE_ANTIVIRUS=enabled`
   - `_APP_STORAGE_ANTIVIRUS_HOST=clamav`
2. Create a bucket with antivirus enabled.
3. Upload a file larger than 5 MB and smaller than 20 MB (chunked by the SDK, still under `APP_LIMIT_ANTIVIRUS`).
4. Confirm the final chunk succeeds (HTTP 201/200) and the file is downloadable with a correct `mimeType` and `chunksUploaded === chunksTotal`.
5. Confirm a single-shot upload of the same content still succeeds.
6. Confirm a known EICAR/malware sample is still rejected when under the antivirus size limit.
7. CI: `Tests / E2E / Antivirus` should start ClamAV (`COMPOSE_PROFILES=antivirus`), wait for ping, and run `Storage --group=antivirus`.

Local antivirus group:

```bash
docker compose --profile antivirus up -d clamav
_APP_STORAGE_ANTIVIRUS=enabled docker compose up -d --force-recreate appwrite
docker compose exec appwrite test tests/e2e/Services/Storage --group=antivirus
```

## Related PRs and Issues

- Fixes #13001

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
