### PR TITLE
Fix deployment rule updates on activation

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Deployment/Update.php
@@ -115,7 +115,6 @@ class Update extends Base
         ])));
 
         $queries = [
-            Query::equal('trigger', ['manual']),
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceType', ['function']),
             Query::equal('deploymentResourceInternalId', [$function->getSequence()]),

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Jobs.php
@@ -542,7 +542,6 @@ class Jobs extends Action
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceInternalId', [$resource->getSequence()]),
             Query::equal('deploymentResourceType', [$resource->getCollection() === 'sites' ? 'site' : 'function']),
-            Query::equal('trigger', ['manual']),
             Query::equal('deploymentVcsProviderBranch', ['']),
         ]);
     }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Deployment/Update.php
@@ -103,7 +103,6 @@ class Update extends Base
         ])));
 
         $queries = [
-            Query::equal('trigger', ['manual']),
             Query::equal('type', ['deployment']),
             Query::equal('deploymentResourceType', ['site']),
             Query::equal('deploymentResourceInternalId', [$site->getSequence()]),

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -1555,6 +1555,79 @@ final class SitesCustomServerTest extends Scope
         $this->cleanupSite($siteId);
     }
 
+    public function testUpdateDeploymentUpdatesSiteRule(): void
+    {
+        $siteId = $this->setupSite([
+            'buildRuntime' => 'node-22',
+            'fallbackFile' => '',
+            'framework' => 'other',
+            'name' => 'Rule Update Site',
+            'outputDirectory' => './',
+            'providerBranch' => 'main',
+            'providerRootDirectory' => './',
+            'siteId' => ID::unique()
+        ]);
+
+        $rule = $this->client->call(Client::METHOD_POST, '/proxy/rules/site', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'domain' => uniqid() . '.custom.localhost',
+            'siteId' => $siteId,
+            'branch' => '',
+        ]);
+
+        $this->assertEquals(201, $rule['headers']['status-code']);
+        $ruleId = $rule['body']['$id'];
+
+        $deployment = $this->createDeployment($siteId, [
+            'code' => $this->packageSite('static-single-file'),
+            'activate' => 'false'
+        ]);
+
+        $deploymentId = $deployment['body']['$id'] ?? '';
+        $this->assertEquals(202, $deployment['headers']['status-code']);
+
+        $this->assertEventually(function () use ($siteId, $deploymentId) {
+            $deployment = $this->getDeployment($siteId, $deploymentId);
+            $this->assertEquals('ready', $deployment['body']['status']);
+        }, 120000, 500);
+
+        $deployment = $this->createDeployment($siteId, [
+            'code' => $this->packageSite('static-single-file'),
+            'activate' => 'false'
+        ]);
+
+        $secondDeploymentId = $deployment['body']['$id'] ?? '';
+        $this->assertEquals(202, $deployment['headers']['status-code']);
+
+        $this->assertEventually(function () use ($siteId, $secondDeploymentId) {
+            $deployment = $this->getDeployment($siteId, $secondDeploymentId);
+            $this->assertEquals('ready', $deployment['body']['status']);
+        }, 120000, 500);
+
+        $response = $this->updateSiteDeployment($siteId, $secondDeploymentId);
+        $this->assertEquals(200, $response['headers']['status-code']);
+
+        $this->assertEventually(function () use ($ruleId, $secondDeploymentId) {
+            $updatedRule = $this->client->call(Client::METHOD_GET, '/proxy/rules/' . $ruleId, array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders()));
+
+            $this->assertEquals(200, $updatedRule['headers']['status-code']);
+            $this->assertEquals($secondDeploymentId, $updatedRule['body']['deploymentId']);
+        }, 60000, 500);
+
+        $this->client->call(Client::METHOD_DELETE, '/proxy/rules/' . $ruleId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+        $this->cleanupDeployment($siteId, $deploymentId);
+        $this->cleanupDeployment($siteId, $secondDeploymentId);
+        $this->cleanupSite($siteId);
+    }
+
     public function testUpdateSiteDeploymentRequiresOwnership(): void
     {
         $siteId = $this->setupSite([


### PR DESCRIPTION
## Summary

Fixes #13088.

This PR fixes deployment activation so site and function deployments keep their proxy-rule deployment references in sync.

## What changed

- Updated deployment activation logic to update the relevant deployment-backed proxy rules for the resource, rather than only the narrower manual-trigger subset.
- Applied the same change to function deployment activation for consistency.
- Added a regression test covering site deployment activation updating the proxy rule’s deployment reference.

## Why

When a deployment was activated, some deployment-backed proxy rules could remain stale, which could lead to routing failures such as router_deployment_not_found for sites.

## Testing

- Added regression coverage in the Sites e2e suite for deployment activation updating a site rule.