### PR TITLE
chore: bump orchestrator to 0.14.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1239,7 +1239,7 @@ services:
       options:
         max-file: "5"
         max-size: 10m
-    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.13.0
+    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.14.0
     restart: unless-stopped
     user: root
     networks:
@@ -1250,7 +1250,7 @@ services:
       - ORCHESTRATOR_BACKEND=docker
       - ORCHESTRATOR_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator-jobs:8080
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.13.0
+      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.14.0
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
## What does this PR do?

Bumps the `orchestrator-jobs` service and its job sidecar from 0.13.0 to [0.14.0](https://github.com/open-runtimes/orchestrator/releases/tag/v0.14.0).

What's in the release:
- `feat(jobs)`: exit callbacks now carry a `reason` alongside `exitCode` (additive — only set when non-empty, so existing consumers are unaffected)
- `fix(metrics)`: HTTP metrics are labelled with the matched route instead of the raw URL, so job IDs and scanner probes no longer create unbounded Prometheus series

No config migration: no env vars were added, removed, or renamed between 0.13.0 and 0.14.0.

## Test Plan

- Verified both tags are published: `docker manifest inspect ghcr.io/open-runtimes/orchestrator/{jobs-service,job-sidecar}:0.14.0`
- `git diff v0.13.0 v0.14.0 -- internal/config/` upstream is empty, so the existing `environment:` block stays valid
- Builds should be exercised end to end (create a function deployment) before merge

## Related PRs and Issues

- https://github.com/open-runtimes/orchestrator/pull/48
- https://github.com/open-runtimes/orchestrator/pull/49

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API's metadata, does it also include updated API specs and example docs? (n/a — image tag bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)