### PR TITLE
fix(users): include the user document in the prefs update event payload

### DIFF
--- a/app/controllers/api/users.php
+++ b/app/controllers/api/users.php
@@ -1750,7 +1750,8 @@ Http::patch('/v1/users/:userId/prefs')
         $user = $dbForProject->updateDocument('users', $user->getId(), new Document(['prefs' => $prefs]));
 
         $queueForEvents
-            ->setParam('userId', $user->getId());
+            ->setParam('userId', $user->getId())
+            ->setPayload($response->output($user, Response::MODEL_USER));
 
         $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);
     });

--- a/tests/e2e/Services/ProjectWebhooks/WebhooksCustomServerTest.php
+++ b/tests/e2e/Services/ProjectWebhooks/WebhooksCustomServerTest.php
@@ -555,7 +555,9 @@ final class WebhooksCustomServerTest extends Scope
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Id'] ?? '', $this->getProject()['webhookId']);
         $this->assertEquals($webhook['headers']['X-Appwrite-Webhook-Project-Id'] ?? '', $this->getProject()['$id']);
         $this->assertSame(empty($webhook['headers']['X-Appwrite-Webhook-User-Id'] ?? ''), ('server' === $this->getSide()));
-        $this->assertEquals('b', $webhook['data']['a']);
+        $this->assertNotEmpty($webhook['data']['$id']);
+        $this->assertEquals($id, $webhook['data']['$id']);
+        $this->assertEquals(['a' => 'b'], $webhook['data']['prefs']);
     }
 
     public function testUpdateUserStatus(): void


### PR DESCRIPTION
## What

`PATCH /v1/users/{userId}/prefs` sets the event parameter but never a payload:

```php
$queueForEvents
    ->setParam('userId', $user->getId());
```

So every webhook and realtime subscriber to `users.[userId].update.prefs` receives an event with an **empty body** — a consumer can't tell what the preferences were changed to without a follow-up API call, which defeats the point of the event.

Fixes #12369.

## How

```php
$queueForEvents
    ->setParam('userId', $user->getId())
    ->setPayload($response->output($user, Response::MODEL_USER));
```

`$response->output(..., MODEL_USER)` is the established idiom for this in the codebase — see `Teams/Http/Teams/Delete.php:98` and `Teams/Http/Memberships/Delete.php:150`. Routing through the response model means the payload gets the same filtering as the HTTP response, so nothing the `User` model hides can leak into a webhook.

`MODEL_USER` rather than `MODEL_PREFERENCES` because the event is namespaced `users.*`, and the user document already carries the updated `prefs`.

## Tests

Extends `WebhooksCustomServerTest::testUpdateUserPrefs` to assert the **delivered webhook body**, not just that a delivery happened:

```php
$this->assertNotEmpty($webhook['data']['$id']);
$this->assertEquals($id, $webhook['data']['$id']);
$this->assertEquals(['a' => 'b'], $webhook['data']['prefs']);
```

This replaces `assertEquals('b', $webhook['data']['a'])`, which asserted against a flat shape the payload never had. The new assertions fail on `main` today, so this is a genuine regression test.

`composer lint` and `composer analyze` (PHPStan level 4) both pass.

## Note for reviewers

This changes the delivered body for `users.*.update.prefs` from empty to a full user document. That's the fix, but it is an observable change for existing webhook consumers and may deserve a `CHANGES.md` entry — happy to add one.

Two sibling gaps exist in the same class (`teams.*.update.prefs` and the TablesDB transaction row events). I've kept this PR to the reported issue; glad to follow up with those, or fold them in here if you'd prefer one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
