### PR TITLE
Clarify default specification list type

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php
@@ -47,7 +47,7 @@ class XList extends Base
                     )
                 ]
             ))
-            ->param('type', 'runtimes', new WhiteList(['runtimes', 'builds']), 'Specification type to list. Can be one of: runtimes, builds.', true)
+            ->param('type', 'runtimes', new WhiteList(['runtimes', 'builds']), 'Specification type to list. Can be one of: runtimes, builds. Defaults to runtimes.', true)
             ->inject('response')
             ->inject('plan')
             ->callback($this->action(...));

--- a/src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php
@@ -47,7 +47,7 @@ class XList extends Base
                     )
                 ]
             ))
-            ->param('type', 'runtimes', new WhiteList(['runtimes', 'builds']), 'Specification type to list. Can be one of: runtimes, builds.', true)
+            ->param('type', 'runtimes', new WhiteList(['runtimes', 'builds']), 'Specification type to list. Can be one of: runtimes, builds. Defaults to runtimes.', true)
             ->inject('response')
             ->inject('plan')
             ->callback($this->action(...));


### PR DESCRIPTION
## What does this PR do?

Clarifies that the optional `type` parameter on the Functions and Sites specification-list endpoints defaults to `runtimes`.

Without this detail, an unqualified specification-list request can appear to advertise runtime specifications for use as build specifications. Stating the default in the API metadata makes the generated API and CLI documentation distinguish the two workloads.

## Test Plan

- `php -l src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php`
- `php -l src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php`
- `composer lint src/Appwrite/Platform/Modules/Functions/Http/Specifications/XList.php src/Appwrite/Platform/Modules/Sites/Http/Specifications/XList.php`
- Verified on staging that an unqualified specification-list request matches `type=runtimes`, while `type=builds` returns the build-compatible specifications.

## Related PRs and Issues

- appwrite/sdk-generator#1746, finding 5
- Follow-up to appwrite/sdk-generator#1737
- Related to appwrite/appwrite#13107

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
