### PR TITLE
fix(vcs): keep serving the existing token when a refresh fails

### DIFF
--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -3,7 +3,6 @@
 namespace Appwrite\Vcs;
 
 use Appwrite\Auth\OAuth2;
-use Appwrite\Extend\Exception;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -41,8 +40,11 @@ class InstallationTokens
             return $installation;
         }
 
+        // Not every provider uses this token. GitHub mints an installation token from the App
+        // credentials and ignores it entirely, so a refresh it never needed must not block the
+        // call. GitLab and Gitea do use it, and surface a real 401 from the provider call itself.
         if (empty($refreshToken)) {
-            throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'This installation has no refresh token on file. Please reconnect it.');
+            return $installation;
         }
 
         try {
@@ -53,7 +55,7 @@ class InstallationTokens
                 return $current;
             }
 
-            throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
+            return $installation;
         }
 
         $accessToken = $oauth2->getAccessToken('');
@@ -66,7 +68,7 @@ class InstallationTokens
                 return $current;
             }
 
-            throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
+            return $installation;
         }
 
         $installation = $installation

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Unit\Vcs;
 
 use Appwrite\Auth\OAuth2;
-use Appwrite\Extend\Exception;
 use Appwrite\Vcs\InstallationTokens;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
@@ -116,7 +115,7 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame($identity->getAttribute('providerAccessTokenExpiry'), $result->getAttribute('personalAccessTokenExpiry'));
     }
 
-    public function testMissingRefreshTokenThrowsClearError(): void
+    public function testMissingRefreshTokenKeepsExistingToken(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
@@ -127,17 +126,30 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        try {
-            (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
-            $this->fail('Expected an Exception');
-        } catch (Exception $e) {
-            $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
-        }
+        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
 
+        $this->assertSame('stale-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(0, $oauth2->refreshCalls);
     }
 
-    public function testFailedRefreshThrows(): void
+    public function testFailedRefreshKeepsExistingToken(): void
+    {
+        $installation = new Document([
+            '$id' => 'installation1',
+            'personalAccessToken' => 'stale-token',
+            'personalRefreshToken' => 'stale-refresh',
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), -3600),
+        ]);
+
+        $oauth2 = $this->fakeOAuth2(throwOnRefresh: true);
+
+        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+
+        $this->assertSame('stale-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
+    }
+
+    public function testFailedVerificationKeepsExistingToken(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
@@ -148,9 +160,9 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2(emptyUserId: true);
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
-        (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+
+        $this->assertSame('stale-token', $result->getAttribute('personalAccessToken'));
     }
 
     public function testFailedRefreshReturnsCurrentInstallationWhenAnotherRequestRefreshed(): void


### PR DESCRIPTION
## What

A failed installation token refresh now returns the installation with the token it already has, instead of throwing.

## Why

The repository list, get, branches, contents and detection endpoints refresh an installation's OAuth2 token before calling the provider, and any failure in that refresh threw.

GitHub never uses that token. `GitHub::initializeVariables()` accepts the access and refresh token arguments and never reads them, minting an App JWT and installation token instead. Only GitLab and Gitea use the personal token.

The stored access token lives about 8 hours and the refresh token about 6 months, captured once when the installation is connected. An installation nobody reconnected inside that window has no working refresh token, so every repository call fails a check standing in front of a path that does not need it. Repository lookups return 400, the git deployment modal shows no repositories, and manual redeployments never leave `processing`. Push-triggered redeployments keep working, since they take another path.

## How

The three failure branches return `$installation` instead of throwing: no refresh token on file, the provider refresh call failed, and the refreshed token could not be verified. The existing "another request already refreshed" re-reads stay ahead of each return, so a token another request just persisted is still preferred over the stale one.

GitHub behaves as it did before the refresh was added. For GitLab and Gitea, which do use the token, a failed refresh now defers the failure to the provider call: `Adapter::call()` has its non-2xx check commented out, so a 401 comes back as an ordinary response and callers see an empty result rather than an authentication error. In the GitLab webhook path that failure also lands outside the `resolveAdapterForRepository()` catch, so a delivery can be retried rather than recorded as failed.

No logging on these paths on purpose: for installations whose refresh token is simply beyond its window, failing is the steady state, and a warning per call would be noise.

## Test plan

`tests/unit/Vcs/InstallationTokensTest.php` — 32 tests in `tests/unit/Vcs/`, all passing:

- `testMissingRefreshTokenKeepsExistingToken` — no refresh token on file returns the existing token, provider never called.
- `testFailedRefreshKeepsExistingToken` — the provider refresh throwing returns the existing token.
- `testFailedVerificationKeepsExistingToken` — an unverifiable refreshed token returns the existing one.
- The two "another request already refreshed" tests are unchanged and still pass, so the re-read is intact.

Pint, PHPStan level 4 and the Rector check pass.
