### PR TITLE
Support wildcard domains in console email whitelist

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -207,7 +207,7 @@ return [
             ],
             [
                 'name' => '_APP_CONSOLE_WHITELIST_EMAILS',
-                'description' => 'This option allows you to limit creation of new users on the Appwrite console. This option is very useful for small teams or sole developers. To enable it, pass a list of allowed email addresses separated by a comma.',
+                'description' => 'This option allows you to limit creation of new users on the Appwrite console. This option is very useful for small teams or sole developers. To enable it, pass a list of allowed email addresses or wildcard domains, such as *@appwrite.io, separated by a comma.',
                 'introduction' => '',
                 'default' => '',
                 'required' => false,

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -4,6 +4,7 @@ use Ahc\Jwt\JWT;
 use Appwrite\Auth\MFA\Type;
 use Appwrite\Auth\OAuth2\Exception as OAuth2Exception;
 use Appwrite\Auth\Phrase;
+use Appwrite\Auth\Validator\EmailWhitelist;
 use Appwrite\Auth\Validator\Password;
 use Appwrite\Auth\Validator\PasswordDictionary;
 use Appwrite\Auth\Validator\PasswordHistory;
@@ -321,7 +322,7 @@ Http::post('/v1/account')
             $whitelistEmails = $project->getAttribute('authWhitelistEmails');
             $whitelistIPs = $project->getAttribute('authWhitelistIPs');
 
-            if (!empty($whitelistEmails) && !\in_array($email, $whitelistEmails) && !\in_array(strtoupper($email), $whitelistEmails)) {
+            if (!empty($whitelistEmails) && !(new EmailWhitelist($whitelistEmails))->isValid($email)) {
                 throw new Exception(Exception::USER_EMAIL_NOT_WHITELISTED);
             }
 

--- a/src/Appwrite/Auth/Validator/EmailWhitelist.php
+++ b/src/Appwrite/Auth/Validator/EmailWhitelist.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Auth\Validator;
+
+use Utopia\Emails\Email;
+use Utopia\Emails\Validator\Email as EmailValidator;
+use Utopia\Validator;
+use Utopia\Validator\WhiteList;
+
+final class EmailWhitelist extends Validator
+{
+    private EmailValidator $validator;
+
+    private WhiteList $emails;
+
+    private WhiteList $domains;
+
+    /**
+     * @param array<mixed> $emails
+     */
+    public function __construct(array $emails)
+    {
+        $allowedEmails = [];
+        $allowedDomains = [];
+
+        foreach ($emails as $email) {
+            if (!\is_string($email)) {
+                continue;
+            }
+
+            $email = \trim($email);
+
+            if (!\str_contains($email, '*')) {
+                $allowedEmails[] = $email;
+                continue;
+            }
+
+            if (\str_starts_with($email, '*@') && \substr_count($email, '*') === 1) {
+                $allowedDomains[] = \substr($email, 2);
+            }
+        }
+
+        $this->validator = new EmailValidator();
+        $this->emails = new WhiteList($allowedEmails);
+        $this->domains = new WhiteList($allowedDomains);
+    }
+
+    public function getDescription(): string
+    {
+        return 'Email must match an allowed email address or domain';
+    }
+
+    public function isArray(): bool
+    {
+        return false;
+    }
+
+    public function isValid($value): bool
+    {
+        if (!\is_string($value) || !$this->validator->isValid($value)) {
+            return false;
+        }
+
+        $email = new Email($value);
+
+        return $this->emails->isValid($email->get()) || $this->domains->isValid($email->getDomain());
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE_STRING;
+    }
+}

--- a/tests/unit/Auth/Validator/EmailWhitelistTest.php
+++ b/tests/unit/Auth/Validator/EmailWhitelistTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth\Validator;
+
+use Appwrite\Auth\Validator\EmailWhitelist;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EmailWhitelistTest extends TestCase
+{
+    #[DataProvider('validEmailProvider')]
+    public function testValidEmails(array $whitelist, string $email): void
+    {
+        $validator = new EmailWhitelist($whitelist);
+
+        $this->assertTrue($validator->isValid($email));
+    }
+
+    public static function validEmailProvider(): array
+    {
+        return [
+            'exact email' => [['user@example.com'], 'user@example.com'],
+            'exact email is case insensitive' => [['USER@EXAMPLE.COM'], 'user@example.com'],
+            'wildcard domain' => [['*@appwrite.io'], 'user@appwrite.io'],
+            'wildcard domain is case insensitive' => [['*@APPWRITE.IO'], 'USER@appwrite.io'],
+            'entries are trimmed' => [[' owner@example.com ', ' *@appwrite.io '], 'user@appwrite.io'],
+            'mixed exact and wildcard entries' => [['owner@example.com', '*@appwrite.io'], 'owner@example.com'],
+        ];
+    }
+
+    #[DataProvider('invalidEmailProvider')]
+    public function testInvalidEmails(array $whitelist, mixed $email): void
+    {
+        $validator = new EmailWhitelist($whitelist);
+
+        $this->assertFalse($validator->isValid($email));
+    }
+
+    public static function invalidEmailProvider(): array
+    {
+        return [
+            'different exact email' => [['owner@example.com'], 'user@example.com'],
+            'different domain' => [['*@appwrite.io'], 'user@example.com'],
+            'subdomain' => [['*@appwrite.io'], 'user@team.appwrite.io'],
+            'domain suffix' => [['*@appwrite.io'], 'user@evilappwrite.io'],
+            'allow all wildcard' => [['*'], 'user@appwrite.io'],
+            'local part wildcard' => [['dev-*@appwrite.io'], 'dev-user@appwrite.io'],
+            'local part wildcard as literal email' => [['dev-*@appwrite.io'], 'dev-*@appwrite.io'],
+            'domain wildcard' => [['*@*.appwrite.io'], 'user@team.appwrite.io'],
+            'empty domain wildcard' => [['*@'], 'user@appwrite.io'],
+            'missing domain separator' => [['*@appwrite.io'], 'user'],
+            'multiple domain separators' => [['*@appwrite.io'], 'user@team@appwrite.io'],
+            'non-string value' => [['*@appwrite.io'], null],
+        ];
+    }
+}

--- a/tests/unit/Auth/Validator/EmailWhitelistTest.php
+++ b/tests/unit/Auth/Validator/EmailWhitelistTest.php
@@ -18,16 +18,14 @@ final class EmailWhitelistTest extends TestCase
         $this->assertTrue($validator->isValid($email));
     }
 
-    public static function validEmailProvider(): array
+    public static function validEmailProvider(): \Iterator
     {
-        return [
-            'exact email' => [['user@example.com'], 'user@example.com'],
-            'exact email is case insensitive' => [['USER@EXAMPLE.COM'], 'user@example.com'],
-            'wildcard domain' => [['*@appwrite.io'], 'user@appwrite.io'],
-            'wildcard domain is case insensitive' => [['*@APPWRITE.IO'], 'USER@appwrite.io'],
-            'entries are trimmed' => [[' owner@example.com ', ' *@appwrite.io '], 'user@appwrite.io'],
-            'mixed exact and wildcard entries' => [['owner@example.com', '*@appwrite.io'], 'owner@example.com'],
-        ];
+        yield 'exact email' => [['user@example.com'], 'user@example.com'];
+        yield 'exact email is case insensitive' => [['USER@EXAMPLE.COM'], 'user@example.com'];
+        yield 'wildcard domain' => [['*@appwrite.io'], 'user@appwrite.io'];
+        yield 'wildcard domain is case insensitive' => [['*@APPWRITE.IO'], 'USER@appwrite.io'];
+        yield 'entries are trimmed' => [[' owner@example.com ', ' *@appwrite.io '], 'user@appwrite.io'];
+        yield 'mixed exact and wildcard entries' => [['owner@example.com', '*@appwrite.io'], 'owner@example.com'];
     }
 
     #[DataProvider('invalidEmailProvider')]
@@ -38,21 +36,19 @@ final class EmailWhitelistTest extends TestCase
         $this->assertFalse($validator->isValid($email));
     }
 
-    public static function invalidEmailProvider(): array
+    public static function invalidEmailProvider(): \Iterator
     {
-        return [
-            'different exact email' => [['owner@example.com'], 'user@example.com'],
-            'different domain' => [['*@appwrite.io'], 'user@example.com'],
-            'subdomain' => [['*@appwrite.io'], 'user@team.appwrite.io'],
-            'domain suffix' => [['*@appwrite.io'], 'user@evilappwrite.io'],
-            'allow all wildcard' => [['*'], 'user@appwrite.io'],
-            'local part wildcard' => [['dev-*@appwrite.io'], 'dev-user@appwrite.io'],
-            'local part wildcard as literal email' => [['dev-*@appwrite.io'], 'dev-*@appwrite.io'],
-            'domain wildcard' => [['*@*.appwrite.io'], 'user@team.appwrite.io'],
-            'empty domain wildcard' => [['*@'], 'user@appwrite.io'],
-            'missing domain separator' => [['*@appwrite.io'], 'user'],
-            'multiple domain separators' => [['*@appwrite.io'], 'user@team@appwrite.io'],
-            'non-string value' => [['*@appwrite.io'], null],
-        ];
+        yield 'different exact email' => [['owner@example.com'], 'user@example.com'];
+        yield 'different domain' => [['*@appwrite.io'], 'user@example.com'];
+        yield 'subdomain' => [['*@appwrite.io'], 'user@team.appwrite.io'];
+        yield 'domain suffix' => [['*@appwrite.io'], 'user@evilappwrite.io'];
+        yield 'allow all wildcard' => [['*'], 'user@appwrite.io'];
+        yield 'local part wildcard' => [['dev-*@appwrite.io'], 'dev-user@appwrite.io'];
+        yield 'local part wildcard as literal email' => [['dev-*@appwrite.io'], 'dev-*@appwrite.io'];
+        yield 'domain wildcard' => [['*@*.appwrite.io'], 'user@team.appwrite.io'];
+        yield 'empty domain wildcard' => [['*@'], 'user@appwrite.io'];
+        yield 'missing domain separator' => [['*@appwrite.io'], 'user'];
+        yield 'multiple domain separators' => [['*@appwrite.io'], 'user@team@appwrite.io'];
+        yield 'non-string value' => [['*@appwrite.io'], null];
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds domain wildcard support to `_APP_CONSOLE_WHITELIST_EMAILS`, allowing entries such as `*@appwrite.io` alongside exact email addresses.

Wildcard entries match only the exact configured domain, remain case-insensitive, and do not enable general glob matching or subdomain matching. The implementation reuses Utopia's email and whitelist validators and documents the new environment variable syntax.

## Test Plan

- `vendor/bin/phpunit tests/unit/Auth/Validator` (27 tests, 119 assertions)
- `composer lint src/Appwrite/Auth/Validator/EmailWhitelist.php app/controllers/api/account.php app/config/variables.php tests/unit/Auth/Validator/EmailWhitelistTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G app/controllers/api/account.php src/Appwrite/Auth/Validator/EmailWhitelist.php tests/unit/Auth/Validator/EmailWhitelistTest.php`

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
