### PR TITLE
test(functions): cover ownership guard when cancelling a scheduled execution

### DIFF
--- a/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
+++ b/tests/e2e/Services/FunctionsSchedule/FunctionsScheduleTest.php
@@ -181,4 +181,72 @@ final class FunctionsScheduleTest extends Scope
 
         $this->cleanupFunction($functionId);
     }
+
+    public function testDeleteScheduledExecutionRequiresOwnership(): void
+    {
+        $functionId = $this->setupFunction([
+            'functionId' => ID::unique(),
+            'name' => 'Test',
+            'execute' => [Role::user($this->getUser()['$id'])->toString()],
+            'runtime' => 'node-22',
+            'entrypoint' => 'index.js',
+            'timeout' => 10,
+            'logging' => true,
+        ]);
+
+        $this->setupDeployment($functionId, [
+            'code' => $this->packageFunction('basic'),
+            'activate' => true
+        ]);
+
+        // A second function the scheduled execution does not belong to. It needs
+        // no deployment; the ownership guard runs before anything is executed.
+        $otherFunctionId = $this->setupFunction([
+            'functionId' => ID::unique(),
+            'name' => 'Other',
+            'execute' => [Role::user($this->getUser()['$id'])->toString()],
+            'runtime' => 'node-22',
+            'entrypoint' => 'index.js',
+            'timeout' => 10,
+        ]);
+
+        $futureTime = (new \DateTime())->add(new \DateInterval('PT10H'));
+        $futureTime->setTime((int) $futureTime->format('H'), (int) $futureTime->format('i'), 0, 0);
+
+        $execution = $this->createExecution($functionId, [
+            'async' => true,
+            'scheduledAt' => $futureTime->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->assertEquals(202, $execution['headers']['status-code']);
+
+        $executionId = $execution['body']['$id'] ?? '';
+        $this->assertNotEmpty($executionId);
+
+        /**
+         * Test for FAILURE
+         */
+        // Cancelling through a function that does not own the execution
+        $execution = $this->client->call(Client::METHOD_DELETE, '/functions/' . $otherFunctionId . '/executions/' . $executionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(404, $execution['headers']['status-code']);
+        $this->assertEquals('execution_not_found', $execution['body']['type']);
+
+        /**
+         * Test for SUCCESS
+         */
+        // The execution is untouched, so the owning function can still cancel it
+        $execution = $this->client->call(Client::METHOD_DELETE, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(204, $execution['headers']['status-code']);
+
+        $this->cleanupFunction($otherFunctionId);
+        $this->cleanupFunction($functionId);
+    }
 }


### PR DESCRIPTION
## What

Adds the missing regression coverage for the ownership guard in `Executions/Delete.php`.

The schedule lookup is keyed only on execution ID, resource type and project — it does **not** filter by function:

```php
$schedule = $authorization->skip(fn () => $dbForPlatform->findOne('schedules', [
    Query::equal('resourceId', [$executionId]),
    Query::equal('resourceType', [SCHEDULE_RESOURCE_TYPE_EXECUTION]),
    Query::equal('projectInternalId', [$project->getSequence()]),
    Query::equal('active', [true]),
]));
```

So this line is the only thing stopping a caller from cancelling **any** pending scheduled execution in the project by pairing its ID with any function they can access:

```php
if (($schedule->getAttribute('data')['functionId'] ?? null) !== $function->getId()) {
    throw new Exception(Exception::EXECUTION_NOT_FOUND);
}
```

It was uncovered. `testDeleteScheduledExecution` only ever cancels through the owning function.

## Relationship to #13081

#13081 fixes this guard on **`1.9.x`**, where it is genuinely broken — it uses `&&` where it needs `||`, so the two operands can never both be true and the check never fires.

**`main` is not affected.** This action was restructured here to cancel scheduled executions only, executions are no longer persisted in Server CE, and `Http/Executions/Get.php` no longer exists. I also checked every analogous `resourceInternalId !== …` guard on `main` (Functions/Sites `Variables` Get/Update/Delete) — all correctly use `||`.

So this PR ports only the part of #13081 that applies to `main`: the regression test, rewritten against the scheduled-execution surface that survived. The source fix belongs on `1.9.x` and stays in #13081.

## Tests

`testDeleteScheduledExecutionRequiresOwnership` in `FunctionsScheduleTest`, covering both directions:

- **failure** — `DELETE /functions/{otherFunctionId}/executions/{executionId}` returns `404` with `execution_not_found`
- **success** — the owning function can then still cancel it, so the guard is verified to reject without over-restricting

The second function needs no deployment; the guard runs before anything is executed.

Verified locally against this branch:

```
docker compose exec appwrite test tests/e2e/Services/FunctionsSchedule
OK (4 tests, 92 assertions)
```

And confirmed the test has teeth — with the guard commented out it fails on the first assertion:

```
1) FunctionsScheduleTest::testDeleteScheduledExecutionRequiresOwnership
Failed asserting that 204 matches expected 404.
```

`composer lint` and `composer refactor:check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)