### PR TITLE
Decouple locale FallbackTest from shipped translations

### DIFF
--- a/tests/unit/Locale/FallbackTest.php
+++ b/tests/unit/Locale/FallbackTest.php
@@ -9,18 +9,37 @@ use Utopia\Locale\Locale;
 
 final class FallbackTest extends TestCase
 {
+    private const COMPLETE = 'test-fallback-complete';
+    private const PARTIAL = 'test-fallback-partial';
+
+    private bool $exceptions;
+
     protected function setUp(): void
     {
-        $translationsDir = __DIR__ . '/../../../app/config/locale/translations';
+        $this->exceptions = Locale::$exceptions;
         Locale::$exceptions = false;
-        Locale::setLanguageFromJSON('en', $translationsDir . '/en.json');
-        Locale::setLanguageFromJSON('fr', $translationsDir . '/fr.json');
+
+        // Synthetic catalogs, because shipped translations get completed over
+        // time (see #12449) and asserting on their coverage is self-breaking.
+        Locale::setLanguageFromArray(self::COMPLETE, [
+            'emails.verification.subject' => 'Account Verification',
+            'emails.verification.preview' => 'Verify your email to activate your {{project}} account.',
+        ]);
+
+        Locale::setLanguageFromArray(self::PARTIAL, [
+            'emails.verification.subject' => 'Vérification du compte',
+        ]);
     }
 
-    public function testIncompleteLocaleFallsBackToEnglishForMissingEmailKeys(): void
+    protected function tearDown(): void
     {
-        $locale = new Locale('fr');
-        $locale->setFallback('en');
+        Locale::$exceptions = $this->exceptions;
+    }
+
+    public function testIncompleteLocaleFallsBackToCompleteLocaleForMissingEmailKeys(): void
+    {
+        $locale = new Locale(self::PARTIAL);
+        $locale->setFallback(self::COMPLETE);
 
         $preview = $locale->getText('emails.verification.preview');
 
@@ -29,15 +48,15 @@ final class FallbackTest extends TestCase
             'Verify your email to activate your {{project}} account.',
             $preview
         );
-        // Keys present in fr stay French.
+        // Keys present in the requested locale are not overridden by the fallback.
         $this->assertSame('Vérification du compte', $locale->getText('emails.verification.subject'));
     }
 
     public function testFallbackMatchingIncompleteLocaleLeaksRawKeys(): void
     {
-        $locale = new Locale('fr');
-        // Mirrors the previous bug: fallback = _APP_LOCALE when that env is fr.
-        $locale->setFallback('fr');
+        $locale = new Locale(self::PARTIAL);
+        // Mirrors the previous bug: fallback = _APP_LOCALE when that env is a partial locale.
+        $locale->setFallback(self::PARTIAL);
 
         $this->assertSame(
             '{{emails.verification.preview}}',


### PR DESCRIPTION
## What does this PR do?

Fixes the `Tests / Unit` job on `main`, which is currently red with two failures in `Tests\Unit\Locale\FallbackTest`.

The test was added in #13041 to guard the locale fallback fix, and it asserted that `emails.verification.preview` was **missing** from `app/config/locale/translations/fr.json` so that it would resolve from English. #12449 then completed the French catalog — `fr.json` now has all 295 keys `en.json` has, including that one — so the key resolves in French and both assertions fail:

```
-'Verify your email to activate your {{project}} account.'
+'Vérifiez votre e-mail pour activer votre compte {{project}}.'

-'{{emails.verification.preview}}'
+'Vérifiez votre e-mail pour activer votre compte {{project}}.'
```

Swapping in a different key is not an option (no French key is missing anymore) and would only defer the same breakage to the next translation PR. Instead, the test now registers its own catalogs via `Locale::setLanguageFromArray()`, so it covers `Locale` fallback behavior rather than the coverage of shipped translations. Both original behaviors are still asserted:

- a key missing from the requested locale resolves from the complete fallback, while keys present in the requested locale are not overridden;
- a fallback pointing at the same partial locale leaks `{{key}}` — the bug shape #13041 fixed.

Locale names are prefixed with `test-fallback-` because `Locale::$language` is static and `phpunit.xml` runs without process isolation. `Locale::$exceptions` is now saved and restored instead of being left mutated for the rest of the suite.

No production code changes; the `setFallback('en')` fix from #13041 is untouched.

## Test Plan

- `docker compose exec appwrite test tests/unit/Locale` — 2 tests, 4 assertions, passing. Verified locally on PHP 8.5 via `php vendor/bin/phpunit tests/unit/Locale`.
- `composer lint tests/unit/Locale/FallbackTest.php` — Pint passes.
- `composer refactor:check` — clean across all 381 files, so the Rector `NarrowUnusedSetUpDefinedProperty` rule that forced 6c974a7da5 does not fire on the new `$exceptions` property (`tearDown` reads it).
- Confirmed `app/init/locales.php` registers all 131 locales at bootstrap, so dropping the `setLanguageFromJSON('en'|'fr', ...)` calls from `setUp` removes no global state that other unit tests could rely on.

## Related PRs and Issues

- Broken by #12449 (missing French translation keys)
- Test introduced in #13041 (always fall back to English for missing translations)
- Original bug: #12448

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (N/A — test-only change)
