### PR TITLE
feat(vcs): report skips as neutral and unauthorized as action_required

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -4,6 +4,7 @@ namespace Appwrite\Platform\Modules\VCS\Http\GitHub;
 
 use Appwrite\Extend\Exception;
 use Appwrite\Filter\BranchDomain as BranchDomainFilter;
+use Appwrite\Vcs\CheckRuns;
 use Appwrite\Vcs\Comment;
 use Utopia\Config\Config;
 use Utopia\Console;
@@ -71,11 +72,11 @@ trait Deployment
             ];
         };
 
+        $checkRuns = new CheckRuns();
+
         // A skipped deployment left the commit with no indicator at all, so a
-        // deliberate skip was indistinguishable from a broken integration. A commit
-        // status has no state for it — 'failure' carries the reason until the richer
-        // check run conclusions land.
-        $reportSkip = function (Document $resource, Document $project, Document $repository, string $reason) use ($vcs, $resolveIdentity, $providerCommitHash, $providerPullRequestId, $external, $platform): void {
+        // deliberate skip was indistinguishable from a broken integration.
+        $reportSkip = function (Document $resource, Document $project, Document $repository, string $reason) use ($checkRuns, $vcs, $resolveIdentity, $providerCommitHash, $providerPullRequestId, $external, $platform): void {
             if (empty($providerCommitHash) || $resource->getAttribute('providerSilentMode', false) === true) {
                 return;
             }
@@ -96,6 +97,13 @@ trait Deployment
 
             try {
                 [$owner, $repositoryName] = $resolveIdentity($repository->getAttribute('providerRepositoryId'));
+
+                // Neutral is one of the conclusions a required check accepts, so a
+                // skip reports itself without blocking a merge.
+                if ($checkRuns->conclude($vcs, $owner, $repositoryName, $providerCommitHash, $name, CheckRuns::CONCLUSION_NEUTRAL, 'Deployment skipped', $reason, $targetUrl)) {
+                    return;
+                }
+
                 $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'failure', $reason, $targetUrl, $name);
             } catch (\Throwable $e) {
                 Console::warning("Failed to report a skipped deployment: " . $e->getMessage());
@@ -383,7 +391,11 @@ trait Deployment
                         $message = 'Authorization required: a maintainer must approve this external contribution.';
 
                         try {
-                            $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'failure', $message, $authorizeUrl, $name);
+                            // action_required is terminal and tells the maintainer the
+                            // next move is theirs, which pending never did.
+                            if (!$checkRuns->conclude($vcs, $owner, $repositoryName, $providerCommitHash, $name, CheckRuns::CONCLUSION_ACTION_REQUIRED, 'Authorization required', $message, $authorizeUrl)) {
+                                $vcs->updateCommitStatus($repositoryName, $providerCommitHash, $owner, 'failure', $message, $authorizeUrl, $name);
+                            }
                         } catch (\Throwable $e) {
                             Console::warning("Failed to report required authorization: " . $e->getMessage());
                         }

--- a/src/Appwrite/Vcs/CheckRuns.php
+++ b/src/Appwrite/Vcs/CheckRuns.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Appwrite\Vcs;
+
+use Utopia\Console;
+use Utopia\VCS\Adapter\Git;
+use Utopia\VCS\Adapter\Git\GitHub;
+
+/**
+ * Reports a deployment that will not build as a provider check run, which
+ * carries conclusions a commit status cannot: deliberately skipped, and waiting
+ * on authorization. Only GitHub implements them, so a false return means fall
+ * back to the commit status.
+ */
+class CheckRuns
+{
+    public const string CONCLUSION_NEUTRAL = 'neutral';
+    public const string CONCLUSION_ACTION_REQUIRED = 'action_required';
+
+    protected const int NAME_LIMIT = 255;
+
+    /**
+     * Owners whose installation refused a run, so an installation missing the
+     * permission does not pay one rejected call per linked resource.
+     *
+     * @var array<string, true>
+     */
+    protected array $refused = [];
+
+    public function supports(Git $vcs): bool
+    {
+        return $vcs instanceof GitHub;
+    }
+
+    /**
+     * Report a deployment that reached a terminal state without building.
+     *
+     * @return bool Whether the run was created.
+     */
+    public function conclude(
+        Git $vcs,
+        string $owner,
+        string $repositoryName,
+        string $commitHash,
+        string $name,
+        string $conclusion,
+        string $title,
+        string $summary,
+        string $detailsUrl = '',
+    ): bool {
+        // A malformed hash is a 422, and without one there is nothing to report against.
+        if (!\preg_match('/^[0-9a-f]{7,40}$/i', $commitHash)) {
+            return false;
+        }
+
+        if (!$this->supports($vcs) || empty($owner) || empty($repositoryName) || isset($this->refused[$owner])) {
+            return false;
+        }
+
+        try {
+            $vcs->createCheckRun(
+                owner: $owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: \mb_strimwidth($name, 0, self::NAME_LIMIT, '...'),
+                status: 'completed',
+                conclusion: $conclusion,
+                title: $title,
+                summary: $summary,
+                detailsUrl: $detailsUrl,
+            );
+
+            return true;
+        } catch (\Throwable $error) {
+            // An installation predating the check run permission answers 403 to
+            // every call, so stop asking for the rest of this event.
+            if ($error->getCode() === 403) {
+                $this->refused[$owner] = true;
+            }
+
+            Console::warning("Failed to create check run on {$owner}/{$repositoryName}: " . $error->getMessage());
+
+            return false;
+        }
+    }
+}

--- a/tests/unit/Vcs/CheckRunsTest.php
+++ b/tests/unit/Vcs/CheckRunsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Vcs;
+
+use Appwrite\Vcs\CheckRuns;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Utopia\VCS\Adapter\Git;
+use Utopia\VCS\Adapter\Git\GitHub;
+
+final class CheckRunsTest extends TestCase
+{
+    private const string SHA = '60c0416257a9cbcdd96b2d370c38d8f8d150ccfb';
+
+    public function testOtherProvidersReportNothing(): void
+    {
+        // Gitea and GitLab inherit a throwing default, so the caller has to be
+        // told to keep using the commit status instead.
+        $adapter = $this->createMock(Git::class);
+        $adapter->expects($this->never())->method('createCheckRun');
+
+        $checkRuns = new CheckRuns();
+
+        $this->assertFalse($checkRuns->supports($adapter));
+        $this->assertFalse($this->skip($checkRuns, $adapter));
+    }
+
+    public function testSkipReportsItsReasonAsNeutral(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willReturnCallback(function (...$arguments) {
+                $this->assertSame('completed', $arguments[4]);
+                $this->assertSame(CheckRuns::CONCLUSION_NEUTRAL, $arguments[5]);
+                $this->assertSame('Deployment skipped', $arguments[6]);
+                // The reason only reaches GitHub when title and summary are both set.
+                $this->assertSame('Commit message matched a skip pattern.', $arguments[7]);
+
+                return ['id' => 7];
+            });
+
+        $this->assertTrue($this->skip(new CheckRuns(), $adapter));
+    }
+
+    public function testAuthorizationIsReportedAsActionRequired(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willReturnCallback(function (...$arguments) {
+                $this->assertSame(CheckRuns::CONCLUSION_ACTION_REQUIRED, $arguments[5]);
+                $this->assertSame('https://console.example.com/authorize', $arguments[12]);
+
+                return ['id' => 8];
+            });
+
+        $reported = (new CheckRuns())->conclude(
+            $adapter,
+            'owner',
+            'repo',
+            self::SHA,
+            'name',
+            CheckRuns::CONCLUSION_ACTION_REQUIRED,
+            'Authorization required',
+            'A maintainer must approve this external contribution.',
+            'https://console.example.com/authorize',
+        );
+
+        $this->assertTrue($reported);
+    }
+
+    public function testDeploymentWithoutACommitReportsNothing(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->never())->method('createCheckRun');
+
+        $checkRuns = new CheckRuns();
+
+        $this->assertFalse($this->skip($checkRuns, $adapter, ''));
+        $this->assertFalse($this->skip($checkRuns, $adapter, 'not-a-sha'));
+    }
+
+    public function testAnUnknownRepositoryReportsNothing(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->never())->method('createCheckRun');
+
+        $this->assertFalse((new CheckRuns())->conclude($adapter, '', '', self::SHA, 'name', CheckRuns::CONCLUSION_NEUTRAL, 'title', 'summary'));
+    }
+
+    public function testAnOverlongNameIsTruncated(): void
+    {
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willReturnCallback(function (...$arguments) {
+                $this->assertSame(255, \mb_strlen($arguments[3]));
+
+                return ['id' => 1];
+            });
+
+        (new CheckRuns())->conclude($adapter, 'owner', 'repo', self::SHA, \str_repeat('a', 300), CheckRuns::CONCLUSION_NEUTRAL, 'title', 'summary');
+    }
+
+    public function testAProviderFailureIsContained(): void
+    {
+        // Reporting must never fail the webhook that triggered it.
+        $adapter = $this->createStub(GitHub::class);
+        $adapter->method('createCheckRun')->willThrowException(new \Exception('HTTP 500', 500));
+
+        $this->assertFalse($this->skip(new CheckRuns(), $adapter));
+    }
+
+    public function testAnInstallationThatRefusesIsAskedOnlyOnce(): void
+    {
+        // A webhook fans out to every resource linked to the repository. An
+        // installation predating the permission would otherwise pay one
+        // rejected call per resource.
+        $adapter = $this->github();
+        $adapter->expects($this->once())
+            ->method('createCheckRun')
+            ->willThrowException(new \Exception('HTTP 403', 403));
+
+        $checkRuns = new CheckRuns();
+
+        foreach (\range(1, 5) as $ignored) {
+            $this->assertFalse($this->skip($checkRuns, $adapter));
+        }
+    }
+
+    private function skip(CheckRuns $checkRuns, Git $adapter, string $commitHash = self::SHA): bool
+    {
+        return $checkRuns->conclude(
+            $adapter,
+            'owner',
+            'repo',
+            $commitHash,
+            'my-function (my-project)',
+            CheckRuns::CONCLUSION_NEUTRAL,
+            'Deployment skipped',
+            'Commit message matched a skip pattern.',
+        );
+    }
+
+    private function github(): GitHub&MockObject
+    {
+        return $this->createMock(GitHub::class);
+    }
+}


### PR DESCRIPTION
Stacked on #13108 — review that one first. **Base is `feat-vcs-skip-status`, so this diff shows only the swap.**

#13108 made the two silent cases visible using the commit status API, which has
only `pending`/`success`/`failure`/`error`. Neither of them is really a failure,
so it had to borrow `failure` and put the meaning in the description. This PR
gives them the conclusions they actually deserve.

## What changes

| Situation | #13108 | This PR |
|---|---|---|
| Skipped deployment | `failure` (red ✗) | `neutral` |
| Unauthorized contributor | `failure` (red ✗) | `action_required` |

Both matter beyond wording:

- **`neutral` counts as passing for branch protection.** In #13108 a skipped
  deployment renders as a red ✗ and, if someone has marked the Appwrite check
  required, blocks the merge. Neutral reports the skip without blocking.
- **`action_required` renders as an actionable state**, not a failure, and
  carries the link to the authorization page in `details_url`.

Everything else — when we report, what the messages say, silent-mode gating,
once-per-commit behaviour — is unchanged from #13108.

