### PR TITLE
fix: stabilize flaky GraphQL avatars getImage test

### DIFF
--- a/tests/e2e/Services/GraphQL/AvatarsTest.php
+++ b/tests/e2e/Services/GraphQL/AvatarsTest.php
@@ -91,18 +91,25 @@ final class AvatarsTest extends Scope
         $graphQLPayload = [
             'query' => $query,
             'variables' => [
-                'url' => 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png',
+                // Same URL as REST AvatarsBase::testGetImage (Google logo fetches flake in CI)
+                'url' => 'https://appwrite.io/images/open-graph/website.avif',
             ],
         ];
 
-        $image = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $projectId,
-        ], $this->getHeaders()), $graphQLPayload);
+        /**
+         * Wrapped in assertEventually to handle transient external URL failures
+         */
+        $image = null;
+        $this->assertEventually(function () use ($projectId, $graphQLPayload, &$image) {
+            $image = $this->client->call(Client::METHOD_POST, '/graphql', \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $projectId,
+            ], $this->getHeaders()), $graphQLPayload);
 
-        $this->assertEquals(200, $image['headers']['status-code']);
-        $this->assertNotEmpty($image['body']);
-        $this->assertStringContainsString('image/', (string) $image['headers']['content-type']);
+            $this->assertEquals(200, $image['headers']['status-code']);
+            $this->assertNotEmpty($image['body']);
+            $this->assertStringContainsString('image/', (string) $image['headers']['content-type']);
+        }, 30_000, 2_000);
 
         return $image['body'];
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Stabilizes the flaky GraphQL E2E test `AvatarsTest::testGetImageFromURL`.

When the remote Google logo fetch fails (timeouts/DNS/network), `getImage` returns JSON (`avatar_remote_url_failed` / similar) instead of an image, so the assertion that `content-type` contains `image/` fails.

This aligns the GraphQL test with REST `AvatarsBase::testGetImage`:
- Use `https://appwrite.io/images/open-graph/website.avif` instead of the Google logo URL
- Wrap the call in `assertEventually` to tolerate transient external URL failures

## Test Plan

- [x] Reproduced the flake locally by blocking `www.google.com` in the Appwrite container (`/etc/hosts` → `127.0.0.1`); old test failed with the exact CI assertion on `application/json`
- [x] With Google blocked, updated test passes via the `appwrite.io` URL
- [x] `docker compose exec appwrite test tests/e2e/Services/GraphQL/AvatarsTest.php --filter=testGetImageFromURL` passes repeatedly on a clean stack

## Related PRs and Issues

- N/A (CI flake fix)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
