### PR TITLE
chore(sdks): bump claude-plugin and codex-plugin to 0.2.0

### DIFF
--- a/app/config/sdks.php
+++ b/app/config/sdks.php
@@ -304,7 +304,7 @@ return [
             [
                 'key' => 'claude-plugin',
                 'name' => 'ClaudePlugin',
-                'version' => '0.1.0',
+                'version' => '0.2.0',
                 'url' => 'https://github.com/appwrite/claude-plugin.git',
                 'enabled' => true,
                 'beta' => false,
@@ -324,7 +324,7 @@ return [
             [
                 'key' => 'codex-plugin',
                 'name' => 'CodexPlugin',
-                'version' => '0.1.1',
+                'version' => '0.2.0',
                 'url' => 'https://github.com/appwrite/codex-plugin.git',
                 'enabled' => true,
                 'beta' => false,

--- a/composer.lock
+++ b/composer.lock
@@ -5416,16 +5416,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "2.4.19",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "d0e58c93a8d7021a69d2a5d6b30fa826a5404fb9"
+                "reference": "68a417436c8c0c3c98f913c86b0cd79d9b5936de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/d0e58c93a8d7021a69d2a5d6b30fa826a5404fb9",
-                "reference": "d0e58c93a8d7021a69d2a5d6b30fa826a5404fb9",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/68a417436c8c0c3c98f913c86b0cd79d9b5936de",
+                "reference": "68a417436c8c0c3c98f913c86b0cd79d9b5936de",
                 "shasum": ""
             },
             "require": {
@@ -5462,9 +5462,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/2.4.19"
+                "source": "https://github.com/appwrite/sdk-generator/tree/2.5.1"
             },
-            "time": "2026-07-24T06:18:23+00:00"
+            "time": "2026-07-28T11:56:13+00:00"
         },
         {
             "name": "brianium/paratest",


### PR DESCRIPTION
Version bumps for the static plugin SDK release:

* `claude-plugin` 0.1.0 → 0.2.0
* `codex-plugin` 0.1.1 → 0.2.0
* `appwrite/sdk-generator` (dev) 2.4.19 → 2.5.1

## What's in the plugin release

* Breaking: Replaced local `appwrite-api` / `appwrite-docs` MCP servers with the hosted server at `https://mcp.appwrite.io/` (OAuth-authenticated)
* Removed: `userConfig` from the Claude plugin manifest — no API key needed with hosted MCP
* Updated: Descriptions reference the hosted Appwrite MCP server
* Updated: Claude plugin LICENSE from MIT to BSD-3-Clause
* Updated: SDK skills content refreshed

Plugin PRs generated from this change:
* appwrite/claude-plugin#3
* appwrite/codex-plugin#3