### PR TITLE
chore: bump orchestrator jobs-service and sidecar to 0.16.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1239,7 +1239,7 @@ services:
       options:
         max-file: "5"
         max-size: 10m
-    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.15.0
+    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.16.0
     restart: unless-stopped
     user: root
     networks:
@@ -1250,7 +1250,7 @@ services:
       - ORCHESTRATOR_BACKEND=docker
       - ORCHESTRATOR_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator-jobs:8080
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.15.0
+      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.16.0
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
## What does this PR do?

Bumps the local-dev `orchestrator-jobs` service and its `JOB_SIDECAR_IMAGE` from 0.15.0 to 0.16.0 in `docker-compose.yml`.

0.16.0 (open-runtimes/orchestrator#52) fixes a diagnostic that cost real debugging time in production: a build failed with

```
unrecognized archive format for source.tar.gz
```

when the archive was a perfectly valid gzip that had simply never been downloaded. The actual cause, logged one line earlier, was the source download returning 403. Two things caused that message to win:

- The header sniff discarded `os.Open`'s and `io.ReadFull`'s errors, so a source that was missing, empty, or unreadable fell through to "unrecognized format".
- `RunInOrder` ran the unarchive even though the download it depends on had just failed, so the dependent's error was the one returned.

Both are fixed in 0.16.0. Getting the improved error locally requires this bump.

## Test Plan

Verified the release before bumping:

- `helm show chart oci://ghcr.io/open-runtimes/charts/orchestrator --version 0.16.0` → `appVersion: 0.16.0`
- Both `jobs-service` and `job-sidecar` `0.16.0` manifests return 200 from ghcr.io
- `v0.16.0` contains the two fix commits
- `docker compose config` parses cleanly

Two lines changed, no behaviour in this repo depends on them beyond which image local dev pulls.

## Related

- open-runtimes/orchestrator#52 — the fix released in 0.16.0
- appwrite/appwrite#13023 — adds `depends: 'source'` to the extract artifact, which is what lets the new ordering pick the root error

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? — no API metadata changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)