### PR TITLE
Bump docker-base to 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist \
     `if [ "$TESTING" != "true" ]; then echo "--no-dev"; fi`
 
-FROM appwrite/base:1.4.4 AS base
+FROM appwrite/base:2.0.0 AS base
 
 LABEL maintainer="team@appwrite.io"
 
@@ -23,12 +23,7 @@ ENV DEBUG=$DEBUG
 ENV _APP_VERSION=$VERSION \
     _APP_HOME=https://appwrite.io
 
-RUN \
-    if [ "$DEBUG" != "true" ]; then \
-    rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    rm -f /usr/local/lib/php/extensions/no-debug-non-zts-*/xdebug.so; \
-    fi && \
-    if [ "$DEBUG" == "true" ]; then \
+RUN if [ "$DEBUG" == "true" ]; then \
     apk add boost boost-dev; \
     fi
 
@@ -107,8 +102,6 @@ RUN mkdir -p /etc/letsencrypt/live/ && chmod -Rf 755 /etc/letsencrypt/live/
 FROM base AS production
 
 RUN rm -rf /usr/src/code/app/config/specs && \
-    rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini && \
-    rm -f /usr/local/lib/php/extensions/no-debug-non-zts-*/xdebug.so && \
     find /usr -name '*.a' -delete 2>/dev/null || true && \
     find /usr -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr -name '*.pyc' -delete 2>/dev/null || true
@@ -117,12 +110,20 @@ EXPOSE 80
 
 CMD [ "php", "app/http.php" ]
 
+FROM appwrite/base:2.0.0-xdebug AS xdebug
+
 FROM base AS development
 
 COPY ./docs /usr/src/code/docs
 COPY ./dev /usr/src/code/dev
 
-RUN if [ "$DEBUG" = "true" ]; then \
+# appwrite/base:2.0.0 ships without XDebug, so it cannot reach production or
+# Cloud. The -xdebug tag is the same build with the extension; mounting it
+# rather than copying keeps xdebug.so out of every layer unless DEBUG asked
+# for it, and guarantees an ABI match because both tags are one base build.
+RUN --mount=from=xdebug,source=/usr/local/lib/php/extensions,target=/tmp/extensions \
+    if [ "$DEBUG" = "true" ]; then \
+    cp /tmp/extensions/no-debug-non-zts-*/xdebug.so "$(php-config --extension-dir)/" && \
     cp /usr/src/code/dev/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini && \
     mkdir -p /tmp/xdebug && \
     apk add --update --no-cache openssh-client github-cli; \

--- a/docs/tutorials/multi-architecture-support.md
+++ b/docs/tutorials/multi-architecture-support.md
@@ -6,7 +6,7 @@ CPU architecture support for Docker images used by the Appwrite stack. Platforms
 |---|---|---|---|---|---|---|---|
 | **Core** | | | | | | | |
 | appwrite/appwrite | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
-| appwrite/base:1.4.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
+| appwrite/base:2.0.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | appwrite/assistant:0.8.4 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | appwrite/browser:0.3.3 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |
 | appwrite/embedding:0.1.0 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 |


### PR DESCRIPTION
Bumps `appwrite/base` from 1.4.4 to [2.0.0](https://github.com/appwrite/docker-base/releases/tag/2.0.0).

## What 2.0.0 brings

Every PHP extension is now fetched by commit SHA and the PECL tarball verified by checksum, so the base is no longer assembled from mutable upstream tags — an upstream tag can be deleted and recreated on a different commit without anyone noticing. It also carries the extension updates that came with that work, on a freshly patched `php:8.5-alpine`: swoole 6.2.2, mongodb 2.3.3, protobuf 5.35.1, zstd 0.17.0, lz4 0.7.0, brotli 0.20.0, scrypt 2.0.2, xdebug 3.5.3.

## The XDebug change, and why this PR is more than one line

2.0.0 also stops shipping XDebug in the default tag. That was never intentional: docker-base's Dockerfile ended with the XDebug stage and its build passed no `--target`, so Docker picked the last stage and the debugger rode along into the image this repo — and Cloud — build on.

This repo depended on that accident. The `development` target copies `dev/xdebug.ini`, which is `zend_extension=xdebug`, but nothing here ever installed the extension; it came free from the base. A bare version bump would leave `DEBUG=true` builds loading a `zend_extension` that isn't there, breaking the debug workflow documented in `CONTRIBUTING.md`.

So XDebug now comes from the `2.0.0-xdebug` tag — the same base build with the extension added, which means the PHP module API always matches:

```dockerfile
FROM appwrite/base:2.0.0-xdebug AS xdebug

FROM base AS development
RUN --mount=from=xdebug,source=/usr/local/lib/php/extensions,target=/tmp/extensions \
    if [ "$DEBUG" = "true" ]; then \
    cp /tmp/extensions/no-debug-non-zts-*/xdebug.so "$(php-config --extension-dir)/" && \
    ...
```

It is mounted rather than copied, so `xdebug.so` only enters a layer when `DEBUG=true`, and only in the `development` stage. `production` is a sibling of `development`, not a parent, so it has no path to the extension at all.

The XDebug removals in the `base` and `production` stages are dropped in the same change. They existed to strip what the base wrongly shipped; against 2.0.0 they strip nothing.

## Verification

Built locally, on the real 2.0.0 images:

| Build | XDebug |
| --- | --- |
| `--target production` | absent — no module, no `xdebug.so`, and the `xdebug` stage is never built |
| `--target development` (default `DEBUG=false`) | absent — nothing left behind by the mount |
| `--target development --build-arg DEBUG=true` | `with Xdebug v3.5.3` |

Cloud was checked directly, not assumed. Its Dockerfile builds `FROM $BASE_IMAGE` defaulting to `appwrite/ce:*`, which is a `--target production` build of this repo. Building Cloud's `final` target against the production image above gives an image whose `php -m` has no xdebug and which has no `xdebug.so` on disk. Every publishing path here — `publish.yml`, `release.yml`, `nightly.yml`, `ci.yml` — passes `--target production`, so that is the image Cloud consumes.

## Worth a separate look

`Dockerfile` line 180 in the Cloud repo removes `/usr/local/lib/php/extensions/no-debug-non-zts-20240924/xdebug.so`. That path is hardcoded to PHP 8.4's module API; base 2.0.0 is `no-debug-non-zts-20250925`, so it has been a no-op for a while and is doubly dead now that the base ships no XDebug. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
