### PR TITLE
fix: avoid explode(null) when _APP_DOMAIN_FUNCTIONS is unset

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -126,7 +126,7 @@ function dispatch(\Swoole\Http\Server $server, int $fd, int $type, $data = null)
             // executions request coming from custom domain
             $risky = true;
         } else {
-            foreach (\explode(',', System::getEnv('_APP_DOMAIN_FUNCTIONS')) as $riskyDomain) {
+            foreach (\explode(',', System::getEnv('_APP_DOMAIN_FUNCTIONS', '')) as $riskyDomain) {
                 if (empty($riskyDomain)) {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Default `_APP_DOMAIN_FUNCTIONS` to `''` in the HTTP dispatch path so `explode()` is never called with `null` under PHP 8.3.
- Stops the per-request deprecation warning reported in #12798 when the env var is unset.

## Test plan
- [ ] With `_APP_DOMAIN_FUNCTIONS` unset, make an API request and confirm logs no longer show `explode(): Passing null to parameter #2`.
- [ ] With `_APP_DOMAIN_FUNCTIONS` set to a comma-separated list, confirm risky-domain matching still works.

Fixes part of #12798

Made with [Cursor](https://cursor.com)