### PR TITLE
chore: bump orchestrator jobs-service and sidecar to 0.18.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1237,7 +1237,7 @@ services:
       options:
         max-file: "5"
         max-size: 10m
-    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.16.0
+    image: ghcr.io/open-runtimes/orchestrator/jobs-service:0.18.0
     restart: unless-stopped
     user: root
     networks:
@@ -1248,7 +1248,7 @@ services:
       - ORCHESTRATOR_BACKEND=docker
       - ORCHESTRATOR_NETWORK=appwrite
       - ARTIFACT_ENDPOINT=http://orchestrator-jobs:8080
-      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.16.0
+      - JOB_SIDECAR_IMAGE=ghcr.io/open-runtimes/orchestrator/job-sidecar:0.18.0
 
   mariadb:
     image: mariadb:10.11


### PR DESCRIPTION
Bumps `jobs-service` and `job-sidecar` `0.16.0` → `0.18.0` in `docker-compose.yml`.

## 0.18.0 — builds failing with "Build produced no output artifact"

The build log showed a completely clean build:

```
[20:33:05] [open-runtimes] Build command execution finished.
[20:33:06] [open-runtimes] Build packaging finished.
[20:33:06] [open-runtimes] Build cache saved. (1007616 bytes)
[20:33:06] [open-runtimes] Build finished.
Build produced no output artifact.
```

The sidecar had the real error:

```json
{"artifactId":"archive","type":"archive","status":"failed",
 "error":"failed to finalize squashfs: open package.json: permission denied"}
{"msg":"artifact skipped because its dependency failed","artifactId":"output","depends":"archive"}
```

Extraction preserved the permission bits from whoever built the source tarball. A file the uploader kept private landed as `0o600` and, once build.sh copied it into the output dir as root, was unreadable to the **non-root** sidecar that packs the build output. `mksquashfs` got `EACCES`, the `archive` artifact failed, the dependent `output` upload was skipped, and `Jobs::ready()` — finding nothing at `buildPath` — fell through to the generic no-artifact message, three steps removed from the cause.

Fixed in open-runtimes/orchestrator#55: an extracted tree is now materialized with fixed modes — `0o755` dirs, `0o644` files, execute bit carried over — applied with an explicit `Chmod` so neither the umask nor a truncating open over an already-existing path can reintroduce a stale mode.

Observed on `package.json`, `.gitignore`, `appwrite.config.json` and macOS AppleDouble (`._*`) entries — whichever unreadable file squashfs reached first.

## 0.17.0 — skipped here, picked up by this jump

`jobs_active`, `orchestrator_trackers` and `dispatcher_queue_size` become observable gauges read from live state at scrape time. They had been UpDownCounters whose increment (job create) and decrement (exit callback) sit on different code paths, so they only stayed balanced while one process saw both halves — which a restart or a leadership handover breaks. `job_errors_total` is removed; `job_duration_seconds_count` already carries `image` and `success`.

## Verified

- Both images are published and multi-arch — `linux/amd64` and `linux/arm64` for `jobs-service:0.18.0` and `job-sidecar:0.18.0`.
- Upstream tag CI green across `lint`, `test`, `helm`, `build`, `chart`, `images`, `integration`, `k8s-integration`.

## Not touched

`docs/tutorials/multi-architecture-support.md` still lists `jobs-service:0.13.0` in its support matrix. Updating that row means re-verifying the architectures it claims, so I left it alone rather than bump the number on trust — worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)