### PR TITLE
fix(usage): type text embedding metrics as lists and scalar totals

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/UsageProject.php
+++ b/src/Appwrite/Utopia/Response/Model/UsageProject.php
@@ -308,46 +308,50 @@ class UsageProject extends Model
                 'type' => Response::MODEL_METRIC,
                 'description' => 'Aggregated number of text embedding calls per period.',
                 'default' => [],
-                'example' => []
+                'example' => [],
+                'array' => true
             ])
             ->addRule('embeddingsTextTokens', [
                 'type' => Response::MODEL_METRIC,
                 'description' => 'Aggregated number of tokens processed by text embeddings per period.',
                 'default' => [],
-                'example' => []
+                'example' => [],
+                'array' => true
             ])
             ->addRule('embeddingsTextDuration', [
                 'type' => Response::MODEL_METRIC,
                 'description' => 'Aggregated duration spent generating text embeddings per period.',
                 'default' => [],
-                'example' => []
+                'example' => [],
+                'array' => true
             ])
             ->addRule('embeddingsTextErrors', [
                 'type' => Response::MODEL_METRIC,
                 'description' => 'Aggregated number of errors while generating text embeddings per period.',
                 'default' => [],
-                'example' => []
+                'example' => [],
+                'array' => true
             ])
             ->addRule('embeddingsTextTotal', [
-                'type' => Response::MODEL_METRIC,
+                'type' => self::TYPE_INTEGER,
                 'description' => 'Total aggregated number of text embedding calls.',
                 'default' => 0,
                 'example' => 0
             ])
             ->addRule('embeddingsTextTokensTotal', [
-                'type' => Response::MODEL_METRIC,
+                'type' => self::TYPE_INTEGER,
                 'description' => 'Total aggregated number of tokens processed by text.',
                 'default' => 0,
                 'example' => 0
             ])
             ->addRule('embeddingsTextDurationTotal', [
-                'type' => Response::MODEL_METRIC,
+                'type' => self::TYPE_INTEGER,
                 'description' => 'Total aggregated duration spent generating text embeddings.',
                 'default' => 0,
                 'example' => 0
             ])
             ->addRule('embeddingsTextErrorsTotal', [
-                'type' => Response::MODEL_METRIC,
+                'type' => self::TYPE_INTEGER,
                 'description' => 'Total aggregated number of errors while generating text embeddings.',
                 'default' => 0,
                 'example' => 0

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -22,6 +22,7 @@ use Appwrite\Utopia\Response\Model\AlgoSha;
 use Appwrite\Utopia\Response\Model\AttributeLine;
 use Appwrite\Utopia\Response\Model\Error as ErrorModel;
 use Appwrite\Utopia\Response\Model\HealthStatus;
+use Appwrite\Utopia\Response\Model\Metric;
 use Appwrite\Utopia\Response\Model\None as NoneModel;
 use Appwrite\Utopia\Response\Model\PlatformAndroid;
 use Appwrite\Utopia\Response\Model\PlatformApple;
@@ -32,6 +33,7 @@ use Appwrite\Utopia\Response\Model\PlatformWindows;
 use Appwrite\Utopia\Response\Model\Preferences;
 use Appwrite\Utopia\Response\Model\Provider;
 use Appwrite\Utopia\Response\Model\Team;
+use Appwrite\Utopia\Response\Model\UsageProject;
 use Appwrite\Utopia\Response\Model\User;
 use Appwrite\Utopia\Response\Model\Webhook;
 use PHPUnit\Framework\TestCase;
@@ -317,6 +319,56 @@ final class FormatTest extends TestCase
         $this->assertSame('object', $openApiPrefs['type']);
         $this->assertSame([['$ref' => '#/components/schemas/preferences']], $openApiPrefs['allOf']);
 
+    }
+
+    /**
+     * The project usage handler writes the text embedding metrics as four
+     * per-period lists plus four scalar totals. A typed SDK generated from a
+     * schema that calls all eight a single metric object rejects every valid
+     * response, so pin the emitted schema rather than the rule table.
+     */
+    public function testUsageProjectEmbeddingsTextSchema(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/usage'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getUsageTest',
+                description: 'Get test.',
+                auth: [],
+                responses: [
+                    new SDKResponse(
+                        code: 200,
+                        model: Response::MODEL_USAGE_PROJECT,
+                    ),
+                ],
+            ));
+
+        $models = [
+            new UsageProject(),
+            new Metric(),
+            new ErrorModel(),
+        ];
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], $models, [], 0, 'console'))->parse();
+
+        $properties = $openApi['components']['schemas']['usageProject']['properties'];
+
+        foreach (['embeddingsText', 'embeddingsTextTokens', 'embeddingsTextDuration', 'embeddingsTextErrors'] as $key) {
+            $this->assertSame('array', $properties[$key]['type'], $key);
+            $this->assertSame(['$ref' => '#/components/schemas/metric'], $properties[$key]['items'], $key);
+            $this->assertArrayNotHasKey('allOf', $properties[$key], $key);
+        }
+
+        foreach (['embeddingsTextTotal', 'embeddingsTextTokensTotal', 'embeddingsTextDurationTotal', 'embeddingsTextErrorsTotal'] as $key) {
+            $this->assertSame('integer', $properties[$key]['type'], $key);
+            $this->assertArrayNotHasKey('allOf', $properties[$key], $key);
+            $this->assertArrayNotHasKey('items', $properties[$key], $key);
+        }
     }
 
     public function testArrayItemsSchemaInfersTypesFromJsonStringExamples(): void


### PR DESCRIPTION
## What

`UsageProject` declared the four per-period text embedding fields without `'array' => true`, and the four `*Total` fields as `Response::MODEL_METRIC`. The generated schema therefore called all eight a single required `metric` object.

The handler writes something else entirely (`app/controllers/api/project.php:340-347` in cloud):

```php
'embeddingsText'      => $usage[METRIC_EMBEDDINGS_TEXT] ?? [],   // list of metric documents
...
'embeddingsTextTotal' => $total[METRIC_EMBEDDINGS_TEXT] ?? 0,    // scalar
```

So every typed SDK generated from that schema rejects every valid `/project/usage` response. `appwrite-console` 0.2.1 fails validation on all eight fields before the caller ever sees the payload:

```
error_count: 8
embeddingsText               model_type input=[]
embeddingsTextTokens         model_type input=[]
embeddingsTextDuration       model_type input=[]
embeddingsTextErrors         model_type input=[]
embeddingsTextTotal          model_type input=0
embeddingsTextTokensTotal    model_type input=0
embeddingsTextDurationTotal  model_type input=0
embeddingsTextErrorsTotal    model_type input=0
```

This breaks `project_get_usage` in the Appwrite MCP server, which depends on the typed SDK. Introduced in f3721f712a1e2e5488c05188c0aec5760b4a6998.

## Change

- `embeddingsText`, `embeddingsTextTokens`, `embeddingsTextDuration`, `embeddingsTextErrors` → added `'array' => true`
- `embeddingsTextTotal`, `embeddingsTextTokensTotal`, `embeddingsTextDurationTotal`, `embeddingsTextErrorsTotal` → `Response::MODEL_METRIC` → `self::TYPE_INTEGER`

All four totals are integers, including duration: `$totalDuration` accumulates from `0` in `Embeddings/Text/Create.php`, and `Metric.value` is `TYPE_INTEGER`. This also matches every other `*Total` rule in the model.

## Test

`FormatTest::testUsageProjectEmbeddingsTextSchema` pins the emitted OpenAPI schema — array-of-`metric` for the four lists, `integer` for the four totals, no `allOf` on either.

It asserts the schema rather than the runtime response deliberately. My first attempt drove `Response::output()` and **passed without the fix** — `output()` passes lists and ints through regardless of the declared rule, so this defect is invisible at runtime and exists only in generated output. That test was discarded.

Seen red with the model change reverted:

```
1) Tests\Unit\SDK\Specification\FormatTest::testUsageProjectEmbeddingsTextSchema
embeddingsText
Failed asserting that two strings are identical.
-'array'
+'object'
```

Green with it. Full `FormatTest` green (19 tests, 101 assertions). Pint passes.

No spec regeneration here: `app/config/specs/*.json` in this repo is a version-pinned 1.9.x snapshot, not per-PR output.

## Follow-ups (other repos)

1. `appwrite-labs/cloud` — regenerate `app/config/specs/*.json` (cloud is the only consumer of this model; it extends `UsageProject` and does not override these rules)
2. regenerate and release `appwrite-console`
3. refresh the MCP server lockfile
