### PR TITLE
fix(vcs): evict stale vcsCommentLocks left by crashed Swoole workers

### DIFF
--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -73,6 +73,30 @@ class InstallationTokens
         }
 
         if (!$acquired) {
+            // Before giving up, check whether the lock document is stale. A Swoole worker crash
+            // skips the finally block, leaving an orphaned document. Any lock older than 120 s
+            // must be abandoned (our own wait cycle is at most 9 s), so it is safe to evict it
+            // and reclaim the critical section.
+            $existingLock = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
+            if (!$existingLock->isEmpty()) {
+                try {
+                    $lockAge = (new \DateTime('now'))->getTimestamp() - (new \DateTime($existingLock->getAttribute('$createdAt', 'now')))->getTimestamp();
+                } catch (\Throwable) {
+                    $lockAge = 0;
+                }
+                if ($lockAge > 120) {
+                    $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+                    try {
+                        $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock])));
+                        $acquired = true;
+                    } catch (\Throwable) {
+                        // Another process beat us to it after we deleted the stale lock — fall through.
+                    }
+                }
+            }
+        }
+
+        if (!$acquired) {
             // The holder outlasted our wait. Reuse its token if it landed, never replay ours.
             $current = $this->getCurrentInstallation($dbForPlatform, $installation);
             if ($this->isUsable($current)) {

--- a/src/Appwrite/Vcs/InstallationTokens.php
+++ b/src/Appwrite/Vcs/InstallationTokens.php
@@ -85,12 +85,30 @@ class InstallationTokens
                     $lockAge = 0;
                 }
                 if ($lockAge > 120) {
-                    $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
-                    try {
-                        $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock])));
-                        $acquired = true;
-                    } catch (\Throwable) {
-                        // Another process beat us to it after we deleted the stale lock — fall through.
+                    // Double-check: re-read the lock before deleting to guard against a concurrent
+                    // worker that evicted the same stale document and placed a fresh one between our
+                    // initial read and this delete. If $createdAt changed, a fresh lock is now active
+                    // and we must not touch it.
+                    $currentLock = $authorization->skip(fn () => $dbForPlatform->getDocument('vcsCommentLocks', $lock));
+                    $stillStale = !$currentLock->isEmpty()
+                        && $currentLock->getAttribute('$createdAt') === $existingLock->getAttribute('$createdAt');
+
+                    if ($stillStale) {
+                        try {
+                            $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $lock));
+                        } catch (\Throwable) {
+                            // Another worker won the race — the stale lock is already gone.
+                            $stillStale = false;
+                        }
+                    }
+
+                    if ($stillStale) {
+                        try {
+                            $authorization->skip(fn () => $dbForPlatform->createDocument('vcsCommentLocks', new Document(['$id' => $lock])));
+                            $acquired = true;
+                        } catch (\Throwable) {
+                            // Another process created a new lock after our delete — fall through.
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When a Swoole worker process crashes while holding a \`vcsCommentLocks\` document, the \`finally\` block that deletes the lock never executes. The orphaned document causes every subsequent token-refresh attempt for that installation to retry nine times (9 s total) then throw \`GENERAL_RESOURCE_LOCKED\` permanently — with no path to recovery short of a manual database purge.

The stale lock is distinguishable from an active one by age: the normal wait window is at most 9 s, so any lock document whose \`\$createdAt\` is more than 120 s old must be abandoned. After the retry loop exhausts its attempts, the new path fetches the existing lock document, computes its age, and — if stale — deletes it and retries the \`createDocument\` call once more. A concurrent process that wins the race after the delete is handled gracefully: the outer \`!$acquired\` block falls through to token reuse or the existing locked-resource error path as before.

Fixes #13065