### PR TITLE
feat: add Python MCP server function template

### DIFF
--- a/app/config/templates/function.php
+++ b/app/config/templates/function.php
@@ -409,6 +409,67 @@ return [
         'scopes' => []
     ],
     [
+        'icon' => 'icon-chip',
+        'id' => 'mcp-server',
+        'name' => 'MCP server',
+        'score' => 8,
+        'tagline' => 'Expose custom tools to AI clients over HTTPS using the Model Context Protocol.',
+        'permissions' => ['any'],
+        'events' => [],
+        'cron' => '',
+        'timeout' => 30,
+        'useCases' => [FunctionUseCases::AI],
+        'runtimes' => [
+            ...getRuntimes(
+                $templateRuntimes['PYTHON'],
+                'pip install -r requirements.txt',
+                'src/main.py',
+                'python/mcp-server',
+                $allowList
+            )
+        ],
+        'instructions' => 'For documentation and instructions check out <a target="_blank" rel="noopener noreferrer" class="link" href="https://github.com/appwrite/templates/tree/main/python/mcp-server">file</a>.',
+        'vcsProvider' => 'github',
+        'providerRepositoryId' => 'templates',
+        'providerOwner' => 'appwrite',
+        'providerVersion' => '1.1.0',
+        'variables' => [
+            [
+                'name' => 'MCP_SERVER_NAME',
+                'description' => 'Display name returned to MCP clients in the initialize handshake.',
+                'value' => 'appwrite-hosted-mcp',
+                'placeholder' => 'appwrite-hosted-mcp',
+                'required' => false,
+                'type' => 'text'
+            ],
+            [
+                'name' => 'MCP_AUTH_MODE',
+                'description' => 'Auth gate for the endpoint. Set to "bearer" to require an Authorization header, or "none" to keep it open.',
+                'value' => 'none',
+                'placeholder' => 'none',
+                'required' => false,
+                'type' => 'text'
+            ],
+            [
+                'name' => 'MCP_AUTH_TOKEN',
+                'description' => 'Shared secret required when MCP_AUTH_MODE is set to "bearer".',
+                'value' => '',
+                'placeholder' => 'your-long-random-secret',
+                'required' => false,
+                'type' => 'password'
+            ],
+            [
+                'name' => 'MCP_TOOL_TIMEOUT',
+                'description' => 'Soft deadline in seconds for the whole request, before the 30s execution hard-cap.',
+                'value' => '25',
+                'placeholder' => '25',
+                'required' => false,
+                'type' => 'number'
+            ]
+        ],
+        'scopes' => []
+    ],
+    [
         'icon' => 'icon-discord',
         'id' => 'discord-command-bot',
         'name' => 'Discord Command Bot',


### PR DESCRIPTION
## What does this PR do?

Registers the **Python MCP server** template (`python/mcp-server`) in `app/config/templates/function.php` so it shows up in the console's function templates catalog.

The template itself shipped in [appwrite/templates#353](https://github.com/appwrite/templates/pull/353) and is included in the [`1.1.0`](https://github.com/appwrite/templates/releases/tag/1.1.0) release, which this entry pins via `providerVersion`.

- Stateless [Model Context Protocol](https://modelcontextprotocol.io/) server over HTTPS (official Python SDK, `mcp==2.0.0`), connectable from Claude Code, Cursor, and other MCP hosts.
- Runtime: Python, entrypoint `src/main.py`, build `pip install -r requirements.txt`, timeout 30s (per template README).
- Variables: `MCP_SERVER_NAME`, `MCP_AUTH_MODE`, `MCP_AUTH_TOKEN`, `MCP_TOOL_TIMEOUT` (all optional; bearer auth off by default).
- `score` 8 ranks it into the featured set on the console create-function page (top 4 by score) and the new console's highlighted templates.

## Test Plan

- `php -l` and `composer lint` pass on the config.
- Verified `GET /v1/functions/templates` sorting (`XList.php`) is score-based, so no client changes are needed.

## Related PRs and Issues

- appwrite/templates#353