### PR TITLE
Fix: stabilize flaky avatars getFavicon test

### DIFF
--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -283,16 +283,21 @@ trait AvatarsBase
     {
         /**
          * Test for SUCCESS
+         *
+         * Wrapped in assertEventually to handle transient external URL failures
          */
-        $response = $this->client->call(Client::METHOD_GET, '/avatars/favicon', [
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], [
-            'url' => 'https://github.com/',
-        ]);
+        $response = null;
+        $this->assertEventually(function () use (&$response) {
+            $response = $this->client->call(Client::METHOD_GET, '/avatars/favicon', [
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], [
+                'url' => 'https://github.com/',
+            ]);
 
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals('image/svg+xml', $response['headers']['content-type']);
-        $this->assertNotEmpty($response['body']);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertEquals('image/svg+xml', $response['headers']['content-type']);
+            $this->assertNotEmpty($response['body']);
+        }, 30_000, 2_000);
 
         $response = $this->client->call(Client::METHOD_GET, '/avatars/favicon', [
             'x-appwrite-project' => $this->getProject()['$id'],


### PR DESCRIPTION
<!--
  Thank you for sending the PR! We appreciate you spending the time to work on these changes.

  Help us understand your motivation by explaining why you decided to make this change.

  You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

  Happy contributing!

  -->

  ## What does this PR do?

  `testGetFavicon` in `tests/e2e/Services/Avatars/AvatarsBase.php` fetches a live favicon from `https://github.com/` with no retry wrapper, and hard-asserts an exact response
  status/content-type. Any transient failure or hiccup in reaching GitHub flakes CI, even though nothing in Appwrite itself is broken.

  This mirrors the exact issue just fixed in #13045 (GraphQL avatars `getImage` test), which wrapped its external fetch in `assertEventually` for the same reason. This PR applies the same
  fix here: the `github.com` favicon fetch is now wrapped in `assertEventually` (30s timeout, 2s poll), so transient remote fetch failures are retried instead of failing the build outright.

  ## Test Plan

  - Ran the full Avatars e2e suite locally via `docker compose exec appwrite test tests/e2e/Services/Avatars`: 33 tests, 653 assertions, 0 failures.
  - Ran `testGetFavicon` specifically across all three test variants (Console/Client/Server) via `--filter=testGetFavicon`: all pass.

  ## Related PRs and Issues

  - #13045: fix: stabilize flaky GraphQL avatars getImage test (same root cause, same fix pattern)

  ## Checklist

  - [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
  - [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

