### PR TITLE
Make the schedule spread window overridable per schedule

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -49,6 +49,16 @@ class ScheduleFunctions extends ScheduleBase
         return $window <= 1 ? 0 : \abs(\crc32($resourceId)) % $window;
     }
 
+    /**
+     * Spread window, in seconds, for a given schedule. The default applies
+     * _APP_FUNCTIONS_SCHEDULE_SPREAD to every schedule; override to scope
+     * or vary the window per schedule (e.g. by project or plan).
+     */
+    protected function spreadWindow(array $schedule, Database $dbForPlatform): int
+    {
+        return (int) System::getEnv('_APP_FUNCTIONS_SCHEDULE_SPREAD', '0');
+    }
+
     protected function enqueueResources(Database $dbForPlatform, callable $getProjectDB): void
     {
         $timerStart = \microtime(true);
@@ -92,7 +102,7 @@ class ScheduleFunctions extends ScheduleBase
 
             $promiseStart = \time(); // in seconds
             $executionStart = $nextDate->getTimestamp(); // in seconds
-            $offset = self::spreadOffset($schedule['resourceId'], $spread);
+            $offset = self::spreadOffset($schedule['resourceId'], $this->spreadWindow($schedule, $dbForPlatform));
             $delay = $executionStart - $promiseStart + $offset; // Time to wait from now until execution needs to be queued
 
             if (!isset($delayedExecutions[$delay])) {

--- a/tests/unit/Platform/Tasks/ScheduleFunctionsTest.php
+++ b/tests/unit/Platform/Tasks/ScheduleFunctionsTest.php
@@ -6,6 +6,10 @@ namespace Tests\Unit\Platform\Tasks;
 
 use Appwrite\Platform\Tasks\ScheduleFunctions;
 use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\None as NoCache;
+use Utopia\Cache\Cache;
+use Utopia\Database\Adapter\Memory;
+use Utopia\Database\Database;
 
 final class ScheduleFunctionsTest extends TestCase
 {
@@ -45,6 +49,30 @@ final class ScheduleFunctionsTest extends TestCase
         // The whole point: functions sharing a cron slot must not all land
         // in the same second. Expect real dispersion across the window.
         $this->assertGreaterThan(10, count(array_unique($offsets)));
+    }
+
+    public function testSpreadWindowDefaultsToEnv(): void
+    {
+        $task = new class () extends ScheduleFunctions {
+            public function window(array $schedule, Database $dbForPlatform): int
+            {
+                return $this->spreadWindow($schedule, $dbForPlatform);
+            }
+        };
+        $dbForPlatform = new Database(new Memory(), new Cache(new NoCache()));
+
+        $previous = getenv('_APP_FUNCTIONS_SCHEDULE_SPREAD');
+        try {
+            putenv('_APP_FUNCTIONS_SCHEDULE_SPREAD=45');
+            $this->assertSame(45, $task->window([], $dbForPlatform));
+
+            putenv('_APP_FUNCTIONS_SCHEDULE_SPREAD');
+            $this->assertSame(0, $task->window([], $dbForPlatform));
+        } finally {
+            $previous === false
+                ? putenv('_APP_FUNCTIONS_SCHEDULE_SPREAD')
+                : putenv("_APP_FUNCTIONS_SCHEDULE_SPREAD={$previous}");
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Follow-up to #13121. Extracts the schedule-spread window into a protected seam:

```php
protected function spreadWindow(array $schedule, Database $dbForPlatform): int
```

The default implementation is behavior-identical to #13121 — `_APP_FUNCTIONS_SCHEDULE_SPREAD` (default `0` = off) applied to every schedule. Subclassing platforms can override the method to scope or vary the window per schedule — e.g. spread only certain projects or plan tiers — without having to copy the ~90-line enqueue loop, which was the only extension point before this.

The call site consults the seam per current-tick schedule; `spreadOffset()` and selection semantics are untouched.

## Test plan

- New unit test covers the default seam via a probe subclass (no reflection): env set → window, env unset → 0, with the env restored afterwards.
- Existing `spreadOffset` tests unchanged and passing.
- Pint, Rector, and PHPStan (level 4) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)