### PR TITLE
fix(sdk): emit path parameters as required

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -832,6 +832,13 @@ class OpenAPI3 extends Format
 
                     if ($parameterNode['path']) { // Param is in URL path (directly or through alias)
                         $node['in'] = 'path';
+                        // A route only matches when every path segment is present, so a
+                        // path parameter is always supplied whatever the PHP param says.
+                        // OpenAPI requires `required: true` here, and generators emit a
+                        // bare identifier for the path substitution — an optional one
+                        // becomes an undefined reference (Go) or interpolates the
+                        // absent value into the URL (Python).
+                        $node['required'] = true;
                         $methodTemp['parameters'][] = $node;
                     } elseif (\in_array($method, ['GET', 'DELETE'], true)) { // Param is in query
                         $node['in'] = 'query';

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -322,6 +322,48 @@ final class FormatTest extends TestCase
     }
 
     /**
+     * A route only matches when every path segment is present, so a path
+     * parameter is always supplied no matter what the PHP param declares.
+     * Marking one optional produced a Go SDK that does not compile
+     * (`undefined: SessionId`) and a Python SDK that requested
+     * `/account/sessions/None`.
+     */
+    public function testOptionalPathParameterIsEmittedAsRequired(): void
+    {
+        Method::$processed = [];
+        Method::$errors = [];
+
+        $route = (new Route('GET', '/v1/tests/:sessionId'))
+            ->desc('Get test')
+            ->label('sdk', new Method(
+                namespace: 'test',
+                group: null,
+                name: 'getPathTest',
+                description: 'Get test.',
+                auth: [],
+                responses: [
+                    new SDKResponse(code: 200, model: Response::MODEL_NONE),
+                ],
+            ))
+            ->param('sessionId', 'current', new Text(256), 'Session ID.', true)
+            ->param('filter', '', new Text(256), 'Optional query filter.', true);
+
+        $openApi = (new OpenAPI3(new Container(), [], [$route], [new NoneModel()], [], 0, 'console'))->parse();
+
+        $parameters = [];
+        foreach ($openApi['paths']['/tests/{sessionId}']['get']['parameters'] as $parameter) {
+            $parameters[$parameter['name']] = $parameter;
+        }
+
+        $this->assertSame('path', $parameters['sessionId']['in']);
+        $this->assertTrue($parameters['sessionId']['required']);
+
+        // An optional query parameter is untouched — only the path is forced.
+        $this->assertSame('query', $parameters['filter']['in']);
+        $this->assertFalse($parameters['filter']['required']);
+    }
+
+    /**
      * The project usage handler writes the text embedding metrics as four
      * per-period lists plus four scalar totals. A typed SDK generated from a
      * schema that calls all eight a single metric object rejects every valid


### PR DESCRIPTION
## What

Three routes mark a **path** parameter optional:

```php
Http::get('/v1/account/sessions/:sessionId')
    ->param('sessionId', 'current', fn (...) => new UID(...), '... Defaults to \'current\'.', true, ['dbForProject'])
```

(same on the `DELETE` and `PATCH` of that path). The spec faithfully emits `in: path` with `required: false`, and that breaks every generated client.

**Go no longer compiles.** The template emits a bare identifier for the path substitution, which only exists when the parameter is a function argument:

```go
func (srv *Account) GetSession(optionalSetters ...GetSessionOption)(*models.Session, error) {
	r := strings.NewReplacer("{sessionId}", SessionId)   // undefined: SessionId
```

```
# github.com/appwrite/sdk-for-go/v6/account
account/account.go:2049:42: undefined: SessionId
account/account.go:2111:42: undefined: SessionId
account/account.go:2175:42: undefined: SessionId
```

**Python compiles but builds a wrong URL.** `session_id` became `Optional[str] = None`, the `None` guard is gone, and the absent value is interpolated into the path:

```python
def get_session(self, session_id: Optional[str] = None) -> Session:
    api_path = '/account/sessions/{sessionId}'
    api_path = api_path.replace('{sessionId}', str(self._normalize_value(session_id)))
    # get_session()  ->  GET /account/sessions/None
```

Both are regressions against what is published today (`sdk-for-go` v6.1.0 and `appwrite-console` 0.2.1 both take `sessionId` as required and are correct).

## Fix

Force `required: true` for `in: path` in the formatter, rather than fixing the three routes.

A route only matches when every path segment is present — `GET /v1/account/sessions/` does not route to `:sessionId` — so a path parameter is *always* supplied regardless of what the PHP param declares. The optional flag is unrepresentable at the HTTP level, and OpenAPI 3 states that for `in: path`, `required` is REQUIRED and MUST be `true`. Fixing it centrally also stops the next optional path param from silently breaking a client.

Runtime behaviour is unchanged: the PHP default still applies, and no route, validator or handler is touched. Only generated clients change, and they change back to what they were.

## Test

`FormatTest::testOptionalPathParameterIsEmittedAsRequired` builds a route with an optional path param *and* an optional query param, then asserts the path one is emitted `required: true` while the query one keeps `required: false` — so the fix is scoped to the path.

Seen red with the one-line change stashed (`Failed asserting that false is true.`), green with it. Full `FormatTest` green: 20 tests, 105 assertions. Pint passes.

## Verified downstream

Regenerated the specs and both SDKs in `appwrite-labs/cloud`:

- `go build ./...` clean, `go vet ./...` clean
- `get_session(session_id: str)` back to required with its `None` guard restored

Both SDK releases were blocked on this.
