### PR TITLE
fix(databases): enforce strict integer type validation for document attributes (#7810)

### DIFF
--- a/app/init/database/formats.php
+++ b/app/init/database/formats.php
@@ -1,5 +1,6 @@
 <?php
 
+use Appwrite\Utopia\Database\Validator\RangeInteger;
 use Utopia\Database\Database;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
 use Utopia\Database\Validator\Structure;
@@ -33,14 +34,14 @@ Structure::addFormat(APP_DATABASE_ATTRIBUTE_URL, function () {
 Structure::addFormat(APP_DATABASE_ATTRIBUTE_INT_RANGE, function ($attribute) {
     $min = $attribute['formatOptions']['min'] ?? -INF;
     $max = $attribute['formatOptions']['max'] ?? INF;
-    return new Range($min, $max, Range::TYPE_INTEGER);
+    return new RangeInteger($min, $max);
 }, Database::VAR_INTEGER);
 
 // BigInt uses a dedicated bigintRange format name to avoid clobbering `intRange`.
 Structure::addFormat(APP_DATABASE_ATTRIBUTE_BIGINT_RANGE, function ($attribute) {
     $min = $attribute['formatOptions']['min'] ?? -INF;
     $max = $attribute['formatOptions']['max'] ?? INF;
-    return new Range($min, $max, Range::TYPE_INTEGER);
+    return new RangeInteger($min, $max);
 }, Database::VAR_BIGINT);
 
 Structure::addFormat(APP_DATABASE_ATTRIBUTE_FLOAT_RANGE, function ($attribute) {

--- a/src/Appwrite/Utopia/Database/Validator/RangeInteger.php
+++ b/src/Appwrite/Utopia/Database/Validator/RangeInteger.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Appwrite\Utopia\Database\Validator;
+
+use Utopia\Validator\Range;
+
+class RangeInteger extends Range
+{
+    /**
+     * @param int|float $min
+     * @param int|float $max
+     */
+    public function __construct(int|float $min, int|float $max)
+    {
+        parent::__construct($min, $max, Range::TYPE_INTEGER);
+    }
+
+    /**
+     * Is valid
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function isValid(mixed $value): bool
+    {
+        if (!\is_int($value)) {
+            return false;
+        }
+
+        return parent::isValid($value);
+    }
+}

--- a/tests/unit/Utopia/Database/Validator/RangeIntegerTest.php
+++ b/tests/unit/Utopia/Database/Validator/RangeIntegerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Database\Validator;
+
+use Appwrite\Utopia\Database\Validator\RangeInteger;
+use PHPUnit\Framework\TestCase;
+
+final class RangeIntegerTest extends TestCase
+{
+    public function testValidIntegers(): void
+    {
+        $validator = new RangeInteger(0, 100);
+
+        $this->assertTrue($validator->isValid(0));
+        $this->assertTrue($validator->isValid(1));
+        $this->assertTrue($validator->isValid(50));
+        $this->assertTrue($validator->isValid(100));
+        $this->assertSame(0, $validator->getMin());
+        $this->assertSame(100, $validator->getMax());
+    }
+
+    public function testRejectsStringIntegers(): void
+    {
+        $validator = new RangeInteger(0, 100);
+
+        // Numeric strings must be rejected
+        $this->assertFalse($validator->isValid('0'));
+        $this->assertFalse($validator->isValid('50'));
+        $this->assertFalse($validator->isValid('100'));
+        $this->assertFalse($validator->isValid('50000'));
+        $this->assertFalse($validator->isValid('1.5'));
+    }
+
+    public function testRejectsInvalidTypesAndOutOfRange(): void
+    {
+        $validator = new RangeInteger(0, 100);
+
+        $this->assertFalse($validator->isValid(-1));
+        $this->assertFalse($validator->isValid(101));
+        $this->assertFalse($validator->isValid(50.5));
+        $this->assertFalse($validator->isValid(null));
+        $this->assertFalse($validator->isValid(false));
+        $this->assertFalse($validator->isValid(true));
+        $this->assertFalse($validator->isValid([]));
+    }
+}


### PR DESCRIPTION
Fixes #7810

## Problem
When creating or updating a document in a collection with an integer attribute, passing a string representation of a number (for example, `{"amount": "50000"}`) was accepted without throwing a structure validation error. The document was created successfully, and the attribute value was preserved and emitted as a String in downstream events (such as Functions `req.body` and Webhooks).

## Root Cause
Document attribute structure validation uses the `APP_DATABASE_ATTRIBUTE_INT_RANGE` format validator registered in `app/init/database/formats.php`, which instantiated `Utopia\Validator\Range`. Inside `Utopia\Validator\Range::isValid()`, the line `$value = $value + 0;` implicitly coerced string numbers (`"50000"`) into integers (`50000`) in local validator scope before invoking `\is_int($value)`. 

While `Range::isValid()` accepted numeric strings for HTTP GET query parameter validation in `utopia-php/http`, it bypassed strict type checking for stored database document attributes.

## Solution
1. Introduced `Appwrite\Utopia\Database\Validator\RangeInteger` extending `Utopia\Validator\Range`. It enforces a strict `\is_int($value)` type check before delegating range boundary validation to `parent::isValid($value)`.
2. Updated `APP_DATABASE_ATTRIBUTE_INT_RANGE` (`Database::VAR_INTEGER`) and `APP_DATABASE_ATTRIBUTE_BIGINT_RANGE` (`Database::VAR_BIGINT`) format registrations in `app/init/database/formats.php` to use `RangeInteger`.
3. Added unit tests in `tests/unit/Utopia/Database/Validator/RangeIntegerTest.php`.

## Impact & Scope
- Passing a numeric string (such as `"50000"`) for integer or bigint attributes now correctly fails document structure validation with HTTP 400 (`DOCUMENT_INVALID_STRUCTURE`).
- Centralized registration in `formats.php` provides system-wide coverage across single create, bulk create, update, upsert, Collections API, and TablesDB API.
- Leaves `utopia-php/validators` untouched, preserving HTTP query parameter validation.

## Test Coverage
- Unit tests added in `tests/unit/Utopia/Database/Validator/RangeIntegerTest.php`:
  - Validates native integers (`0`, `1`, `50`, `100`) pass validation.
  - Validates numeric strings (`"0"`, `"50"`, `"100"`, `"50000"`) are rejected.
  - Validates floats (`50.5`), nulls, booleans, and arrays are rejected.

## Checklists
- [x] Code follows repository coding guidelines and PSR-12 formatting.
- [x] Unit tests added and passing.
- [x] No breaking changes to existing valid integer attributes or HTTP query parameter validators.
