### PR TITLE
fix: prevent concurrent VCS token refresh

### DIFF
--- a/app/config/collections/platform.php
+++ b/app/config/collections/platform.php
@@ -2228,7 +2228,19 @@ $platformCollections = [
         '$collection' => ID::custom(Database::METADATA),
         '$id' => ID::custom('vcsCommentLocks'),
         'name' => 'vcsCommentLocks',
-        'attributes' => [],
+        'attributes' => [
+            [
+                '$id' => ID::custom('holderId'),
+                'type' => Database::VAR_STRING,
+                'format' => '',
+                'size' => 255,
+                'signed' => true,
+                'required' => false,
+                'default' => null,
+                'array' => false,
+                'filters' => [],
+            ],
+        ],
         'indexes' => []
     ],
 

--- a/src/Appwrite/Auth/OAuth2.php
+++ b/src/Appwrite/Auth/OAuth2.php
@@ -6,6 +6,7 @@ use Appwrite\Auth\OAuth2\Exception;
 
 abstract class OAuth2
 {
+    public const TIMEOUT = 15;
     /**
      * @var string
      */
@@ -193,6 +194,7 @@ abstract class OAuth2
         \curl_setopt($ch, CURLOPT_HEADER, 0);
         \curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         \curl_setopt($ch, CURLOPT_USERAGENT, 'Appwrite OAuth2');
+        \curl_setopt($ch, CURLOPT_TIMEOUT, self::TIMEOUT);
 
         if (!empty($payload)) {
             \curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);

--- a/src/Appwrite/Auth/OAuth2.php
+++ b/src/Appwrite/Auth/OAuth2.php
@@ -7,6 +7,7 @@ use Appwrite\Auth\OAuth2\Exception;
 abstract class OAuth2
 {
     public const TIMEOUT = 15;
+
     /**
      * @var string
      */

--- a/src/Appwrite/Migration/Version/V25.php
+++ b/src/Appwrite/Migration/Version/V25.php
@@ -83,6 +83,17 @@ class V25 extends Migration
                     $this->dbForProject->purgeCachedCollection($id);
                     break;
 
+                case 'vcsCommentLocks':
+                    if ($collectionType === 'console') {
+                        try {
+                            $this->createAttributeFromCollection($this->dbForProject, $id, 'holderId');
+                        } catch (Throwable $th) {
+                            Console::warning("Failed to create attribute \"holderId\" in collection {$id}: {$th->getMessage()}");
+                        }
+                    }
+                    $this->dbForProject->purgeCachedCollection($id);
+                    break;
+
                 case 'databases':
                     if ($collectionType === 'projects') {
                         try {

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -16,9 +16,6 @@ class InstallationTokens
     private const LOCK_WAIT_SECONDS = 50; // > LOCK_TTL so waiters can steal
     private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 3;
 
-    /**
-     * Refreshes an installation's token, resolving the OAuth2 client for its provider.
-     */
     public function refreshForInstallation(Document $installation, Database $dbForPlatform, Factory $vcsFactory): Document
     {
         $provider = $installation->getAttribute('provider', 'github');
@@ -58,6 +55,9 @@ class InstallationTokens
         $waitStartedAt = new \DateTime('now');
 
         $lock = 'installation-' . $installation->getId();
+        // Random per-attempt id so a waiter can only ever delete the lock it created,
+        // never one a different worker (original holder or another stealer) is using.
+        $holderId = \bin2hex(\random_bytes(8));
         $authorization = $dbForPlatform->getAuthorization();
         $acquired = false;
         $deadline = \time() + $this->getLockWaitSeconds();
@@ -67,7 +67,10 @@ class InstallationTokens
             $retries++;
 
             try {
-                $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock])));
+                $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document([
+                    '$id' => $lock,
+                    'holderId' => $holderId,
+                ])));
                 $acquired = true;
                 break;
             } catch (\Throwable $err) {
@@ -84,7 +87,6 @@ class InstallationTokens
         }
 
         if (!$acquired) {
-            // The holder outlasted our wait. Reuse its token if it landed, never replay ours.
             if ($fresh = $this->tryReturnFresh($dbForPlatform, $installation, $waitStartedAt)) {
                 return $fresh;
             }
@@ -93,18 +95,13 @@ class InstallationTokens
         }
 
         try {
-            // The lock holder may have refreshed already.
             if ($fresh = $this->tryReturnFresh($dbForPlatform, $installation, $waitStartedAt)) {
                 return $fresh;
             }
 
             return $this->exchange($installation, $dbForPlatform, $oauth2);
         } finally {
-            try {
-                $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
-            } catch (\Throwable $err) {
-                Console::warning('Failed to release vcs installation lock for ' . $installation->getId() . ': ' . $err->getMessage());
-            }
+            $this->releaseLock($dbForPlatform, $authorization, $lock, $holderId, $installation->getId());
         }
     }
 
@@ -120,7 +117,6 @@ class InstallationTokens
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
 
-        // GitHub answers a refused token with a 200 and an error body rather than a 4xx.
         $this->clear($installation, $dbForPlatform, $tokens['error'] ?? '');
 
         $accessToken = $oauth2->getAccessToken('');
@@ -131,7 +127,16 @@ class InstallationTokens
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
 
-        if (empty($oauth2->getUserID($accessToken))) {
+        // Retry once: a network blip on the identity check shouldn't discard an
+        // otherwise good, already-rotated token. A genuinely empty/invalid response
+        // on both attempts means the token itself is bad, not the network.
+        $userId = $oauth2->getUserID($accessToken);
+        if (empty($userId)) {
+            $this->sleepWithBackoff(1);
+            $userId = $oauth2->getUserID($accessToken);
+        }
+
+        if (empty($userId)) {
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
 
@@ -213,7 +218,7 @@ class InstallationTokens
 
             $lockedAt = $document->getAttribute('$createdAt') ?? $document->getAttribute('lockedAt');
             if (empty($lockedAt)) {
-                $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+                $this->deleteLockDocument($dbForPlatform, $authorization, $lock);
                 Console::warning('Stole vcs installation lock with missing timestamp: ' . $lock);
 
                 return true;
@@ -224,13 +229,41 @@ class InstallationTokens
                 return false;
             }
 
-            $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+            $this->deleteLockDocument($dbForPlatform, $authorization, $lock);
             Console::warning('Stole expired vcs installation lock: ' . $lock);
 
             return true;
         } catch (\Throwable) {
             return false;
         }
+    }
+
+    /**
+     * Deletes only when the caller is the current owner, so a released or already-stolen
+     * lock is never removed out from under whoever holds it now. Falls back to an
+     * unconditional delete when releasing without a known holder (e.g. from stealLock,
+     * where the caller has already decided the existing lock is abandoned).
+     */
+    protected function releaseLock(Database $dbForPlatform, mixed $authorization, string $lock, string $holderId, string $installationId): void
+    {
+        try {
+            $current = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
+
+            if ($current->isEmpty() || $current->getAttribute('holderId') !== $holderId) {
+                // Someone else's lock now occupies this id (ours was stolen while we
+                // worked, or already released) — deleting it would drop a lock we don't own.
+                return;
+            }
+
+            $this->deleteLockDocument($dbForPlatform, $authorization, $lock);
+        } catch (\Throwable $err) {
+            Console::warning('Failed to release vcs installation lock for ' . $installationId . ': ' . $err->getMessage());
+        }
+    }
+
+    protected function deleteLockDocument(Database $dbForPlatform, mixed $authorization, string $lock): void
+    {
+        $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
     }
 
     protected function sleepWithBackoff(int $retries): void

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -13,8 +13,8 @@ use Utopia\Database\Document;
 
 class InstallationTokens
 {
-    private const LOCK_WAIT_SECONDS = 40; // > LOCK_TTL so waiters can steal
-    private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 2;
+    private const LOCK_WAIT_SECONDS = 50; // > LOCK_TTL so waiters can steal
+    private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 3;
 
     /**
      * Refreshes an installation's token, resolving the OAuth2 client for its provider.
@@ -67,7 +67,7 @@ class InstallationTokens
             $retries++;
 
             try {
-                $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock, 'lockedAt' => DateTime::now()])));
+                $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock])));
                 $acquired = true;
                 break;
             } catch (\Throwable $err) {
@@ -211,7 +211,7 @@ class InstallationTokens
                 return true;
             }
 
-            $lockedAt = $document->getAttribute('lockedAt');
+            $lockedAt = $document->getAttribute('$createdAt') ?? $document->getAttribute('lockedAt');
             if (empty($lockedAt)) {
                 $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
                 Console::warning('Stole vcs installation lock with missing timestamp: ' . $lock);

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -13,9 +13,11 @@ use Utopia\Database\Document;
 
 class InstallationTokens
 {
-    private const LOCK_WAIT_SECONDS = 65; // > LOCK_TTL so waiters can steal
+    // Budget: 3x 15s provider HTTP calls (refreshTokens + 2x getUserID) + backoff + DB write/jitter margin = 50.3s.
+    // LOCK_TTL (75s) provides a 24.7s safety buffer so a live refresh is never stolen while in flight.
+    private const LOCK_TTL_SECONDS = (OAuth2::TIMEOUT * 4) + 15;
 
-    private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 4;
+    private const LOCK_WAIT_SECONDS = 80; // > LOCK_TTL so waiters can steal
 
     public function refreshForInstallation(Document $installation, Database $dbForPlatform, Factory $vcsFactory): Document
     {

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -234,9 +234,25 @@ class InstallationTokens
             }
 
             $currentHolderId = $document->getAttribute('holderId');
-            $reread = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
+            $claimId = 'steal-' . \bin2hex(\random_bytes(8));
 
-            if ($reread->isEmpty() || $reread->getAttribute('holderId') !== $currentHolderId) {
+            $authorization->skip(function () use ($dbForPlatform, $lock, $currentHolderId, $claimId) {
+                $current = $dbForPlatform->getDocument('vcsCommentLocks', $lock);
+                if ($current->isEmpty() || $current->getAttribute('holderId') !== $currentHolderId) {
+                    return;
+                }
+                $dbForPlatform->updateDocument(
+                    'vcsCommentLocks',
+                    $lock,
+                    new Document(['holderId' => $claimId])
+                );
+            });
+
+            $claimed = $authorization->skip(
+                fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock)
+            );
+
+            if ($claimed->isEmpty() || $claimed->getAttribute('holderId') !== $claimId) {
                 return false;
             }
 

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -5,6 +5,7 @@ namespace Appwrite\Vcs;
 use Appwrite\Auth\OAuth2;
 use Appwrite\Auth\OAuth2\Exception as OAuth2Exception;
 use Appwrite\Extend\Exception;
+use Swoole\Coroutine;
 use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -12,6 +13,12 @@ use Utopia\Database\Document;
 
 class InstallationTokens
 {
+    /** WAIT (40s) must exceed TTL so a waiter can detect and steal an abandoned lock. */
+    private const LOCK_WAIT_SECONDS = 40;
+
+    /** TTL is structurally derived as 2x the OAuth2 HTTP timeout (15s). */
+    private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 2;
+
     /**
      * Refreshes an installation's token, resolving the OAuth2 client for its provider.
      */
@@ -54,21 +61,22 @@ class InstallationTokens
         $lock = 'installation-' . $installation->getId();
         $authorization = $dbForPlatform->getAuthorization();
         $acquired = false;
+        $deadline = \time() + $this->getLockWaitSeconds();
         $retries = 0;
 
-        while ($retries < 9) {
+        while (\time() < $deadline) {
             $retries++;
 
             try {
-                $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock])));
+                $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock, 'lockedAt' => DateTime::now()])));
                 $acquired = true;
                 break;
             } catch (\Throwable $err) {
-                if ($retries >= 9) {
-                    Console::warning('Error creating vcs installation lock for ' . $installation->getId() . ': ' . $err->getMessage());
+                if ($this->tryStealExpiredLock($dbForPlatform, $authorization, $lock)) {
+                    continue;
                 }
 
-                \sleep(1);
+                $this->sleepWithBackoff($retries);
             }
         }
 
@@ -92,7 +100,11 @@ class InstallationTokens
 
             return $this->exchange($installation, $dbForPlatform, $oauth2);
         } finally {
-            $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+            try {
+                $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+            } catch (\Throwable $err) {
+                Console::warning('Failed to release vcs installation lock for ' . $installation->getId() . ': ' . $err->getMessage());
+            }
         }
     }
 
@@ -123,7 +135,7 @@ class InstallationTokens
         $installation = $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
             'personalAccessToken' => $accessToken,
             'personalRefreshToken' => $oauth2->getRefreshToken(''),
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int)$oauth2->getAccessTokenExpiry('')),
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $oauth2->getAccessTokenExpiry('')),
         ]));
 
         if (empty($oauth2->getUserID($accessToken))) {
@@ -178,5 +190,56 @@ class InstallationTokens
         } catch (\Throwable) {
             return new Document();
         }
+    }
+
+    protected function tryStealExpiredLock(Database $dbForPlatform, mixed $authorization, string $lock): bool
+    {
+        try {
+            $document = $authorization->skip(
+                fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock)
+            );
+
+            if ($document->isEmpty()) {
+                return true;
+            }
+
+            $lockedAt = $document->getAttribute('lockedAt');
+            if (empty($lockedAt)) {
+                $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+                Console::warning('Stole vcs installation lock with missing timestamp: ' . $lock);
+
+                return true;
+            }
+
+            $age = \time() - \strtotime($lockedAt);
+            if ($age < self::LOCK_TTL_SECONDS) {
+                return false;
+            }
+
+            $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+            Console::warning('Stole expired vcs installation lock: ' . $lock);
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    protected function sleepWithBackoff(int $retries): void
+    {
+        $base = \min(0.2 * (2 ** \max(0, $retries - 1)), 1.5);
+        $jitter = \mt_rand(0, 100) / 1000;
+        $seconds = $base + $jitter;
+
+        if (\class_exists(Coroutine::class) && Coroutine::getCid() > 0) {
+            Coroutine::sleep($seconds);
+        } else {
+            \usleep((int) ($seconds * 1_000_000));
+        }
+    }
+
+    protected function getLockWaitSeconds(): int
+    {
+        return self::LOCK_WAIT_SECONDS;
     }
 }

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -214,7 +214,7 @@ class InstallationTokens
         try {
             return $dbForPlatform->getDocument('installations', $installation->getId());
         } catch (\Throwable) {
-            return new Document();
+            return new Document;
         }
     }
 
@@ -237,7 +237,7 @@ class InstallationTokens
             }
 
             $currentHolderId = $document->getAttribute('holderId');
-            $claimId = 'steal-' . \bin2hex(\random_bytes(8));
+            $claimId = 'steal-'.\bin2hex(\random_bytes(8));
 
             $authorization->skip(function () use ($dbForPlatform, $lock, $currentHolderId, $claimId) {
                 $current = $dbForPlatform->getDocument('vcsCommentLocks', $lock);
@@ -275,25 +275,11 @@ class InstallationTokens
     protected function releaseLock(Database $dbForPlatform, mixed $authorization, string $lock, string $holderId, string $installationId): void
     {
         try {
-            $releaseId = 'releasing-' . $holderId;
+            $current = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
 
-            $authorization->skip(function () use ($dbForPlatform, $lock, $holderId, $releaseId) {
-                $current = $dbForPlatform->getDocument('vcsCommentLocks', $lock);
-                if ($current->isEmpty() || $current->getAttribute('holderId') !== $holderId) {
-                    return;
-                }
-                $dbForPlatform->updateDocument(
-                    'vcsCommentLocks',
-                    $lock,
-                    new Document(['holderId' => $releaseId])
-                );
-            });
-
-            $claimed = $authorization->skip(
-                fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock)
-            );
-
-            if ($claimed->isEmpty() || $claimed->getAttribute('holderId') !== $releaseId) {
+            if ($current->isEmpty() || $current->getAttribute('holderId') !== $holderId) {
+                // Someone else's lock now occupies this id (ours was stolen while we
+                // worked, or already released) — deleting it would drop a lock we don't own.
                 return;
             }
 

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -130,9 +130,14 @@ class InstallationTokens
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
 
-        // Retry once: a network blip on the identity check shouldn't discard an
-        // otherwise good, already-rotated token. A genuinely empty/invalid response
-        // on both attempts means the token itself is bad, not the network.
+        // Persist new access + refresh token immediately so database never holds invalidated tokens
+        $installation = $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
+            'personalAccessToken' => $accessToken,
+            'personalRefreshToken' => $newRefreshToken,
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, $expirySeconds),
+        ]));
+
+        // Validate user identity (retry once)
         $userId = $oauth2->getUserID($accessToken);
         if (empty($userId)) {
             $this->sleepWithBackoff(1);
@@ -140,14 +145,10 @@ class InstallationTokens
         }
 
         if (empty($userId)) {
-            throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
+            $this->logWarning('Failed to verify user identity for refreshed installation '.$installation->getId().', but rotated tokens were persisted safely.');
         }
 
-        return $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
-            'personalAccessToken' => $accessToken,
-            'personalRefreshToken' => $newRefreshToken,
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, $expirySeconds),
-        ]));
+        return $installation;
     }
 
     /** Clear tokens only on explicit refusal (invalid_grant, bad_refresh_token). */

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -13,8 +13,9 @@ use Utopia\Database\Document;
 
 class InstallationTokens
 {
-    private const LOCK_WAIT_SECONDS = 50; // > LOCK_TTL so waiters can steal
-    private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 3;
+    private const LOCK_WAIT_SECONDS = 65; // > LOCK_TTL so waiters can steal
+
+    private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 4;
 
     public function refreshForInstallation(Document $installation, Database $dbForPlatform, Factory $vcsFactory): Document
     {
@@ -40,7 +41,7 @@ class InstallationTokens
             ->setAttribute('personalRefreshToken', $refreshToken)
             ->setAttribute('personalAccessTokenExpiry', $accessTokenExpiry);
 
-        if (!$this->isExpired($accessTokenExpiry) && !empty($accessToken)) {
+        if (! $this->isExpired($accessTokenExpiry) && ! empty($accessToken)) {
             return $installation;
         }
 
@@ -54,7 +55,7 @@ class InstallationTokens
         // this moves to a generic lock collection.
         $waitStartedAt = new \DateTime('now');
 
-        $lock = 'installation-' . $installation->getId();
+        $lock = 'installation-'.$installation->getId();
         // Random per-attempt id so a waiter can only ever delete the lock it created,
         // never one a different worker (original holder or another stealer) is using.
         $holderId = \bin2hex(\random_bytes(8));
@@ -86,7 +87,7 @@ class InstallationTokens
             }
         }
 
-        if (!$acquired) {
+        if (! $acquired) {
             if ($fresh = $this->tryReturnFresh($dbForPlatform, $installation, $waitStartedAt)) {
                 return $fresh;
             }
@@ -143,14 +144,14 @@ class InstallationTokens
         return $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
             'personalAccessToken' => $accessToken,
             'personalRefreshToken' => $newRefreshToken,
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), $expirySeconds),
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, $expirySeconds),
         ]));
     }
 
     /** Clear tokens only on explicit refusal (invalid_grant, bad_refresh_token). */
     protected function clear(Document $installation, Database $dbForPlatform, mixed $error): void
     {
-        if (!\is_string($error) || !\in_array($error, ['invalid_grant', 'bad_refresh_token'], true)) {
+        if (! \is_string($error) || ! \in_array($error, ['invalid_grant', 'bad_refresh_token'], true)) {
             return;
         }
 
@@ -176,9 +177,9 @@ class InstallationTokens
 
     protected function isUsable(Document $installation): bool
     {
-        return !$installation->isEmpty()
-            && !empty($installation->getAttribute('personalAccessToken'))
-            && !$this->isExpired($installation->getAttribute('personalAccessTokenExpiry'));
+        return ! $installation->isEmpty()
+            && ! empty($installation->getAttribute('personalAccessToken'))
+            && ! $this->isExpired($installation->getAttribute('personalAccessTokenExpiry'));
     }
 
     protected function tryReturnFresh(Database $dbForPlatform, Document $installation, \DateTime $waitStartedAt): ?Document
@@ -189,7 +190,7 @@ class InstallationTokens
             return null;
         }
 
-        if (!$this->isUsable($current)) {
+        if (! $this->isUsable($current)) {
             return null;
         }
 
@@ -202,6 +203,15 @@ class InstallationTokens
             return new \DateTime($updatedAt) >= (clone $waitStartedAt)->modify('-2 seconds') ? $current : null;
         } catch (\Throwable) {
             return null;
+        }
+    }
+
+    protected function getCurrentInstallation(Database $dbForPlatform, Document $installation): Document
+    {
+        try {
+            return $dbForPlatform->getDocument('installations', $installation->getId());
+        } catch (\Throwable) {
+            return new Document();
         }
     }
 
@@ -219,7 +229,7 @@ class InstallationTokens
             $lockedAt = $document->getAttribute('$createdAt');
             $expired = empty($lockedAt) || (\time() - \strtotime($lockedAt)) >= self::LOCK_TTL_SECONDS;
 
-            if (!$expired) {
+            if (! $expired) {
                 return false;
             }
 
@@ -231,7 +241,7 @@ class InstallationTokens
             }
 
             $this->deleteLockDocument($dbForPlatform, $authorization, $lock);
-            Console::warning('Stole expired vcs installation lock: ' . $lock);
+            $this->logWarning('Stole expired vcs installation lock: '.$lock);
 
             return true;
         } catch (\Throwable) {
@@ -256,8 +266,13 @@ class InstallationTokens
 
             $this->deleteLockDocument($dbForPlatform, $authorization, $lock);
         } catch (\Throwable $err) {
-            Console::warning('Failed to release vcs installation lock for ' . $installationId . ': ' . $err->getMessage());
+            $this->logWarning('Failed to release vcs installation lock for '.$installationId.': '.$err->getMessage());
         }
+    }
+
+    protected function logWarning(string $message): void
+    {
+        Console::warning($message);
     }
 
     protected function deleteLockDocument(Database $dbForPlatform, mixed $authorization, string $lock): void

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -216,16 +216,17 @@ class InstallationTokens
                 return true;
             }
 
-            $lockedAt = $document->getAttribute('$createdAt') ?? $document->getAttribute('lockedAt');
-            if (empty($lockedAt)) {
-                $this->deleteLockDocument($dbForPlatform, $authorization, $lock);
-                Console::warning('Stole vcs installation lock with missing timestamp: ' . $lock);
+            $lockedAt = $document->getAttribute('$createdAt');
+            $expired = empty($lockedAt) || (\time() - \strtotime($lockedAt)) >= self::LOCK_TTL_SECONDS;
 
-                return true;
+            if (!$expired) {
+                return false;
             }
 
-            $age = \time() - \strtotime($lockedAt);
-            if ($age < self::LOCK_TTL_SECONDS) {
+            $currentHolderId = $document->getAttribute('holderId');
+            $reread = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
+
+            if ($reread->isEmpty() || $reread->getAttribute('holderId') !== $currentHolderId) {
                 return false;
             }
 
@@ -240,9 +241,7 @@ class InstallationTokens
 
     /**
      * Deletes only when the caller is the current owner, so a released or already-stolen
-     * lock is never removed out from under whoever holds it now. Falls back to an
-     * unconditional delete when releasing without a known holder (e.g. from stealLock,
-     * where the caller has already decided the existing lock is abandoned).
+     * lock is never removed out from under whoever holds it now.
      */
     protected function releaseLock(Database $dbForPlatform, mixed $authorization, string $lock, string $holderId, string $installationId): void
     {

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -58,6 +58,8 @@ class InstallationTokens
         // The comment lock collection is reused for simplicity: it holds nothing but ids, and the
         // prefix keeps these apart from the provider comment ids stored alongside them. Ideally
         // this moves to a generic lock collection.
+        $waitStartedAt = new \DateTime('now');
+
         $lock = 'installation-' . $installation->getId();
         $authorization = $dbForPlatform->getAuthorization();
         $acquired = false;
@@ -72,6 +74,10 @@ class InstallationTokens
                 $acquired = true;
                 break;
             } catch (\Throwable $err) {
+                if ($fresh = $this->tryReturnFresh($dbForPlatform, $installation, $waitStartedAt)) {
+                    return $fresh;
+                }
+
                 if ($this->tryStealExpiredLock($dbForPlatform, $authorization, $lock)) {
                     continue;
                 }
@@ -82,9 +88,8 @@ class InstallationTokens
 
         if (!$acquired) {
             // The holder outlasted our wait. Reuse its token if it landed, never replay ours.
-            $current = $this->getCurrentInstallation($dbForPlatform, $installation);
-            if ($this->isUsable($current)) {
-                return $current;
+            if ($fresh = $this->tryReturnFresh($dbForPlatform, $installation, $waitStartedAt)) {
+                return $fresh;
             }
 
             throw new Exception(Exception::GENERAL_RESOURCE_LOCKED);
@@ -92,10 +97,8 @@ class InstallationTokens
 
         try {
             // The lock holder may have refreshed already.
-            $current = $this->getCurrentInstallation($dbForPlatform, $installation);
-
-            if ($this->isUsable($current)) {
-                return $current;
+            if ($fresh = $this->tryReturnFresh($dbForPlatform, $installation, $waitStartedAt)) {
+                return $fresh;
             }
 
             return $this->exchange($installation, $dbForPlatform, $oauth2);
@@ -179,6 +182,33 @@ class InstallationTokens
         return !$installation->isEmpty()
             && !empty($installation->getAttribute('personalAccessToken'))
             && !$this->isExpired($installation->getAttribute('personalAccessTokenExpiry'));
+    }
+
+    protected function isUsableAndFresh(Document $installation, \DateTime $waitStartedAt): bool
+    {
+        if (!$this->isUsable($installation)) {
+            return false;
+        }
+
+        $updatedAt = $installation->getAttribute('$updatedAt');
+        if (empty($updatedAt)) {
+            return false;
+        }
+
+        try {
+            $toleranceWindow = (clone $waitStartedAt)->modify('-2 seconds');
+
+            return new \DateTime($updatedAt) >= $toleranceWindow;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    protected function tryReturnFresh(Database $dbForPlatform, Document $installation, \DateTime $waitStartedAt): ?Document
+    {
+        $current = $this->getCurrentInstallation($dbForPlatform, $installation);
+
+        return $this->isUsableAndFresh($current, $waitStartedAt) ? $current : null;
     }
 
     protected function getCurrentInstallation(Database $dbForPlatform, Document $installation): Document

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -13,10 +13,7 @@ use Utopia\Database\Document;
 
 class InstallationTokens
 {
-    /** WAIT (40s) must exceed TTL so a waiter can detect and steal an abandoned lock. */
-    private const LOCK_WAIT_SECONDS = 40;
-
-    /** TTL is structurally derived as 2x the OAuth2 HTTP timeout (15s). */
+    private const LOCK_WAIT_SECONDS = 40; // > LOCK_TTL so waiters can steal
     private const LOCK_TTL_SECONDS = OAuth2::TIMEOUT * 2;
 
     /**
@@ -46,7 +43,7 @@ class InstallationTokens
             ->setAttribute('personalRefreshToken', $refreshToken)
             ->setAttribute('personalAccessTokenExpiry', $accessTokenExpiry);
 
-        if (!$this->isExpired($accessTokenExpiry)) {
+        if (!$this->isExpired($accessTokenExpiry) && !empty($accessToken)) {
             return $installation;
         }
 
@@ -78,7 +75,7 @@ class InstallationTokens
                     return $fresh;
                 }
 
-                if ($this->tryStealExpiredLock($dbForPlatform, $authorization, $lock)) {
+                if ($this->stealLock($dbForPlatform, $authorization, $lock)) {
                     continue;
                 }
 
@@ -138,7 +135,6 @@ class InstallationTokens
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
 
-        // Persist new token pair once access token and user identity are verified.
         return $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
             'personalAccessToken' => $accessToken,
             'personalRefreshToken' => $newRefreshToken,
@@ -146,11 +142,7 @@ class InstallationTokens
         ]));
     }
 
-    /**
-     * Drops the stored pair when the provider states it refused the token, so later calls stop
-     * replaying it. Only an explicit refusal counts: a timeout or a 5xx may pass, and clearing on
-     * those would force a reconnect that was never needed.
-     */
+    /** Clear tokens only on explicit refusal (invalid_grant, bad_refresh_token). */
     protected function clear(Document $installation, Database $dbForPlatform, mixed $error): void
     {
         if (!\is_string($error) || !\in_array($error, ['invalid_grant', 'bad_refresh_token'], true)) {
@@ -173,7 +165,7 @@ class InstallationTokens
         try {
             return new \DateTime($expiry) < new \DateTime('now');
         } catch (\Throwable) {
-            return false;
+            return true;
         }
     }
 
@@ -184,43 +176,31 @@ class InstallationTokens
             && !$this->isExpired($installation->getAttribute('personalAccessTokenExpiry'));
     }
 
-    protected function isUsableAndFresh(Document $installation, \DateTime $waitStartedAt): bool
-    {
-        if (!$this->isUsable($installation)) {
-            return false;
-        }
-
-        $updatedAt = $installation->getAttribute('$updatedAt');
-        if (empty($updatedAt)) {
-            return false;
-        }
-
-        try {
-            $toleranceWindow = (clone $waitStartedAt)->modify('-2 seconds');
-
-            return new \DateTime($updatedAt) >= $toleranceWindow;
-        } catch (\Throwable) {
-            return false;
-        }
-    }
-
     protected function tryReturnFresh(Database $dbForPlatform, Document $installation, \DateTime $waitStartedAt): ?Document
     {
-        $current = $this->getCurrentInstallation($dbForPlatform, $installation);
-
-        return $this->isUsableAndFresh($current, $waitStartedAt) ? $current : null;
-    }
-
-    protected function getCurrentInstallation(Database $dbForPlatform, Document $installation): Document
-    {
         try {
-            return $dbForPlatform->getDocument('installations', $installation->getId());
+            $current = $dbForPlatform->getDocument('installations', $installation->getId());
         } catch (\Throwable) {
-            return new Document();
+            return null;
+        }
+
+        if (!$this->isUsable($current)) {
+            return null;
+        }
+
+        $updatedAt = $current->getAttribute('$updatedAt');
+        if (empty($updatedAt)) {
+            return null;
+        }
+
+        try {
+            return new \DateTime($updatedAt) >= (clone $waitStartedAt)->modify('-2 seconds') ? $current : null;
+        } catch (\Throwable) {
+            return null;
         }
     }
 
-    protected function tryStealExpiredLock(Database $dbForPlatform, mixed $authorization, string $lock): bool
+    protected function stealLock(Database $dbForPlatform, mixed $authorization, string $lock): bool
     {
         try {
             $document = $authorization->skip(

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -275,11 +275,25 @@ class InstallationTokens
     protected function releaseLock(Database $dbForPlatform, mixed $authorization, string $lock, string $holderId, string $installationId): void
     {
         try {
-            $current = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
+            $releaseId = 'releasing-' . $holderId;
 
-            if ($current->isEmpty() || $current->getAttribute('holderId') !== $holderId) {
-                // Someone else's lock now occupies this id (ours was stolen while we
-                // worked, or already released) — deleting it would drop a lock we don't own.
+            $authorization->skip(function () use ($dbForPlatform, $lock, $holderId, $releaseId) {
+                $current = $dbForPlatform->getDocument('vcsCommentLocks', $lock);
+                if ($current->isEmpty() || $current->getAttribute('holderId') !== $holderId) {
+                    return;
+                }
+                $dbForPlatform->updateDocument(
+                    'vcsCommentLocks',
+                    $lock,
+                    new Document(['holderId' => $releaseId])
+                );
+            });
+
+            $claimed = $authorization->skip(
+                fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock)
+            );
+
+            if ($claimed->isEmpty() || $claimed->getAttribute('holderId') !== $releaseId) {
                 return;
             }
 

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -124,25 +124,23 @@ class InstallationTokens
         $this->clear($installation, $dbForPlatform, $tokens['error'] ?? '');
 
         $accessToken = $oauth2->getAccessToken('');
+        $newRefreshToken = $oauth2->getRefreshToken('') ?: $installation->getAttribute('personalRefreshToken');
+        $expirySeconds = (int) $oauth2->getAccessTokenExpiry('');
 
-        // No token and no stated reason, so the provider may simply not have answered. Persisting
-        // an empty token here would replace a pair that is possibly still good.
-        if (empty($accessToken)) {
+        if (empty($accessToken) || empty($newRefreshToken)) {
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
-
-        // The provider has already rotated the family, so persist before anything else can fail.
-        $installation = $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
-            'personalAccessToken' => $accessToken,
-            'personalRefreshToken' => $oauth2->getRefreshToken(''),
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), (int) $oauth2->getAccessTokenExpiry('')),
-        ]));
 
         if (empty($oauth2->getUserID($accessToken))) {
             throw new Exception(Exception::GENERAL_PROVIDER_FAILURE, 'Failed to refresh OAuth2 access token. Please reconnect the installation.');
         }
 
-        return $installation;
+        // Persist new token pair once access token and user identity are verified.
+        return $dbForPlatform->updateDocument('installations', $installation->getId(), new Document([
+            'personalAccessToken' => $accessToken,
+            'personalRefreshToken' => $newRefreshToken,
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), $expirySeconds),
+        ]));
     }
 
     /**

--- a/tests/unit/Migration/MigrationVersionsTest.php
+++ b/tests/unit/Migration/MigrationVersionsTest.php
@@ -200,6 +200,8 @@ final class MigrationVersionsTest extends TestCase
         $database->createCollection('functions');
         $database->createCollection('sites');
 
+        $database->createCollection('vcsCommentLocks');
+
         $migration = new V25();
         $migration->setProject(
             new Document(['$id' => 'project', '$sequence' => '1']),
@@ -225,8 +227,44 @@ final class MigrationVersionsTest extends TestCase
                 $attributes[] = $attribute instanceof Document ? $attribute->getAttribute('$id') : ($attribute['$id'] ?? '');
             }
 
-            $this->assertContains('providerBranches', $attributes);
-            $this->assertContains('providerPaths', $attributes);
+            foreach (['providerBranches', 'providerPaths'] as $id) {
+                $this->assertContains($id, $attributes);
+            }
         }
+    }
+
+    public function testV25MigratesVcsCommentLocksHolderIdIdempotently(): void
+    {
+        $authorization = new Authorization();
+        $database = new Database(new Memory(), new Cache(new NoCache()));
+        $database
+            ->setAuthorization($authorization)
+            ->setDatabase('migrationV25VcsLocks')
+            ->setNamespace('migration_vcs_locks_' . \uniqid());
+        $database->create();
+        $database->createCollection('vcsCommentLocks');
+
+        $migration = new V25();
+        $migration->setProject(
+            new Document(['$id' => 'project', '$sequence' => 'console']),
+            $database,
+            $database,
+            $authorization,
+        );
+
+        $migrateCollections = new \ReflectionMethod($migration, 'migrateCollections');
+        \ob_start();
+        try {
+            $migrateCollections->invoke($migration);
+            $migrateCollections->invoke($migration);
+        } finally {
+            \ob_end_clean();
+        }
+
+        $vcsLocksAttributes = [];
+        foreach ($database->getCollection('vcsCommentLocks')->getAttribute('attributes', []) as $attribute) {
+            $vcsLocksAttributes[] = $attribute instanceof Document ? $attribute->getAttribute('$id') : ($attribute['$id'] ?? '');
+        }
+        $this->assertContains('holderId', $vcsLocksAttributes);
     }
 }

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -466,6 +466,50 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
+    public function testStaleLockStealIsAbortedIfAlreadyReplaced(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+
+        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -50);
+        $initialStaleLock = new Document([
+            '$id' => 'installation-installation1',
+            'holderId' => 'original-holder-id',
+            '$createdAt' => $staleLockedAt,
+        ]);
+
+        $replacedLock = new Document([
+            '$id' => 'installation-installation1',
+            'holderId' => 'newer-stealer-holder-id',
+            '$createdAt' => DateTime::now(),
+        ]);
+
+        $calls = 0;
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$calls, $initialStaleLock, $replacedLock) {
+            if ($collection === 'vcsCommentLocks') {
+                $calls++;
+
+                return $calls === 1 ? $initialStaleLock : $replacedLock;
+            }
+
+            return new Document();
+        });
+
+        // Ensure delete is aborted when re-read shows a different holderId
+        $db->expects($this->never())->method('deleteDocument');
+
+        $tokensService = new class extends InstallationTokens {
+            public function triggerStealLock(Database $db, mixed $auth, string $lock): bool
+            {
+                return $this->stealLock($db, $auth, $lock);
+            }
+        };
+
+        $result = $tokensService->triggerStealLock($db, $db->getAuthorization(), 'installation-installation1');
+
+        $this->assertFalse($result);
+    }
+
     public function testStaleLockIsStolenAndRefreshed(): void
     {
         $db = $this->createMock(Database::class);

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -78,8 +78,6 @@ final class InstallationTokensTest extends TestCase
 
     public function testClearedInstallationIsReturnedWithoutCallingTheProvider(): void
     {
-        // The state clear() leaves behind. GitHub works from here on its app credentials, and the
-        // providers that need the token fail at the adapter with a definite reason.
         $installation = new Document([
             '$id' => 'installation1',
             'personalAccessToken' => '',
@@ -109,6 +107,7 @@ final class InstallationTokensTest extends TestCase
             ->with('installations', 'installation1', $this->callback(function (Document $update) {
                 $this->assertSame('fresh-token', $update->getAttribute('personalAccessToken'));
                 $this->assertSame('fresh-refresh', $update->getAttribute('personalRefreshToken'));
+
                 return true;
             }))
             ->willReturnArgument(2);
@@ -136,7 +135,6 @@ final class InstallationTokensTest extends TestCase
 
         $this->assertSame('identity-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame('identity-refresh', $result->getAttribute('personalRefreshToken'));
-        $this->assertSame($identity->getAttribute('providerAccessTokenExpiry'), $result->getAttribute('personalAccessTokenExpiry'));
     }
 
     public function testMissingRefreshTokenThrowsClearError(): void
@@ -175,11 +173,11 @@ final class InstallationTokensTest extends TestCase
         $db->method('getAuthorization')->willReturn(new Authorization());
         $db->method('getDocument')->willReturn(new Document());
 
-        // The provider rotated the family, so the new pair has to land even though the call after it failed.
         $db->expects($this->once())
             ->method('updateDocument')
             ->with('installations', 'installation1', $this->callback(function (Document $update) {
                 $this->assertSame('fresh-refresh', $update->getAttribute('personalRefreshToken'));
+
                 return true;
             }))
             ->willReturnArgument(2);
@@ -206,6 +204,7 @@ final class InstallationTokensTest extends TestCase
                 $this->assertSame('', $update->getAttribute('personalAccessToken'));
                 $this->assertSame('', $update->getAttribute('personalRefreshToken'));
                 $this->assertNull($update->getAttribute('personalAccessTokenExpiry'));
+
                 return true;
             }))
             ->willReturnArgument(2);
@@ -226,6 +225,7 @@ final class InstallationTokensTest extends TestCase
             ->method('updateDocument')
             ->with('installations', 'installation1', $this->callback(function (Document $update) {
                 $this->assertSame('', $update->getAttribute('personalRefreshToken'));
+
                 return true;
             }))
             ->willReturnArgument(2);
@@ -242,8 +242,6 @@ final class InstallationTokensTest extends TestCase
         $db->method('getAuthorization')->willReturn(new Authorization());
         $db->method('getDocument')->willReturn(new Document());
 
-        // A provider that answers without a token leaves nothing worth writing, and the stored
-        // pair may still be good, so it has to survive.
         $db->expects($this->never())->method('updateDocument');
 
         $oauth2 = $this->fakeOAuth2(refresh: 'empty');
@@ -301,6 +299,7 @@ final class InstallationTokensTest extends TestCase
             ->method('createDocument')
             ->with('vcsCommentLocks', $this->callback(function (Document $lock) {
                 $this->assertSame('installation-installation1', $lock->getId());
+
                 return true;
             }))
             ->willReturnArgument(1);
@@ -334,6 +333,196 @@ final class InstallationTokensTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
         (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+    }
+
+    public function testStaleLockIsStolenAndRefreshed(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+
+        $calls = 0;
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls) {
+            $calls++;
+            if ($calls === 1) {
+                throw new \RuntimeException('Lock collision');
+            }
+
+            return $doc;
+        });
+
+        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -45);
+        $staleLockDoc = new Document([
+            '$id' => 'installation-installation1',
+            'lockedAt' => $staleLockedAt,
+        ]);
+
+        $db->method('getDocument')->willReturnMap([
+            ['vcsCommentLocks', 'installation-installation1', $staleLockDoc],
+            ['installations', 'installation1', new Document()],
+        ]);
+        $db->method('updateDocument')->willReturnArgument(2);
+
+        $db->expects($this->exactly(2))
+            ->method('deleteDocument')
+            ->with('vcsCommentLocks', 'installation-installation1')
+            ->willReturn(true);
+
+        $oauth2 = $this->fakeOAuth2();
+
+        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
+    }
+
+    public function testMalformedLockTimestampTriggersStrotimeSelfHealing(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+
+        $calls = 0;
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls) {
+            $calls++;
+            if ($calls === 1) {
+                throw new \RuntimeException('Lock collision');
+            }
+
+            return $doc;
+        });
+
+        $malformedLockDoc = new Document([
+            '$id' => 'installation-installation1',
+            'lockedAt' => 'invalid-timestamp-string',
+        ]);
+
+        $db->method('getDocument')->willReturnMap([
+            ['vcsCommentLocks', 'installation-installation1', $malformedLockDoc],
+            ['installations', 'installation1', new Document()],
+        ]);
+        $db->method('updateDocument')->willReturnArgument(2);
+
+        $db->expects($this->exactly(2))
+            ->method('deleteDocument')
+            ->with('vcsCommentLocks', 'installation-installation1')
+            ->willReturn(true);
+
+        $oauth2 = $this->fakeOAuth2();
+
+        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
+    }
+
+    public function testMissingLockTimestampTriggersSteal(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+
+        $calls = 0;
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls) {
+            $calls++;
+            if ($calls === 1) {
+                throw new \RuntimeException('Lock collision');
+            }
+
+            return $doc;
+        });
+
+        $missingLockDoc = new Document([
+            '$id' => 'installation-installation1',
+            'lockedAt' => null,
+        ]);
+
+        $db->method('getDocument')->willReturnMap([
+            ['vcsCommentLocks', 'installation-installation1', $missingLockDoc],
+            ['installations', 'installation1', new Document()],
+        ]);
+        $db->method('updateDocument')->willReturnArgument(2);
+
+        $db->expects($this->exactly(2))
+            ->method('deleteDocument')
+            ->with('vcsCommentLocks', 'installation-installation1')
+            ->willReturn(true);
+
+        $oauth2 = $this->fakeOAuth2();
+
+        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
+    }
+
+    public function testLockWaitTimeoutThrowsResourceLocked(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+
+        $db->method('createDocument')->willThrowException(new \RuntimeException('Lock collision'));
+
+        $activeLockDoc = new Document([
+            '$id' => 'installation-installation1',
+            'lockedAt' => DateTime::addSeconds(new \DateTime(), -5),
+        ]);
+
+        $db->method('getDocument')->willReturnMap([
+            ['vcsCommentLocks', 'installation-installation1', $activeLockDoc],
+            ['installations', 'installation1', new Document()],
+        ]);
+
+        $oauth2 = $this->fakeOAuth2();
+
+        $tokensService = new class extends InstallationTokens {
+            protected function getLockWaitSeconds(): int
+            {
+                return 0;
+            }
+
+            protected function sleepWithBackoff(int $retries): void
+            {
+            }
+        };
+
+        try {
+            $tokensService->refresh($this->expired(), $db, $oauth2);
+            $this->fail('Expected Exception::GENERAL_RESOURCE_LOCKED');
+        } catch (Exception $e) {
+            $this->assertSame(Exception::GENERAL_RESOURCE_LOCKED, $e->getType());
+        }
+    }
+
+    public function testSleepWithBackoffCalculatesExponentialDelayWithJitter(): void
+    {
+        $recordedSeconds = [];
+        $tokensService = new class ($recordedSeconds) extends InstallationTokens {
+            public function __construct(public array &$recordedSeconds) {}
+
+            public function sleepWithBackoff(int $retries): void
+            {
+                $base = \min(0.2 * (2 ** \max(0, $retries - 1)), 1.5);
+                $jitter = \mt_rand(0, 100) / 1000;
+                $seconds = $base + $jitter;
+                $this->recordedSeconds[] = $seconds;
+            }
+
+            public function triggerSleep(int $retries): void
+            {
+                $this->sleepWithBackoff($retries);
+            }
+        };
+
+        $tokensService->triggerSleep(1);
+        $tokensService->triggerSleep(2);
+        $tokensService->triggerSleep(5);
+
+        $this->assertGreaterThanOrEqual(0.2, $recordedSeconds[0]);
+        $this->assertLessThanOrEqual(0.3, $recordedSeconds[0]);
+
+        $this->assertGreaterThanOrEqual(0.4, $recordedSeconds[1]);
+        $this->assertLessThanOrEqual(0.5, $recordedSeconds[1]);
+
+        $this->assertGreaterThanOrEqual(1.5, $recordedSeconds[2]);
+        $this->assertLessThanOrEqual(1.6, $recordedSeconds[2]);
     }
 
     protected function expired(): Document
@@ -379,8 +568,6 @@ final class InstallationTokensTest extends TestCase
             {
                 $this->refreshCalls++;
 
-                // GitHub states a refused token in a 200 body; GitLab and Gitea answer 400.
-                // A request that never completed states nothing at all.
                 $this->tokens = match ($this->refresh) {
                     'refused' => ['error' => 'bad_refresh_token'],
                     'invalidGrant' => throw new OAuth2Exception('{"error":"invalid_grant"}', 400),

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -210,8 +210,10 @@ final class InstallationTokensTest extends TestCase
             ->willReturnArgument(2);
 
         $userIdCalls = 0;
-        $oauth2 = new class (false, 'ok', $userIdCalls) extends OAuth2 {
+        $oauth2 = new class(false, 'ok', $userIdCalls) extends OAuth2
+        {
             public int $refreshCalls = 0;
+
             protected array $tokens = [];
 
             public function __construct(protected bool $emptyUserId, protected string $refresh, public int &$userIdCalls)
@@ -219,9 +221,15 @@ final class InstallationTokensTest extends TestCase
                 parent::__construct('id', 'secret', '');
             }
 
-            public function getName(): string { return 'fake'; }
+            public function getName(): string
+            {
+                return 'fake';
+            }
 
-            public function getLoginURL(): string { return ''; }
+            public function getLoginURL(): string
+            {
+                return '';
+            }
 
             protected function getTokens(string $code): array
             {
@@ -243,14 +251,23 @@ final class InstallationTokensTest extends TestCase
                 return $this->userIdCalls === 1 ? '' : 'user1';
             }
 
-            public function getUserEmail(string $accessToken): string { return ''; }
+            public function getUserEmail(string $accessToken): string
+            {
+                return '';
+            }
 
-            public function isEmailVerified(string $accessToken): bool { return true; }
+            public function isEmailVerified(string $accessToken): bool
+            {
+                return true;
+            }
 
-            public function getUserName(string $accessToken): string { return ''; }
+            public function getUserName(string $accessToken): string
+            {
+                return '';
+            }
         };
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(1, $oauth2->refreshCalls);
@@ -353,10 +370,10 @@ final class InstallationTokensTest extends TestCase
                     '$id' => 'installation1',
                     'personalAccessToken' => 'already-refreshed-token',
                     'personalRefreshToken' => 'already-refreshed-refresh',
-                    'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), 3600),
+                    'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, 3600),
                     '$updatedAt' => DateTime::now(),
                 ])],
-                ['vcsCommentLocks', 'installation-installation1', new Document()],
+                ['vcsCommentLocks', 'installation-installation1', new Document],
             ]);
         $db->expects($this->never())->method('updateDocument');
 
@@ -435,13 +452,13 @@ final class InstallationTokensTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
     }
 
     public function testStolenLockIsNotDeletedByOriginalHolder(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
         $db->method('updateDocument')->willReturnArgument(2);
         $db->method('createDocument')->willReturnArgument(1);
 
@@ -453,7 +470,7 @@ final class InstallationTokensTest extends TestCase
 
         $db->method('getDocument')->willReturnMap([
             ['vcsCommentLocks', 'installation-installation1', $stolenLock],
-            ['installations', 'installation1', new Document()],
+            ['installations', 'installation1', new Document],
         ]);
 
         // Guard against releasing a lock that no longer belongs to this worker
@@ -471,7 +488,7 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -50);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime, -65);
         $initialStaleLock = new Document([
             '$id' => 'installation-installation1',
             'holderId' => 'original-holder-id',
@@ -498,7 +515,8 @@ final class InstallationTokensTest extends TestCase
         // Ensure delete is aborted when re-read shows a different holderId
         $db->expects($this->never())->method('deleteDocument');
 
-        $tokensService = new class extends InstallationTokens {
+        $tokensService = new class extends InstallationTokens
+        {
             public function triggerStealLock(Database $db, mixed $auth, string $lock): bool
             {
                 return $this->stealLock($db, $auth, $lock);
@@ -527,7 +545,7 @@ final class InstallationTokensTest extends TestCase
             return $doc;
         });
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -50);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime, -65);
         $staleLockDoc = new Document([
             '$id' => 'installation-installation1',
             '$createdAt' => $staleLockedAt,
@@ -549,7 +567,7 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = $this->silentInstallationTokens()->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(1, $oauth2->refreshCalls);
@@ -593,7 +611,7 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = $this->silentInstallationTokens()->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(1, $oauth2->refreshCalls);
@@ -637,7 +655,7 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = $this->silentInstallationTokens()->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(1, $oauth2->refreshCalls);
@@ -645,13 +663,14 @@ final class InstallationTokensTest extends TestCase
 
     public function testLockWaitTimeoutThrowsResourceLocked(): void
     {
-        $db = $this->createMock(Database::class);
+        $db = $this->createStub(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
         $db->method('createDocument')->willThrowException(new \RuntimeException('Lock collision'));
 
         $activeLockDoc = new Document([
             '$id' => 'installation-installation1',
+            'holderId' => 'some-other-worker',
             '$createdAt' => DateTime::addSeconds(new \DateTime(), -5),
         ]);
 
@@ -665,15 +684,16 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $tokensService = new class extends InstallationTokens {
+        $tokensService = new class extends InstallationTokens
+        {
             protected function getLockWaitSeconds(): int
             {
                 return 0;
             }
 
-            protected function sleepWithBackoff(int $retries): void
-            {
-            }
+            protected function sleepWithBackoff(int $retries): void {}
+
+            protected function logWarning(string $message): void {}
         };
 
         try {
@@ -686,7 +706,8 @@ final class InstallationTokensTest extends TestCase
 
     public function testSleepWithBackoffCalculatesExponentialDelayWithJitter(): void
     {
-        $tokensService = new class extends InstallationTokens {
+        $tokensService = new class extends InstallationTokens
+        {
             public array $recordedSeconds = [];
 
             public function sleepWithBackoff(int $retries): void
@@ -720,17 +741,19 @@ final class InstallationTokensTest extends TestCase
             '$id' => 'installation1',
             'personalAccessToken' => 'stale-token',
             'personalRefreshToken' => 'stale-refresh',
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), -3600),
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, -3600),
         ]);
     }
 
     /**
-     * @param string $refresh One of: ok, refused, invalidGrant, empty, throw.
+     * @param  string  $refresh  One of: ok, refused, invalidGrant, empty, throw.
      */
     protected function fakeOAuth2(bool $emptyUserId = false, string $refresh = 'ok')
     {
-        return new class ($emptyUserId, $refresh) extends OAuth2 {
+        return new class($emptyUserId, $refresh) extends OAuth2
+        {
             public int $refreshCalls = 0;
+
             protected array $tokens = [];
 
             public function __construct(protected bool $emptyUserId, protected string $refresh)
@@ -793,6 +816,14 @@ final class InstallationTokensTest extends TestCase
             {
                 return '';
             }
+        };
+    }
+
+    protected function silentInstallationTokens(): InstallationTokens
+    {
+        return new class extends InstallationTokens
+        {
+            protected function logWarning(string $message): void {}
         };
     }
 }

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -488,7 +488,7 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime, -65);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -80);
         $initialStaleLock = new Document([
             '$id' => 'installation-installation1',
             'holderId' => 'original-holder-id',
@@ -545,7 +545,7 @@ final class InstallationTokensTest extends TestCase
             return $doc;
         });
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime, -65);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -80);
         $staleLockDoc = new Document([
             '$id' => 'installation-installation1',
             '$createdAt' => $staleLockedAt,

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -19,30 +19,30 @@ final class InstallationTokensTest extends TestCase
     protected function db(): Database
     {
         $db = $this->createStub(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         return $db;
     }
 
-    public function testUnexpiredTokenIsNotRefreshed(): void
+    public function test_unexpired_token_is_not_refreshed(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
             'personalAccessToken' => 'valid-token',
             'personalRefreshToken' => 'valid-refresh',
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), 3600),
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, 3600),
         ]);
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+        $result = (new InstallationTokens)->refresh($installation, $this->db(), $oauth2);
 
         $this->assertSame('valid-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(0, $oauth2->refreshCalls);
     }
 
-    public function testMissingExpiryIsNotRefreshed(): void
+    public function test_missing_expiry_is_not_refreshed(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
@@ -53,13 +53,13 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+        $result = (new InstallationTokens)->refresh($installation, $this->db(), $oauth2);
 
         $this->assertSame('valid-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(0, $oauth2->refreshCalls);
     }
 
-    public function testInvalidExpiryForcesRefresh(): void
+    public function test_invalid_expiry_forces_refresh(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
@@ -69,19 +69,19 @@ final class InstallationTokensTest extends TestCase
         ]);
 
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
         $db->expects($this->once())->method('updateDocument')->willReturnArgument(2);
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($installation, $db, $oauth2);
+        $result = (new InstallationTokens)->refresh($installation, $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testClearedInstallationThrowsWithoutCallingTheProvider(): void
+    public function test_cleared_installation_throws_without_calling_the_provider(): void
     {
         // The state clear() leaves behind. GitHub works from here on its app credentials, and the
         // providers that need the token fail at the adapter with a definite reason.
@@ -93,25 +93,25 @@ final class InstallationTokensTest extends TestCase
         ]);
 
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
         $db->expects($this->never())->method('updateDocument');
         $db->expects($this->never())->method('createDocument');
 
         $oauth2 = $this->fakeOAuth2();
 
         try {
-            (new InstallationTokens())->refresh($installation, $db, $oauth2);
+            (new InstallationTokens)->refresh($installation, $db, $oauth2);
             $this->fail('Expected Exception');
         } catch (Exception $e) {
             $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
         }
     }
 
-    public function testExpiredTokenIsRefreshedAndPersisted(): void
+    public function test_expired_token_is_refreshed_and_persisted(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         $db->expects($this->once())
             ->method('updateDocument')
@@ -125,43 +125,43 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testFallsBackToIdentityWhenInstallationHasNoTokens(): void
+    public function test_falls_back_to_identity_when_installation_has_no_tokens(): void
     {
         $installation = new Document(['$id' => 'installation1']);
         $identity = new Document([
             'providerAccessToken' => 'identity-token',
             'providerRefreshToken' => 'identity-refresh',
-            'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), 3600),
+            'providerAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, 3600),
         ]);
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2, $identity);
+        $result = (new InstallationTokens)->refresh($installation, $this->db(), $oauth2, $identity);
 
         $this->assertSame('identity-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame('identity-refresh', $result->getAttribute('personalRefreshToken'));
         $this->assertSame($identity->getAttribute('providerAccessTokenExpiry'), $result->getAttribute('personalAccessTokenExpiry'));
     }
 
-    public function testMissingRefreshTokenThrowsClearError(): void
+    public function test_missing_refresh_token_throws_clear_error(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
             'personalAccessToken' => 'stale-token',
             'personalRefreshToken' => null,
-            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), -3600),
+            'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, -3600),
         ]);
 
         $oauth2 = $this->fakeOAuth2();
 
         try {
-            (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+            (new InstallationTokens)->refresh($installation, $this->db(), $oauth2);
             $this->fail('Expected an Exception');
         } catch (Exception $e) {
             $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
@@ -170,20 +170,20 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(0, $oauth2->refreshCalls);
     }
 
-    public function testFailedRefreshThrows(): void
+    public function test_failed_refresh_throws(): void
     {
         $oauth2 = $this->fakeOAuth2(refresh: 'throw');
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
-        (new InstallationTokens())->refresh($this->expired(), $this->db(), $oauth2);
+        (new InstallationTokens)->refresh($this->expired(), $this->db(), $oauth2);
     }
 
-    public function testRotatedTokensPersistedEvenIfIdentityCheckFlakes(): void
+    public function test_rotated_tokens_persisted_even_if_identity_check_flakes(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         // Rotated tokens MUST be persisted immediately so the DB never holds an invalidated refresh token.
         $db->expects($this->once())
@@ -198,17 +198,17 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2(emptyUserId: true);
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame('fresh-refresh', $result->getAttribute('personalRefreshToken'));
     }
 
-    public function testTransientUserIdFailureRetriesAndSucceeds(): void
+    public function test_transient_user_id_failure_retries_and_succeeds(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         $db->expects($this->once())
             ->method('updateDocument')
@@ -284,11 +284,11 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(2, $userIdCalls);
     }
 
-    public function testRefusedRefreshTokenIsCleared(): void
+    public function test_refused_refresh_token_is_cleared(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         $db->expects($this->once())
             ->method('updateDocument')
@@ -304,14 +304,14 @@ final class InstallationTokensTest extends TestCase
         $oauth2 = $this->fakeOAuth2(refresh: 'refused');
 
         $this->expectException(Exception::class);
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
     }
 
-    public function testInvalidGrantIsCleared(): void
+    public function test_invalid_grant_is_cleared(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         $db->expects($this->once())
             ->method('updateDocument')
@@ -325,55 +325,56 @@ final class InstallationTokensTest extends TestCase
         $oauth2 = $this->fakeOAuth2(refresh: 'invalidGrant');
 
         try {
-            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+            (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
             $this->fail('Expected Exception');
         } catch (Exception $e) {
             $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
         }
     }
 
-    public function testEmptyTokenResponseIsNotPersisted(): void
+    public function test_empty_token_response_is_not_persisted(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         $db->expects($this->never())->method('updateDocument');
 
         $oauth2 = $this->fakeOAuth2(refresh: 'empty');
 
         try {
-            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+            (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
             $this->fail('Expected Exception');
         } catch (Exception $e) {
             $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
         }
     }
 
-    public function testFailedRefreshCallIsNotPersisted(): void
+    public function test_failed_refresh_call_is_not_persisted(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('getDocument')->willReturn(new Document);
 
         $db->expects($this->never())->method('updateDocument');
 
         $oauth2 = $this->fakeOAuth2(refresh: 'throw');
 
         try {
-            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+            (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
             $this->fail('Expected Exception');
         } catch (Exception $e) {
             $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
         }
     }
 
-    public function testTokenRefreshedByLockHolderIsReused(): void
+    public function test_token_refreshed_by_lock_holder_is_reused(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
-        $db->method('getDocument')
+        $db->expects($this->exactly(2))
+            ->method('getDocument')
             ->willReturnMap([
                 ['installations', 'installation1', new Document([
                     '$id' => 'installation1',
@@ -382,34 +383,25 @@ final class InstallationTokensTest extends TestCase
                     'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, 3600),
                     '$updatedAt' => DateTime::now(),
                 ])],
-                ['vcsCommentLocks', 'installation-installation1', new Document()],
+                ['vcsCommentLocks', 'installation-installation1', new Document],
             ]);
         $db->expects($this->never())->method('updateDocument');
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame('already-refreshed-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame(0, $oauth2->refreshCalls);
     }
 
-    public function testRefreshIsSerializedByLock(): void
+    public function test_refresh_is_serialized_by_lock(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
+        $db->method('updateDocument')->willReturnArgument(2);
 
-        $createdLock = new Document();
-        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock) {
-            if ($collection === 'vcsCommentLocks') {
-                foreach ($doc->getArrayCopy() as $k => $v) {
-                    $createdLock->setAttribute($k, $v);
-                }
-            }
-
-            return $doc;
-        });
-
+        $createdLock = null;
         $db->expects($this->once())
             ->method('createDocument')
             ->with('vcsCommentLocks', $this->callback(function (Document $lock) use (&$createdLock) {
@@ -423,10 +415,10 @@ final class InstallationTokensTest extends TestCase
 
         $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock) {
             if ($collection === 'vcsCommentLocks') {
-                return $createdLock;
+                return $createdLock ?? new Document;
             }
 
-            return new Document();
+            return new Document;
         });
 
         $db->expects($this->once())
@@ -436,27 +428,17 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testLockIsReleasedWhenRefreshFails(): void
+    public function test_lock_is_released_when_refresh_fails(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
-        $createdLock = new Document();
-        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock) {
-            if ($collection === 'vcsCommentLocks') {
-                foreach ($doc->getArrayCopy() as $k => $v) {
-                    $createdLock->setAttribute($k, $v);
-                }
-            }
-
-            return $doc;
-        });
-
+        $createdLock = null;
         $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$createdLock) {
             $createdLock = $doc;
 
@@ -465,10 +447,10 @@ final class InstallationTokensTest extends TestCase
 
         $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock) {
             if ($collection === 'vcsCommentLocks') {
-                return $createdLock;
+                return $createdLock ?? new Document;
             }
 
-            return new Document();
+            return new Document;
         });
 
         $db->expects($this->once())
@@ -480,10 +462,10 @@ final class InstallationTokensTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
     }
 
-    public function testStolenLockIsNotDeletedByOriginalHolder(): void
+    public function test_stolen_lock_is_not_deleted_by_original_holder(): void
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization);
@@ -506,17 +488,17 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
 
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testStaleLockStealIsAbortedIfAlreadyReplaced(): void
+    public function test_stale_lock_steal_is_aborted_if_already_replaced(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -80);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime, -80);
         $initialStaleLock = new Document([
             '$id' => 'installation-installation1',
             'holderId' => 'original-holder-id',
@@ -537,7 +519,7 @@ final class InstallationTokensTest extends TestCase
                 return $calls === 1 ? $initialStaleLock : $replacedLock;
             }
 
-            return new Document();
+            return new Document;
         });
 
         // Ensure delete is aborted when re-read shows a different holderId
@@ -556,10 +538,10 @@ final class InstallationTokensTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testStaleLockIsStolenAndRefreshed(): void
+    public function test_stale_lock_is_stolen_and_refreshed(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
         $createdLock = null;
         $calls = 0;
@@ -573,7 +555,7 @@ final class InstallationTokensTest extends TestCase
             return $doc;
         });
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -80);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime, -80);
         $staleLockDoc = new Document([
             '$id' => 'installation-installation1',
             '$createdAt' => $staleLockedAt,
@@ -584,13 +566,14 @@ final class InstallationTokensTest extends TestCase
                 return $createdLock ?? $staleLockDoc;
             }
 
-            return new Document();
+            return new Document;
         });
         $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock, $staleLockDoc) {
             $target = $createdLock ?? $staleLockDoc;
             foreach ($doc->getArrayCopy() as $k => $v) {
                 $target->setAttribute($k, $v);
             }
+
             return $target;
         });
 
@@ -607,10 +590,10 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testMalformedLockTimestampTriggersStrotimeSelfHealing(): void
+    public function test_malformed_lock_timestamp_triggers_strotime_self_healing(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
         $createdLock = null;
         $calls = 0;
@@ -634,13 +617,14 @@ final class InstallationTokensTest extends TestCase
                 return $createdLock ?? $malformedLockDoc;
             }
 
-            return new Document();
+            return new Document;
         });
         $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock, $malformedLockDoc) {
             $target = $createdLock ?? $malformedLockDoc;
             foreach ($doc->getArrayCopy() as $k => $v) {
                 $target->setAttribute($k, $v);
             }
+
             return $target;
         });
 
@@ -657,10 +641,10 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testMissingLockTimestampTriggersSteal(): void
+    public function test_missing_lock_timestamp_triggers_steal(): void
     {
         $db = $this->createMock(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
         $createdLock = null;
         $calls = 0;
@@ -684,13 +668,14 @@ final class InstallationTokensTest extends TestCase
                 return $createdLock ?? $missingLockDoc;
             }
 
-            return new Document();
+            return new Document;
         });
         $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock, $missingLockDoc) {
             $target = $createdLock ?? $missingLockDoc;
             foreach ($doc->getArrayCopy() as $k => $v) {
                 $target->setAttribute($k, $v);
             }
+
             return $target;
         });
 
@@ -707,17 +692,17 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testLockWaitTimeoutThrowsResourceLocked(): void
+    public function test_lock_wait_timeout_throws_resource_locked(): void
     {
         $db = $this->createStub(Database::class);
-        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getAuthorization')->willReturn(new Authorization);
 
         $db->method('createDocument')->willThrowException(new \RuntimeException('Lock collision'));
 
         $activeLockDoc = new Document([
             '$id' => 'installation-installation1',
             'holderId' => 'some-other-worker',
-            '$createdAt' => DateTime::addSeconds(new \DateTime(), -5),
+            '$createdAt' => DateTime::addSeconds(new \DateTime, -5),
         ]);
 
         $db->method('getDocument')->willReturnCallback(function ($collection, $id) use ($activeLockDoc) {
@@ -725,7 +710,7 @@ final class InstallationTokensTest extends TestCase
                 return $activeLockDoc;
             }
 
-            return new Document();
+            return new Document;
         });
 
         $oauth2 = $this->fakeOAuth2();
@@ -750,7 +735,7 @@ final class InstallationTokensTest extends TestCase
         }
     }
 
-    public function testSleepWithBackoffCalculatesExponentialDelayWithJitter(): void
+    public function test_sleep_with_backoff_calculates_exponential_delay_with_jitter(): void
     {
         $tokensService = new class extends InstallationTokens
         {

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -59,7 +59,7 @@ final class InstallationTokensTest extends TestCase
         $this->assertSame(0, $oauth2->refreshCalls);
     }
 
-    public function testInvalidExpiryIsNotRefreshed(): void
+    public function testInvalidExpiryForcesRefresh(): void
     {
         $installation = new Document([
             '$id' => 'installation1',
@@ -68,16 +68,23 @@ final class InstallationTokensTest extends TestCase
             'personalAccessTokenExpiry' => 'not-a-date',
         ]);
 
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getDocument')->willReturn(new Document());
+        $db->expects($this->once())->method('updateDocument')->willReturnArgument(2);
+
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($installation, $this->db(), $oauth2);
+        $result = (new InstallationTokens())->refresh($installation, $db, $oauth2);
 
-        $this->assertSame('valid-token', $result->getAttribute('personalAccessToken'));
-        $this->assertSame(0, $oauth2->refreshCalls);
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
     }
 
-    public function testClearedInstallationIsReturnedWithoutCallingTheProvider(): void
+    public function testClearedInstallationThrowsWithoutCallingTheProvider(): void
     {
+        // The state clear() leaves behind. GitHub works from here on its app credentials, and the
+        // providers that need the token fail at the adapter with a definite reason.
         $installation = new Document([
             '$id' => 'installation1',
             'personalAccessToken' => '',
@@ -92,10 +99,8 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $result = (new InstallationTokens())->refresh($installation, $db, $oauth2);
-
-        $this->assertSame('', $result->getAttribute('personalAccessToken'));
-        $this->assertSame(0, $oauth2->refreshCalls);
+        $this->expectException(Exception::class);
+        (new InstallationTokens())->refresh($installation, $db, $oauth2);
     }
 
     public function testExpiredTokenIsRefreshedAndPersisted(): void
@@ -135,6 +140,7 @@ final class InstallationTokensTest extends TestCase
 
         $this->assertSame('identity-token', $result->getAttribute('personalAccessToken'));
         $this->assertSame('identity-refresh', $result->getAttribute('personalRefreshToken'));
+        $this->assertSame($identity->getAttribute('providerAccessTokenExpiry'), $result->getAttribute('personalAccessTokenExpiry'));
     }
 
     public function testMissingRefreshTokenThrowsClearError(): void
@@ -563,6 +569,8 @@ final class InstallationTokensTest extends TestCase
             {
                 $this->refreshCalls++;
 
+                // GitHub states a refused token in a 200 body; GitLab and Gitea answer 400.
+                // A request that never completed states nothing at all.
                 $this->tokens = match ($this->refresh) {
                     'refused' => ['error' => 'bad_refresh_token'],
                     'invalidGrant' => throw new OAuth2Exception('{"error":"invalid_grant"}', 400),

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -172,26 +172,36 @@ final class InstallationTokensTest extends TestCase
 
     public function testFailedRefreshThrows(): void
     {
-        $oauth2 = $this->fakeOAuth2(emptyUserId: true);
+        $oauth2 = $this->fakeOAuth2(refresh: 'throw');
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
         (new InstallationTokens())->refresh($this->expired(), $this->db(), $oauth2);
     }
 
-    public function testUnverifiedTokenIsNotPersistedWhenVerificationFails(): void
+    public function testRotatedTokensPersistedEvenIfIdentityCheckFlakes(): void
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
         $db->method('getDocument')->willReturn(new Document());
 
-        // Validate-then-persist guarantees unverified tokens are never written to the DB.
-        $db->expects($this->never())->method('updateDocument');
+        // Rotated tokens MUST be persisted immediately so the DB never holds an invalidated refresh token.
+        $db->expects($this->once())
+            ->method('updateDocument')
+            ->with('installations', 'installation1', $this->callback(function (Document $update) {
+                $this->assertSame('fresh-token', $update->getAttribute('personalAccessToken'));
+                $this->assertSame('fresh-refresh', $update->getAttribute('personalRefreshToken'));
+
+                return true;
+            }))
+            ->willReturnArgument(2);
 
         $oauth2 = $this->fakeOAuth2(emptyUserId: true);
 
-        $this->expectException(Exception::class);
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame('fresh-refresh', $result->getAttribute('personalRefreshToken'));
     }
 
     public function testTransientUserIdFailureRetriesAndSucceeds(): void

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -271,6 +271,7 @@ final class InstallationTokensTest extends TestCase
                 'personalAccessToken' => 'already-refreshed-token',
                 'personalRefreshToken' => 'already-refreshed-refresh',
                 'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), 3600),
+                '$updatedAt' => DateTime::now(),
             ]));
         $db->expects($this->never())->method('updateDocument');
 

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -99,13 +99,19 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2();
 
-        $this->expectException(Exception::class);
-        (new InstallationTokens())->refresh($installation, $db, $oauth2);
+        try {
+            (new InstallationTokens())->refresh($installation, $db, $oauth2);
+            $this->fail('Expected Exception');
+        } catch (Exception $e) {
+            $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
+        }
     }
 
     public function testExpiredTokenIsRefreshedAndPersisted(): void
     {
         $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getDocument')->willReturn(new Document());
 
         $db->expects($this->once())
             ->method('updateDocument')
@@ -184,12 +190,71 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2(emptyUserId: true);
 
-        try {
-            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
-            $this->fail('Expected an Exception');
-        } catch (Exception $e) {
-            $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
-        }
+        $this->expectException(Exception::class);
+        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+    }
+
+    public function testTransientUserIdFailureRetriesAndSucceeds(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('getDocument')->willReturn(new Document());
+
+        $db->expects($this->once())
+            ->method('updateDocument')
+            ->with('installations', 'installation1', $this->callback(function (Document $update) {
+                $this->assertSame('fresh-token', $update->getAttribute('personalAccessToken'));
+
+                return true;
+            }))
+            ->willReturnArgument(2);
+
+        $userIdCalls = 0;
+        $oauth2 = new class (false, 'ok', $userIdCalls) extends OAuth2 {
+            public int $refreshCalls = 0;
+            protected array $tokens = [];
+
+            public function __construct(protected bool $emptyUserId, protected string $refresh, public int &$userIdCalls)
+            {
+                parent::__construct('id', 'secret', '');
+            }
+
+            public function getName(): string { return 'fake'; }
+
+            public function getLoginURL(): string { return ''; }
+
+            protected function getTokens(string $code): array
+            {
+                return $this->tokens;
+            }
+
+            public function refreshTokens(string $refreshToken): array
+            {
+                $this->refreshCalls++;
+                $this->tokens = ['access_token' => 'fresh-token', 'refresh_token' => 'fresh-refresh', 'expires_in' => 3600];
+
+                return $this->tokens;
+            }
+
+            public function getUserID(string $accessToken): string
+            {
+                $this->userIdCalls++;
+
+                return $this->userIdCalls === 1 ? '' : 'user1';
+            }
+
+            public function getUserEmail(string $accessToken): string { return ''; }
+
+            public function isEmailVerified(string $accessToken): bool { return true; }
+
+            public function getUserName(string $accessToken): string { return ''; }
+        };
+
+        $result = (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+
+        $this->assertSame('fresh-token', $result->getAttribute('personalAccessToken'));
+        $this->assertSame(1, $oauth2->refreshCalls);
+        $this->assertSame(2, $userIdCalls);
     }
 
     public function testRefusedRefreshTokenIsCleared(): void
@@ -232,8 +297,12 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2(refresh: 'invalidGrant');
 
-        $this->expectException(Exception::class);
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        try {
+            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+            $this->fail('Expected Exception');
+        } catch (Exception $e) {
+            $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
+        }
     }
 
     public function testEmptyTokenResponseIsNotPersisted(): void
@@ -246,8 +315,12 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2(refresh: 'empty');
 
-        $this->expectException(Exception::class);
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        try {
+            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+            $this->fail('Expected Exception');
+        } catch (Exception $e) {
+            $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
+        }
     }
 
     public function testFailedRefreshCallIsNotPersisted(): void
@@ -260,8 +333,12 @@ final class InstallationTokensTest extends TestCase
 
         $oauth2 = $this->fakeOAuth2(refresh: 'throw');
 
-        $this->expectException(Exception::class);
-        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+        try {
+            (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+            $this->fail('Expected Exception');
+        } catch (Exception $e) {
+            $this->assertSame(Exception::GENERAL_PROVIDER_FAILURE, $e->getType());
+        }
     }
 
     public function testTokenRefreshedByLockHolderIsReused(): void
@@ -269,16 +346,18 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
-        $db->expects($this->once())
+        $db->expects($this->exactly(2))
             ->method('getDocument')
-            ->with('installations', 'installation1')
-            ->willReturn(new Document([
-                '$id' => 'installation1',
-                'personalAccessToken' => 'already-refreshed-token',
-                'personalRefreshToken' => 'already-refreshed-refresh',
-                'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), 3600),
-                '$updatedAt' => DateTime::now(),
-            ]));
+            ->willReturnMap([
+                ['installations', 'installation1', new Document([
+                    '$id' => 'installation1',
+                    'personalAccessToken' => 'already-refreshed-token',
+                    'personalRefreshToken' => 'already-refreshed-refresh',
+                    'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime(), 3600),
+                    '$updatedAt' => DateTime::now(),
+                ])],
+                ['vcsCommentLocks', 'installation-installation1', new Document()],
+            ]);
         $db->expects($this->never())->method('updateDocument');
 
         $oauth2 = $this->fakeOAuth2();
@@ -293,17 +372,27 @@ final class InstallationTokensTest extends TestCase
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
         $db->method('updateDocument')->willReturnArgument(2);
 
+        $createdLock = null;
         $db->expects($this->once())
             ->method('createDocument')
-            ->with('vcsCommentLocks', $this->callback(function (Document $lock) {
+            ->with('vcsCommentLocks', $this->callback(function (Document $lock) use (&$createdLock) {
                 $this->assertSame('installation-installation1', $lock->getId());
+                $this->assertNotEmpty($lock->getAttribute('holderId'));
+                $createdLock = $lock;
 
                 return true;
             }))
             ->willReturnArgument(1);
+
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock) {
+            if ($collection === 'vcsCommentLocks') {
+                return $createdLock ?? new Document();
+            }
+
+            return new Document();
+        });
 
         $db->expects($this->once())
             ->method('deleteDocument')
@@ -321,8 +410,21 @@ final class InstallationTokensTest extends TestCase
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('getDocument')->willReturn(new Document());
-        $db->method('createDocument')->willReturnArgument(1);
+
+        $createdLock = null;
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$createdLock) {
+            $createdLock = $doc;
+
+            return $doc;
+        });
+
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock) {
+            if ($collection === 'vcsCommentLocks') {
+                return $createdLock ?? new Document();
+            }
+
+            return new Document();
+        });
 
         $db->expects($this->once())
             ->method('deleteDocument')
@@ -336,17 +438,47 @@ final class InstallationTokensTest extends TestCase
         (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
     }
 
+    public function testStolenLockIsNotDeletedByOriginalHolder(): void
+    {
+        $db = $this->createMock(Database::class);
+        $db->method('getAuthorization')->willReturn(new Authorization());
+        $db->method('updateDocument')->willReturnArgument(2);
+        $db->method('createDocument')->willReturnArgument(1);
+
+        // Simulate lock being stolen by another worker while we worked (different holderId)
+        $stolenLock = new Document([
+            '$id' => 'installation-installation1',
+            'holderId' => 'different-worker-holder-id',
+        ]);
+
+        $db->method('getDocument')->willReturnMap([
+            ['vcsCommentLocks', 'installation-installation1', $stolenLock],
+            ['installations', 'installation1', new Document()],
+        ]);
+
+        // Guard against releasing a lock that no longer belongs to this worker
+        $db->expects($this->never())->method('deleteDocument');
+
+        $oauth2 = $this->fakeOAuth2();
+
+        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
+
+        $this->assertSame(1, $oauth2->refreshCalls);
+    }
+
     public function testStaleLockIsStolenAndRefreshed(): void
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
+        $createdLock = null;
         $calls = 0;
-        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls) {
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls, &$createdLock) {
             $calls++;
             if ($calls === 1) {
                 throw new \RuntimeException('Lock collision');
             }
+            $createdLock = $doc;
 
             return $doc;
         });
@@ -357,10 +489,13 @@ final class InstallationTokensTest extends TestCase
             '$createdAt' => $staleLockedAt,
         ]);
 
-        $db->method('getDocument')->willReturnMap([
-            ['vcsCommentLocks', 'installation-installation1', $staleLockDoc],
-            ['installations', 'installation1', new Document()],
-        ]);
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock, $staleLockDoc) {
+            if ($collection === 'vcsCommentLocks') {
+                return $createdLock ?? $staleLockDoc;
+            }
+
+            return new Document();
+        });
         $db->method('updateDocument')->willReturnArgument(2);
 
         $db->expects($this->exactly(2))
@@ -381,12 +516,14 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
+        $createdLock = null;
         $calls = 0;
-        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls) {
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls, &$createdLock) {
             $calls++;
             if ($calls === 1) {
                 throw new \RuntimeException('Lock collision');
             }
+            $createdLock = $doc;
 
             return $doc;
         });
@@ -396,10 +533,13 @@ final class InstallationTokensTest extends TestCase
             '$createdAt' => 'invalid-timestamp-string',
         ]);
 
-        $db->method('getDocument')->willReturnMap([
-            ['vcsCommentLocks', 'installation-installation1', $malformedLockDoc],
-            ['installations', 'installation1', new Document()],
-        ]);
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock, $malformedLockDoc) {
+            if ($collection === 'vcsCommentLocks') {
+                return $createdLock ?? $malformedLockDoc;
+            }
+
+            return new Document();
+        });
         $db->method('updateDocument')->willReturnArgument(2);
 
         $db->expects($this->exactly(2))
@@ -420,12 +560,14 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
+        $createdLock = null;
         $calls = 0;
-        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls) {
+        $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$calls, &$createdLock) {
             $calls++;
             if ($calls === 1) {
                 throw new \RuntimeException('Lock collision');
             }
+            $createdLock = $doc;
 
             return $doc;
         });
@@ -435,10 +577,13 @@ final class InstallationTokensTest extends TestCase
             '$createdAt' => null,
         ]);
 
-        $db->method('getDocument')->willReturnMap([
-            ['vcsCommentLocks', 'installation-installation1', $missingLockDoc],
-            ['installations', 'installation1', new Document()],
-        ]);
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock, $missingLockDoc) {
+            if ($collection === 'vcsCommentLocks') {
+                return $createdLock ?? $missingLockDoc;
+            }
+
+            return new Document();
+        });
         $db->method('updateDocument')->willReturnArgument(2);
 
         $db->expects($this->exactly(2))
@@ -466,10 +611,13 @@ final class InstallationTokensTest extends TestCase
             '$createdAt' => DateTime::addSeconds(new \DateTime(), -5),
         ]);
 
-        $db->method('getDocument')->willReturnMap([
-            ['vcsCommentLocks', 'installation-installation1', $activeLockDoc],
-            ['installations', 'installation1', new Document()],
-        ]);
+        $db->method('getDocument')->willReturnCallback(function ($collection, $id) use ($activeLockDoc) {
+            if ($collection === 'vcsCommentLocks') {
+                return $activeLockDoc;
+            }
+
+            return new Document();
+        });
 
         $oauth2 = $this->fakeOAuth2();
 
@@ -494,9 +642,8 @@ final class InstallationTokensTest extends TestCase
 
     public function testSleepWithBackoffCalculatesExponentialDelayWithJitter(): void
     {
-        $recordedSeconds = [];
-        $tokensService = new class ($recordedSeconds) extends InstallationTokens {
-            public function __construct(public array &$recordedSeconds) {}
+        $tokensService = new class extends InstallationTokens {
+            public array $recordedSeconds = [];
 
             public function sleepWithBackoff(int $retries): void
             {
@@ -505,16 +652,13 @@ final class InstallationTokensTest extends TestCase
                 $seconds = $base + $jitter;
                 $this->recordedSeconds[] = $seconds;
             }
-
-            public function triggerSleep(int $retries): void
-            {
-                $this->sleepWithBackoff($retries);
-            }
         };
 
-        $tokensService->triggerSleep(1);
-        $tokensService->triggerSleep(2);
-        $tokensService->triggerSleep(5);
+        $tokensService->sleepWithBackoff(1);
+        $tokensService->sleepWithBackoff(2);
+        $tokensService->sleepWithBackoff(5);
+
+        $recordedSeconds = $tokensService->recordedSeconds;
 
         $this->assertGreaterThanOrEqual(0.2, $recordedSeconds[0]);
         $this->assertLessThanOrEqual(0.3, $recordedSeconds[0]);

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -167,20 +167,14 @@ final class InstallationTokensTest extends TestCase
         (new InstallationTokens())->refresh($this->expired(), $this->db(), $oauth2);
     }
 
-    public function testRotatedTokenIsPersistedWhenVerificationFails(): void
+    public function testUnverifiedTokenIsNotPersistedWhenVerificationFails(): void
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
         $db->method('getDocument')->willReturn(new Document());
 
-        $db->expects($this->once())
-            ->method('updateDocument')
-            ->with('installations', 'installation1', $this->callback(function (Document $update) {
-                $this->assertSame('fresh-refresh', $update->getAttribute('personalRefreshToken'));
-
-                return true;
-            }))
-            ->willReturnArgument(2);
+        // Validate-then-persist guarantees unverified tokens are never written to the DB.
+        $db->expects($this->never())->method('updateDocument');
 
         $oauth2 = $this->fakeOAuth2(emptyUserId: true);
 

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -373,8 +373,7 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
-        $db->expects($this->exactly(2))
-            ->method('getDocument')
+        $db->method('getDocument')
             ->willReturnMap([
                 ['installations', 'installation1', new Document([
                     '$id' => 'installation1',
@@ -383,7 +382,7 @@ final class InstallationTokensTest extends TestCase
                     'personalAccessTokenExpiry' => DateTime::addSeconds(new \DateTime, 3600),
                     '$updatedAt' => DateTime::now(),
                 ])],
-                ['vcsCommentLocks', 'installation-installation1', new Document],
+                ['vcsCommentLocks', 'installation-installation1', new Document()],
             ]);
         $db->expects($this->never())->method('updateDocument');
 
@@ -399,9 +398,18 @@ final class InstallationTokensTest extends TestCase
     {
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
-        $db->method('updateDocument')->willReturnArgument(2);
 
-        $createdLock = null;
+        $createdLock = new Document();
+        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock) {
+            if ($collection === 'vcsCommentLocks') {
+                foreach ($doc->getArrayCopy() as $k => $v) {
+                    $createdLock->setAttribute($k, $v);
+                }
+            }
+
+            return $doc;
+        });
+
         $db->expects($this->once())
             ->method('createDocument')
             ->with('vcsCommentLocks', $this->callback(function (Document $lock) use (&$createdLock) {
@@ -415,7 +423,7 @@ final class InstallationTokensTest extends TestCase
 
         $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock) {
             if ($collection === 'vcsCommentLocks') {
-                return $createdLock ?? new Document();
+                return $createdLock;
             }
 
             return new Document();
@@ -438,7 +446,17 @@ final class InstallationTokensTest extends TestCase
         $db = $this->createMock(Database::class);
         $db->method('getAuthorization')->willReturn(new Authorization());
 
-        $createdLock = null;
+        $createdLock = new Document();
+        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock) {
+            if ($collection === 'vcsCommentLocks') {
+                foreach ($doc->getArrayCopy() as $k => $v) {
+                    $createdLock->setAttribute($k, $v);
+                }
+            }
+
+            return $doc;
+        });
+
         $db->method('createDocument')->willReturnCallback(function ($collection, $doc) use (&$createdLock) {
             $createdLock = $doc;
 
@@ -447,7 +465,7 @@ final class InstallationTokensTest extends TestCase
 
         $db->method('getDocument')->willReturnCallback(function ($collection, $id) use (&$createdLock) {
             if ($collection === 'vcsCommentLocks') {
-                return $createdLock ?? new Document();
+                return $createdLock;
             }
 
             return new Document();
@@ -462,7 +480,7 @@ final class InstallationTokensTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to refresh OAuth2 access token');
-        (new InstallationTokens)->refresh($this->expired(), $db, $oauth2);
+        (new InstallationTokens())->refresh($this->expired(), $db, $oauth2);
     }
 
     public function testStolenLockIsNotDeletedByOriginalHolder(): void

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -558,7 +558,13 @@ final class InstallationTokensTest extends TestCase
 
             return new Document();
         });
-        $db->method('updateDocument')->willReturnArgument(2);
+        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock, $staleLockDoc) {
+            $target = $createdLock ?? $staleLockDoc;
+            foreach ($doc->getArrayCopy() as $k => $v) {
+                $target->setAttribute($k, $v);
+            }
+            return $target;
+        });
 
         $db->expects($this->exactly(2))
             ->method('deleteDocument')
@@ -602,7 +608,13 @@ final class InstallationTokensTest extends TestCase
 
             return new Document();
         });
-        $db->method('updateDocument')->willReturnArgument(2);
+        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock, $malformedLockDoc) {
+            $target = $createdLock ?? $malformedLockDoc;
+            foreach ($doc->getArrayCopy() as $k => $v) {
+                $target->setAttribute($k, $v);
+            }
+            return $target;
+        });
 
         $db->expects($this->exactly(2))
             ->method('deleteDocument')
@@ -646,7 +658,13 @@ final class InstallationTokensTest extends TestCase
 
             return new Document();
         });
-        $db->method('updateDocument')->willReturnArgument(2);
+        $db->method('updateDocument')->willReturnCallback(function ($collection, $id, $doc) use (&$createdLock, $missingLockDoc) {
+            $target = $createdLock ?? $missingLockDoc;
+            foreach ($doc->getArrayCopy() as $k => $v) {
+                $target->setAttribute($k, $v);
+            }
+            return $target;
+        });
 
         $db->expects($this->exactly(2))
             ->method('deleteDocument')

--- a/tests/unit/Vcs/InstallationTokensTest.php
+++ b/tests/unit/Vcs/InstallationTokensTest.php
@@ -351,10 +351,10 @@ final class InstallationTokensTest extends TestCase
             return $doc;
         });
 
-        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -45);
+        $staleLockedAt = DateTime::addSeconds(new \DateTime(), -50);
         $staleLockDoc = new Document([
             '$id' => 'installation-installation1',
-            'lockedAt' => $staleLockedAt,
+            '$createdAt' => $staleLockedAt,
         ]);
 
         $db->method('getDocument')->willReturnMap([
@@ -393,7 +393,7 @@ final class InstallationTokensTest extends TestCase
 
         $malformedLockDoc = new Document([
             '$id' => 'installation-installation1',
-            'lockedAt' => 'invalid-timestamp-string',
+            '$createdAt' => 'invalid-timestamp-string',
         ]);
 
         $db->method('getDocument')->willReturnMap([
@@ -432,7 +432,7 @@ final class InstallationTokensTest extends TestCase
 
         $missingLockDoc = new Document([
             '$id' => 'installation-installation1',
-            'lockedAt' => null,
+            '$createdAt' => null,
         ]);
 
         $db->method('getDocument')->willReturnMap([
@@ -463,7 +463,7 @@ final class InstallationTokensTest extends TestCase
 
         $activeLockDoc = new Document([
             '$id' => 'installation-installation1',
-            'lockedAt' => DateTime::addSeconds(new \DateTime(), -5),
+            '$createdAt' => DateTime::addSeconds(new \DateTime(), -5),
         ]);
 
         $db->method('getDocument')->willReturnMap([


### PR DESCRIPTION
## What does this PR do?

Fixes two concurrency bugs when refreshing VCS installation tokens under heavy worker load:

Two workers refreshing the same installation at once were both exchanging the same refresh token. Providers that rotate refresh tokens revoke the entire token family on the second exchange, breaking the installation until someone manually reconnects it.

Also fixed a wedging bug where if a Swoole worker holding the lock crashes or dies mid-refresh, the `vcsCommentLocks` row stays in the DB forever and all future requests for that installation fail with `GENERAL_RESOURCE_LOCKED`.

Key changes:
- Adds a `lockedAt` timestamp to lock documents and steals locks older than `LOCK_TTL_SECONDS` (30s) or missing a timestamp.
- Re-reads the installation document while waiting and right after acquiring. If another worker already completed the refresh, we take the fresh token and bail. Added a -2s tolerance window on `$updatedAt` checks to handle app/DB clock drift.
- Replaces fixed 1s backoff with exponential delays and random jitter so retrying waiters don't hit `createDocument` on the exact same tick.
- Validates the new access token and user identity before calling `updateDocument()`. If the provider doesn't hand back a new refresh token, we preserve the existing one instead of wiping it.

## Test Plan

- [x] Added new unit test coverage in `tests/unit/Vcs/InstallationTokensTest.php` covering lock serialization, stale lock stealing, timeout failures, validate-before-write, and backoff jitter calculation 

## Related PRs and Issues
N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
