### PR TITLE
chore: bump orchestrator to 0.15.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1239,7 +1239,7 @@ services:
       options:
         max-file: "5"
         max-size: 10m
-    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.14.0
+    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.15.0
     restart: unless-stopped
     user: root
     networks:
@@ -1250,7 +1250,7 @@ services:
       - ORCHESTRATOR_BACKEND=docker
       - ORCHESTRATOR_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator-jobs:8080
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.14.0
+      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.15.0
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
## What does this PR do?

Bumps the `orchestrator-jobs` service and its job sidecar from 0.14.0 to [0.15.0](https://github.com/open-runtimes/orchestrator/releases/tag/v0.15.0).

0.15.0 is a single bug fix — [#50](https://github.com/open-runtimes/orchestrator/pull/50): the tar extractor created directories with the archive entry's own mode, so a source tarball containing a directory that is not owner-writable (`0o555`, or `0o000` as Windows tooling emits) aborted the build in the pre-job artifact phase:

```
failed to create directory: mkdir /mnt/code/source/src/admin-frontend: permission denied
```

The sidecar runs as a non-root user, so it could not write into the directory it had just created. Directories are now extracted `0o755`, matching what the squashfs/erofs path already did. Directory modes from the archive are no longer preserved; file modes are unchanged.

No config migration — no env vars added, removed, or renamed.

## Test Plan

- Verified both tags are published: `docker manifest inspect ghcr.io/open-runtimes/orchestrator/{jobs-service,job-sidecar}:0.15.0`
- Upstream regression test extracts a nested file under `0o555`/`0o500`/`0o000` parent directories and fails on the pre-fix code
- Worth deploying a function whose source archive contains a read-only directory to confirm the build now completes

## Related PRs and Issues

- https://github.com/open-runtimes/orchestrator/pull/50

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API's metadata, does it also include updated API specs and example docs? (n/a — image tag bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)