### PR TITLE
Announce immediate async executions on the bus at submission

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Executions/Create.php
@@ -332,12 +332,12 @@ class Create extends Base
                     ->setAttribute('scheduleId', $schedule->getId())
                     ->setAttribute('scheduleInternalId', $schedule->getSequence())
                     ->setAttribute('scheduledAt', $scheduledAt);
-
-                $bus->dispatch(new ExecutionScheduled(
-                    execution: $execution->getArrayCopy(),
-                    project: $project->getArrayCopy(),
-                ));
             }
+
+            $bus->dispatch(new ExecutionScheduled(
+                execution: $execution->getArrayCopy(),
+                project: $project->getArrayCopy(),
+            ));
 
             if ($executionsRetentionCount > 0 && ENABLE_EXECUTIONS_LIMIT_ON_ROUTE) {
                 $publisherForDeletes->enqueue(new DeleteMessage(


### PR DESCRIPTION
## What does this PR do?

Moves the `ExecutionScheduled` dispatch in `POST /v1/functions/:functionId/executions` out of the `scheduledAt` branch so **both** async branches announce the accepted execution on the bus. The immediate-async branch previously enqueued the function message and returned 202 without dispatching anything.

## Why?

Since 185cf7f76b dropped executions writes from server-ce, the platform consuming these bus events (cloud) is the only writer of the executions collection. An immediate async submission never announced itself, so no pending document could be persisted anywhere: `GET /v1/functions/{functionId}/executions/{executionId}` returned 404 from the 202 until the run completed — up to the function's full 900s timeout — while the create endpoint's own description promises "You can ping the `Get Execution` endpoint to get updates on the current execution status". It also left nothing in place for downstream stuck-execution handling, which needs a pending document to exist.

The scheduled branch already solved exactly this with `ExecutionScheduled`; this extends the same announcement to the immediate branch. The request path stays free of database writes — subscribers decide what to persist.

## Behavior in server-ce standalone

None of server-ce's listeners (`Mails`, `Usage`) subscribe to `ExecutionScheduled`, so this is a no-op standalone: no extra usage counting, no writes. `Usage` counts executions on `ExecutionCompleted` only.

## Test coverage

The seam this fixes spans submission → bus → executions queue → executions worker, which only exists on cloud. The failing-without / passing-with regression test (`testAsyncExecutionVisibleBeforeCompletion`) lands in cloud's `tests/e2e/Services/Functions/FunctionsCustomServerTest.php` together with the consumer-side hardening (insert-only pending writes, per-tenant shedding); there is no observable behavior to assert in server-ce alone.

Related documented design context: cloud commit 71739a4d7f (2026-08-04) budgets this exact visibility window in E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)