### PR TITLE
fix(functions): correct the ownership check when deleting an execution

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Delete.php
@@ -86,7 +86,7 @@ class Delete extends Base
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
 
-        if ($execution->getAttribute('resourceType') !== 'functions' && $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
+        if ($execution->getAttribute('resourceType') !== 'functions' || $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
             throw new Exception(Exception::EXECUTION_NOT_FOUND);
         }
         $status = $execution->getAttribute('status');

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1844,6 +1844,61 @@ final class FunctionsCustomServerTest extends Scope
         $this->assertStringContainsString('Can\'t delete ongoing execution.', (string) $execution['body']['message']);
     }
 
+    public function testDeleteExecutionRequiresOwnership(): void
+    {
+        $data = $this->setupTestDeployment();
+
+        $execution = $this->createExecution($data['functionId'], [
+            'async' => 'false',
+        ]);
+
+        $this->assertEquals(201, $execution['headers']['status-code']);
+        $executionId = $execution['body']['$id'] ?? '';
+        $this->assertNotEmpty($executionId);
+
+        // A second function the execution does not belong to.
+        $otherFunctionId = $this->setupFunction([
+            'functionId' => ID::unique(),
+            'name' => 'Other function',
+            'runtime' => 'node-22',
+            'entrypoint' => 'index.js',
+            'execute' => [Role::any()->toString()],
+        ]);
+
+        /**
+         * Test for FAILURE — deleting through a function that does not own the
+         * execution must not succeed.
+         */
+        $response = $this->client->call(Client::METHOD_DELETE, '/functions/' . $otherFunctionId . '/executions/' . $executionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(404, $response['headers']['status-code']);
+        $this->assertEquals('execution_not_found', $response['body']['type']);
+
+        // The execution is still there.
+        $response = $this->client->call(Client::METHOD_GET, '/functions/' . $data['functionId'] . '/executions/' . $executionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals($executionId, $response['body']['$id']);
+
+        /**
+         * Test for SUCCESS — the owning function can still delete it.
+         */
+        $response = $this->client->call(Client::METHOD_DELETE, '/functions/' . $data['functionId'] . '/executions/' . $executionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(204, $response['headers']['status-code']);
+
+        $this->cleanupFunction($otherFunctionId);
+    }
+
 
 
     public function testUpdateSpecs(): void


### PR DESCRIPTION
## What

`Executions/Delete.php` guards the "does this execution belong to this function?" check with `&&` instead of `||`:

```php
if ($execution->getAttribute('resourceType') !== 'functions'
    && $execution->getAttribute('resourceInternalId') !== $function->getSequence()) {
    throw new Exception(Exception::EXECUTION_NOT_FOUND);
}
```

The two operands can never both be true for a function execution — `resourceType` *is* `functions`, so the first is `false` and short-circuits the whole expression. **The guard never fires for an execution belonging to a different function.**

A caller can therefore delete any execution in the project by pairing its ID with any function they can access:

```
DELETE /v1/functions/{someOtherFunctionId}/executions/{executionId}   →  204
```

Fixes #12537.

## How

One operator:

```diff
- if (... !== 'functions' && ... !== $function->getSequence()) {
+ if (... !== 'functions' || ... !== $function->getSequence()) {
```

This makes `Delete` agree with the sibling read endpoint, which already gets it right — the strongest evidence that `||` is the intended semantics:

| File | Operator |
|---|---|
| `Http/Executions/Get.php:79` | `\|\|` |
| `Http/Executions/Delete.php:89` | `&&` ← fixed here |

Non-function executions (e.g. `sites`) were already rejected by accident, so this only ever narrows access — it cannot widen it.

## Base branch

Targeting **`1.9.x`**, not `main`: on `main` this action has been restructured to delete *scheduled* executions and already uses a single correct condition, so the bug is specific to `1.9.x`. Please retarget if you'd rather take it elsewhere.

## Tests

Adds `testDeleteExecutionRequiresOwnership` to `FunctionsCustomServerTest`, covering both directions:

- **failure** — `DELETE /functions/{otherFunctionId}/executions/{executionId}` returns `404` with `execution_not_found`, and a follow-up `GET` confirms the execution is **still there** (asserting the side effect did not happen, not just the status code)
- **success** — the owning function can still delete it, so the fix doesn't over-restrict

The failure case fails on `1.9.x` today.

`composer lint` passes. `composer analyze` reports 94 errors both with and without this change on `1.9.x` — all pre-existing in my environment, none added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
