### PR TITLE
fix: stop doctor SMTP check from sending live email

### DIFF
--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -220,10 +220,7 @@ class Doctor extends Action
             }
         }
 
-        // Never send a live message from doctor. Older compose files used `doctor` as the
-        // container healthcheck (~every 5s), which flooded SMTP with "Test SMTP Connection"
-        // mail to demo@example.com (#12760). Probe TCP reachability only; operators can use
-        // POST /v1/project/smtp/tests for an intentional end-to-end send.
+        // Probe SMTP reachability only; do not send a live message.
         try {
             $smtpHost = System::getEnv('_APP_SMTP_HOST', '');
             $smtpPort = (int) System::getEnv('_APP_SMTP_PORT', '25');

--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -14,8 +14,6 @@ use Utopia\Domains\Domain;
 use Utopia\DSN\DSN;
 use Utopia\Http\Http;
 use Utopia\Logger\Logger;
-use Utopia\Messaging\Adapter\Email as EmailAdapter;
-use Utopia\Messaging\Messages\Email as EmailMessage;
 use Utopia\Platform\Action;
 use Utopia\Pools\Group;
 use Utopia\Queue\Broker\Pool as BrokerPool;
@@ -222,20 +220,26 @@ class Doctor extends Action
             }
         }
 
+        // Never send a live message from doctor. Older compose files used `doctor` as the
+        // container healthcheck (~every 5s), which flooded SMTP with "Test SMTP Connection"
+        // mail to demo@example.com (#12760). Probe TCP reachability only; operators can use
+        // POST /v1/project/smtp/tests for an intentional end-to-end send.
         try {
-            /** @var EmailAdapter $smtp */
-            $smtp = $register->get('smtp');
+            $smtpHost = System::getEnv('_APP_SMTP_HOST', '');
+            $smtpPort = (int) System::getEnv('_APP_SMTP_PORT', '25');
 
-            $emailMessage = new EmailMessage(
-                to: ['demo@example.com'],
-                subject: 'Test SMTP Connection',
-                content: 'Hello World',
-                fromName: \urldecode(System::getEnv('_APP_SYSTEM_EMAIL_NAME', APP_NAME . ' Server')),
-                fromEmail: System::getEnv('_APP_SYSTEM_EMAIL_ADDRESS', APP_EMAIL_TEAM),
-            );
+            if ($smtpHost === '') {
+                Console::log('⚪ ' . str_pad("SMTP", 50, '.') . 'not configured');
+            } else {
+                $connection = @\fsockopen($smtpHost, $smtpPort > 0 ? $smtpPort : 25, $errno, $errstr, 3);
 
-            $smtp->send($emailMessage);
-            Console::success('🟢 ' . str_pad("SMTP", 50, '.') . 'connected');
+                if ($connection !== false) {
+                    \fclose($connection);
+                    Console::success('🟢 ' . str_pad("SMTP", 50, '.') . 'connected');
+                } else {
+                    Console::error('🔴 ' . str_pad("SMTP", 47, '.') . 'disconnected');
+                }
+            }
         } catch (\Throwable) {
             Console::error('🔴 ' . str_pad("SMTP", 47, '.') . 'disconnected');
         }


### PR DESCRIPTION
## What does this PR do?

Hardens the `doctor` CLI SMTP check so it never sends a live message.

Previously `doctor` sent a real "Test SMTP Connection" email to `demo@example.com` on every run. Older Compose healthchecks still invoke `doctor` (~every 5s), which flooded SMTP providers (Discord reports / #12760). Compose healthcheck was already fixed in #12765; this changes `doctor` itself to a short TCP connect probe (or "not configured" when `_APP_SMTP_HOST` is empty).

Intentional end-to-end SMTP sends remain available via `POST /v1/project/smtp/tests`.

## Test Plan

1. Configure system SMTP (`_APP_SMTP_HOST` / `_APP_SMTP_PORT`) in `.env`.
2. Run `docker compose exec appwrite doctor`.
3. Confirm SMTP shows connected/disconnected from a TCP probe and **no** outbound test mail is sent.
4. Unset `_APP_SMTP_HOST` and confirm doctor reports SMTP as not configured.

## Related PRs and Issues

- Related to #12760 (closed; compose healthcheck fixed in #12765)
- Related open PR with similar scope: #12782 (TCP probe + optional `_APP_SMTP_TEST_EMAIL`)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
