### PR TITLE
Cover the membership accessedAt privacy policy

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/XList.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Policies/XList.php
@@ -143,6 +143,7 @@ class XList extends Action
                 'userPhone' => $auths['membershipsUserPhone'] ?? false,
                 'userName' => $auths['membershipsUserName'] ?? false,
                 'userMFA' => $auths['membershipsMfa'] ?? false,
+                'userAccessedAt' => $auths['membershipsUserAccessedAt'] ?? false,
             ]),
         ];
     }

--- a/tests/e2e/Services/Project/PoliciesBase.php
+++ b/tests/e2e/Services/Project/PoliciesBase.php
@@ -22,7 +22,7 @@ trait PoliciesBase
             'session-invalidation' => ['enabled'],
             'session-limit' => ['total'],
             'user-limit' => ['total'],
-            'membership-privacy' => ['userId', 'userEmail', 'userPhone', 'userName', 'userMFA'],
+            'membership-privacy' => ['userId', 'userEmail', 'userPhone', 'userName', 'userMFA', 'userAccessedAt'],
         ];
     }
 
@@ -81,6 +81,7 @@ trait PoliciesBase
             'userPhone' => false,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
 
         $passwordDictionary = $this->getPolicy('password-dictionary');
@@ -111,6 +112,7 @@ trait PoliciesBase
         $this->assertSame(false, $membershipPrivacy['body']['userPhone']);
         $this->assertSame(true, $membershipPrivacy['body']['userName']);
         $this->assertSame(true, $membershipPrivacy['body']['userMFA']);
+        $this->assertSame(true, $membershipPrivacy['body']['userAccessedAt']);
 
         // Cleanup
         $this->updatePasswordDictionaryPolicy(false);
@@ -123,6 +125,7 @@ trait PoliciesBase
             'userPhone' => false,
             'userName' => false,
             'userMFA' => false,
+            'userAccessedAt' => false,
         ]);
     }
 
@@ -211,6 +214,7 @@ trait PoliciesBase
             'userPhone' => false,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
 
         $response = $this->listPolicies();
@@ -235,6 +239,7 @@ trait PoliciesBase
         $this->assertSame(false, $byId['membership-privacy']['userPhone']);
         $this->assertSame(true, $byId['membership-privacy']['userName']);
         $this->assertSame(true, $byId['membership-privacy']['userMFA']);
+        $this->assertSame(true, $byId['membership-privacy']['userAccessedAt']);
 
         // Cleanup
         $this->updatePasswordDictionaryPolicy(false);
@@ -247,6 +252,7 @@ trait PoliciesBase
             'userPhone' => false,
             'userName' => false,
             'userMFA' => false,
+            'userAccessedAt' => false,
         ]);
     }
 
@@ -1010,6 +1016,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
 
         $this->assertSame(200, $response['headers']['status-code']);
@@ -1019,6 +1026,7 @@ trait PoliciesBase
         $this->assertSame(true, $response['body']['authMembershipsUserPhone']);
         $this->assertSame(true, $response['body']['authMembershipsUserName']);
         $this->assertSame(true, $response['body']['authMembershipsMfa']);
+        $this->assertSame(true, $response['body']['authMembershipsUserAccessedAt']);
 
         $project = $this->getProjectDocument();
         $this->assertSame(200, $project['headers']['status-code']);
@@ -1027,6 +1035,7 @@ trait PoliciesBase
         $this->assertSame(true, $project['body']['authMembershipsUserPhone']);
         $this->assertSame(true, $project['body']['authMembershipsUserName']);
         $this->assertSame(true, $project['body']['authMembershipsMfa']);
+        $this->assertSame(true, $project['body']['authMembershipsUserAccessedAt']);
     }
 
     public function testUpdateMembershipPrivacyPolicyAllDisabled(): void
@@ -1037,6 +1046,7 @@ trait PoliciesBase
             'userPhone' => false,
             'userName' => false,
             'userMFA' => false,
+            'userAccessedAt' => false,
         ]);
 
         $this->assertSame(200, $response['headers']['status-code']);
@@ -1045,6 +1055,7 @@ trait PoliciesBase
         $this->assertSame(false, $response['body']['authMembershipsUserPhone']);
         $this->assertSame(false, $response['body']['authMembershipsUserName']);
         $this->assertSame(false, $response['body']['authMembershipsMfa']);
+        $this->assertSame(false, $response['body']['authMembershipsUserAccessedAt']);
 
         $project = $this->getProjectDocument();
         $this->assertSame(200, $project['headers']['status-code']);
@@ -1053,6 +1064,7 @@ trait PoliciesBase
         $this->assertSame(false, $project['body']['authMembershipsUserPhone']);
         $this->assertSame(false, $project['body']['authMembershipsUserName']);
         $this->assertSame(false, $project['body']['authMembershipsMfa']);
+        $this->assertSame(false, $project['body']['authMembershipsUserAccessedAt']);
 
         // Cleanup (restore defaults)
         $this->updateMembershipPrivacyPolicy([
@@ -1061,6 +1073,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
     }
 
@@ -1072,6 +1085,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => false,
             'userMFA' => true,
+            'userAccessedAt' => false,
         ]);
 
         $this->assertSame(200, $response['headers']['status-code']);
@@ -1080,6 +1094,7 @@ trait PoliciesBase
         $this->assertSame(true, $response['body']['authMembershipsUserPhone']);
         $this->assertSame(false, $response['body']['authMembershipsUserName']);
         $this->assertSame(true, $response['body']['authMembershipsMfa']);
+        $this->assertSame(false, $response['body']['authMembershipsUserAccessedAt']);
 
         // Cleanup
         $this->updateMembershipPrivacyPolicy([
@@ -1088,6 +1103,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
     }
 
@@ -1100,6 +1116,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
 
         $fields = [
@@ -1108,6 +1125,7 @@ trait PoliciesBase
             'userPhone' => 'authMembershipsUserPhone',
             'userName' => 'authMembershipsUserName',
             'userMFA' => 'authMembershipsMfa',
+            'userAccessedAt' => 'authMembershipsUserAccessedAt',
         ];
 
         // Each field can be toggled individually without clobbering the others
@@ -1138,16 +1156,19 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
 
         $response = $this->updateMembershipPrivacyPolicy([
             'userId' => false,
             'userPhone' => false,
+            'userAccessedAt' => false,
         ]);
 
         $this->assertSame(200, $response['headers']['status-code']);
         $this->assertSame(false, $response['body']['authMembershipsUserId']);
         $this->assertSame(false, $response['body']['authMembershipsUserPhone']);
+        $this->assertSame(false, $response['body']['authMembershipsUserAccessedAt']);
         $this->assertSame(true, $response['body']['authMembershipsUserEmail']);
         $this->assertSame(true, $response['body']['authMembershipsUserName']);
         $this->assertSame(true, $response['body']['authMembershipsMfa']);
@@ -1159,6 +1180,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
     }
 
@@ -1171,6 +1193,7 @@ trait PoliciesBase
             'userPhone' => false,
             'userName' => false,
             'userMFA' => false,
+            'userAccessedAt' => false,
         ]);
 
         $response = $this->updateMembershipPrivacyPolicy([]);
@@ -1180,6 +1203,7 @@ trait PoliciesBase
         $this->assertSame(false, $response['body']['authMembershipsUserPhone']);
         $this->assertSame(false, $response['body']['authMembershipsUserName']);
         $this->assertSame(false, $response['body']['authMembershipsMfa']);
+        $this->assertSame(false, $response['body']['authMembershipsUserAccessedAt']);
 
         // Cleanup
         $this->updateMembershipPrivacyPolicy([
@@ -1188,6 +1212,7 @@ trait PoliciesBase
             'userPhone' => true,
             'userName' => true,
             'userMFA' => true,
+            'userAccessedAt' => true,
         ]);
     }
 

--- a/tests/e2e/Services/Project/PoliciesMembershipPrivacyIntegrationTest.php
+++ b/tests/e2e/Services/Project/PoliciesMembershipPrivacyIntegrationTest.php
@@ -205,4 +205,185 @@ final class PoliciesMembershipPrivacyIntegrationTest extends Scope
         $this->assertFalse($membershipsByUser[$user2Id]['mfa']);
         $this->assertNotEmpty($membershipsByUser[$user2Id]['userAccessedAt']);
     }
+
+    public function testMembershipUserAccessedAtDefault(): void
+    {
+        // A project that never set the policy hides the last access time
+        $project = $this->getProject(true);
+        $projectId = $project['$id'];
+
+        $serverHeaders = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-key' => $project['apiKey'],
+        ];
+
+        $policy = $this->client->call(Client::METHOD_GET, '/project/policies/membership-privacy', $serverHeaders);
+        $this->assertSame(200, $policy['headers']['status-code']);
+        $this->assertFalse($policy['body']['userAccessedAt']);
+
+        $member = $this->createTeamWithMember($projectId, $serverHeaders);
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships', $member['clientHeaders']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertCount(1, $response['body']['memberships']);
+        $this->assertSame('', $response['body']['memberships'][0]['userAccessedAt']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships/' . $member['membershipId'], $member['clientHeaders']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['userAccessedAt']);
+
+        // The policy only applies to client requests, an API key still sees it
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships/' . $member['membershipId'], $serverHeaders);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertNotEmpty($response['body']['userAccessedAt']);
+    }
+
+    public function testMembershipUserAccessedAtPolicy(): void
+    {
+        $projectId = $this->getProject()['$id'];
+
+        $serverHeaders = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+            'x-appwrite-response-format' => '1.9.4',
+        ];
+
+        $setAccessedAt = function (bool $visible) use ($serverHeaders): void {
+            $response = $this->client->call(Client::METHOD_PATCH, '/project/policies/membership-privacy', $serverHeaders, [
+                'userAccessedAt' => $visible,
+            ]);
+            $this->assertSame(200, $response['headers']['status-code']);
+            $this->assertSame($visible, $response['body']['authMembershipsUserAccessedAt']);
+        };
+
+        $readPolicy = function () use ($serverHeaders): array {
+            $get = $this->client->call(Client::METHOD_GET, '/project/policies/membership-privacy', $serverHeaders);
+            $this->assertSame(200, $get['headers']['status-code']);
+
+            $list = $this->client->call(Client::METHOD_GET, '/project/policies', $serverHeaders);
+            $this->assertSame(200, $list['headers']['status-code']);
+
+            $byId = [];
+            foreach ($list['body']['policies'] as $policy) {
+                $byId[$policy['$id']] = $policy;
+            }
+            $this->assertArrayHasKey('membership-privacy', $byId);
+
+            // Both endpoints report the same policy
+            $this->assertSame($get['body'], $byId['membership-privacy']);
+
+            return $get['body'];
+        };
+
+        // Only userAccessedAt is toggled below, the rest must survive untouched
+        $response = $this->client->call(Client::METHOD_PATCH, '/project/policies/membership-privacy', $serverHeaders, [
+            'userId' => true,
+            'userEmail' => true,
+            'userPhone' => true,
+            'userName' => true,
+            'userMFA' => true,
+            'userAccessedAt' => false,
+        ]);
+        $this->assertSame(200, $response['headers']['status-code']);
+
+        $member = $this->createTeamWithMember($projectId, $serverHeaders);
+
+        $policy = $readPolicy();
+        $this->assertFalse($policy['userAccessedAt']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships/' . $member['membershipId'], $member['clientHeaders']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['userAccessedAt']);
+
+        $setAccessedAt(true);
+
+        $policy = $readPolicy();
+        $this->assertTrue($policy['userAccessedAt']);
+        $this->assertTrue($policy['userId']);
+        $this->assertTrue($policy['userEmail']);
+        $this->assertTrue($policy['userPhone']);
+        $this->assertTrue($policy['userName']);
+        $this->assertTrue($policy['userMFA']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships/' . $member['membershipId'], $member['clientHeaders']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertNotEmpty($response['body']['userAccessedAt']);
+        $this->assertNotFalse(\strtotime($response['body']['userAccessedAt']));
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships', $member['clientHeaders']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertCount(1, $response['body']['memberships']);
+        $this->assertNotEmpty($response['body']['memberships'][0]['userAccessedAt']);
+
+        $setAccessedAt(false);
+
+        $this->assertFalse($readPolicy()['userAccessedAt']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/teams/' . $member['teamId'] . '/memberships', $member['clientHeaders']);
+        $this->assertSame(200, $response['headers']['status-code']);
+        $this->assertSame('', $response['body']['memberships'][0]['userAccessedAt']);
+    }
+
+    /**
+     * Create a team with a single member, signed in, whose accessedAt is populated.
+     *
+     * @param  array<string, string>  $serverHeaders
+     * @return array{teamId: string, membershipId: string, clientHeaders: array<string, string>}
+     */
+    private function createTeamWithMember(string $projectId, array $serverHeaders): array
+    {
+        $email = 'member_' . uniqid() . '@localhost.test';
+        $name = 'Casey Carter';
+        $password = 'password1234';
+
+        $user = $this->client->call(Client::METHOD_POST, '/users', $serverHeaders, [
+            'userId' => ID::unique(),
+            'email' => $email,
+            'password' => $password,
+            'name' => $name,
+        ]);
+        $this->assertSame(201, $user['headers']['status-code']);
+
+        $team = $this->client->call(Client::METHOD_POST, '/teams', $serverHeaders, [
+            'teamId' => ID::unique(),
+            'name' => 'Access Team',
+            'roles' => ['member'],
+        ]);
+        $this->assertSame(201, $team['headers']['status-code']);
+
+        $membership = $this->client->call(Client::METHOD_POST, '/teams/' . $team['body']['$id'] . '/memberships', $serverHeaders, [
+            'userId' => $user['body']['$id'],
+            'roles' => ['member'],
+        ]);
+        $this->assertSame(201, $membership['headers']['status-code']);
+
+        $session = $this->client->call(Client::METHOD_POST, '/account/sessions/email', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], [
+            'email' => $email,
+            'password' => $password,
+        ]);
+        $this->assertSame(201, $session['headers']['status-code']);
+
+        $clientHeaders = [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'cookie' => 'a_session_' . $projectId . '=' . $session['cookies']['a_session_' . $projectId],
+        ];
+
+        // Populate accessedAt
+        $response = $this->client->call(Client::METHOD_GET, '/account', $clientHeaders);
+        $this->assertSame(200, $response['headers']['status-code']);
+
+        return [
+            'teamId' => $team['body']['$id'],
+            'membershipId' => $membership['body']['$id'],
+            'clientHeaders' => $clientHeaders,
+        ];
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Adds test coverage for the `userAccessedAt` membership privacy policy, which was only exercised by two assertions in the memberships list.

While writing the tests I found that `GET /v1/project/policies` built the `membership-privacy` document without `userAccessedAt`, so the response model filled it from its default and the list always reported the policy as disabled — disagreeing with `GET /v1/project/policies/membership-privacy`, which returned the real value. That one-line omission is fixed in the first commit.

Coverage added:

* `PoliciesBase` — `userAccessedAt` is now part of the expected policy fields, the get/list "reflects updates" assertions, and the all-enabled, all-disabled, mixed, individual-fields, multiple-fields, and empty-body update tests, matching how the other five flags are covered. This runs in both the console client and custom server suites.
* `PoliciesMembershipPrivacyIntegrationTest` — two tests: a project that never set the policy reports `false` and hides the value from a session user while an API key still sees it; and toggling only `userAccessedAt` flips visibility on both `GET /v1/teams/:teamId/memberships/:membershipId` (previously untested) and the list, leaves the other flags untouched, and is reported identically by both policy read endpoints.

Unlike the other membership privacy flags, `userAccessedAt` is not written into `auths` when a project is created, so its default comes from the `?? false` fallbacks — the new default test pins that behaviour.

## Test Plan

```
docker compose exec appwrite test tests/e2e/Services/Project/PoliciesMembershipPrivacyIntegrationTest.php
docker compose exec appwrite test tests/e2e/Services/Project/PoliciesCustomServerTest.php
docker compose exec appwrite test tests/e2e/Services/Project/PoliciesConsoleClientTest.php
```

Pint passes on the changed files. The suites have not been run locally — the `appwrite` container is not up in my environment — so CI is the first execution of these tests.

## Related PRs and Issues

None.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.