### PR TITLE
chore(ci): run MongoDB only where tests need it

### DIFF
--- a/.env
+++ b/.env
@@ -36,6 +36,9 @@ _APP_CONSOLE_COUNTRIES_DENYLIST=AQ
 _APP_CONSOLE_WHITELIST_EMAILS=
 _APP_CONSOLE_WHITELIST_IPS=
 _APP_CONSOLE_WHITELIST_ROOT=disabled
+# MariaDB and MongoDB only start when their profile is listed here; PostgreSQL always
+# runs because VectorsDB requires it. MongoDB is on by default for DocumentsDB.
+COMPOSE_PROFILES=mongodb
 _APP_DB_ADAPTER=postgresql
 _APP_DB_HOST=postgresql
 _APP_DB_PORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
               { name: 'Account',           runner: runner4, functional: true,  processes: null },
               { name: 'Avatars',           runner: runner4, functional: true,  processes: null },
               { name: 'Console',           runner: runner4, functional: true,  processes: null },
-              { name: 'Databases',         runner: runner8, functional: false, processes: 3 },
+              { name: 'Databases',         runner: runner8, functional: false, processes: 3, documentsdb: true },
               { name: 'TablesDB',          runner: runner8, functional: false, processes: 3 },
               { name: 'Functions',         runner: runner4, functional: false, processes: null },
               { name: 'FunctionsSchedule', runner: runner4, functional: true,  processes: null },
@@ -204,8 +204,8 @@ jobs:
               { name: 'Health',            runner: runner4, functional: true,  processes: null },
               { name: 'Advisor',           runner: runner4, functional: true,  processes: null },
               { name: 'Locale',            runner: runner4, functional: true,  processes: null },
-              { name: 'Projects',          runner: runner4, functional: true,  processes: null },
-              { name: 'Realtime',          runner: runner4, functional: false, processes: null },
+              { name: 'Projects',          runner: runner4, functional: true,  processes: null, documentsdb: true },
+              { name: 'Realtime',          runner: runner4, functional: false, processes: null, documentsdb: true },
               { name: 'Sites',             runner: runner4, functional: true,  processes: null },
               { name: 'Proxy',             runner: runner4, functional: true,  processes: null },
               { name: 'Storage',           runner: runner4, functional: true,  processes: null },
@@ -218,7 +218,7 @@ jobs:
               { name: 'VCSGitea',          runner: runner4, functional: false, processes: null },
               { name: 'Messaging',         runner: runner4, functional: true,  processes: null },
               { name: 'Notifications',     runner: runner4, functional: true,  processes: null },
-              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1 },
+              { name: 'Migrations',        runner: runner4, functional: true,  processes: 1, documentsdb: true },
               { name: 'Project',           runner: runner4, functional: true,  processes: null },
               { name: 'Presences',         runner: runner4, functional: true,  processes: null },
             ];
@@ -298,6 +298,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      COMPOSE_PROFILES: ''
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -354,6 +356,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      COMPOSE_PROFILES: ''
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -450,6 +454,13 @@ jobs:
             echo "_APP_DB_ADAPTER=postgresql" >> $GITHUB_ENV
             echo "_APP_DB_HOST=postgresql" >> $GITHUB_ENV
             echo "_APP_DB_PORT=5432" >> $GITHUB_ENV
+          fi
+
+          # DocumentsDB is MongoDB-only, so Mongo runs alongside another primary just for
+          # the suites that use it, and in shared tables mode where boot connects every pool.
+          if [ "${{ matrix.database }}" != "MongoDB" ] \
+            && { [ "${{ matrix.service.documentsdb }}" = "true" ] || [ "${{ matrix.mode }}" = "shared" ]; }; then
+            COMPOSE_PROFILES="${COMPOSE_PROFILES},mongodb"
           fi
 
           # Gitea runs alongside Appwrite only where VCS tests need it.
@@ -580,7 +591,8 @@ jobs:
             compose_profiles: antivirus
             wait: clamav
     env:
-      COMPOSE_PROFILES: ${{ matrix.config.compose_profiles }}
+      # Shared tables mode connects every pool at boot, including the MongoDB-only DocumentsDB.
+      COMPOSE_PROFILES: ${{ matrix.mode == 'shared' && format('mongodb,{0}', matrix.config.compose_profiles) || matrix.config.compose_profiles }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -692,6 +704,8 @@ jobs:
       issues: write
       pull-requests: write
       packages: read
+    env:
+      COMPOSE_PROFILES: ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,7 +705,10 @@ jobs:
       pull-requests: write
       packages: read
     env:
-      COMPOSE_PROFILES: ''
+      # The before stack is a worktree at an arbitrary older SHA, so its compose file
+      # may not gate databases at all. Start the superset on both sides, otherwise the
+      # two runs measure different amounts of idle container load rather than the diff.
+      COMPOSE_PROFILES: mariadb,mongodb
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -400,10 +400,11 @@ services:
       - gateway
     environment:
       - ADMINER_DESIGN=pepa-linha
-      - ADMINER_DEFAULT_SERVER=mariadb
-      - ADMINER_DEFAULT_USERNAME=root
-      - ADMINER_DEFAULT_PASSWORD=rootsecretpassword
-      - ADMINER_DEFAULT_DB=appwrite
+      - ADMINER_DEFAULT_SERVER=${_APP_DB_HOST:-postgresql}
+      - ADMINER_DEFAULT_DRIVER=${_APP_DB_ADAPTER:-postgresql}
+      - ADMINER_DEFAULT_USERNAME=${_APP_DB_USER}
+      - ADMINER_DEFAULT_PASSWORD=${_APP_DB_PASS}
+      - ADMINER_DEFAULT_DB=${_APP_DB_SCHEMA}
     configs:
       - source: adminer-index.php
         target: /var/www/html/index.php
@@ -556,7 +557,8 @@ configs:
         if(!count($$_GET)) {
           $$_POST['auth'] = [
             'server' => $$_ENV['ADMINER_DEFAULT_SERVER'],
-            'driver' => 'server', /* seems to autodetect the driver from server settings */
+            /* Adminer calls the MySQL/MariaDB driver "server". */
+            'driver' => $$_ENV['ADMINER_DEFAULT_DRIVER'] === 'postgresql' ? 'pgsql' : 'server',
             'username' => $$_ENV['ADMINER_DEFAULT_USERNAME'],
             'password' => $$_ENV['ADMINER_DEFAULT_PASSWORD'],
             'db' => $$_ENV['ADMINER_DEFAULT_DB'],

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -484,9 +484,13 @@ services:
         aliases:
           - appwrite.test
   mariadb:
+    profiles:
+      - mariadb
     ports:
       - "9510:3306"
   mongodb:
+    profiles:
+      - mongodb
     ports:
       - "9511:27017"
   postgresql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -751,7 +751,7 @@ services:
       - appwrite
     depends_on:
       - redis
-      - ${_APP_DB_HOST:-mariadb}
+      - ${_APP_DB_HOST:-postgresql}
     environment:
       - _APP_ENV
       - _APP_WORKERS_NUM=1
@@ -796,7 +796,7 @@ services:
       - appwrite
     depends_on:
       - redis
-      - ${_APP_DB_HOST:-mariadb}
+      - ${_APP_DB_HOST:-postgresql}
     environment:
       - _APP_ENV
       - _APP_WORKER_PER_CORE

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -56,8 +56,6 @@ class Generator
             ],
             'placeholders' => [
                 '${_APP_DB_HOST:-postgresql}',
-                '${_APP_DB_HOST:-mongodb}',
-                '${_APP_DB_HOST:-mariadb}',
             ],
         ],
     ];


### PR DESCRIPTION
## What

`mariadb`, `mongodb` and `postgresql` had no compose profiles, so **all three database containers started on every test run** — the `COMPOSE_PROFILES=mariadb|mongodb|postgresql` values already in `ci.yml` were inert for them.

MariaDB and MongoDB are now gated behind their own profiles in the dev/CI override. PostgreSQL stays unprofiled because VectorsDB requires it unconditionally.

Mongo now runs on Mongo installs, the suites that exercise DocumentsDB, and shared-tables mode. It no longer runs on the other 24 service suites, unit tests, general E2E, the grouped jobs, or the benchmark. MariaDB no longer starts unless it is the primary — that came free with the same gating.

## Why Mongo can't go away entirely

`documentsdb` pools reject any non-Mongo DSN (`app/init/registers.php:203` → hard throw at `registers.php:277`), so the four suites that touch DocumentsDB — `Databases`, `Projects`, `Realtime`, `Migrations` — still need it. They are flagged `documentsdb: true` in the matrix.

Shared-tables mode needs it regardless of suite, because `app/http.php:403` connects *every* shared-tables pool at boot.

Widening `schemes` to include `postgresql`/`mysql` does not work today and would fail silently: DocumentsDB is schemaless mode, switched on via `setSupportForAttributes(false)` (`src/Appwrite/Database/Factory.php:114`), and in `utopia-php/database` `SQL.php` that setter is a no-op stub that discards its argument while `getSupportForAttributes()` is hard-coded `true` — same on upstream `main`. Only `Mongo.php` honors the flag. You would get a fully schema-ful database labelled `documentsdb` that breaks on first write. Worth an upstream issue; not this PR.

## Drive-by

Two workers defaulted `depends_on` to `${_APP_DB_HOST:-mariadb}` while the rest of the file defaults to `postgresql`. Harmless before, a hard failure once profiles are active, so it is aligned and the now-dead placeholders are dropped from the compose generator.

## Self-hosted installs are unaffected

Profiles live only in `docker-compose.override.yml`, which `Docker\Compose\Generator` never reads — it renders from `docker-compose.yml`. Verified by running the generator against the edited file for each database: exactly one DB service survives, both touched workers rewrite to the selected DB, no `profiles:` key leaks into the output.

## Local dev

`.env` sets `COMPOSE_PROFILES=mongodb` so DocumentsDB keeps working out of the box. Switching your primary to MariaDB now means `COMPOSE_PROFILES=mariadb,mongodb`; there is a comment in `.env` saying so.

## Verification

- Compose resolution across `postgresql` / `''` / `postgresql,mongodb` / `mariadb` / `mongodb,antivirus` — correct containers each time. A MariaDB primary *without* its profile now fails at `docker compose config` rather than silently starting nothing.
- Confirmed against real `docker compose` that an empty `COMPOSE_PROFILES` in job env overrides the `.env` value (the three always-off jobs depend on this) and that a trailing comma is harmless (`e2e_grouped`'s shared-mode expression can produce one).
- The `Set environment` branching across all six matrix shapes.
- PHPUnit and Pint were not run locally (no `vendor/`); `php -l` passes and `GeneratorTest` asserts only on the `postgresql` placeholder that was kept. CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-ups in this PR

**Adminer followed the MariaDB host.** It was hardcoded to `ADMINER_DEFAULT_SERVER=mariadb` with MariaDB-only `root` credentials, so once MariaDB stopped starting by default the bundled UI at `mysql.localhost` / `:9506` opened onto a service that was not running. It now follows `_APP_DB_HOST` / `_APP_DB_ADAPTER` / `_APP_DB_USER` / `_APP_DB_PASS` / `_APP_DB_SCHEMA`, and the auto-login config picks the driver from the adapter — Adminer calls the MySQL/MariaDB driver `server` and needs `pgsql` for PostgreSQL, so the old `'driver' => 'server'` would not have worked against Postgres even with the host corrected. Verified by auto-logging a throwaway Adminer container into both engines: PostgreSQL lands on `?pgsql=postgresql&username=user&db=appwrite&ns=public`, MariaDB on `?server=mariadb&username=user&db=appwrite`, no credential or driver errors. Mongo primaries are covered by mongo-express, which is on the `mongodb` profile; Adminer cannot talk to Mongo either way.

**Benchmark stacks are now comparable.** The benchmark job builds its before stack as a `git worktree` at an arbitrary older SHA, so that revision's compose file need not gate databases at all. An empty `COMPOSE_PROFILES` therefore constrained only the head side, leaving the before run carrying MariaDB and Mongo as idle load on a 4-CPU runner and the after run without them — the reported delta would have included two fewer containers rather than the code change. Both sides now start the same superset.
