### PR TITLE
List only plan-enabled compute specifications

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php
@@ -62,8 +62,8 @@ class XList extends Base
         foreach ($allSpecs as $spec) {
             $spec['enabled'] = true;
 
-            if (array_key_exists($planKey, $plan)) {
-                $spec['enabled'] = in_array($spec['slug'], $plan[$planKey]);
+            if (array_key_exists($planKey, $plan) && !in_array($spec['slug'], $plan[$planKey], true)) {
+                continue;
             }
 
             $maxCpus = System::getEnv('_APP_COMPUTE_CPUS', 0);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php
@@ -62,8 +62,8 @@ class XList extends Base
         foreach ($allSpecs as $spec) {
             $spec['enabled'] = true;
 
-            if (array_key_exists($planKey, $plan)) {
-                $spec['enabled'] = in_array($spec['slug'], $plan[$planKey]);
+            if (array_key_exists($planKey, $plan) && !in_array($spec['slug'], $plan[$planKey], true)) {
+                continue;
             }
 
             $maxCpus = System::getEnv('_APP_COMPUTE_CPUS', 0);


### PR DESCRIPTION
## What does this PR do?

Makes the Functions and Sites specification endpoints return only specifications enabled for the requested workload by the current plan.

`buildSpecifications` and `runtimeSpecifications` are treated as authoritative allowlists instead of using them only to set an `enabled` flag. This prevents clients from seeing build specifications the API will reject and removes the need to infer availability from list ordering. Self-hosted behavior remains unchanged because plans without the corresponding key continue to return every instance-supported specification.

## Test Plan

- `php -l src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php`
- `php -l src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php`
- `composer lint src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php`

## Related PRs and Issues

- Follow-up to appwrite/sdk-generator#1737

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
