### PR TITLE
Bump self-hosted Console to 8.7.37

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# Version 1.9.7
+
+## What's Changed
+
+### Miscellaneous
+
+* Update the self-hosted Console image to [8.7.37](https://github.com/appwrite/console/releases/tag/8.7.37) for array column editing, relationship filtering, messaging permission, and dependency audit fixes
+
 # Version 1.9.6
 
 ## What's Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,3 @@
-# Version 1.9.7
-
-## What's Changed
-
-### Miscellaneous
-
-* Update the self-hosted Console image to [8.7.37](https://github.com/appwrite/console/releases/tag/8.7.37) for array column editing, relationship filtering, messaging permission, and dependency audit fixes
-
 # Version 1.9.6
 
 ## What's Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,7 +209,7 @@ services:
         max-file: "5"
         max-size: 10m
     container_name: appwrite-console
-    image: appwrite/console:8.7.30
+    image: appwrite/console:8.7.37
     restart: unless-stopped
     networks:
       - appwrite


### PR DESCRIPTION
## What does this PR do?

Bumps the self-hosted Console image from `8.7.30` to [`8.7.37`](https://github.com/appwrite/console/releases/tag/8.7.37).

The motivating fix is [appwrite/console#3151](https://github.com/appwrite/console/pull/3151): the row create/edit form rendered **every** array column as a string input regardless of its element type. A `Boolean[]` column showed "Enter string" for each item instead of a True/False select, `Integer[]` lost its number input and min/max, and `Datetime[]` lost the date picker.

It also caused intermittent save failures, which is how it was reported. The string component still ran `parseValue()` against the column type, so typing literally `true`/`false`/`1`/`0` coerced and saved — anything else became `null`, and a `null` inside a typed array is rejected by the API.

This was reported against self-hosted 1.9.6. The affected code path has no `isCloud` gating and no database-type branching, so it applies to every self-hosted install, not just the MongoDB-backed database the reporter happened to be using.

### Also included (8.7.31..8.7.37)

* Materialize filter queries so the relationship fallback keeps them
* Don't fail the grid when relationship resolution exceeds the query value limit
* Gate the messaging delete card on write scope; show delete for a processing message
* Stop a zero seat limit turning free orgs read-only
* Prevent the project Usage tab crashing on missing usage breakdowns
* Show the real OAuth error on the failure relay page
* Dev-key deprecation notice; removal of dev key creation
* Several dependency floors raised to clear high-severity advisories (`js-yaml`, `brace-expansion`, `immutable`, `postcss`)

## Test Plan

* `docker compose up -d` and confirm `appwrite-console` starts on `appwrite/console:8.7.37` (published for amd64 and arm64).
* Create a table with a `Boolean[]` column, add a row, click `+ Add item` — each item should render a True/False/NULL select rather than a text field, and the row should save.

## Related PRs and Issues

* Console fix: [appwrite/console#3151](https://github.com/appwrite/console/pull/3151)

Cloud needs the same console bump; this PR only covers self-hosted.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.