### PR TITLE
Add opt-in spread for scheduled function enqueues

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -1200,6 +1200,15 @@ return [
                 'question' => '',
                 'filter' => ''
             ],
+            [
+                'name' => '_APP_FUNCTIONS_SCHEDULE_SPREAD',
+                'description' => 'Number of seconds over which scheduled executions sharing the same cron slot are spread, using a stable per-function offset, so they don\'t all start in the same second. Each function keeps a consistent slot within the window, preserving exact run intervals. The default value is 0 (disabled): every execution is enqueued at the exact cron time.',
+                'introduction' => '2.0.0',
+                'default' => '0',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
         ],
     ],
     [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1079,6 +1079,7 @@ services:
       - _APP_DB_USER
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
+      - _APP_FUNCTIONS_SCHEDULE_SPREAD
   appwrite-task-scheduler-executions:
     entrypoint: schedule-executions
     restart: unless-stopped

--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -9,6 +9,7 @@ use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Span\Span;
+use Utopia\System\System;
 
 /**
  * ScheduleFunctions
@@ -36,10 +37,24 @@ class ScheduleFunctions extends ScheduleBase
         return RESOURCE_TYPE_FUNCTIONS;
     }
 
+    /**
+     * Deterministic per-function offset, in seconds, within [0, $window).
+     *
+     * Schedules that share a cron slot (everyone runs `0 * * * *`) are spread
+     * across the window instead of all being enqueued in the same second,
+     * while each function keeps a stable slot so run intervals stay exact.
+     */
+    public static function spreadOffset(string $resourceId, int $window): int
+    {
+        return $window <= 1 ? 0 : \abs(\crc32($resourceId)) % $window;
+    }
+
     protected function enqueueResources(Database $dbForPlatform, callable $getProjectDB): void
     {
         $timerStart = \microtime(true);
         $time = DateTime::now();
+
+        $spread = (int) System::getEnv('_APP_FUNCTIONS_SCHEDULE_SPREAD', '0');
 
         // TODO: Track the last enqueue timestamp to subtract ENQUEUE_TIMER drift from
         // the time frame. Previously this used $this->lastEnqueueUpdate as a property
@@ -47,7 +62,7 @@ class ScheduleFunctions extends ScheduleBase
         $enqueueDiff = 0;
         $timeFrame = DateTime::addSeconds(new \DateTime(), static::ENQUEUE_TIMER - $enqueueDiff);
 
-        Console::log("Enqueue tick: started at: $time (with diff $enqueueDiff)");
+        Console::log("Enqueue tick: started at: $time (with diff $enqueueDiff, spread {$spread}s)");
 
         $total = 0;
 
@@ -77,13 +92,16 @@ class ScheduleFunctions extends ScheduleBase
 
             $promiseStart = \time(); // in seconds
             $executionStart = $nextDate->getTimestamp(); // in seconds
-            $delay = $executionStart - $promiseStart; // Time to wait from now until execution needs to be queued
+            $offset = self::spreadOffset($schedule['resourceId'], $spread);
+            $delay = $executionStart - $promiseStart + $offset; // Time to wait from now until execution needs to be queued
 
             if (!isset($delayedExecutions[$delay])) {
                 $delayedExecutions[$delay] = [];
             }
 
-            $delayedExecutions[$delay][] = ['key' => $key, 'nextDate' => $nextDate];
+            // nextDate carries the offset so enqueue-delay telemetry measures
+            // lateness against the intended (spread) enqueue time.
+            $delayedExecutions[$delay][] = ['key' => $key, 'nextDate' => $nextDate->modify("+{$offset} seconds")];
         }
 
         foreach ($delayedExecutions as $delay => $schedules) {

--- a/tests/unit/Platform/Tasks/ScheduleFunctionsTest.php
+++ b/tests/unit/Platform/Tasks/ScheduleFunctionsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Tasks;
+
+use Appwrite\Platform\Tasks\ScheduleFunctions;
+use PHPUnit\Framework\TestCase;
+
+final class ScheduleFunctionsTest extends TestCase
+{
+    public function testSpreadOffsetIsDeterministic(): void
+    {
+        $this->assertSame(
+            ScheduleFunctions::spreadOffset('64f5c8e2a1b3d4e5f6a7b8c9', 60),
+            ScheduleFunctions::spreadOffset('64f5c8e2a1b3d4e5f6a7b8c9', 60)
+        );
+    }
+
+    public function testSpreadOffsetIsBounded(): void
+    {
+        foreach ($this->sampleIds() as $id) {
+            foreach ([2, 30, 60, 300] as $window) {
+                $offset = ScheduleFunctions::spreadOffset($id, $window);
+                $this->assertGreaterThanOrEqual(0, $offset);
+                $this->assertLessThan($window, $offset);
+            }
+        }
+    }
+
+    public function testSpreadOffsetIsZeroWhenDisabled(): void
+    {
+        $this->assertSame(0, ScheduleFunctions::spreadOffset('64f5c8e2a1b3d4e5f6a7b8c9', 1));
+        $this->assertSame(0, ScheduleFunctions::spreadOffset('64f5c8e2a1b3d4e5f6a7b8c9', 0));
+        $this->assertSame(0, ScheduleFunctions::spreadOffset('64f5c8e2a1b3d4e5f6a7b8c9', -5));
+    }
+
+    public function testSpreadOffsetDispersesDistinctFunctions(): void
+    {
+        $offsets = [];
+        foreach ($this->sampleIds() as $id) {
+            $offsets[] = ScheduleFunctions::spreadOffset($id, 60);
+        }
+
+        // The whole point: functions sharing a cron slot must not all land
+        // in the same second. Expect real dispersion across the window.
+        $this->assertGreaterThan(10, count(array_unique($offsets)));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function sampleIds(): array
+    {
+        $ids = [];
+        for ($i = 0; $i < 50; $i++) {
+            $ids[] = md5("function-{$i}");
+        }
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `_APP_FUNCTIONS_SCHEDULE_SPREAD` env var that spreads scheduled function enqueues sharing the same cron slot across a window, instead of enqueuing them all in the same second.

Cron schedules cluster on shared slots — a large share of all scheduled functions run `0 * * * *` or similar. `ScheduleFunctions::enqueueResources()` groups schedules by identical delay and enqueues each bucket in one tight loop, so every same-slot execution hits the `v1-functions` queue at exactly `:00:00`. At scale this is a thundering herd: a burst of simultaneous invocations and runtime cold starts at the top of every hour.

With `_APP_FUNCTIONS_SCHEDULE_SPREAD=N`, each function gets a deterministic offset — `abs(crc32(functionId)) % N` seconds — added to its enqueue delay:

- **Stable slot per function**: an hourly cron always fires at e.g. `:00:37`, so run intervals stay exact.
- **Selection is untouched**: the offset applies to the coroutine sleep only, so no occurrence is double-enqueued or skipped (the 60s selection windows tile exactly with the enqueue loop).
- **Telemetry stays honest**: enqueue-delay is recorded against the intended (offset) time, so the deliberate spread doesn't read as scheduler lateness while a genuine stall still shows.
- **Default `0` = disabled**: behavior is byte-for-byte unchanged unless the env var is set.

Also registers the variable in `app/config/variables.php` and forwards it to the `appwrite-task-scheduler-functions` service in `docker-compose.yml`.

## Test plan

- New unit tests for `spreadOffset()`: determinism, bounds (`[0, window)`), disabled windows (`<= 1` → `0`), and dispersion across distinct function IDs. Verified red with the offset neutered to a constant, green with the real implementation.
- The enqueue-loop wiring itself has no unit-testable seam (coroutine timing); verified by watching scheduler logs with the spread enabled — enqueues land at distinct offsets within the window instead of one second.
- Pint, Rector, and PHPStan (level 4) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)