### PR TITLE
feat(vcs): report deployment state as GitHub check runs

### DIFF
--- a/app/config/collections/projects.php
+++ b/app/config/collections/projects.php
@@ -1726,6 +1726,17 @@ return [
                 'array' => false,
             ],
             [
+                '$id' => ID::custom('providerCheckRunId'),
+                'type' => Database::VAR_INTEGER,
+                'format' => '',
+                'size' => 8,
+                'signed' => false,
+                'required' => false,
+                'default' => null,
+                'array' => false,
+                'filters' => [],
+            ],
+            [
                 '$id' => ID::custom('sourceSize'),
                 'type' => Database::VAR_INTEGER,
                 'format' => '',

--- a/src/Appwrite/Deployment/GitAction.php
+++ b/src/Appwrite/Deployment/GitAction.php
@@ -21,8 +21,6 @@ final class GitAction
 {
     /**
      * Resolve the provider for a deployment and report a build state to it.
-     * Best-effort: a deployment that never came from git, or whose installation
-     * is gone, reports nothing.
      */
     public static function report(
         string $status,
@@ -73,9 +71,8 @@ final class GitAction
         $checkRunId = (int) $deployment->getAttribute('providerCheckRunId', 0);
         $silent = $resource->getAttribute('providerSilentMode', false) === true;
 
-        // A run Appwrite opened is always closed. Silent mode is force-set when a
-        // resource is disconnected from git, which would otherwise leave the check
-        // spinning on the commit for good.
+        // Silent mode is force-set on git disconnect, so return only once any run
+        // we opened has been closed.
         if ($silent && $checkRunId <= 0) {
             return;
         }
@@ -95,8 +92,7 @@ final class GitAction
                 'ready' => 'success',
                 'failed' => 'failure',
                 'processing' => 'pending',
-                // A commit status has no canceled state, and reporting one as
-                // failed would misrepresent it. Only a check run says this.
+                // No commit status says canceled, and failed would misrepresent it.
                 'canceled' => '',
                 default => $status
             };
@@ -115,7 +111,6 @@ final class GitAction
             };
 
             if ($checkRunId > 0) {
-                // 'processing' leaves the run as it is — it was opened in progress.
                 if (!empty($conclusion)) {
                     $title = match ($status) {
                         'ready' => 'Deployment ready',

--- a/src/Appwrite/Deployment/GitAction.php
+++ b/src/Appwrite/Deployment/GitAction.php
@@ -4,6 +4,7 @@ namespace Appwrite\Deployment;
 
 use Appwrite\Vcs\CheckRuns;
 use Appwrite\Vcs\Comment;
+use Appwrite\Vcs\Factory as VcsFactory;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
@@ -18,6 +19,45 @@ use Utopia\VCS\Adapter\Git;
  */
 final class GitAction
 {
+    /**
+     * Resolve the provider for a deployment and report a build state to it.
+     * Best-effort: a deployment that never came from git, or whose installation
+     * is gone, reports nothing.
+     */
+    public static function report(
+        string $status,
+        Document $deployment,
+        Document $project,
+        Database $dbForProject,
+        Database $dbForPlatform,
+        VcsFactory $vcsFactory,
+        array $platform,
+    ): void {
+        if ($deployment->getAttribute('providerCommitHash', '') === '' && $deployment->getAttribute('providerCommentId', '') === '') {
+            return;
+        }
+
+        $resource = $dbForProject->getDocument($deployment->getAttribute('resourceType', 'functions'), $deployment->getAttribute('resourceId'));
+        $installation = $dbForPlatform->getDocument('installations', $resource->getAttribute('installationId', ''));
+
+        if ($resource->isEmpty() || $installation->getAttribute('providerInstallationId', '') === '') {
+            return;
+        }
+
+        self::run(
+            $status,
+            $vcsFactory->fromInstallation($installation),
+            $deployment->getAttribute('providerCommitHash', ''),
+            $deployment->getAttribute('providerRepositoryOwner', ''),
+            $deployment->getAttribute('providerRepositoryName', ''),
+            $project,
+            $resource,
+            $deployment,
+            $dbForPlatform,
+            $platform,
+        );
+    }
+
     public static function run(
         string $status,
         Git $vcs,
@@ -55,6 +95,9 @@ final class GitAction
                 'ready' => 'success',
                 'failed' => 'failure',
                 'processing' => 'pending',
+                // A commit status has no canceled state, and reporting one as
+                // failed would misrepresent it. Only a check run says this.
+                'canceled' => '',
                 default => $status
             };
 
@@ -82,7 +125,7 @@ final class GitAction
 
                     (new CheckRuns())->close($vcs, $owner, $repositoryName, $checkRunId, $conclusion, $title, $message, $targetUrl);
                 }
-            } elseif (!$silent) {
+            } elseif (!empty($state)) {
                 $vcs->updateCommitStatus($repositoryName, $commitHash, $owner, $state, $message, $targetUrl, $name);
             }
         }

--- a/src/Appwrite/Deployment/GitAction.php
+++ b/src/Appwrite/Deployment/GitAction.php
@@ -12,10 +12,11 @@ use Utopia\System\System;
 use Utopia\VCS\Adapter\Git;
 
 /**
- * Reports a deployment build state to the VCS provider: a commit status and,
- * for pull-request deployments, the PR comment listing the build with its
- * console and preview links. Shared by both build backends; callers own
- * error handling — a failed report never fails a build.
+ * Reports a deployment build state to the VCS provider: the check run opened
+ * when the deployment was triggered, or a commit status where no run was opened,
+ * and for pull-request deployments the PR comment listing the build with its
+ * console and preview links. Shared by both build backends; callers own error
+ * handling — a failed report never fails a build.
  */
 final class GitAction
 {

--- a/src/Appwrite/Deployment/GitAction.php
+++ b/src/Appwrite/Deployment/GitAction.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Deployment;
 
+use Appwrite\Vcs\CheckRuns;
 use Appwrite\Vcs\Comment;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -29,7 +30,13 @@ final class GitAction
         Database $dbForPlatform,
         array $platform,
     ): void {
-        if ($resource->getAttribute('providerSilentMode', false) === true) {
+        $checkRunId = (int) $deployment->getAttribute('providerCheckRunId', 0);
+        $silent = $resource->getAttribute('providerSilentMode', false) === true;
+
+        // A run Appwrite opened is always closed. Silent mode is force-set when a
+        // resource is disconnected from git, which would otherwise leave the check
+        // spinning on the commit for good.
+        if ($silent && $checkRunId <= 0) {
             return;
         }
 
@@ -41,6 +48,7 @@ final class GitAction
                 'ready' => 'Build succeeded.',
                 'failed' => 'Build failed.',
                 'processing' => 'Building...',
+                'canceled' => 'Build canceled.',
                 default => $status
             };
             $state = match ($status) {
@@ -56,7 +64,31 @@ final class GitAction
             $targetUrl = "{$protocol}://{$hostname}/console/project-{$region}-{$project->getId()}/{$segment}";
             $name = $resource->getAttribute('name') . ' (' . $project->getAttribute('name') . ')';
 
-            $vcs->updateCommitStatus($repositoryName, $commitHash, $owner, $state, $message, $targetUrl, $name);
+            $conclusion = match ($status) {
+                'ready' => CheckRuns::CONCLUSION_SUCCESS,
+                'failed' => CheckRuns::CONCLUSION_FAILURE,
+                'canceled' => CheckRuns::CONCLUSION_CANCELLED,
+                default => ''
+            };
+
+            if ($checkRunId > 0) {
+                // 'processing' leaves the run as it is — it was opened in progress.
+                if (!empty($conclusion)) {
+                    $title = match ($status) {
+                        'ready' => 'Deployment ready',
+                        'failed' => 'Deployment failed',
+                        default => 'Deployment canceled'
+                    };
+
+                    (new CheckRuns())->close($vcs, $owner, $repositoryName, $checkRunId, $conclusion, $title, $message, $targetUrl);
+                }
+            } elseif (!$silent) {
+                $vcs->updateCommitStatus($repositoryName, $commitHash, $owner, $state, $message, $targetUrl, $name);
+            }
+        }
+
+        if ($silent) {
+            return;
         }
 
         $commentId = $deployment->getAttribute('providerCommentId', '');

--- a/src/Appwrite/Migration/Version/V25.php
+++ b/src/Appwrite/Migration/Version/V25.php
@@ -124,6 +124,20 @@ class V25 extends Migration
                     }
                     break;
 
+                case 'deployments':
+                    if ($collectionType === 'projects') {
+                        $attributes = ['providerCheckRunId'];
+                        try {
+                            $this->createAttributesFromCollection($this->dbForProject, $id, $attributes);
+                        } catch (Throwable $th) {
+                            Console::warning('Failed to create attributes "' . \implode(', ', $attributes) . "\" in collection {$id}: {$th->getMessage()}");
+                        }
+
+                        $this->dbForProject->purgeCachedCollection($id);
+                        $this->dbForProject->purgeCachedDocument(Database::METADATA, $id);
+                    }
+                    break;
+
                 case 'migrations':
                     if ($collectionType === 'projects') {
                         $attributes = [

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -134,6 +134,9 @@ class Create extends Action
             'buildSize' => null,
             'buildPath' => '',
             'buildLogs' => '',
+            // Belongs to the commit the source deployment reported on; inheriting it
+            // would rewrite that already-concluded check run.
+            'providerCheckRunId' => null,
             // Not inherited: a redeploy always goes live, and the source's own
             // flag is unset by deactivateOthers() once anything newer builds.
             'activate' => true,

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -3,12 +3,14 @@
 namespace Appwrite\Platform\Modules\Functions\Http\Deployments\Status;
 
 use Appwrite\Deployment\Deployments;
+use Appwrite\Deployment\GitAction;
 use Appwrite\Event\Event;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Vcs\Factory as VcsFactory;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -62,6 +64,10 @@ class Update extends Action
             ->inject('queueForEvents')
             ->inject('deployments')
             ->inject('locks')
+            ->inject('dbForPlatform')
+            ->inject('project')
+            ->inject('vcsFactory')
+            ->inject('platform')
             ->callback($this->action(...));
     }
 
@@ -73,6 +79,10 @@ class Update extends Action
         Event $queueForEvents,
         Deployments $deployments,
         callable $locks,
+        Database $dbForPlatform,
+        Document $project,
+        VcsFactory $vcsFactory,
+        array $platform,
     ) {
         $function = $dbForProject->getDocument('functions', $functionId);
 
@@ -128,6 +138,13 @@ class Update extends Action
         // Best-effort cleanup — the deployment is already marked 'canceled'.
         try {
             $deployments->cancel($deploymentId);
+        } catch (\Throwable) {
+        }
+
+        // Nothing else reports a canceled build, so a check run opened when it was
+        // triggered would stay in progress on the commit for good.
+        try {
+            GitAction::report('canceled', $deployment, $project, $dbForProject, $dbForPlatform, $vcsFactory, $platform);
         } catch (\Throwable) {
         }
 

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Status/Update.php
@@ -141,8 +141,7 @@ class Update extends Action
         } catch (\Throwable) {
         }
 
-        // Nothing else reports a canceled build, so a check run opened when it was
-        // triggered would stay in progress on the commit for good.
+        // Nothing else reports a canceled build, leaving any open run in progress.
         try {
             GitAction::report('canceled', $deployment, $project, $dbForProject, $dbForPlatform, $vcsFactory, $platform);
         } catch (\Throwable) {

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -18,6 +18,7 @@ use Appwrite\Usage\Context as UsageContext;
 use Appwrite\Utopia\Response\Model\Deployment;
 use Appwrite\Vcs\Factory as VcsFactory;
 use Utopia\Cache\Cache;
+use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -514,8 +515,10 @@ class Jobs extends Action
                 $dbForPlatform,
                 $platform,
             );
-        } catch (\Throwable) {
-            // Best-effort — never fails the build.
+        } catch (\Throwable $e) {
+            // Best-effort — never fails the build, but say so; a provider that
+            // rejects the report leaves the commit with no build state at all.
+            Console::warning("Failed to report build state for deployment '{$deployment->getId()}': " . $e->getMessage());
         }
     }
 

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -492,29 +492,8 @@ class Jobs extends Action
      */
     protected function gitAction(string $status, Document $deployment, Document $project, Database $dbForProject, Database $dbForPlatform, VcsFactory $vcsFactory, array $platform): void
     {
-        if ($deployment->getAttribute('providerCommitHash', '') === '' && $deployment->getAttribute('providerCommentId', '') === '') {
-            return;
-        }
-
         try {
-            $resource = $dbForProject->getDocument($deployment->getAttribute('resourceType', 'functions'), $deployment->getAttribute('resourceId'));
-            $installation = $dbForPlatform->getDocument('installations', $resource->getAttribute('installationId', ''));
-            if ($resource->isEmpty() || $installation->getAttribute('providerInstallationId', '') === '') {
-                return;
-            }
-
-            GitAction::run(
-                $status,
-                $vcsFactory->fromInstallation($installation),
-                $deployment->getAttribute('providerCommitHash', ''),
-                $deployment->getAttribute('providerRepositoryOwner', ''),
-                $deployment->getAttribute('providerRepositoryName', ''),
-                $project,
-                $resource,
-                $deployment,
-                $dbForPlatform,
-                $platform,
-            );
+            GitAction::report($status, $deployment, $project, $dbForProject, $dbForPlatform, $vcsFactory, $platform);
         } catch (\Throwable $e) {
             // Best-effort — never fails the build, but say so; a provider that
             // rejects the report leaves the commit with no build state at all.

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -495,8 +495,8 @@ class Jobs extends Action
         try {
             GitAction::report($status, $deployment, $project, $dbForProject, $dbForPlatform, $vcsFactory, $platform);
         } catch (\Throwable $e) {
-            // Best-effort — never fails the build, but say so; a provider that
-            // rejects the report leaves the commit with no build state at all.
+            // Best-effort — never fails the build, but a rejected report leaves the
+            // commit with no build state at all.
             Console::warning("Failed to report build state for deployment '{$deployment->getId()}': " . $e->getMessage());
         }
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -154,6 +154,9 @@ class Create extends Action
             'buildSize' => 0,
             'buildPath' => '',
             'buildLogs' => '',
+            // Belongs to the commit the source deployment reported on; inheriting it
+            // would rewrite that already-concluded check run.
+            'providerCheckRunId' => null,
             'type' => $request->getHeaderLine('x-sdk-language') === 'cli' ? 'cli' : 'manual',
             // Not inherited: a redeploy always goes live, and the source's own
             // flag is unset by deactivateOthers() once anything newer builds.

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -3,12 +3,14 @@
 namespace Appwrite\Platform\Modules\Sites\Http\Deployments\Status;
 
 use Appwrite\Deployment\Deployments;
+use Appwrite\Deployment\GitAction;
 use Appwrite\Event\Event;
 use Appwrite\Extend\Exception;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Vcs\Factory as VcsFactory;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -60,6 +62,10 @@ class Update extends Action
             ->inject('queueForEvents')
             ->inject('deployments')
             ->inject('locks')
+            ->inject('dbForPlatform')
+            ->inject('project')
+            ->inject('vcsFactory')
+            ->inject('platform')
             ->callback($this->action(...));
     }
 
@@ -70,7 +76,11 @@ class Update extends Action
         Database $dbForProject,
         Event $queueForEvents,
         Deployments $deployments,
-        callable $locks
+        callable $locks,
+        Database $dbForPlatform,
+        Document $project,
+        VcsFactory $vcsFactory,
+        array $platform,
     ) {
         $site = $dbForProject->getDocument('sites', $siteId);
 
@@ -126,6 +136,13 @@ class Update extends Action
         // Best-effort cleanup — the deployment is already marked 'canceled'.
         try {
             $deployments->cancel($deploymentId);
+        } catch (\Throwable) {
+        }
+
+        // Nothing else reports a canceled build, so a check run opened when it was
+        // triggered would stay in progress on the commit for good.
+        try {
+            GitAction::report('canceled', $deployment, $project, $dbForProject, $dbForPlatform, $vcsFactory, $platform);
         } catch (\Throwable) {
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Status/Update.php
@@ -139,8 +139,7 @@ class Update extends Action
         } catch (\Throwable) {
         }
 
-        // Nothing else reports a canceled build, so a check run opened when it was
-        // triggered would stay in progress on the commit for good.
+        // Nothing else reports a canceled build, leaving any open run in progress.
         try {
             GitAction::report('canceled', $deployment, $project, $dbForProject, $dbForPlatform, $vcsFactory, $platform);
         } catch (\Throwable) {

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -73,6 +73,24 @@ trait Deployment
             ];
         };
 
+        // A skipped deployment used to leave the commit with no indicator at all, so
+        // there was no way to tell a deliberate skip from a broken integration.
+        $reportSkip = function (Document $resource, Document $project, Document $repository, string $reason) use ($checkRuns, $vcs, $resolveIdentity, $providerCommitHash): void {
+            if (!$checkRuns->supports($vcs) || $resource->getAttribute('providerSilentMode', false) === true) {
+                return;
+            }
+
+            try {
+                [$owner, $repositoryName] = $resolveIdentity($repository->getAttribute('providerRepositoryId'));
+            } catch (\Throwable) {
+                return;
+            }
+
+            $name = $resource->getAttribute('name') . ' (' . $project->getAttribute('name') . ')';
+
+            $checkRuns->conclude($vcs, $owner, $repositoryName, $providerCommitHash, $name, CheckRuns::CONCLUSION_NEUTRAL, 'Deployment skipped', $reason);
+        };
+
         foreach ($repositories as $repository) {
             $logBase = "vcs.{$provider}.event.repo.unknown";
 
@@ -128,6 +146,7 @@ trait Deployment
                 if ($validator->isValid($providerCommitMessage)) {
                     Span::add("{$logBase}.build.skipped.reason", $validator->getDescription());
                     Span::add("{$logBase}.build.skipped", 'true');
+                    $reportSkip($resource, $project, $repository, 'The commit message contains ' . \implode(' or ', VCS_DEPLOYMENT_SKIP_PATTERNS) . '.');
                     continue;
                 }
 
@@ -136,6 +155,7 @@ trait Deployment
                 if (!$branchTrigger->isValid($providerBranch)) {
                     Span::add("{$logBase}.build.skipped.reason", 'branch');
                     Span::add("{$logBase}.build.skipped", 'true');
+                    $reportSkip($resource, $project, $repository, "Branch '{$providerBranch}' does not match the branch triggers configured for this resource.");
                     continue;
                 }
 
@@ -153,6 +173,7 @@ trait Deployment
                     if (!$pathMatched) {
                         Span::add("{$logBase}.build.skipped.reason", 'path');
                         Span::add("{$logBase}.build.skipped", 'true');
+                        $reportSkip($resource, $project, $repository, 'None of the changed files match the path filters configured for this resource.');
                         continue;
                     }
                 }

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\VCS\Http\GitHub;
 
 use Appwrite\Extend\Exception;
 use Appwrite\Filter\BranchDomain as BranchDomainFilter;
+use Appwrite\Vcs\CheckRuns;
 use Appwrite\Vcs\Comment;
 use Utopia\Config\Config;
 use Utopia\Console;
@@ -50,6 +51,7 @@ trait Deployment
     ) {
         $errors = [];
         $provider = $vcs->getName();
+        $checkRuns = new CheckRuns();
 
         // A webhook fans out to every resource linked to the same provider repository,
         // so resolve its owner and name once per provider repository rather than per resource.
@@ -374,8 +376,28 @@ trait Deployment
                     $commands[] = $resource->getAttribute('commands', '');
                 }
 
+                $region = $project->getAttribute('region', 'default');
+                $providerTargetUrl = $protocol . '://' . $hostname . "/console/project-$region-$projectId/$resourceCollection/$resourceType-$resourceId";
+                $resourceName = $resource->getAttribute('name');
+                $projectName = $project->getAttribute('name');
+                $name = "{$resourceName} ({$projectName})";
+                $silent = $resource->getAttribute('providerSilentMode', false) === true;
+
+                // Open the run before the deployment is persisted so its id can ride
+                // along: the build worker submitted below can finish before a report
+                // written afterwards lands, which would reopen a completed run.
+                $checkRunId = 0;
+                if (!$silent) {
+                    $checkRunId = $checkRuns->open($vcs, $owner, $repositoryName, $providerCommitHash, $name, 'Starting...', $providerTargetUrl, $deploymentId);
+
+                    if ($checkRunId === 0 && !empty($providerCommitHash)) {
+                        $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', 'Starting...', $providerTargetUrl, $name);
+                    }
+                }
+
                 $deployment = new Document([
                     '$id' => $deploymentId,
+                    'providerCheckRunId' => $checkRunId,
                     'resourceId' => $resourceId,
                     'resourceInternalId' => $resourceInternalId,
                     'resourceType' => $resourceCollection,
@@ -407,13 +429,20 @@ trait Deployment
 
                 // The Deployments service is built per repository: a webhook fans out to
                 // many tenant projects, each with its own database.
-                $deployment = $authorization->skip(fn () => $deploymentsFactory($dbForProject, $project)
-                    ->createFromUrl(
-                        $resource,
-                        $deployment,
-                        $vcs->getRepositoryPresignedUrl($providerRepositoryOwner, $providerRepositoryName, $providerCommitHash),
-                        $resource->getAttribute('providerRootDirectory', ''),
-                    ));
+                try {
+                    $deployment = $authorization->skip(fn () => $deploymentsFactory($dbForProject, $project)
+                        ->createFromUrl(
+                            $resource,
+                            $deployment,
+                            $vcs->getRepositoryPresignedUrl($providerRepositoryOwner, $providerRepositoryName, $providerCommitHash),
+                            $resource->getAttribute('providerRootDirectory', ''),
+                        ));
+                } catch (\Throwable $e) {
+                    // Nothing will build, so nothing will close the run we just opened.
+                    $checkRuns->close($vcs, $owner, $repositoryName, $checkRunId, CheckRuns::CONCLUSION_FAILURE, 'Deployment failed', 'Could not queue the build.', $providerTargetUrl);
+
+                    throw $e;
+                }
 
                 if ($resource->getCollection() === 'sites') {
                     $projectId = $project->getId();
@@ -555,17 +584,6 @@ trait Deployment
                             $authorization->skip(fn () => $dbForPlatform->deleteDocument('vcsCommentLocks', $latestCommentId));
                         }
                     }
-                }
-
-                if (!empty($providerCommitHash) && $resource->getAttribute('providerSilentMode', false) === false) {
-                    $resourceName = $resource->getAttribute('name');
-                    $projectName = $project->getAttribute('name');
-                    $region = $project->getAttribute('region', 'default');
-                    $name = "{$resourceName} ({$projectName})";
-                    $message = 'Starting...';
-
-                    $providerTargetUrl = $protocol . '://' . $hostname . "/console/project-$region-$projectId/$resourceCollection/$resourceType-$resourceId";
-                    $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', $message, $providerTargetUrl, $name);
                 }
 
                 Span::add("{$logBase}.build.triggered", 'true');

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -53,8 +53,7 @@ trait Deployment
         $provider = $vcs->getName();
         $checkRuns = new CheckRuns();
 
-        // A webhook fans out to every resource linked to the same provider repository,
-        // so resolve its owner and name once per provider repository rather than per resource.
+        // A webhook fans out to every resource linked to the same provider repository.
         $identities = [];
         $resolveIdentity = function (string $providerRepositoryId) use ($vcs, $providerInstallationId, &$identities): array {
             if (isset($identities[$providerRepositoryId])) {
@@ -73,8 +72,6 @@ trait Deployment
             ];
         };
 
-        // A skipped deployment used to leave the commit with no indicator at all, so
-        // there was no way to tell a deliberate skip from a broken integration.
         $reportSkip = function (Document $resource, Document $project, Document $repository, string $reason) use ($checkRuns, $vcs, $resolveIdentity, $providerCommitHash): void {
             if (!$checkRuns->supports($vcs) || $resource->getAttribute('providerSilentMode', false) === true) {
                 return;
@@ -362,8 +359,6 @@ trait Deployment
                 }
 
                 if (!$isAuthorized) {
-                    // Gated like every other report: silent mode otherwise left a
-                    // permanent pending status on the commit.
                     if ($resource->getAttribute('providerSilentMode', false) === false) {
                         $resourceName = $resource->getAttribute('name');
                         $projectName = $project->getAttribute('name');
@@ -422,9 +417,8 @@ trait Deployment
                 $name = "{$resourceName} ({$projectName})";
                 $silent = $resource->getAttribute('providerSilentMode', false) === true;
 
-                // Open the run before the deployment is persisted so its id can ride
-                // along: the build worker submitted below can finish before a report
-                // written afterwards lands, which would reopen a completed run.
+                // Open before persisting: the build submitted below can finish first,
+                // and a later report would reopen a run the worker already completed.
                 $checkRunId = 0;
                 if (!$silent) {
                     $checkRunId = $checkRuns->open($vcs, $owner, $repositoryName, $providerCommitHash, $name, 'Starting...', $providerTargetUrl, $deploymentId);
@@ -477,7 +471,6 @@ trait Deployment
                             $resource->getAttribute('providerRootDirectory', ''),
                         ));
                 } catch (\Throwable $e) {
-                    // Nothing will build, so nothing will close the run we just opened.
                     $checkRuns->close($vcs, $owner, $repositoryName, $checkRunId, CheckRuns::CONCLUSION_FAILURE, 'Deployment failed', 'Could not queue the build.', $providerTargetUrl);
 
                     throw $e;

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -50,6 +50,27 @@ trait Deployment
     ) {
         $errors = [];
         $provider = $vcs->getName();
+
+        // A webhook fans out to every resource linked to the same provider repository,
+        // so resolve its owner and name once per provider repository rather than per resource.
+        $identities = [];
+        $resolveIdentity = function (string $providerRepositoryId) use ($vcs, $providerInstallationId, &$identities): array {
+            if (isset($identities[$providerRepositoryId])) {
+                return $identities[$providerRepositoryId];
+            }
+
+            try {
+                $repositoryName = $vcs->getRepositoryName($providerRepositoryId);
+            } catch (RepositoryNotFound $e) {
+                throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
+            }
+
+            return $identities[$providerRepositoryId] = [
+                $vcs->getOwnerName($providerInstallationId, (int) $providerRepositoryId),
+                $repositoryName,
+            ];
+        };
+
         foreach ($repositories as $repository) {
             $logBase = "vcs.{$provider}.event.repo.unknown";
 
@@ -94,6 +115,11 @@ trait Deployment
                 $dbForProject = $getProjectDB($project);
                 $resourceCollection = $resourceType === "function" ? 'functions' : 'sites';
                 $resource = $authorization->skip(fn () => $dbForProject->getDocument($resourceCollection, $resourceId));
+
+                if ($resource->isEmpty()) {
+                    throw new Exception($resourceType === 'function' ? Exception::FUNCTION_NOT_FOUND : Exception::SITE_NOT_FOUND, 'Repository references non-existent ' . $resourceType);
+                }
+
                 $resourceInternalId = $resource->getSequence();
 
                 $validator = new Contains(VCS_DEPLOYMENT_SKIP_PATTERNS);
@@ -142,12 +168,7 @@ trait Deployment
                     $activate = true;
                 }
 
-                $owner = $vcs->getOwnerName($providerInstallationId, (int) $providerRepositoryId);
-                try {
-                    $repositoryName = $vcs->getRepositoryName($providerRepositoryId);
-                } catch (RepositoryNotFound $e) {
-                    throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
-                }
+                [$owner, $repositoryName] = $resolveIdentity($providerRepositoryId);
 
                 $isAuthorized = !$external;
 
@@ -323,13 +344,6 @@ trait Deployment
                     $name = "{$resourceName} ({$projectName})";
                     $message = 'Authorization required for external contributor.';
 
-                    $providerRepositoryId = $repository->getAttribute('providerRepositoryId');
-                    try {
-                        $repositoryName = $vcs->getRepositoryName($providerRepositoryId);
-                    } catch (RepositoryNotFound $e) {
-                        throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
-                    }
-                    $owner = $vcs->getOwnerName($providerInstallationId, (int) $providerRepositoryId);
                     $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', $message, $authorizeUrl, $name);
                     continue;
                 }
@@ -549,14 +563,6 @@ trait Deployment
                     $region = $project->getAttribute('region', 'default');
                     $name = "{$resourceName} ({$projectName})";
                     $message = 'Starting...';
-
-                    $providerRepositoryId = $repository->getAttribute('providerRepositoryId');
-                    try {
-                        $repositoryName = $vcs->getRepositoryName($providerRepositoryId);
-                    } catch (RepositoryNotFound $e) {
-                        throw new Exception(Exception::PROVIDER_REPOSITORY_NOT_FOUND);
-                    }
-                    $owner = $vcs->getOwnerName($providerInstallationId, (int) $providerRepositoryId);
 
                     $providerTargetUrl = $protocol . '://' . $hostname . "/console/project-$region-$projectId/$resourceCollection/$resourceType-$resourceId";
                     $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', $message, $providerTargetUrl, $name);

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -72,8 +72,14 @@ trait Deployment
             ];
         };
 
-        $reportSkip = function (Document $resource, Document $project, Document $repository, string $reason) use ($checkRuns, $vcs, $resolveIdentity, $providerCommitHash): void {
+        $reportSkip = function (Document $resource, Document $project, Document $repository, string $reason) use ($checkRuns, $vcs, $resolveIdentity, $providerCommitHash, $providerPullRequestId, $external): void {
             if (!$checkRuns->supports($vcs) || $resource->getAttribute('providerSilentMode', false) === true) {
+                return;
+            }
+
+            // A pull request on this repository also raised a push event, which
+            // reported the same skip on the same commit. A fork raises no push.
+            if (!empty($providerPullRequestId) && !$external) {
                 return;
             }
 
@@ -377,7 +383,11 @@ trait Deployment
                         );
 
                         if ($reported === 0 && !empty($providerCommitHash)) {
-                            $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', 'Authorization required for external contributor.', $authorizeUrl, $name);
+                            try {
+                                $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', 'Authorization required for external contributor.', $authorizeUrl, $name);
+                            } catch (\Throwable $e) {
+                                Console::warning("Failed to report required authorization on {$owner}/{$repositoryName}: " . $e->getMessage());
+                            }
                         }
                     }
 
@@ -424,7 +434,13 @@ trait Deployment
                     $checkRunId = $checkRuns->open($vcs, $owner, $repositoryName, $providerCommitHash, $name, 'Starting...', $providerTargetUrl, $deploymentId);
 
                     if ($checkRunId === 0 && !empty($providerCommitHash)) {
-                        $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', 'Starting...', $providerTargetUrl, $name);
+                        // This now runs before the deployment is created, so a rejected
+                        // status must not be what stops it being created.
+                        try {
+                            $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', 'Starting...', $providerTargetUrl, $name);
+                        } catch (\Throwable $e) {
+                            Console::warning("Failed to report deployment start on {$owner}/{$repositoryName}: " . $e->getMessage());
+                        }
                     }
                 }
 
@@ -471,7 +487,16 @@ trait Deployment
                             $resource->getAttribute('providerRootDirectory', ''),
                         ));
                 } catch (\Throwable $e) {
-                    $checkRuns->close($vcs, $owner, $repositoryName, $checkRunId, CheckRuns::CONCLUSION_FAILURE, 'Deployment failed', 'Could not queue the build.', $providerTargetUrl);
+                    // Nothing will build, so nothing else will resolve what was just
+                    // reported. Never let the compensation mask the original failure.
+                    try {
+                        if ($checkRunId > 0) {
+                            $checkRuns->close($vcs, $owner, $repositoryName, $checkRunId, CheckRuns::CONCLUSION_FAILURE, 'Deployment failed', 'Could not queue the build.', $providerTargetUrl);
+                        } elseif (!$silent && !empty($providerCommitHash)) {
+                            $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'failure', 'Could not queue the build.', $providerTargetUrl, $name);
+                        }
+                    } catch (\Throwable) {
+                    }
 
                     throw $e;
                 }

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -362,12 +362,30 @@ trait Deployment
                 }
 
                 if (!$isAuthorized) {
-                    $resourceName = $resource->getAttribute('name');
-                    $projectName = $project->getAttribute('name');
-                    $name = "{$resourceName} ({$projectName})";
-                    $message = 'Authorization required for external contributor.';
+                    // Gated like every other report: silent mode otherwise left a
+                    // permanent pending status on the commit.
+                    if ($resource->getAttribute('providerSilentMode', false) === false) {
+                        $resourceName = $resource->getAttribute('name');
+                        $projectName = $project->getAttribute('name');
+                        $name = "{$resourceName} ({$projectName})";
 
-                    $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', $message, $authorizeUrl, $name);
+                        $reported = $checkRuns->conclude(
+                            $vcs,
+                            $owner,
+                            $repositoryName,
+                            $providerCommitHash,
+                            $name,
+                            CheckRuns::CONCLUSION_ACTION_REQUIRED,
+                            'Authorization required',
+                            'A maintainer must authorize this external contributor before Appwrite deploys this pull request.',
+                            $authorizeUrl,
+                        );
+
+                        if ($reported === 0 && !empty($providerCommitHash)) {
+                            $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'pending', 'Authorization required for external contributor.', $authorizeUrl, $name);
+                        }
+                    }
+
                     continue;
                 }
 

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -339,6 +339,8 @@ trait Deployment
                     $authorization->skip(fn () => $dbForProject->updateDocuments('deployments', new Document([
                         'providerCommentId' => \strval($latestCommentId)
                     ]), [
+                        Query::equal('resourceInternalId', [$resourceInternalId]),
+                        Query::equal('resourceType', [$resourceCollection]),
                         Query::equal('providerCommitHash', [$providerCommitHash]),
                         Query::equal('providerBranch', [$providerBranch]),
                     ]));

--- a/src/Appwrite/Vcs/CheckRuns.php
+++ b/src/Appwrite/Vcs/CheckRuns.php
@@ -7,17 +7,9 @@ use Utopia\VCS\Adapter\Git;
 use Utopia\VCS\Adapter\Git\GitHub;
 
 /**
- * Reports deployment state as provider check runs.
- *
- * A commit status can only say pending, success, failure or error, so a
- * deployment Appwrite deliberately skipped looked identical to one that never
- * ran, and one waiting on a maintainer's authorization sat pending forever. A
- * check run carries a conclusion for both.
- *
- * Only GitHub implements check runs; every other provider keeps the commit
- * status, so callers treat a zero return as "fall back". Reporting is
- * best-effort throughout — a provider that refuses the call must never fail
- * the deployment that triggered it.
+ * Reports deployment state as provider check runs, which carry conclusions a
+ * commit status cannot: skipped, and waiting on authorization. Only GitHub
+ * implements them, so a zero return means fall back to the commit status.
  */
 class CheckRuns
 {
@@ -27,32 +19,22 @@ class CheckRuns
     public const string CONCLUSION_FAILURE = 'failure';
     public const string CONCLUSION_CANCELLED = 'cancelled';
 
-    /**
-     * GitHub rejects a name longer than this.
-     */
     protected const int NAME_LIMIT = 255;
 
     /**
-     * Owners whose installation has already refused a check run. A webhook fans
-     * out to every resource linked to a repository, so without this an
-     * installation that was never granted the permission pays one rejected
-     * call per resource.
+     * Owners whose installation refused a run, so an installation missing the
+     * permission does not pay one rejected call per linked resource.
      *
      * @var array<string, true>
      */
     protected array $refused = [];
 
-    /**
-     * Whether this provider reports check runs at all.
-     */
     public function supports(Git $vcs): bool
     {
         return $vcs instanceof GitHub;
     }
 
     /**
-     * Open a run for a deployment that is about to build.
-     *
      * @return int The run's id, or 0 when none was opened.
      */
     public function open(
@@ -69,8 +51,6 @@ class CheckRuns
     }
 
     /**
-     * Report a deployment that reached a terminal state without building.
-     *
      * @return int The run's id, or 0 when none was opened.
      */
     public function conclude(
@@ -88,8 +68,6 @@ class CheckRuns
     }
 
     /**
-     * Close a run opened earlier.
-     *
      * @return bool Whether the run was closed.
      */
     public function close(
@@ -141,8 +119,7 @@ class CheckRuns
         string $detailsUrl,
         string $externalId = '',
     ): int {
-        // An empty or malformed hash is a 422; a deployment without one has no
-        // commit to report against in the first place.
+        // A malformed hash is a 422, and without one there is nothing to report against.
         if (!\preg_match('/^[0-9a-f]{7,40}$/i', $commitHash)) {
             return 0;
         }
@@ -176,21 +153,13 @@ class CheckRuns
 
     protected function reportable(Git $vcs, string $owner, string $repositoryName): bool
     {
-        if (!$this->supports($vcs)) {
-            return false;
-        }
-
-        if (empty($owner) || empty($repositoryName)) {
+        if (!$this->supports($vcs) || empty($owner) || empty($repositoryName)) {
             return false;
         }
 
         return !isset($this->refused[$owner]);
     }
 
-    /**
-     * An installation predating the check run permission answers 403 to every
-     * call, so stop asking for the rest of this event.
-     */
     protected function remember(string $owner, \Throwable $error): void
     {
         if ($error->getCode() === 403) {

--- a/src/Appwrite/Vcs/CheckRuns.php
+++ b/src/Appwrite/Vcs/CheckRuns.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Appwrite\Vcs;
+
+use Utopia\Console;
+use Utopia\VCS\Adapter\Git;
+use Utopia\VCS\Adapter\Git\GitHub;
+
+/**
+ * Reports deployment state as provider check runs.
+ *
+ * A commit status can only say pending, success, failure or error, so a
+ * deployment Appwrite deliberately skipped looked identical to one that never
+ * ran, and one waiting on a maintainer's authorization sat pending forever. A
+ * check run carries a conclusion for both.
+ *
+ * Only GitHub implements check runs; every other provider keeps the commit
+ * status, so callers treat a zero return as "fall back". Reporting is
+ * best-effort throughout — a provider that refuses the call must never fail
+ * the deployment that triggered it.
+ */
+class CheckRuns
+{
+    public const string CONCLUSION_NEUTRAL = 'neutral';
+    public const string CONCLUSION_ACTION_REQUIRED = 'action_required';
+    public const string CONCLUSION_SUCCESS = 'success';
+    public const string CONCLUSION_FAILURE = 'failure';
+    public const string CONCLUSION_CANCELLED = 'cancelled';
+
+    /**
+     * GitHub rejects a name longer than this.
+     */
+    protected const int NAME_LIMIT = 255;
+
+    /**
+     * Owners whose installation has already refused a check run. A webhook fans
+     * out to every resource linked to a repository, so without this an
+     * installation that was never granted the permission pays one rejected
+     * call per resource.
+     *
+     * @var array<string, true>
+     */
+    protected array $refused = [];
+
+    /**
+     * Whether this provider reports check runs at all.
+     */
+    public function supports(Git $vcs): bool
+    {
+        return $vcs instanceof GitHub;
+    }
+
+    /**
+     * Open a run for a deployment that is about to build.
+     *
+     * @return int The run's id, or 0 when none was opened.
+     */
+    public function open(
+        Git $vcs,
+        string $owner,
+        string $repositoryName,
+        string $commitHash,
+        string $name,
+        string $summary,
+        string $detailsUrl = '',
+        string $externalId = '',
+    ): int {
+        return $this->create($vcs, $owner, $repositoryName, $commitHash, $name, '', 'Deployment queued', $summary, $detailsUrl, $externalId);
+    }
+
+    /**
+     * Report a deployment that reached a terminal state without building.
+     *
+     * @return int The run's id, or 0 when none was opened.
+     */
+    public function conclude(
+        Git $vcs,
+        string $owner,
+        string $repositoryName,
+        string $commitHash,
+        string $name,
+        string $conclusion,
+        string $title,
+        string $summary,
+        string $detailsUrl = '',
+    ): int {
+        return $this->create($vcs, $owner, $repositoryName, $commitHash, $name, $conclusion, $title, $summary, $detailsUrl);
+    }
+
+    /**
+     * Close a run opened earlier.
+     *
+     * @return bool Whether the run was closed.
+     */
+    public function close(
+        Git $vcs,
+        string $owner,
+        string $repositoryName,
+        int $checkRunId,
+        string $conclusion,
+        string $title,
+        string $summary,
+        string $detailsUrl = '',
+    ): bool {
+        if ($checkRunId <= 0 || !$this->reportable($vcs, $owner, $repositoryName)) {
+            return false;
+        }
+
+        try {
+            $vcs->updateCheckRun(
+                owner: $owner,
+                repositoryName: $repositoryName,
+                checkRunId: $checkRunId,
+                conclusion: $conclusion,
+                title: $title,
+                summary: $summary,
+                detailsUrl: $detailsUrl,
+            );
+
+            return true;
+        } catch (\Throwable $error) {
+            $this->remember($owner, $error);
+            Console::warning("Failed to close check run {$checkRunId} on {$owner}/{$repositoryName}: " . $error->getMessage());
+
+            return false;
+        }
+    }
+
+    /**
+     * @return int The run's id, or 0 when none was created.
+     */
+    protected function create(
+        Git $vcs,
+        string $owner,
+        string $repositoryName,
+        string $commitHash,
+        string $name,
+        string $conclusion,
+        string $title,
+        string $summary,
+        string $detailsUrl,
+        string $externalId = '',
+    ): int {
+        // An empty or malformed hash is a 422; a deployment without one has no
+        // commit to report against in the first place.
+        if (!\preg_match('/^[0-9a-f]{7,40}$/i', $commitHash)) {
+            return 0;
+        }
+
+        if (!$this->reportable($vcs, $owner, $repositoryName)) {
+            return 0;
+        }
+
+        try {
+            $run = $vcs->createCheckRun(
+                owner: $owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: \mb_strimwidth($name, 0, self::NAME_LIMIT, '...'),
+                status: empty($conclusion) ? 'in_progress' : 'completed',
+                conclusion: $conclusion,
+                title: $title,
+                summary: $summary,
+                detailsUrl: $detailsUrl,
+                externalId: $externalId,
+            );
+
+            return (int) ($run['id'] ?? 0);
+        } catch (\Throwable $error) {
+            $this->remember($owner, $error);
+            Console::warning("Failed to create check run on {$owner}/{$repositoryName}: " . $error->getMessage());
+
+            return 0;
+        }
+    }
+
+    protected function reportable(Git $vcs, string $owner, string $repositoryName): bool
+    {
+        if (!$this->supports($vcs)) {
+            return false;
+        }
+
+        if (empty($owner) || empty($repositoryName)) {
+            return false;
+        }
+
+        return !isset($this->refused[$owner]);
+    }
+
+    /**
+     * An installation predating the check run permission answers 403 to every
+     * call, so stop asking for the rest of this event.
+     */
+    protected function remember(string $owner, \Throwable $error): void
+    {
+        if ($error->getCode() === 403) {
+            $this->refused[$owner] = true;
+        }
+    }
+}

--- a/src/Appwrite/Vcs/Comment.php
+++ b/src/Appwrite/Vcs/Comment.php
@@ -157,6 +157,8 @@ class Comment
                         'building' => $this->generatImage($pathLight, $pathDark, 'Building', 85) . ' _Building_',
                         'ready' => $this->generatImage($pathLight, $pathDark, 'Ready', 85) . ' _Ready_',
                         'failed' => $this->generatImage($pathLight, $pathDark, 'Failed', 85) . ' _Failed_',
+                        // No icon ships for a canceled build; text alone beats a blank cell.
+                        'canceled' => '_Canceled_',
                         default => '',
                     };
 
@@ -208,6 +210,8 @@ class Comment
                         'building' => $this->generatImage($pathLight, $pathDark, 'Building', 85) . ' _Building_',
                         'ready' => $this->generatImage($pathLight, $pathDark, 'Ready', 85) . ' _Ready_',
                         'failed' => $this->generatImage($pathLight, $pathDark, 'Failed', 85) . ' _Failed_',
+                        // No icon ships for a canceled build; text alone beats a blank cell.
+                        'canceled' => '_Canceled_',
                         default => '',
                     };
 

--- a/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
@@ -107,6 +107,20 @@ final class VCSGiteaConsoleClientTest extends Scope
         $webhookDeploymentId = $this->waitForNewDeploymentReadyHelper($functionId, $knownIds);
         $this->assertNotContains($webhookDeploymentId, $knownIds);
         $this->assertEventually(fn () => $this->assertExecutionOutputHelper($functionId, 'gitea-v2'), 30000, 1000);
+
+        // A skipped push reports the reason to the provider. Gitea has no check
+        // runs, so reporting must stay a no-op rather than throw and take the
+        // webhook — and the push must still not deploy.
+        $knownIds = $this->listDeploymentIdsHelper($functionId);
+
+        $this->writeFunctionHelper($workdir, 'gitea-v3');
+        $this->gitHelper('git add index.js && git commit -m "Update function [skip ci]"', $workdir);
+        $this->gitHelper('git push origin main', $workdir);
+
+        \sleep(15);
+
+        $this->assertEqualsCanonicalizing($knownIds, $this->listDeploymentIdsHelper($functionId));
+        $this->assertEventually(fn () => $this->assertExecutionOutputHelper($functionId, 'gitea-v2'), 30000, 1000);
     }
 
     /**

--- a/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
+++ b/tests/e2e/Services/VCSGitea/VCSGiteaConsoleClientTest.php
@@ -108,19 +108,27 @@ final class VCSGiteaConsoleClientTest extends Scope
         $this->assertNotContains($webhookDeploymentId, $knownIds);
         $this->assertEventually(fn () => $this->assertExecutionOutputHelper($functionId, 'gitea-v2'), 30000, 1000);
 
-        // A skipped push reports the reason to the provider. Gitea has no check
-        // runs, so reporting must stay a no-op rather than throw and take the
-        // webhook — and the push must still not deploy.
+        // A skipped push reports its reason to the provider. Gitea has no check
+        // runs, so that report must stay a no-op rather than throw and take the
+        // webhook down with it.
         $knownIds = $this->listDeploymentIdsHelper($functionId);
 
         $this->writeFunctionHelper($workdir, 'gitea-v3');
         $this->gitHelper('git add index.js && git commit -m "Update function [skip ci]"', $workdir);
         $this->gitHelper('git push origin main', $workdir);
 
-        \sleep(15);
+        // The next ordinary push is the synchronisation point. Waiting a fixed
+        // interval on the skipped push instead would prove nothing: no deployment
+        // appears whether the skip worked or the webhook failed outright.
+        $this->writeFunctionHelper($workdir, 'gitea-v4');
+        $this->gitHelper('git add index.js && git commit -m "Update function"', $workdir);
+        $this->gitHelper('git push origin main', $workdir);
 
-        $this->assertEqualsCanonicalizing($knownIds, $this->listDeploymentIdsHelper($functionId));
-        $this->assertEventually(fn () => $this->assertExecutionOutputHelper($functionId, 'gitea-v2'), 30000, 1000);
+        $this->waitForNewDeploymentReadyHelper($functionId, $knownIds);
+        $this->assertEventually(fn () => $this->assertExecutionOutputHelper($functionId, 'gitea-v4'), 30000, 1000);
+
+        // Exactly one: the skipped push built nothing, and the handler survived it.
+        $this->assertCount(\count($knownIds) + 1, $this->listDeploymentIdsHelper($functionId));
     }
 
     /**

--- a/tests/unit/Vcs/CheckRunsTest.php
+++ b/tests/unit/Vcs/CheckRunsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Vcs;
 
 use Appwrite\Vcs\CheckRuns;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Utopia\VCS\Adapter\Git;
 use Utopia\VCS\Adapter\Git\GitHub;
@@ -188,7 +189,7 @@ final class CheckRunsTest extends TestCase
         $this->assertFalse((new CheckRuns())->close($adapter, 'owner', 'repo', 0, CheckRuns::CONCLUSION_SUCCESS, 'title', 'summary'));
     }
 
-    private function github(): GitHub
+    private function github(): GitHub&MockObject
     {
         return $this->createMock(GitHub::class);
     }

--- a/tests/unit/Vcs/CheckRunsTest.php
+++ b/tests/unit/Vcs/CheckRunsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Vcs;
+
+use Appwrite\Vcs\CheckRuns;
+use PHPUnit\Framework\TestCase;
+use Utopia\VCS\Adapter\Git;
+use Utopia\VCS\Adapter\Git\GitHub;
+
+final class CheckRunsTest extends TestCase
+{
+    private const string SHA = '60c0416257a9cbcdd96b2d370c38d8f8d150ccfb';
+
+    public function testOtherProvidersReportNothing(): void
+    {
+        // Gitea and GitLab inherit a throwing default, so the caller has to be
+        // told to keep using the commit status instead.
+        $adapter = $this->createMock(Git::class);
+        $adapter->expects($this->never())->method('createCheckRun');
+
+        $checkRuns = new CheckRuns();
+
+        $this->assertFalse($checkRuns->supports($adapter));
+        $this->assertSame(0, $checkRuns->open($adapter, 'owner', 'repo', self::SHA, 'name', 'Starting...'));
+        $this->assertSame(0, $checkRuns->conclude($adapter, 'owner', 'repo', self::SHA, 'name', CheckRuns::CONCLUSION_NEUTRAL, 'title', 'summary'));
+        $this->assertFalse($checkRuns->close($adapter, 'owner', 'repo', 1, CheckRuns::CONCLUSION_SUCCESS, 'title', 'summary'));
+    }
+
+    public function testOpenReturnsTheRunId(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->with(
+                'owner',
+                'repo',
+                self::SHA,
+                'my-function (my-project)',
+                'in_progress',
+                '',
+                'Deployment queued',
+                'Starting...',
+                '',
+                [],
+                [],
+                [],
+                'https://console.example.com/build',
+                'deployment-1',
+            )
+            ->willReturn(['id' => 4242]);
+
+        $checkRunId = (new CheckRuns())->open(
+            $adapter,
+            'owner',
+            'repo',
+            self::SHA,
+            'my-function (my-project)',
+            'Starting...',
+            'https://console.example.com/build',
+            'deployment-1',
+        );
+
+        $this->assertSame(4242, $checkRunId);
+    }
+
+    public function testSkippedDeploymentReportsItsReason(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willReturnCallback(function (...$arguments) {
+                // A conclusion completes the run in a single call, and the
+                // reason only reaches GitHub when title and summary are both set.
+                $this->assertSame('completed', $arguments[4]);
+                $this->assertSame(CheckRuns::CONCLUSION_NEUTRAL, $arguments[5]);
+                $this->assertSame('Deployment skipped', $arguments[6]);
+                $this->assertSame('Commit message matched a skip pattern.', $arguments[7]);
+
+                return ['id' => 7];
+            });
+
+        $checkRunId = (new CheckRuns())->conclude(
+            $adapter,
+            'owner',
+            'repo',
+            self::SHA,
+            'name',
+            CheckRuns::CONCLUSION_NEUTRAL,
+            'Deployment skipped',
+            'Commit message matched a skip pattern.',
+        );
+
+        $this->assertSame(7, $checkRunId);
+    }
+
+    public function testDeploymentWithoutACommitReportsNothing(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->never())->method('createCheckRun');
+
+        $checkRuns = new CheckRuns();
+
+        $this->assertSame(0, $checkRuns->open($adapter, 'owner', 'repo', '', 'name', 'Starting...'));
+        $this->assertSame(0, $checkRuns->open($adapter, 'owner', 'repo', 'not-a-sha', 'name', 'Starting...'));
+    }
+
+    public function testAnUnknownRepositoryReportsNothing(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->never())->method('createCheckRun');
+
+        $this->assertSame(0, (new CheckRuns())->open($adapter, '', '', self::SHA, 'name', 'Starting...'));
+    }
+
+    public function testAnOverlongNameIsTruncated(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willReturnCallback(function (...$arguments) {
+                $this->assertSame(255, \mb_strlen($arguments[3]));
+
+                return ['id' => 1];
+            });
+
+        (new CheckRuns())->open($adapter, 'owner', 'repo', self::SHA, \str_repeat('a', 300), 'Starting...');
+    }
+
+    public function testAProviderFailureIsContained(): void
+    {
+        $adapter = $this->createStub(GitHub::class);
+        $adapter->method('createCheckRun')->willThrowException(new \Exception('HTTP 500', 500));
+        $adapter->method('updateCheckRun')->willThrowException(new \Exception('HTTP 500', 500));
+
+        $checkRuns = new CheckRuns();
+
+        // Never propagates: a report that fails must not fail the deployment.
+        $this->assertSame(0, $checkRuns->open($adapter, 'owner', 'repo', self::SHA, 'name', 'Starting...'));
+        $this->assertFalse($checkRuns->close($adapter, 'owner', 'repo', 1, CheckRuns::CONCLUSION_SUCCESS, 'title', 'summary'));
+    }
+
+    public function testAnInstallationThatRefusesIsAskedOnlyOnce(): void
+    {
+        // A webhook fans out to every resource linked to the repository. An
+        // installation predating the permission would otherwise pay one
+        // rejected call per resource.
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willThrowException(new \Exception('HTTP 403', 403));
+
+        $checkRuns = new CheckRuns();
+
+        foreach (\range(1, 5) as $ignored) {
+            $this->assertSame(0, $checkRuns->open($adapter, 'owner', 'repo', self::SHA, 'name', 'Starting...'));
+        }
+    }
+
+    public function testCloseCompletesTheOpenedRun(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('updateCheckRun')
+            ->with('owner', 'repo', 4242, '', '', CheckRuns::CONCLUSION_SUCCESS, 'Deployment ready', 'Build succeeded.', '', [], [], [], 'https://console.example.com/build')
+            ->willReturn(['id' => 4242]);
+
+        $closed = (new CheckRuns())->close(
+            $adapter,
+            'owner',
+            'repo',
+            4242,
+            CheckRuns::CONCLUSION_SUCCESS,
+            'Deployment ready',
+            'Build succeeded.',
+            'https://console.example.com/build',
+        );
+
+        $this->assertTrue($closed);
+    }
+
+    public function testCloseWithoutARunReportsNothing(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->never())->method('updateCheckRun');
+
+        $this->assertFalse((new CheckRuns())->close($adapter, 'owner', 'repo', 0, CheckRuns::CONCLUSION_SUCCESS, 'title', 'summary'));
+    }
+
+    private function github(): GitHub
+    {
+        return $this->createMock(GitHub::class);
+    }
+}

--- a/tests/unit/Vcs/CommentTest.php
+++ b/tests/unit/Vcs/CommentTest.php
@@ -35,6 +35,24 @@ final class CommentTest extends TestCase
         $this->assertSame($firstTip, $secondTip);
     }
 
+    public function testCanceledBuildRendersAStatus(): void
+    {
+        foreach (['function', 'site'] as $resourceType) {
+            $comment = new Comment(['consoleHostname' => 'localhost', 'sitesDomain' => 'sites.localhost']);
+            $comment->addBuild(
+                new Document(['$id' => 'project1', 'name' => 'Test Project', 'region' => 'default']),
+                new Document(['$id' => 'resource1', 'name' => 'Test Resource']),
+                $resourceType,
+                'canceled',
+                'dep1',
+                ['type' => 'logs'],
+                ''
+            );
+
+            $this->assertStringContainsString('_Canceled_', $comment->generateComment(), "Empty status cell for a canceled {$resourceType}");
+        }
+    }
+
     public function testTipIsRestoredFromParsedComment(): void
     {
         $comment = new Comment(['consoleHostname' => 'localhost']);


### PR DESCRIPTION
## What

Reports deployment state to GitHub as **check runs** instead of commit statuses.

A commit status can only say `pending`, `success`, `failure` or `error`. That left two states unexpressible:

1. **A deployment Appwrite deliberately skipped** — `[skip ci]` in the commit message, a branch that doesn't match the resource's branch triggers, or changed files that don't match its path filters — reported *nothing at all*. The commit showed no indicator, so a deliberate skip was indistinguishable from a broken integration.
2. **A pull request from an unauthorized external contributor** got a `pending` status linking to the authorization page. Nothing revisits the commit once a maintainer authorizes, so it sat pending forever.

Both now conclude a check run: `neutral` with the exact reason, and `action_required` linking to the authorization page. An active deployment opens an `in_progress` run on trigger and closes it `success` / `failure` / `cancelled` when the build ends.

`neutral` and `action_required` are handled differently by branch protection on purpose — `neutral` counts as passing, so a skipped deployment reports itself without blocking a merge, while `action_required` is terminal and does gate.

## How

The run id comes back from `createCheckRun` at creation time and is stored on the deployment as `providerCheckRunId`, so the build worker closes the same run it opened. The deployment `Document` is assembled in memory before `createFromUrl` persists it, so the id rides along at no extra write.

`Appwrite\Vcs\CheckRuns` holds everything the five call sites would otherwise repeat: only GitHub implements check runs (GitLab/Gitea/Bitbucket inherit a throwing default), a rejected report is contained rather than failing the deployment that triggered it, and an installation that answers `403` is asked once per event rather than once per linked resource.

Providers without check runs keep the commit status unchanged, as do GitHub deployments whose call is refused, and console/manual deployments that never opened a run.

## Also fixed

Adjacent bugs in the same paths, each its own commit:

- **Comment ID backfill was unscoped.** A pull request event stamped one resource's `providerCommentId` onto *every* deployment matching the commit and branch, so in a monorepo build results were written into the wrong comment.
- **Repository identity was re-resolved per resource** — up to six API calls per linked resource per webhook. Now resolved once per provider repository.
- **A deleted function or site wasn't rejected.** Its `providerBranches` read as an empty list, which `Globstar` accepts, so the event ran past the branch trigger before failing downstream.
- **Canceling a build reported nothing**, which would have left a check run spinning forever.
- **The empty `catch` around `GitAction::run`** now says what failed.

## Rollout note for self-hosters

Check runs require the GitHub App's **Checks: Read & write** permission. GitHub never back-grants — an App that predates it puts every existing installation into pending approval the owner must accept. The code degrades cleanly (`403` falls back to the commit status), but the self-hosting docs and release notes should mention it.

An already-hung `pending` status self-heals: required checks resolve against the PR head SHA, so the next push carries a check run instead. No compatibility shim needed.

## Deliberately not included

- **`$external` defaulting to `true` on a parse failure stays as-is.** It was suggested to flip it, but `external = true` is what *requires* authorization — defaulting to `false` would let a fork PR deploy unreviewed code without a maintainer. It's also unreachable in practice: the adapter always sets the key for `pull_request` events.
- **The fork-PR authorization dead end.** Authorizing an external contributor re-enters `createGitDeployments`, which then hits the `continue` that exists to prevent double deployments on same-repo PRs (where a `push` event already made one). A fork PR fires no `push` on the base repo, so nothing is created and the new `action_required` check never resolves. Fixing it changes *when* deployments are created rather than how state is reported, and the path has no CI coverage — worth its own PR.

## Testing

- `tests/unit/Vcs/CheckRunsTest.php` — 10 tests, 59 assertions, mocking the adapter as `RepositoryWebhooksTest` already does. Covers the capability gate, error containment, the `403` memo, SHA and name validation, and that a skip sets both `output.title` and `output.summary` (GitHub drops the output block, and therefore the reason, if either is missing).
- `tests/e2e/Services/VCSGitea/` — asserts a `[skip ci]` push against a provider *without* check runs still deploys nothing and doesn't throw. This is the only CI-runnable proof of the capability gate; `tests/e2e/Services/VCSGitHub/` is skipped wholesale because `_APP_VCS_GITHUB_PRIVATE_KEY` is `disabled`.
- Unit suite compared against an `origin/main` worktree: baseline 1006 tests / 91 errors / 13 failures, this branch 1016 / 91 / 12. No new failures; the 91 errors are environmental and identical on both.
- `composer lint`, `composer refactor:check`, and PHPStan clean on every changed file.

**Still needs manual verification** against a real GitHub App, on a repo with the Appwrite check marked required: a `[skip ci]` push shows grey and stays mergeable; a fork PR shows `action_required` linking to the authorize page; a canceled build reports `cancelled`.

## Library

`createCheckRun` / `updateCheckRun` shipped in utopia-php/vcs 5.0.0 via utopia-php/vcs#107 and are already vendored — **no version bump needed**.

utopia-php/vcs#109 (`getCheckRunByName`) is **not used by this PR**. Resolving a run by name breaks on rename (the name is recomputed from a freshly re-read resource at build completion), on redeploy (`Duplicate/Create` clones `providerCommitHash`), and for console deployments that never pass through the webhook path. Storing the id sidesteps all of it, so #109 can be closed or landed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
