### PR TITLE
Update function templates to 1.0.1

### DIFF
--- a/app/config/templates/function.php
+++ b/app/config/templates/function.php
@@ -85,7 +85,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [],
         'scopes' => ['users.read']
     ],
@@ -113,7 +113,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'UPSTASH_URL',
@@ -159,7 +159,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'REDIS_HOST',
@@ -204,7 +204,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'NEO4J_URI',
@@ -258,7 +258,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'MONGO_URI',
@@ -297,7 +297,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'PGHOST',
@@ -387,7 +387,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -446,7 +446,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'DISCORD_PUBLIC_KEY',
@@ -499,7 +499,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'PERSPECTIVE_API_KEY',
@@ -551,7 +551,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'PANGEA_REDACT_TOKEN',
@@ -582,7 +582,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [],
         'scopes' => []
     ],
@@ -611,7 +611,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'GITHUB_TOKEN',
@@ -656,7 +656,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -723,7 +723,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -822,7 +822,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -928,7 +928,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'VONAGE_API_KEY',
@@ -986,7 +986,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'FCM_PROJECT_ID',
@@ -1058,7 +1058,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'SMTP_HOST',
@@ -1131,7 +1131,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'STRIPE_SECRET_KEY',
@@ -1174,7 +1174,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'STRIPE_SECRET_KEY',
@@ -1233,7 +1233,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'HUGGINGFACE_ACCESS_TOKEN',
@@ -1269,7 +1269,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'HUGGINGFACE_ACCESS_TOKEN',
@@ -1305,7 +1305,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1365,7 +1365,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1425,7 +1425,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1488,7 +1488,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1548,7 +1548,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'REPLICATE_API_KEY',
@@ -1585,7 +1585,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'TOGETHER_API_KEY',
@@ -1629,7 +1629,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'PERPLEXITY_API_KEY',
@@ -1672,7 +1672,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'REPLICATE_API_KEY',
@@ -1709,7 +1709,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -1774,7 +1774,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -1839,7 +1839,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'ELEVENLABS_API_KEY',
@@ -1896,7 +1896,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'LMNT_API_KEY',
@@ -1939,7 +1939,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'ANYSCALE_API_KEY',
@@ -1982,7 +1982,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_BUCKET_ID',
@@ -2026,7 +2026,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'FAL_API_KEY',
@@ -2063,7 +2063,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'LEMON_SQUEEZY_API_KEY',
@@ -2120,7 +2120,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -2187,7 +2187,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.0',
+        'providerVersion' => '1.0.1',
         'variables' => [
             [
                 'name' => 'BUNDLE_ID',

--- a/app/config/templates/function.php
+++ b/app/config/templates/function.php
@@ -85,7 +85,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [],
         'scopes' => ['users.read']
     ],
@@ -113,7 +113,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'UPSTASH_URL',
@@ -159,7 +159,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'REDIS_HOST',
@@ -204,7 +204,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'NEO4J_URI',
@@ -258,7 +258,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'MONGO_URI',
@@ -297,7 +297,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'PGHOST',
@@ -387,7 +387,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -446,7 +446,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'DISCORD_PUBLIC_KEY',
@@ -499,7 +499,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'PERSPECTIVE_API_KEY',
@@ -551,7 +551,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'PANGEA_REDACT_TOKEN',
@@ -582,7 +582,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [],
         'scopes' => []
     ],
@@ -611,7 +611,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'GITHUB_TOKEN',
@@ -656,7 +656,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -723,7 +723,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -822,7 +822,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -928,7 +928,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'VONAGE_API_KEY',
@@ -986,7 +986,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'FCM_PROJECT_ID',
@@ -1058,7 +1058,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'SMTP_HOST',
@@ -1131,7 +1131,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'STRIPE_SECRET_KEY',
@@ -1174,7 +1174,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'STRIPE_SECRET_KEY',
@@ -1233,7 +1233,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'HUGGINGFACE_ACCESS_TOKEN',
@@ -1269,7 +1269,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'HUGGINGFACE_ACCESS_TOKEN',
@@ -1305,7 +1305,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1365,7 +1365,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1425,7 +1425,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1488,7 +1488,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1548,7 +1548,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'REPLICATE_API_KEY',
@@ -1585,7 +1585,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'TOGETHER_API_KEY',
@@ -1629,7 +1629,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'PERPLEXITY_API_KEY',
@@ -1672,7 +1672,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'REPLICATE_API_KEY',
@@ -1709,7 +1709,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -1774,7 +1774,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -1839,7 +1839,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'ELEVENLABS_API_KEY',
@@ -1896,7 +1896,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'LMNT_API_KEY',
@@ -1939,7 +1939,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'ANYSCALE_API_KEY',
@@ -1982,7 +1982,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_BUCKET_ID',
@@ -2018,15 +2018,15 @@ return [
                 $templateRuntimes['NODE'],
                 'npm install',
                 'src/main.js',
-                'node/generate-with-fal-ai',
+                'node/generate-with-fal',
                 $allowList
             )
         ],
-        'instructions' => 'For documentation and instructions check out <a target="_blank" rel="noopener noreferrer" class="link" href="https://github.com/appwrite/templates/tree/main/node/generate-with-fal-ai">file</a>.',
+        'instructions' => 'For documentation and instructions check out <a target="_blank" rel="noopener noreferrer" class="link" href="https://github.com/appwrite/templates/tree/main/node/generate-with-fal">file</a>.',
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'FAL_API_KEY',
@@ -2063,7 +2063,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'LEMON_SQUEEZY_API_KEY',
@@ -2120,7 +2120,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -2187,7 +2187,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '1.0.*',
+        'providerVersion' => '1.0.0',
         'variables' => [
             [
                 'name' => 'BUNDLE_ID',

--- a/app/config/templates/function.php
+++ b/app/config/templates/function.php
@@ -85,7 +85,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.3.*',
+        'providerVersion' => '1.0.*',
         'variables' => [],
         'scopes' => ['users.read']
     ],
@@ -113,7 +113,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'UPSTASH_URL',
@@ -159,7 +159,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'REDIS_HOST',
@@ -204,7 +204,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'NEO4J_URI',
@@ -258,7 +258,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'MONGO_URI',
@@ -297,7 +297,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'PGHOST',
@@ -387,7 +387,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -446,7 +446,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'DISCORD_PUBLIC_KEY',
@@ -499,7 +499,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'PERSPECTIVE_API_KEY',
@@ -551,7 +551,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'PANGEA_REDACT_TOKEN',
@@ -582,7 +582,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [],
         'scopes' => []
     ],
@@ -611,7 +611,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'GITHUB_TOKEN',
@@ -656,7 +656,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -723,7 +723,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -822,7 +822,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -928,7 +928,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'VONAGE_API_KEY',
@@ -986,7 +986,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'FCM_PROJECT_ID',
@@ -1058,7 +1058,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'SMTP_HOST',
@@ -1131,7 +1131,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'STRIPE_SECRET_KEY',
@@ -1174,7 +1174,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'STRIPE_SECRET_KEY',
@@ -1233,7 +1233,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'HUGGINGFACE_ACCESS_TOKEN',
@@ -1269,7 +1269,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'HUGGINGFACE_ACCESS_TOKEN',
@@ -1305,7 +1305,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1365,7 +1365,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1425,7 +1425,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1488,7 +1488,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -1548,7 +1548,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'REPLICATE_API_KEY',
@@ -1585,7 +1585,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'TOGETHER_API_KEY',
@@ -1629,7 +1629,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'PERPLEXITY_API_KEY',
@@ -1672,7 +1672,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'REPLICATE_API_KEY',
@@ -1709,7 +1709,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -1774,7 +1774,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'OPENAI_API_KEY',
@@ -1839,7 +1839,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'ELEVENLABS_API_KEY',
@@ -1896,7 +1896,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'LMNT_API_KEY',
@@ -1939,7 +1939,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'ANYSCALE_API_KEY',
@@ -1982,7 +1982,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_BUCKET_ID',
@@ -2026,7 +2026,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'FAL_API_KEY',
@@ -2063,7 +2063,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'LEMON_SQUEEZY_API_KEY',
@@ -2120,7 +2120,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'APPWRITE_DATABASE_ID',
@@ -2187,7 +2187,7 @@ return [
         'vcsProvider' => 'github',
         'providerRepositoryId' => 'templates',
         'providerOwner' => 'appwrite',
-        'providerVersion' => '0.2.*',
+        'providerVersion' => '1.0.*',
         'variables' => [
             [
                 'name' => 'BUNDLE_ID',


### PR DESCRIPTION
## What does this PR do?

Pins all 40 function template catalog entries to the published `appwrite/templates` `1.0.1` tag and corrects the Fal.ai template root directory from `node/generate-with-fal-ai` to `node/generate-with-fal`.

The exact tag is intentional. Template deployments using `1.0.*` resolve the wildcard through GitHub's unauthenticated tags API. A 40-template validation run can exhaust the 60-request/hour limit; resolution then falls back to the literal wildcard and the source download returns 404. Exact tags are deterministic and skip that API call.

Template releases do not propagate into an existing Appwrite server automatically: the server serves the version configured in this catalog. A future templates release requires another catalog pin update and an Appwrite image containing that change.

## Test Plan

- Merged appwrite/templates#355 after approval and all dependency-audit checks passed.
- Published and verified [appwrite/templates 1.0.1](https://github.com/appwrite/templates/releases/tag/1.0.1) from merge commit `2eaf5417f49e93d6e84a7e07ff42648f9aec7b36`.
- Started a fresh local Appwrite 1.9.5 Docker Compose stack with Node 22, Dart 3.10, and Go 1.23 executors.
- Used Playwright with headless Chrome 150 to create a console account, project, API key, all 40 functions, and template deployments through the Appwrite API.
- Verified the catalog returns exactly 40 entries and every entry is pinned to `1.0.1`.
- Published `1.0.1` tag: **40/40 ready**, **0 failed**, completed in **83.8s**.
- `composer lint app/config/templates/function.php`: passed.
- `git diff --check`: passed.

### Published 1.0.1 matrix

![Playwright build results for all 40 templates](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/appwrite-template-results-b1dbbadc.png)

## Related PRs and Issues

- appwrite/templates#354
- appwrite/templates#355

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
