### PR TITLE
fix(specs): normalise every Queries validator to an array type

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -16,6 +16,7 @@ use Appwrite\Utopia\Response\Model\Any;
 use Utopia\Database\Database;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
+use Utopia\Database\Validator\Queries;
 use Utopia\Database\Validator\Spatial;
 use Utopia\Platform\Enum;
 use Utopia\Validator;
@@ -456,12 +457,10 @@ class OpenAPI3 extends Format
 
                 $class = \get_class($validator);
 
-                $base = \get_parent_class($class);
-
-                switch ($base) {
-                    case \Appwrite\Utopia\Database\Validator\Queries\Base::class:
-                        $class = $base;
-                        break;
+                // Every Queries validator serialises to an array of query strings, so
+                // normalise the whole hierarchy instead of enumerating each subclass.
+                if (\is_subclass_of($class, Queries::class)) {
+                    $class = Queries::class;
                 }
 
                 if ($class === \Utopia\Validator\AnyOf::class) {
@@ -588,36 +587,7 @@ class OpenAPI3 extends Format
                             $node['schema']['x-example'] = $param['example'];
                         }
                         break;
-                    case \Appwrite\Utopia\Database\Validator\Queries\Base::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Columns::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Attributes::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Buckets::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Tables::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Collections::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Databases::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Deployments::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Executions::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Files::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Functions::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Identities::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Indexes::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Installations::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Branches::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Memberships::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Messages::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Migrations::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Projects::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Providers::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Rules::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Subscribers::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Targets::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Teams::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Topics::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Users::class:
-                    case \Appwrite\Utopia\Database\Validator\Queries\Variables::class:
-                    case \Utopia\Database\Validator\Queries::class:
-                    case \Utopia\Database\Validator\Queries\Document::class:
-                    case \Utopia\Database\Validator\Queries\Documents::class:
+                    case Queries::class:
                         $node['schema']['type'] = 'array';
                         $node['schema']['items'] = [
                             'type' => 'string',

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\Specification\Format;
 use Appwrite\SDK\Specification\Format\OpenAPI3;
 use Appwrite\SDK\Specification\Validator\PasswordFormat;
 use Appwrite\Utopia\Database\Validator\CustomId;
+use Appwrite\Utopia\Database\Validator\Queries\VcsRepositories;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model\AlgoArgon2;
 use Appwrite\Utopia\Response\Model\AlgoBcrypt;
@@ -35,6 +36,9 @@ use Appwrite\Utopia\Response\Model\User;
 use Appwrite\Utopia\Response\Model\Webhook;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
+use Utopia\Database\Validator\Queries;
+use Utopia\Database\Validator\Query\Limit;
+use Utopia\Database\Validator\Query\Offset;
 use Utopia\Database\Validator\Spatial;
 use Utopia\DI\Container;
 use Utopia\Http\Route;
@@ -601,5 +605,41 @@ final class FormatTest extends TestCase
 
         $this->assertTrue($openApiOptions['additionalProperties']);
         $this->assertArrayNotHasKey('nullable', $openApiOptions);
+    }
+
+    public function testQueriesSubclassesEmitArrayOfStrings(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        // VcsRepositories extends Queries directly rather than Queries\Base, and a
+        // deeper subclass proves arbitrary inheritance depth is normalised too.
+        $deepSubclass = new class () extends VcsRepositories {};
+
+        $route = (new Route('GET', '/v1/tests/queries'))
+            ->desc('List tests')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'listTests',
+                description: 'List tests.',
+                auth: [],
+                responses: [],
+            ))
+            ->param('queries', [], new Queries([new Limit(), new Offset()]), 'Queries.', true)
+            ->param('repositoryQueries', [], new VcsRepositories(), 'Repository queries.', true)
+            ->param('deepQueries', [], $deepSubclass, 'Deeply nested queries.', true);
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [], [], 0, 'console'))->parse();
+
+        $parameters = $openApi['paths']['/tests/queries']['get']['parameters'];
+        $schemas = \array_column($parameters, 'schema', 'name');
+
+        $this->assertCount(3, $schemas);
+
+        foreach (['queries', 'repositoryQueries', 'deepQueries'] as $name) {
+            $this->assertSame('array', $schemas[$name]['type'], "{$name} must serialise as an array");
+            $this->assertSame(['type' => 'string'], $schemas[$name]['items'], "{$name} must hold query strings");
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Spec generation mapped validators to types with a `switch` on an exact `get_class()`, normalising only `Queries\Base` subclasses:

```php
$base = \get_parent_class($class);
switch ($base) {
    case \Appwrite\Utopia\Database\Validator\Queries\Base::class:
        $class = $base;
        break;
}
```

Any validator that extends Utopia's `Queries` **directly** therefore had to be listed by hand in a 30-case group. Miss the entry and it silently falls through to `default`, emitting `"type": "string"` alongside a `"default": []` — a self-contradictory schema.

`VcsRepositories` is the live casualty. It extends `Queries` directly (correctly — `Queries\Base` requires a real collection in `Config::getParam('collections')`, and provider repositories aren't one), but was never added to the enumeration:

```
vcsListRepositories       "type": "string"                              ❌
vcsListRepositoryBranches "type": "array", items: {"type": "string"}    ✅
```

`Branches` also extends `Queries` directly and only works because someone remembered to list it.

Downstream, `CLI.php` gates its query-flag generation on the array type, so `vcs list-repositories` lost `--limit`, `--offset` and `--filter`, and `--queries` degraded from variadic to a single value. This affects **every** generated SDK, not just the CLI — any language reading `queries` as a scalar instead of a list.

## Changes

- Normalise the whole hierarchy with `is_subclass_of($class, Queries::class)` instead of enumerating subclasses. This collapses the 30-case group to a single `case Queries::class`.
- All 30 previously-enumerated classes were verified to be `Queries` descendants and shared one identical case body, so the collapse is behaviour-identical.
- Added `testQueriesSubclassesEmitArrayOfStrings`, covering a direct `Queries` instance, `VcsRepositories`, and an anonymous deeper subclass to prove arbitrary inheritance depth normalises.

## Test Plan

- New test fails on `main` with `repositoryQueries must serialise as an array` / `'array'` vs `'string'`, and passes with the fix.
- `php vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — 18 tests, 77 assertions, green.
- `composer lint` on both changed files — passed.
- `vendor/bin/phpstan analyse src/Appwrite/SDK/Specification/Format/OpenAPI3.php --level=4` — no errors.

## Related PRs and Issues

Found while releasing the CLI SDK from `appwrite/cloud`, where the regenerated `vcs list-repositories` command silently lost its pagination flags.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/HEAD/CONTRIBUTING.md)?

Yes.
