### PR TITLE
test(e2e): fix two ordering flakes — realtime handshake and migration execution

### DIFF
--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -2287,6 +2287,22 @@ trait MigrationsBase
             $this->assertEquals(1, $deployments['body']['total']);
 
             $this->assertEquals('ready', $deployments['body']['deployments'][0]['status'], 'Deployment status is not ready, deployment: ' . json_encode($deployments['body']['deployments'][0], JSON_PRETTY_PRINT));
+
+            // The jobs worker marks the deployment ready before activate() points the
+            // function at it, and the execution below reads that pointer -- ready
+            // alone still 404s until the activation write lands.
+            $function = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getDestinationProject()['$id'],
+                'x-appwrite-key' => $this->getDestinationProject()['apiKey'],
+            ]));
+
+            $this->assertEquals(200, $function['headers']['status-code']);
+            $this->assertSame(
+                $deployments['body']['deployments'][0]['$id'],
+                $function['body']['deploymentId'] ?? '',
+                'Function is not yet activated on the ready deployment',
+            );
         }, 100000, 500);
 
         // Attempt execution

--- a/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
+++ b/tests/e2e/Services/Realtime/RealtimeCustomClientTest.php
@@ -3180,8 +3180,22 @@ final class RealtimeCustomClientTest extends Scope
             'cookie' => 'a_session_' . $projectId . '=' . $session,
         ]);
 
-        $response = json_decode($client->receive(), true);
+        // The row seed above fires an async .create broadcast on the channels just
+        // subscribed to, and its fanout can land on this connection before the
+        // connected frame is written. Skip event frames until the handshake; any
+        // other frame type falls through to the assertions below.
+        $response = null;
+        $deadline = \time() + 10;
+        while (\time() < $deadline) {
+            $frame = json_decode($client->receive(), true);
+            if (($frame['type'] ?? '') === 'event') {
+                continue;
+            }
+            $response = $frame;
+            break;
+        }
 
+        $this->assertNotNull($response, 'Timed out waiting for the connected frame');
         $this->assertArrayHasKey('type', $response);
         $this->assertArrayHasKey('data', $response);
         $this->assertEquals('connected', $response['type']);


### PR DESCRIPTION
Fixes two E2E ordering flakes, both observed on appwrite-labs/cloud CI (which runs these suites from the vendored package) and both diagnosed to a specific write-order window in production code. Neither fix loosens an outcome assertion — each makes the test wait for the state the code under test actually reads.

## 1. Realtime: `testChannelTablesDBRowUpdate` — expected `connected`, got `event`

The test seeds the row whose channel it subscribes to, so the `.create` broadcast from that seed is in flight when the websocket opens. The realtime server registers the subscription before it writes the `connected` frame; when the fanout lands in that window, the first frame is `event` and the strict first-frame assertion fails.

The update drain later in the same test already skips exactly these frames and documents why ("Earlier events (e.g. a late-arriving .create from the row seed above) are skipped") — only the first receive was left strict. The fix applies the same bounded drain to the handshake: skip `event` frames for up to 10s, then run the original assertions unchanged. A non-`event` frame (e.g. an error) still falls through and fails with its real content.

Checked the other resource-channel subscribes in the file (`3525`, `3619`, `3693`): each subscribes before writing to the channel, so this is the only site with the seed-before-subscribe shape.

Seen on cloud CI: expected `'connected'`, actual `'event'` at the first receive; green on a same-SHA re-run.

## 2. Migrations: `testAppwriteMigrationFunction` — 404 vs expected 201

The test polled the deployment's own `status` to `ready`, then executed. But those are two different writes with a window between them:

- `Functions/Workers/Jobs.php` → `outcome()` writes `'status' => 'ready'` on the deployment, **then** calls `activate()`, which sets the function's `deploymentId` pointer.
- `Functions/Http/Executions/Create.php` reads **that pointer** — `$function->getAttribute('deploymentId', '')` — and throws `DEPLOYMENT_NOT_FOUND` (404) when it points nowhere.

A freshly migrated function has never had an active deployment, so in the window between the two writes the deployment lists as `ready` while execution 404s. That is the observed `Failed asserting that 404 matches expected 201`.

The fix extends the existing `assertEventually` to also require `function.deploymentId` to equal the ready deployment's id — the precondition the execution actually reads, and a state the production writer genuinely reaches. The `201` assertion on the execution itself stays strict, so a real execution failure still fails.

Seen twice on cloud main within a day with the identical signature, on unrelated commits ([91891128393](https://github.com/appwrite-labs/cloud/actions/runs/30877190502/job/91891128393), [91610735214](https://github.com/appwrite-labs/cloud/actions/runs/30789711223/job/91610735214)).

The site-migration sibling polls `ready` but never executes afterwards, so it does not carry the race and is left unchanged.

## Verification

- Both files `php -l` and Pint clean.
- The patched realtime test was run against a local harness and executes cleanly through its fixtures to the websocket connect (the harness lacked a routable realtime service, so the full pass runs here in CI).
- These are timing races, so no local run can demonstrate the red; the diagnosis is the write-order evidence above, matched line-for-line to the CI failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
