### PR TITLE
fix(release): refuse to publish a version that already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,29 @@ jobs:
         # Fetch submodules
         submodules: recursive
 
+    - name: Ensure this version was not already published
+      env:
+        TAG: ${{ github.event.release.tag_name }}
+      run: |
+        set -euo pipefail
+        version="${TAG#v}"
+        status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+          --retry 3 --retry-all-errors --max-time 30 \
+          "https://hub.docker.com/v2/repositories/appwrite/appwrite/tags/${version}" || true)
+        case "$status" in
+          404)
+            echo "appwrite/appwrite:${version} has not been published yet, proceeding."
+            ;;
+          200)
+            echo "::error::appwrite/appwrite:${version} already exists on Docker Hub. Published versions are immutable — ship a new patch version instead of re-tagging ${TAG}."
+            exit 1
+            ;;
+          *)
+            echo "::error::Unexpected response ${status} from Docker Hub while checking appwrite/appwrite:${version}. Refusing to publish."
+            exit 1
+            ;;
+        esac
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 


### PR DESCRIPTION
## What does this PR do?

Adds a guard to the release workflow that refuses to publish a version that has already been published.

During the 1.9.5 release the `1.9.5` tag was moved four times (`e31c142` → `03f3498` → `5e22bd5` → `9852f2b`) while chasing self-host installer fixes. Each re-publish rebuilt and overwrote `appwrite/appwrite:1.9.5` on Docker Hub, so anyone who pulled between Jun 30 07:42 and Jul 1 02:10 UTC got a different build under the same version. That breaks the reasonable expectation that a published version is an immutable, reproducible artifact — see #12753.

The new step runs before QEMU, Docker Hub login, and the build. It resolves the release tag to a version, asks Docker Hub whether `appwrite/appwrite:<version>` already exists, and:

- `404` — unpublished, proceed as normal
- `200` — already published, fail with a message pointing at shipping a new patch version instead of re-tagging
- anything else — fail closed rather than risk overwriting on an inconclusive check

Only the full `{major}.{minor}.{patch}` tag is checked. The `{major}.{minor}` and `{major}` tags stay intentionally mutable, since those are meant to track the newest patch.

## Test Plan

Ran the guard script against the live Docker Hub API:

| `tag_name` | Docker Hub | Result |
|---|---|---|
| `1.9.5` (published) | 200 | fails, blocks the re-publish |
| `v1.9.5` (prefix variant) | 200 | fails, `v` prefix stripped correctly |
| `1.99.99` (unpublished) | 404 | passes, proceeds to build |

The first row is the 1.9.5 incident: with this in place, the second, third, and fourth re-publishes would each have been blocked.

## Related PRs and Issues

Fixes #12753

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/HEAD/CONTRIBUTING.md)?

Yes
