### PR TITLE
Fix: stabilize flaky health certificate test

### DIFF
--- a/tests/e2e/Services/Health/CertificateTest.php
+++ b/tests/e2e/Services/Health/CertificateTest.php
@@ -11,8 +11,13 @@ final class CertificateTest extends HealthBase
         $this->assertCertificate('www.google.com', '/CN=www.google.com', 'www.google.com');
         $this->assertCertificate('appwrite.io', '/CN=appwrite.io', 'appwrite.io');
 
-        $response = $this->callGet('/health/certificate', ['domain' => 'https://google.com']);
-        $this->assertEquals(200, $response['headers']['status-code']);
+        /**
+         * Wrapped in assertEventually to handle transient external URL failures
+         */
+        $this->assertEventually(function () {
+            $response = $this->callGet('/health/certificate', ['domain' => 'https://google.com']);
+            $this->assertEquals(200, $response['headers']['status-code']);
+        }, 30_000, 2_000);
 
         $this->assertCertificateFailure('localhost', 400);
         $this->assertCertificateFailure('doesnotexist.com', 404);
@@ -20,15 +25,20 @@ final class CertificateTest extends HealthBase
         $this->assertCertificateFailure('', 400);
     }
 
+    /**
+     * Wrapped in assertEventually to handle transient external URL failures
+     */
     private function assertCertificate(string $domain, string $expectedName, string $expectedSN): void
     {
-        $response = $this->callGet('/health/certificate', ['domain' => $domain]);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals($expectedName, $response['body']['name']);
-        $this->assertEquals($expectedSN, $response['body']['subjectSN']);
-        $this->assertContains($response['body']['issuerOrganisation'], ["Let's Encrypt", 'Google Trust Services']);
-        $this->assertIsInt($response['body']['validFrom']);
-        $this->assertIsInt($response['body']['validTo']);
+        $this->assertEventually(function () use ($domain, $expectedName, $expectedSN) {
+            $response = $this->callGet('/health/certificate', ['domain' => $domain]);
+            $this->assertEquals(200, $response['headers']['status-code']);
+            $this->assertEquals($expectedName, $response['body']['name']);
+            $this->assertEquals($expectedSN, $response['body']['subjectSN']);
+            $this->assertContains($response['body']['issuerOrganisation'], ["Let's Encrypt", 'Google Trust Services']);
+            $this->assertIsInt($response['body']['validFrom']);
+            $this->assertIsInt($response['body']['validTo']);
+        }, 30_000, 2_000);
     }
 
     private function assertCertificateFailure(string $domain, int $status): void


### PR DESCRIPTION
<!--
  Thank you for sending the PR! We appreciate you spending the time to work on these changes.

  Help us understand your motivation by explaining why you decided to make this change.

  You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

  Happy contributing!

  -->

  ## What does this PR do?

  `testCertificateValidity` in `tests/e2e/Services/Health/CertificateTest.php` makes live TLS handshakes to `www.google.com`, `appwrite.io`, and `google.com` with no retry wrapper. Any
  transient network hiccup reaching these external hosts fails the test for reasons unrelated to Appwrite itself, the same class of issue already fixed for the GraphQL avatars getImage test
  (#13045) and the REST avatars getFavicon test.

  This PR wraps those live external calls in `assertEventually` (30s timeout, 2s poll), so transient remote fetch failures are retried instead of failing the build outright.

  ## Test Plan

  - Ran `tests/e2e/Services/Health/CertificateTest.php` locally via `docker compose exec appwrite test tests/e2e/Services/Health --filter=CertificateTest`: 1 test, 30 assertions, 0 failures.
  - Confirmed `vendor/bin/phpstan analyse` reports no errors on the changed file.

  ## Related PRs and Issues

  - #13045: fix: stabilize flaky GraphQL avatars getImage test (same root cause, same fix pattern)

  ## Checklist

  - [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
  - [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

