### PR TITLE
feat(spec): declare the X-Appwrite-Organization security scheme

### DIFF
--- a/app/init/constants.php
+++ b/app/init/constants.php
@@ -273,6 +273,7 @@ const APP_AUTH_TYPE_SESSION = 'Session';
 const APP_AUTH_TYPE_JWT = 'JWT';
 const APP_AUTH_TYPE_KEY = 'Key';
 const APP_AUTH_TYPE_ADMIN = 'Admin';
+const APP_AUTH_TYPE_ORGANIZATION = 'Organization';
 // Response related
 const MAX_OUTPUT_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
 const APP_LIMIT_UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024; // 5MB

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Create.php
@@ -54,7 +54,7 @@ class Create extends Action
                 description: <<<EOT
                 Create a new project.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN, AuthType::KEY, AuthType::ORGANIZATION],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Delete.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Delete.php
@@ -42,7 +42,7 @@ class Delete extends Action
                 description: <<<EOT
                 Delete a project by its unique ID.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN, AuthType::KEY, AuthType::ORGANIZATION],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_NOCONTENT,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Get.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Get.php
@@ -37,7 +37,7 @@ class Get extends Action
                 description: <<<EOT
                 Get a project.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN, AuthType::KEY, AuthType::ORGANIZATION],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/Update.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/Update.php
@@ -40,7 +40,7 @@ class Update extends Action
                 description: <<<EOT
                 Update a project by its unique ID.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN, AuthType::KEY, AuthType::ORGANIZATION],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/src/Appwrite/Platform/Modules/Organization/Http/Projects/XList.php
+++ b/src/Appwrite/Platform/Modules/Organization/Http/Projects/XList.php
@@ -54,7 +54,7 @@ class XList extends Action
                 description: <<<EOT
                 Get a list of all projects. You can use the query params to filter your results.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN, AuthType::KEY, AuthType::ORGANIZATION],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -234,6 +234,12 @@ class Specs extends Action
                     'description' => 'Your secret API key',
                     'in' => 'header',
                 ],
+                'Organization' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Organization',
+                    'description' => 'Your organization ID',
+                    'in' => 'header',
+                ],
                 'JWT' => [
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-JWT',
@@ -325,6 +331,12 @@ class Specs extends Action
                     'type' => 'apiKey',
                     'name' => 'X-Appwrite-Key',
                     'description' => 'Your secret API key',
+                    'in' => 'header',
+                ],
+                'Organization' => [
+                    'type' => 'apiKey',
+                    'name' => 'X-Appwrite-Organization',
+                    'description' => 'Your organization ID',
                     'in' => 'header',
                 ],
                 'JWT' => [

--- a/src/Appwrite/SDK/AuthType.php
+++ b/src/Appwrite/SDK/AuthType.php
@@ -8,4 +8,11 @@ enum AuthType: string
     case KEY = APP_AUTH_TYPE_KEY;
     case SESSION = APP_AUTH_TYPE_SESSION;
     case ADMIN = APP_AUTH_TYPE_ADMIN;
+
+    /**
+     * Scopes a request to an organization via the X-Appwrite-Organization
+     * header. Carries no platform of its own, so routes must still declare the
+     * auth types that make them reachable (ADMIN, KEY, ...).
+     */
+    case ORGANIZATION = APP_AUTH_TYPE_ORGANIZATION;
 }

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -86,6 +86,7 @@ class OpenAPI3 extends Format
             'Project' => '<YOUR_PROJECT_ID>',
             'ProjectPath' => '<YOUR_PROJECT_ID>',
             'Key' => '<YOUR_API_KEY>',
+            'Organization' => '<YOUR_ORGANIZATION_ID>',
             'JWT' => '<YOUR_JWT>',
             'Locale' => 'en',
             'Mode' => '',


### PR DESCRIPTION
## What

The API resolves the current organization for `/v1/organization*` routes from the `x-appwrite-organization` header, but the spec never described that header. Declare it as an `Organization` security scheme on the console and server platforms, and tag the `/v1/organization/projects` routes with it.

## Why

`app/init/resources/request.php` builds the `team` context from the header:

```php
$orgHeader = $request->getHeaderLine('x-appwrite-organization', '');
...
} elseif (!empty($orgHeader)) {
    return $authorization->skip(fn () => $dbForPlatform->getDocument('teams', $orgHeader));
}
```

and rejects org-scoped API keys that omit it:

```php
if (!empty($key->getTeamId())) {
    if (empty($organizationHeader) || $organizationHeader !== $key->getTeamId()) {
        throw new Exception(Exception::ORGANIZATION_ID_MISSING);
    }
}
```

`ORGANIZATION_ID_MISSING` is already in the error catalog and tells users to "pass x-appwrite-organization header with your organization ID" — but no generated SDK can. `grep X-Appwrite-Organization` over the published console spec returns zero hits, so:

- console and server SDKs have no way to target an organization; a server SDK holding an organization API key literally cannot satisfy the check above
- consumers hand-roll the header instead. The CLI sets it manually in `config-filters.ts` and re-derives the org ID in five other places, including a raw `client.call("get", new URL(.../projects/{id}))` that bypasses its own generated SDK

Once the scheme is declared, `getGlobalHeaders()` in sdk-generator emits a setter for it automatically, exactly like `setProject()`/`setKey()` — no per-language work.

## Design notes

`AuthType::ORGANIZATION` carries no SDK platform in `getSDKPlatformsForRouteSecurity()`, so routes keep declaring `ADMIN`/`KEY` for reachability and platform routing is untouched. It is appended last in each `auth:` array, so the `array_slice($securities, 0, $this->authCount)` that builds `x-appwrite.auth` is unaffected.

`Method::getAuth()` is read only by spec generation (the only other reference in the tree is one unit test on an unrelated route), so **this has no runtime authentication effect**.

## Test plan

Generated all three specs from `origin/main` and from this branch and diffed them:

| | client | server | console |
|---|---|---|---|
| securitySchemes added | – | `Organization` | `Organization` |
| operations | 149 → 149 | 554 → 554 | 608 → 608 |
| operations with changed `x-appwrite.auth` | 0 | 0 | 0 |
| operations with changed `security` | 0 | 5 | 5 |

The client spec is unchanged. The 5 changed operations are exactly the organization routes, going from `[Key, Project]` to `[Key, Organization, Project]`.

Then ran sdk-generator against the new console spec to confirm the downstream effect:

```
$ SDK_GEN_SPEC_FILE=.../open-api3-1.9.x-console.json php example.php node console
$ grep -n setOrganization examples/node/src/client.ts
245:    setOrganization(value: string): this {
246:        this.headers['X-Appwrite-Organization'] = value;
```

- [x] `composer lint` (Pint) passes on changed files
- [x] Spec generation succeeds for all three platforms

## Follow-ups

- appwrite-labs/cloud tags the other 18 `/v1/organization/*` routes (organization, keys, memberships, installations). Needs this merged first, since `AuthType::ORGANIZATION` ships via `appwrite/server-ce`.
- appwrite/sdk-generator then exposes the per-method security set so the CLI can generate `--organization-id` / `--project-id` flags and delete its hand-rolled resolution.