### PR TITLE
fix(builds): fail the deployment when job submission is rejected

### DIFF
--- a/src/Appwrite/Deployment/Backend/Orchestrator.php
+++ b/src/Appwrite/Deployment/Backend/Orchestrator.php
@@ -16,6 +16,7 @@ use OpenRuntimes\Orchestrator\Model\Callback;
 use OpenRuntimes\Orchestrator\Model\Volume;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
+use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\System\System;
 
@@ -91,7 +92,17 @@ readonly class Orchestrator extends Backend
             'buildPath' => static::buildPath($this->project->getId(), $deployment->getId()),
         ]));
 
-        $this->jobs->create(...static::payload($this->project, $resource, $deployment, $this->platform, $source));
+        try {
+            $this->jobs->create(...static::payload($this->project, $resource, $deployment, $this->platform, $source));
+        } catch (\Throwable $error) {
+            $deployment = $this->dbForProject->updateDocument('deployments', $deployment->getId(), new Document([
+                'status' => 'failed',
+                'buildLogs' => "\nAn internal error occurred while building. Please try again, and contact support if the problem persists.\n",
+                'buildEndedAt' => DateTime::now(),
+            ]));
+
+            throw $error;
+        }
 
         return $deployment;
     }


### PR DESCRIPTION
## What does this PR do?

`Orchestrator::submit()` sets the deployment to `waiting`, then submits the build job. If the submission throws — validation rejection, unreachable jobs-service, timeout — the deployment stayed `waiting` forever: callbacks are the only thing that advances it, and there are none for a job that was never created.

Now a failed submission marks the deployment `failed`, writes the same generic build-failure message the Builds worker uses for internal errors, and rethrows so the real error still reaches our logs. One site covers every entry point (`createFromUpload`, `createFromUrl`, `createFromRef`).

Hit in production with project ids containing dots, which the orchestrator's job ID validation rejected (fixed upstream in open-runtimes/orchestrator#51). This is the part that makes any future submission failure visible instead of silently queueing.

## Test Plan

- Create a deployment with the jobs-service unreachable → deployment lands in `failed` with the generic message in build logs, instead of hanging in `waiting`
- A normal deployment still reaches `ready` — the `try` wraps only the submit call

## Related PRs and Issues

- https://github.com/open-runtimes/orchestrator/pull/51

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] If the PR includes a change to an API's metadata, does it also include updated API specs and example docs? (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)