### PR TITLE
fix(auth): reject JWT when linked session is expired

### DIFF
--- a/app/init/realtime/connection.php
+++ b/app/init/realtime/connection.php
@@ -288,8 +288,10 @@ return function (Container $container): void {
             $jwtUserId = $payload['userId'] ?? '';
             if (!empty($jwtUserId)) {
                 if ($mode === APP_MODE_ADMIN) {
+                    /** @var User $user */
                     $user = $dbForPlatform->getDocument('users', $jwtUserId);
                 } else {
+                    /** @var User $user */
                     $user = $dbForProject->getDocument('users', $jwtUserId);
                 }
             }

--- a/app/init/realtime/connection.php
+++ b/app/init/realtime/connection.php
@@ -295,7 +295,7 @@ return function (Container $container): void {
             }
 
             $jwtSessionId = $payload['sessionId'] ?? '';
-            if (!empty($jwtSessionId) && empty($user->find('$id', $jwtSessionId, 'sessions'))) {
+            if (!empty($jwtSessionId) && !$user->sessionActive($jwtSessionId)) {
                 $user = new User([]);
             }
         }

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -542,10 +542,8 @@ return function (Container $context): void {
                 }
             }
             $jwtSessionId = $payload['sessionId'] ?? '';
-            if (! empty($jwtSessionId)) {
-                if (empty($user->find('$id', $jwtSessionId, 'sessions'))) { // Match JWT to active token
-                    $user = new User([]);
-                }
+            if (! empty($jwtSessionId) && ! $user->sessionActive($jwtSessionId)) { // Match JWT to active session
+                $user = new User([]);
             }
         }
 

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -536,8 +536,10 @@ return function (Container $context): void {
             $jwtUserId = $payload['userId'] ?? '';
             if (! empty($jwtUserId)) {
                 if ($mode === APP_MODE_ADMIN) {
+                    /** @var User $user */
                     $user = $dbForPlatform->getDocument('users', $jwtUserId);
                 } else {
+                    /** @var User $user */
                     $user = $dbForProject->getDocument('users', $jwtUserId);
                 }
             }

--- a/src/Appwrite/Utopia/Database/Documents/User.php
+++ b/src/Appwrite/Utopia/Database/Documents/User.php
@@ -174,4 +174,22 @@ class User extends Document
 
         return false;
     }
+
+    /**
+     * Check that a session exists on the user and has not expired.
+     *
+     * Used by JWT authentication, which binds to a session ID rather than a
+     * session secret.
+     */
+    public function sessionActive(string $sessionId): bool
+    {
+        $session = $this->find('$id', $sessionId, 'sessions');
+
+        if (empty($session)) {
+            return false;
+        }
+
+        return $session->isSet('expire')
+            && DateTime::formatTz(DateTime::format(new \DateTime($session->getAttribute('expire')))) >= DateTime::formatTz(DateTime::now());
+    }
 }

--- a/tests/unit/Utopia/Database/Documents/UserTest.php
+++ b/tests/unit/Utopia/Database/Documents/UserTest.php
@@ -97,6 +97,37 @@ final class UserTest extends TestCase
         $this->assertEquals(false, $user2->sessionVerify('false-secret', $proofForToken));
     }
 
+    public function testSessionActive(): void
+    {
+        $user = new User([
+            '$id' => ID::custom('user1'),
+            'sessions' => [
+                new Document([
+                    '$id' => ID::custom('active'),
+                    'secret' => 'secret',
+                    'provider' => SESSION_PROVIDER_EMAIL,
+                    'expire' => DateTime::addSeconds(new \DateTime(), 60 * 60),
+                ]),
+                new Document([
+                    '$id' => ID::custom('expired'),
+                    'secret' => 'secret',
+                    'provider' => SESSION_PROVIDER_EMAIL,
+                    'expire' => DateTime::addSeconds(new \DateTime(), -60),
+                ]),
+                new Document([
+                    '$id' => ID::custom('missing-expire'),
+                    'secret' => 'secret',
+                    'provider' => SESSION_PROVIDER_EMAIL,
+                ]),
+            ],
+        ]);
+
+        $this->assertTrue($user->sessionActive('active'));
+        $this->assertFalse($user->sessionActive('expired'));
+        $this->assertFalse($user->sessionActive('missing-expire'));
+        $this->assertFalse($user->sessionActive('missing'));
+    }
+
     public function testTokenVerify(): void
     {
         $proofForToken = new Token();


### PR DESCRIPTION
## Summary
- Fixes #8000: JWT authentication accepted tokens after the linked session timed out, because only session existence was checked — not `expire`.
- Adds `User::sessionActive()` (same expiry rules as `sessionVerify()`) and uses it for JWT auth in HTTP request handling and realtime.
- Covers active, expired, missing-expire, and missing session IDs with a unit test.

## Test plan
- [ ] `composer lint` on touched files
- [ ] `docker compose exec appwrite test tests/unit/Utopia/Database/Documents/UserTest.php --filter=testSessionActive`
- [ ] Manually: set short session length → sign in → `account.createJWT()` → wait for session timeout → `account.get()` with JWT should return 401
- [ ] Confirm deleted-session JWT rejection still works (`testCreateJWT` path)


Made with [Cursor](https://cursor.com)