### PR TITLE
Bump appwrite/geo to 0.3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1169,7 +1169,7 @@ services:
       options:
         max-file: "5"
         max-size: 10m
-    image: appwrite/geo:0.3.0
+    image: appwrite/geo:0.3.1
     restart: unless-stopped
     networks:
       - appwrite

--- a/docs/tutorials/multi-architecture-support.md
+++ b/docs/tutorials/multi-architecture-support.md
@@ -10,7 +10,7 @@ CPU architecture support for Docker images used by the Appwrite stack. Platforms
 | appwrite/assistant:0.8.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | appwrite/browser:0.3.3 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | appwrite/embedding:0.1.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
-| appwrite/geo:0.3.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/geo:0.3.1 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | appwrite/postgres:0.1.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | openruntimes/executor:0.25.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | ghcr.io/open-runtimes/orchestrator/jobs-service:0.13.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |


### PR DESCRIPTION
## What does this PR do?

Bumps the bundled `appwrite-geo` service from `appwrite/geo:0.3.0` to [`0.3.1`](https://github.com/appwrite/docker-geo/releases/tag/0.3.1).

The only change in the geo release is a refresh of the bundled free-tier [DB-IP Country Lite](https://db-ip.com/db/download/ip-to-country) database — from the `2026-06` build to `2026-08` — so IP-to-country lookups reflect recent address-block reallocations. No API, config, or env-var changes; `_APP_GEO_ENDPOINT` / `_APP_GEO_SECRET` are untouched.

Files changed:
- `docker-compose.yml` — the `appwrite-geo` service image tag
- `docs/tutorials/multi-architecture-support.md` — the version in the image support table

## Test Plan

- `appwrite/geo:0.3.1` is published on Docker Hub with a multi-arch manifest covering `linux/amd64` and `linux/arm64` — same platforms as `0.3.0`, so the support row is unchanged apart from the tag.
- The geo release itself was verified upstream: the new database is a valid MMDB (binary format 2.0, `DBIP-Country-Lite`, build date 2026-08-01), the record shape is unchanged, and appwrite/docker-geo#8 passed its E2E suite against it.

## Related PRs and Issues

- appwrite/docker-geo#8 — the database upgrade
- https://github.com/appwrite/docker-geo/releases/tag/0.3.1

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/main/CONTRIBUTING.md)?

Yes.