### PR TITLE
fix(graphql): backport missing CORS headers fix to 1.9.x

### DIFF
--- a/app/controllers/general.php
+++ b/app/controllers/general.php
@@ -988,7 +988,7 @@ Http::init()
  * @see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
  */
 Http::init()
-    ->groups(['api', 'web'])
+    ->groups(['api', 'web', 'graphql'])
     ->inject('request')
     ->inject('response')
     ->inject('cors')


### PR DESCRIPTION
## What

Backports the already-merged GraphQL CORS fix to `1.9.x`.

The CORS/security-headers `Http::init()` hook is registered with `groups(['api', 'web'])`, but every GraphQL route uses `groups(['graphql'])` (`app/controllers/api/graphql.php:29, 50, 97, 148`). The hook never fires for GraphQL, so responses from `GET /v1/graphql` and `POST /v1/graphql` carry no `Access-Control-Allow-Origin` — cross-origin browser clients can't use the GraphQL API at all on `1.9.x`.

Fixes #11959 and #12526 (same defect, two reports).

## How

This is a straight `git cherry-pick -x` of **4b239a4ebb**, which is already merged on `main`:

```diff
 Http::init()
-    ->groups(['api', 'web'])
+    ->groups(['api', 'web', 'graphql'])
```

Nothing was re-implemented — the approach is the one you already accepted, and the original author (@deepshekhardas) is preserved as the commit author.

Worth noting the fix is deliberately applied to the **hook's** groups rather than the **routes'** groups. Adding `'api'` to the GraphQL routes would have pulled in every other `groups(['api'])` hook in `app/controllers/shared/api.php` (auth, abuse limiting, usage metrics, audits) — a much larger behaviour change. This way exactly one hook comes into scope.

Side effect worth flagging: the same hook also sets the non-CORS security headers (`Server`, etc.), so GraphQL responses now get those too. That's consistent with the REST API and is the behaviour already on `main`.

## Verification

`main` has carried this since 2026-05-25; `1.9.x` does not:

```
$ git merge-base --is-ancestor 4b239a4ebb origin/1.9.x   # not an ancestor
$ git show origin/main:app/controllers/general.php  | grep "'api', 'web'"
    ->groups(['api', 'web', 'graphql'])
$ git show origin/1.9.x:app/controllers/general.php | grep "'api', 'web'"
    ->groups(['api', 'web'])
```

`composer lint` passes.

No test is included — the cherry-picked commit has none, and I didn't want to alter a already-merged change in a backport. If you'd like one, an e2e assertion that `POST /v1/graphql` returns `Access-Control-Allow-Origin` for an allow-listed origin would be the natural addition, and I'm happy to add it here or on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
