### PR TITLE
chore(sdks): bump cursor-plugin to 0.2.0 and add its changelog

### DIFF
--- a/app/config/sdks.php
+++ b/app/config/sdks.php
@@ -284,7 +284,7 @@ return [
             [
                 'key' => 'cursor-plugin',
                 'name' => 'CursorPlugin',
-                'version' => '0.1.0',
+                'version' => '0.2.0',
                 'url' => 'https://github.com/appwrite/cursor-plugin.git',
                 'enabled' => true,
                 'beta' => false,

--- a/docs/sdks/cursor-plugin/CHANGELOG.md
+++ b/docs/sdks/cursor-plugin/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+## 0.2.0
+
+* Breaking: Replaced local `appwrite-api` and `appwrite-docs` MCP servers with the hosted server
+* Added: Hosted Appwrite MCP server at `https://mcp.appwrite.io/`, authenticated via OAuth
+* Added: README guidance for MCP sign-in, reauthentication, and connection troubleshooting
+* Updated: CLI skill covers `includes` multi-file config, `settings`, and `webhooks`
+* Updated: CLI skill documents `--where`, `--sort-asc`, `--sort-desc`, `--select` query flags
+* Updated: CLI skill moves function and site variables to `.env` with `--with-variables`
+* Updated: CLI skill adds `buildSpecification`, `runtimeSpecification`, `deploymentRetention` fields
+* Updated: CLI skill adds `project` service, Homebrew tap install, and `login --switch`
+* Updated: SDK skills use TablesDB row and table terminology for permissions
+* Updated: LICENSE changed from MIT to the Appwrite BSD-style license
+
+## 0.1.0
+
+* Added: Initial release of the Appwrite plugin for Cursor


### PR DESCRIPTION
## What does this PR do?

Prepares the `cursor-plugin` static SDK for its `0.2.0` release.

- Bumps `cursor-plugin` from `0.1.0` to `0.2.0` in `app/config/sdks.php`
- Adds `docs/sdks/cursor-plugin/CHANGELOG.md`

The SDK config already pointed `changelog` at `docs/sdks/cursor-plugin/CHANGELOG.md`, but that file never existed. `realpath()` resolved to `false`, so `SDKs.php` fell back to the bare `# Change Log` string and every generated release shipped an empty changelog. With the file in place the generator emits real release notes and `sdks --release` can extract them for the GitHub release body.

## Changelog for 0.2.0

* Breaking: Replaced local `appwrite-api` and `appwrite-docs` MCP servers with the hosted server
* Added: Hosted Appwrite MCP server at `https://mcp.appwrite.io/`, authenticated via OAuth
* Added: README guidance for MCP sign-in, reauthentication, and connection troubleshooting
* Updated: CLI skill covers `includes` multi-file config, `settings`, and `webhooks`
* Updated: CLI skill documents `--where`, `--sort-asc`, `--sort-desc`, `--select` query flags
* Updated: CLI skill moves function and site variables to `.env` with `--with-variables`
* Updated: CLI skill adds `buildSpecification`, `runtimeSpecification`, `deploymentRetention` fields
* Updated: CLI skill adds `project` service, Homebrew tap install, and `login --switch`
* Updated: SDK skills use TablesDB row and table terminology for permissions
* Updated: LICENSE changed from MIT to the Appwrite BSD-style license

`0.x` versioning, so the MCP config break is a minor bump.

## Test Plan

Generated the SDK locally and diffed against `appwrite/cursor-plugin@main`:

```
php app/cli.php sdks --platform=static --sdk=cursor-plugin --version=1.9.x --git=no --ai=no
```

Verified the changelog resolves and the `0.2.0` section is emitted into the generated `CHANGELOG.md`.

## Related PRs and Issues

Follow-up: once merged, `appwrite/cursor-plugin` gets a regenerated PR and a `0.2.0` GitHub release.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/HEAD/CONTRIBUTING.md)?

Yes