### PR TITLE
fix(deployment): declare the extract artifact's dependency on source

### DIFF
--- a/src/Appwrite/Deployment/Backend/Orchestrator.php
+++ b/src/Appwrite/Deployment/Backend/Orchestrator.php
@@ -145,7 +145,7 @@ readonly class Orchestrator extends Backend
             $subdir = \trim($source['subdir'] ?? '', '/');
             $sourceArtifacts = [
                 new DownloadArtifact(id: 'source', in: $source['url'], out: 'source.tar.gz'),
-                new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', subdir: $subdir !== '' ? $subdir : null, strip: true),
+                new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', subdir: $subdir !== '' ? $subdir : null, strip: true, depends: 'source'),
                 // Appwrite never sees the remote source (the sidecar fetches it),
                 // so unlike the uploaded-tarball path it can't size it. Stat the
                 // downloaded archive so the orchestrator reports its byte size in
@@ -165,7 +165,7 @@ readonly class Orchestrator extends Backend
             ]);
             $sourceArtifacts = [
                 new DownloadArtifact(id: 'source', in: $sourceUrl, out: 'source.tar.gz'),
-                new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source'),
+                new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', depends: 'source'),
             ];
         }
 


### PR DESCRIPTION
## What does this PR do?

The `extract` (unarchive) artifact reads `source.tar.gz`, but never declared that the `source` (download) artifact produces it. With no dependency edge, the sidecar ran the extract even when the download had failed.

Extracting a file that was never written fails with `unrecognized archive format`, and because that error came last it was the one that aborted the job and reached the user — burying the download's actual error. A production build hit exactly this:

```
artifactId=source  type=download  status=failed  error="download failed with status 403"
artifactId=extract type=unarchive status=failed  error="unrecognized archive format for source.tar.gz"
→ job aborted: "unrecognized archive format for source.tar.gz"
```

The source was a valid gzip. The 403 was the real cause, and the surfaced message pointed away from it.

`sourceSize` in the same list already declared `depends: 'source'` for the same file. `extract` just never did.

## Test Plan

There is no existing test covering `Orchestrator::payload()`, and this repo's vendor tree does not include `open-runtimes/sdk-for-php`, so I verified the emitted wire format against the real SDK in a production image:

```
before: {"id":"extract","type":"unarchive","in":"source.tar.gz","out":"source"}
after:  {"id":"extract","type":"unarchive","depends":"source","in":"source.tar.gz","out":"source"}
```

`depends` lands where the orchestrator's `RunInOrder` reads it. `php -l` and `pint --test` both pass.

I also checked the Appwrite Cloud subclass, which overrides `storage()` and adds `archive`/`output`/`cache`/`cachePull`: those already declare `depends` correctly, and `cachePull` correctly declares none as a root download.

## Related PRs and Issues

- open-runtimes/orchestrator#52 — makes the orchestrator skip artifacts whose dependency failed, so the root error is the one returned. That change is what makes this edge take effect; this PR alone adds the edge.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no API metadata changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)