### PR TITLE
Document executor container_name/hostname requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,7 @@
 * Fix installer compose executor config in [#11874](https://github.com/appwrite/appwrite/pull/11874)
 * Fix public hostname validation under Swoole DNS in [#12431](https://github.com/appwrite/appwrite/pull/12431)
 * Fix host validation and regional endpoint validation in [#12411](https://github.com/appwrite/appwrite/pull/12411) and [#12357](https://github.com/appwrite/appwrite/pull/12357)
+* **Upgrade note:** As of this release, the `openruntimes-executor` service's `container_name` must match its `hostname` in `docker-compose.yml` ([#11874](https://github.com/appwrite/appwrite/pull/11874)). The executor looks up its own container at startup by matching `hostname` against Docker container `name`; if you run a custom Compose file where these differ (common in installs predating 1.9.5), the executor will crash-loop on start. See [#13016](https://github.com/appwrite/appwrite/issues/13016).
 
 ### API, SDKs, and specs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1194,7 +1194,10 @@ services:
     # container_name and hostname must be identical: on startup the executor
     # looks up its own container in Docker by matching `hostname` against
     # container `name`. If you change one of these in a custom compose file,
-    # keep the other in sync or the executor will crash-loop on start.
+    # keep the other in sync, and also update _APP_EXECUTOR_HOST (.env),
+    # which points at this hostname (default: http://exc1/v1) — otherwise
+    # the executor will crash-loop on start, or Appwrite won't be able to
+    # reach it.
     # See https://github.com/appwrite/appwrite/issues/13016
     container_name: exc1
     hostname: exc1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1191,6 +1191,11 @@ services:
     networks:
       - appwrite
   openruntimes-executor:
+    # container_name and hostname must be identical: on startup the executor
+    # looks up its own container in Docker by matching `hostname` against
+    # container `name`. If you change one of these in a custom compose file,
+    # keep the other in sync or the executor will crash-loop on start.
+    # See https://github.com/appwrite/appwrite/issues/13016
     container_name: exc1
     hostname: exc1
     logging:


### PR DESCRIPTION
## Summary
- Adds an inline comment in `docker-compose.yml` above the `openruntimes-executor` service explaining that `container_name` and `hostname` must match, since the executor looks itself up in Docker at startup by matching `hostname` against container `name`.
- Adds an "Upgrade note" bullet to `CHANGES.md` under the 1.9.5 "Installer and self-hosted" section (next to PR #11874, which is what made these values match), so self-hosters upgrading from a custom pre-1.9.5 compose file know why the executor can crash-loop.

This covers the documentation half of #13016. The reporter also found that when the executor's `onStart` hook throws, the framework's global error-hook machinery itself fails trying to resolve a `response` dependency that doesn't exist yet at startup — and that secondary failure is all that gets logged, masking the real error. That fix belongs in `open-runtimes/executor` (`app/error.php`) and/or `utopia-php/http` (`Http::start()`), not in this repo, so it's out of scope here.

## Test plan
- [x] `docker compose config -q` parses the modified `docker-compose.yml` without error
- [x] Manually reviewed `CHANGES.md` rendering for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)