### PR TITLE
fix: default router protection to disabled when unset

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -132,7 +132,8 @@ function router(Http $utopia, Database $dbForPlatform, callable $getProjectDB, S
             }
         }
 
-        if (!in_array($host, $platformHostnames) && System::getEnv('_APP_OPTIONS_ROUTER_PROTECTION', 'enabled') === 'enabled') {
+        // Default must match app/config/variables.php and .env (`disabled`). Opt in with `enabled`.
+        if (!in_array($host, $platformHostnames) && System::getEnv('_APP_OPTIONS_ROUTER_PROTECTION', 'disabled') === 'enabled') {
             throw new AppwriteException(AppwriteException::GENERAL_ACCESS_FORBIDDEN, 'Router protection does not allow accessing Appwrite over this domain. Please add it as custom domain to your project or disable _APP_OPTIONS_ROUTER_PROTECTION environment variable.', view: $errorView);
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining part of #12798: when `_APP_OPTIONS_ROUTER_PROTECTION` is unset, `System::getEnv` previously fell back to `'enabled'`, which disagreed with `app/config/variables.php` and `.env` (`disabled`).

This aligns the runtime fallback to `disabled` so unset / default installs match documented config. Operators still opt in with `enabled`.

Note: 1.9.0 ignored the env entirely; gating has existed since 1.9.5+. The `explode(null)` deprecation half of #12798 was already merged in #13025.

## Test Plan

1. Leave `_APP_OPTIONS_ROUTER_PROTECTION` unset (or remove it from `.env`).
2. Hit Appwrite over a hostname that is not a registered platform/custom domain.
3. Confirm the request is **not** rejected solely due to router protection defaulting on.
4. Set `_APP_OPTIONS_ROUTER_PROTECTION=enabled` and repeat — unknown hosts should get `GENERAL_ACCESS_FORBIDDEN` as before.

## Related PRs and Issues

- Fixes #12798 (remaining default mismatch; explode half closed via #13025)
- Related: #13025

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
