### PR TITLE
fix(proxy): use correct variable in empty check for function domains

### DIFF
--- a/src/Appwrite/Platform/Modules/Proxy/Action.php
+++ b/src/Appwrite/Platform/Modules/Proxy/Action.php
@@ -106,7 +106,7 @@ class Action extends PlatformAction
 
         $functionsDomains = System::getEnv('_APP_DOMAIN_FUNCTIONS', '');
         foreach (\explode(',', $functionsDomains) as $functionsDomain) {
-            if (empty($functionsDomains)) {
+            if (empty($functionsDomain)) {
                 continue;
             }
 


### PR DESCRIPTION
## Description

In `validateDomainRestrictions()` in `Proxy/Action.php`, the `foreach` loop over `_APP_DOMAIN_FUNCTIONS` checked `empty($functionsDomains)` (the full comma-separated string) instead of `empty($functionsDomain)` (the individual element). This was a copy-paste error from the sites domain loop above.

## Impact

Empty entries in the `_APP_DOMAIN_FUNCTIONS` environment variable were never skipped, causing empty strings to be added to:
- The `$deniedDomains` list
- The domain restriction validators

This could cause domain validation to reject valid domains or accept invalid configurations.

## Evidence

The identical loop for `_APP_DOMAIN_SITES` at lines 95-97 already used the correct variable name (`$sitesDomain`). This fix makes the functions domain loop consistent.

## Changes

- `src/Appwrite/Platform/Modules/Proxy/Action.php`: Changed `empty($functionsDomains)` to `empty($functionsDomain)`
