### PR TITLE
chore(deps): bump appwrite/sdk-generator to 2.10.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5417,16 +5417,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "2.10.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "fb40ba0484f3254fd483d9bf7fd915543320d617"
+                "reference": "3019e3e939cc5f12a41dab98ded1043423467dd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/fb40ba0484f3254fd483d9bf7fd915543320d617",
-                "reference": "fb40ba0484f3254fd483d9bf7fd915543320d617",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/3019e3e939cc5f12a41dab98ded1043423467dd0",
+                "reference": "3019e3e939cc5f12a41dab98ded1043423467dd0",
                 "shasum": ""
             },
             "require": {
@@ -5463,9 +5463,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/2.10.0"
+                "source": "https://github.com/appwrite/sdk-generator/tree/2.10.1"
             },
-            "time": "2026-08-06T07:29:00+00:00"
+            "time": "2026-08-06T07:56:50+00:00"
         },
         {
             "name": "brianium/paratest",


### PR DESCRIPTION
2.10.1 registers `LICENSE.md`, `CHANGELOG.md` and `docs/examples/**` for the Go CLI (appwrite/sdk-generator#1747).

A release wipes the SDK repository and copies the generated tree over it, so on 2.10.0 generating the CLI from here would delete the license, the changelog and every example doc from `appwrite/sdk-for-cli`. The `26.0.0-rc.1` release runs from cloud, which pins the generator itself and is already on 2.10.1 — this closes the same hole for anyone generating from this repository.