### PR TITLE
feat: allow the pip package name to be set per Python SDK

### DIFF
--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -390,7 +390,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                         break;
                     case 'python':
                         $config = new Python();
-                        $config->setPipPackage('appwrite');
+                        $config->setPipPackage($language['pipPackage'] ?? 'appwrite');
                         $license = 'BSD License'; // license edited due to classifiers in pypi
                         break;
                     case 'ruby':


### PR DESCRIPTION
## What does this PR do?

Makes the PyPI package name of a generated Python SDK configurable, instead of hardcoding `appwrite`.

```php
case 'python':
    $config = new Python();
-   $config->setPipPackage('appwrite');
+   $config->setPipPackage($language['pipPackage'] ?? 'appwrite');
```

## Why

Every Python SDK the task generates writes a `setup.py` claiming the `appwrite` name on PyPI, so only one Python SDK can ever exist. A second one — a console/platform SDK alongside `sdk-for-python` — cannot be published without colliding with it.

The PHP case immediately above already resolves its package identity from the language config:

```php
case 'php':
    $config = new PHP();
    $config->setComposerVendor($language['composerVendor'] ?? 'appwrite');
    $config->setComposerPackage($language['composerPackage'] ?? 'appwrite');
```

That is what lets `sdk-for-manager` publish as `appwrite-labs/sdk-for-manager` from the same task. This applies the same pattern to Python.

## Test Plan

Behaviour is unchanged for every SDK in the repo — no language config sets `pipPackage`, so the `??` falls through to `appwrite` and `sdk-for-python` generates byte-identical output.

No unit test accompanies this. The language switch lives inside the `sdks` task's `action()` closure, which needs specs, a filesystem target and git to run; the whole `Appwrite\SDK` namespace has one test file and it covers spec formatting. The honest test of this line is that a config setting `pipPackage` produces a `setup.py` with that name, which needs a consumer that sets it — that lands in appwrite-labs/cloud, and I'll confirm the generated `setup.py` there before this is relied on.

## Related

Unblocks a console Python SDK in appwrite-labs/cloud, which cannot be generated while the name is fixed.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/HEAD/CONTRIBUTING.md)?

Yes.