### PR TITLE
feat(sdks): release the CLI from the Go language class

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5417,16 +5417,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "2.4.19",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "d0e58c93a8d7021a69d2a5d6b30fa826a5404fb9"
+                "reference": "fb40ba0484f3254fd483d9bf7fd915543320d617"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/d0e58c93a8d7021a69d2a5d6b30fa826a5404fb9",
-                "reference": "d0e58c93a8d7021a69d2a5d6b30fa826a5404fb9",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/fb40ba0484f3254fd483d9bf7fd915543320d617",
+                "reference": "fb40ba0484f3254fd483d9bf7fd915543320d617",
                 "shasum": ""
             },
             "require": {
@@ -5463,9 +5463,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/2.4.19"
+                "source": "https://github.com/appwrite/sdk-generator/tree/2.10.0"
             },
-            "time": "2026-07-24T06:18:23+00:00"
+            "time": "2026-08-06T07:29:00+00:00"
         },
         {
             "name": "brianium/paratest",

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -5,13 +5,13 @@ namespace Appwrite\Platform\Tasks;
 use Appwrite\SDK\Language\Android;
 use Appwrite\SDK\Language\Apple;
 use Appwrite\SDK\Language\ClaudePlugin;
-use Appwrite\SDK\Language\CLI;
 use Appwrite\SDK\Language\CodexPlugin;
 use Appwrite\SDK\Language\CursorPlugin;
 use Appwrite\SDK\Language\Dart;
 use Appwrite\SDK\Language\DotNet;
 use Appwrite\SDK\Language\Flutter;
 use Appwrite\SDK\Language\Go;
+use Appwrite\SDK\Language\GoCLI;
 use Appwrite\SDK\Language\GraphQL;
 use Appwrite\SDK\Language\Kotlin;
 use Appwrite\SDK\Language\Node;
@@ -198,6 +198,7 @@ class SDKs extends Action
 
                     $releaseTitle = $releaseVersion;
                     $releaseTarget = $language['repoBranch'] ?? 'main';
+                    $isPrerelease = (bool) \preg_match('/^v?\d+\.\d+\.\d+-/', $releaseVersion);
 
                     if ($repoName === '/') {
                         Console::warning('  Not a releasable SDK, skipping');
@@ -255,6 +256,7 @@ class SDKs extends Action
                         Console::log("    Version:          {$releaseVersion}");
                         Console::log("    Title:            {$releaseTitle}");
                         Console::log("    Target Branch:    {$releaseTarget}");
+                        Console::log('    Prerelease:       ' . ($isPrerelease ? 'yes' : 'no'));
                         Console::log('    Previous Version: ' . ($previousVersion ?: 'N/A'));
                         Console::log('    Release Notes:');
                         Console::log('    ' . str_replace("\n", "\n    ", $formattedNotes));
@@ -264,12 +266,13 @@ class SDKs extends Action
                         $tempNotesFile = \tempnam(\sys_get_temp_dir(), 'release_notes_');
                         \file_put_contents($tempNotesFile, $formattedNotes);
 
-                        $releaseCommand = 'gh release create ' . \escapeshellarg($releaseVersion) . ' \
-                            --repo ' . \escapeshellarg($repoName) . ' \
-                            --title ' . \escapeshellarg($releaseTitle) . ' \
-                            --notes-file ' . \escapeshellarg($tempNotesFile) . ' \
-                            --target ' . \escapeshellarg($releaseTarget) . ' \
-                            2>&1';
+                        $releaseCommand = 'gh release create ' . \escapeshellarg($releaseVersion)
+                            . ' --repo ' . \escapeshellarg($repoName)
+                            . ' --title ' . \escapeshellarg($releaseTitle)
+                            . ' --notes-file ' . \escapeshellarg($tempNotesFile)
+                            . ' --target ' . \escapeshellarg($releaseTarget)
+                            . ($isPrerelease ? ' --prerelease' : '')
+                            . ' 2>&1';
 
                         $releaseOutput = [];
                         $releaseReturnCode = 0;
@@ -356,10 +359,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                         }
                         break;
                     case 'cli':
-                        $config = new CLI();
+                        $config = new GoCLI();
                         $config->setNPMPackage('appwrite-cli');
                         $config->setExecutableName('appwrite');
-                        $config->setLogo(json_encode("
+                        $config->setLogo("
     _                            _ _           ___   __   _____
    /_\  _ __  _ ____      ___ __(_) |_ ___    / __\ / /   \_   \
   //_\\\| '_ \| '_ \ \ /\ / / '__| | __/ _ \  / /   / /     / /\/
@@ -367,7 +370,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
  \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
        |_|   |_|
 
-"));
+");
                         $config->setLogoUnescaped("
      _                            _ _           ___   __   _____
     /_\  _ __  _ ____      ___ __(_) |_ ___    / __\ / /   \_   \


### PR DESCRIPTION
Selects `GoCLI` for the `cli` key so the CLI releases from the Go rewrite in
appwrite/sdk-generator#1733, and makes an rc able to stay an rc.

## The `cli` key does not change

The Go CLI ships as the same npm package, the same repository and the same
changelog as the TypeScript one, continuing its version line — so it releases
under the same key rather than a second one. `setLogo` is passed the art raw
rather than JSON-encoded: JSON escapes `/` as `\/`, which is not a valid Go
escape, so each template escapes the art for its own language.

## An rc had no way to stay an rc

`gh release create` was called without `--prerelease`, and the CLI's publish
workflow reads `github.event.release.prerelease` twice — once to pick the npm
dist-tag (`next` vs `latest`), once to gate the Homebrew formula commit. Without
the flag, `26.0.0-rc.1` would publish to npm as `latest` and rewrite the stable
formula. The version now decides: anything with a semver prerelease identifier
is released as a prerelease, which the dry run prints.

Two incidental changes come with it: the release command is built by
concatenation rather than a backslash-continued heredoc, because a conditional
flag inside a continued line leaves a dangling `\` when the flag is absent; and
the `Appwrite\SDK\Language\CLI` import goes, having had this one call site.

## Verification

`pint` passes. Generation itself is proven upstream — sdk-generator's
`GoCLI126` job runs the conformance suite against the mock API, and
`validation.yml` builds, vets and race-tests the generated tree — so what this
PR adds is the selection, checked end to end by the `26.0.0-rc.1` release run
that follows it. `appwrite/sdk-generator` moves to 2.10.0, the release carrying
`GoCLI`.

