### PR TITLE
fix(vcs): clone the repository an archive url cannot reach

### DIFF
--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -168,10 +168,8 @@ class Base extends Action
         ]);
 
         // Build a plain (non-template) VCS deployment through $deployments.
-        // Template-into-repo pushes go through the Builds worker, which does the
-        // git write and then hands the build to the jobs-service itself, as does
-        // a provider whose archive url the jobs-service cannot authenticate --
-        // the worker clones it instead.
+        // Template-into-repo pushes, and providers whose archive url carries no
+        // credential, go through the Builds worker, which clones instead.
         if ($template->isEmpty() && $vcs->supportsAuthenticatedArchiveUrl()) {
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
             $deployment = $deployments->createFromUrl(
@@ -391,10 +389,7 @@ class Base extends Action
 
         $this->updateEmptyManualRule($project, $site, $deployment, $dbForPlatform, $authorization);
 
-        // Plain VCS deployments build through $deployments; template-into-repo
-        // pushes, and providers whose archive url the jobs-service cannot
-        // authenticate, go through the Builds worker (same split as
-        // redeployVcsFunction).
+        // Same split as redeployVcsFunction.
         if ($template->isEmpty() && $vcs->supportsAuthenticatedArchiveUrl()) {
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
             $deployment = $deployments->createFromUrl(

--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -169,8 +169,10 @@ class Base extends Action
 
         // Build a plain (non-template) VCS deployment through $deployments.
         // Template-into-repo pushes go through the Builds worker, which does the
-        // git write and then hands the build to the jobs-service itself.
-        if ($template->isEmpty()) {
+        // git write and then hands the build to the jobs-service itself, as does
+        // a provider whose archive url the jobs-service cannot authenticate --
+        // the worker clones it instead.
+        if ($template->isEmpty() && $vcs->supportsAuthenticatedArchiveUrl()) {
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
             $deployment = $deployments->createFromUrl(
                 $function,
@@ -390,8 +392,10 @@ class Base extends Action
         $this->updateEmptyManualRule($project, $site, $deployment, $dbForPlatform, $authorization);
 
         // Plain VCS deployments build through $deployments; template-into-repo
-        // pushes go through the Builds worker (same split as redeployVcsFunction).
-        if ($template->isEmpty()) {
+        // pushes, and providers whose archive url the jobs-service cannot
+        // authenticate, go through the Builds worker (same split as
+        // redeployVcsFunction).
+        if ($template->isEmpty() && $vcs->supportsAuthenticatedArchiveUrl()) {
             $ref = $deployment->getAttribute('providerCommitHash') ?: $deployment->getAttribute('providerBranch');
             $deployment = $deployments->createFromUrl(
                 $site,


### PR DESCRIPTION
A Bitbucket deployment sat waiting forever with nothing built. Its source comes from an archive url the jobs-service fetches, and Bitbucket's archive host takes no credential from a url -- it answers a redirect to a login page, so the fetch lands empty and no build is ever queued.

A provider that says its archive url stands on its own is fetched as before. One that doesn't takes the path template pushes already take, where the builds worker clones with the token the git endpoint does accept.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does and why it's needed.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Screenshots may also be helpful.)

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
