### PR TITLE
chore: bump utopia-php/queue to 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "utopia-php/pools": "2.*",
         "utopia-php/span": "3.0.*",
         "utopia-php/preloader": "0.2.*",
-        "utopia-php/queue": "1.0.*",
+        "utopia-php/queue": "^1.0.0",
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "utopia-php/pools": "2.*",
         "utopia-php/span": "3.0.*",
         "utopia-php/preloader": "0.2.*",
-        "utopia-php/queue": "^0.24",
+        "utopia-php/queue": "1.0.*",
         "utopia-php/servers": "0.4.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/storage": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1bdfa80653b02ca0006815cf5f7e163",
+    "content-hash": "d8a70fd5e0008bfc1e81450fa4657cf8",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4474,16 +4474,16 @@
         },
         {
             "name": "utopia-php/platform",
-            "version": "1.0.0-rc15",
+            "version": "1.0.0-rc16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/platform.git",
-                "reference": "e71b97e247d9fcdc07bb350b63aaaf35acad21ff"
+                "reference": "0d270c05fdeef59b6404addd403dbe0eb0b1c0e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/platform/zipball/e71b97e247d9fcdc07bb350b63aaaf35acad21ff",
-                "reference": "e71b97e247d9fcdc07bb350b63aaaf35acad21ff",
+                "url": "https://api.github.com/repos/utopia-php/platform/zipball/0d270c05fdeef59b6404addd403dbe0eb0b1c0e1",
+                "reference": "0d270c05fdeef59b6404addd403dbe0eb0b1c0e1",
                 "shasum": ""
             },
             "require": {
@@ -4492,7 +4492,7 @@
                 "php": ">=8.5",
                 "utopia-php/cli": "^0.24",
                 "utopia-php/http": "^2.0@RC",
-                "utopia-php/queue": "^0.23 || ^0.24",
+                "utopia-php/queue": "0.23.* || 0.24.* || 1.0.*",
                 "utopia-php/servers": "^0.4"
             },
             "type": "library",
@@ -4515,9 +4515,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/platform/issues",
-                "source": "https://github.com/utopia-php/platform/tree/1.0.0-rc15"
+                "source": "https://github.com/utopia-php/platform/tree/1.0.0-rc16"
             },
-            "time": "2026-07-31T09:20:57+00:00"
+            "time": "2026-08-04T06:38:05+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -4722,16 +4722,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "0.24.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "9ac210fb516307b114db1d8972b057206d47257a"
+                "reference": "8054108dd29fe8812ffbcbc8685c2b993a2b17fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/9ac210fb516307b114db1d8972b057206d47257a",
-                "reference": "9ac210fb516307b114db1d8972b057206d47257a",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/8054108dd29fe8812ffbcbc8685c2b993a2b17fa",
+                "reference": "8054108dd29fe8812ffbcbc8685c2b993a2b17fa",
                 "shasum": ""
             },
             "require": {
@@ -4749,6 +4749,7 @@
                 "workerman/workerman": "^4.0"
             },
             "suggest": {
+                "ext-pcntl": "Fallback for Adapter\\KubernetesJob graceful shutdown when Swoole is unavailable.",
                 "ext-swoole": "Needed to support Swoole.",
                 "workerman/workerman": "Needed to support Workerman."
             },
@@ -4779,9 +4780,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/0.24.0"
+                "source": "https://github.com/utopia-php/queue/tree/1.0.0"
             },
-            "time": "2026-07-31T08:38:16+00:00"
+            "time": "2026-08-04T06:22:06+00:00"
         },
         {
             "name": "utopia-php/registry",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8a70fd5e0008bfc1e81450fa4657cf8",
+    "content-hash": "47fed84fa9ca6c3d7da20266a4e04587",
     "packages": [
         {
             "name": "adhocore/jwt",


### PR DESCRIPTION
Bumps `utopia-php/queue` `^0.24` → `1.0.*` and `utopia-php/platform` to `1.0.0-rc16` (which widens its queue constraint to allow 1.0).

Queue [1.0.0](https://github.com/utopia-php/monorepo/releases/tag/queue%2F1.0.0) is 0.24.0 plus the run-to-completion `KubernetesJob` adapter ([utopia-php/monorepo#41](https://github.com/utopia-php/monorepo/pull/41)) — additive; no APIs this repository consumes changed. `Server::start()` now rethrows fatal lifecycle failures after running the error hooks, so a worker that dies at startup exits non-zero for its supervisor instead of exiting 0.

Unblocks running cloud queue workers as KEDA-spawned Kubernetes Jobs ([appwrite-labs/cloud#4563](https://github.com/appwrite-labs/cloud/pull/4563)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)