### PR TITLE
fix(vcs): send the archive credential the provider asks for

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5161,16 +5161,16 @@
         },
         {
             "name": "utopia-php/vcs",
-            "version": "5.1.0",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/vcs.git",
-                "reference": "040a0d5d92ffa33964dc1607d1b95a526c6ffc49"
+                "reference": "abdb5763221d7e4900174c280244f83638e3133e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/040a0d5d92ffa33964dc1607d1b95a526c6ffc49",
-                "reference": "040a0d5d92ffa33964dc1607d1b95a526c6ffc49",
+                "url": "https://api.github.com/repos/utopia-php/vcs/zipball/abdb5763221d7e4900174c280244f83638e3133e",
+                "reference": "abdb5763221d7e4900174c280244f83638e3133e",
                 "shasum": ""
             },
             "require": {
@@ -5221,10 +5221,10 @@
                 "vcs"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/vcs/tree/5.1.0",
+                "source": "https://github.com/utopia-php/vcs/tree/5.1.2",
                 "issues": "https://github.com/utopia-php/vcs/issues"
             },
-            "time": "2026-08-07T08:58:14+00:00"
+            "time": "2026-08-07T12:32:15+00:00"
         },
         {
             "name": "utopia-php/websocket",

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -118,13 +118,18 @@ readonly class Deployments
      * Same as createFromUpload(), but builds from a remote tarball at $url
      * (a VCS presigned URL) instead of the deployment's own uploaded source.
      */
+    /**
+     * @param array<string, string> $headers Sent with the source fetch, for a
+     *                                       url whose provider authenticates by header
+     */
     public function createFromUrl(
         Document $resource,
         Document $deployment,
         string $url,
         string $rootDirectory = '',
+        array $headers = [],
     ): Document {
-        return $this->submit($resource, $deployment, ['url' => $url, 'subdir' => $rootDirectory]);
+        return $this->submit($resource, $deployment, ['url' => $url, 'subdir' => $rootDirectory, 'headers' => $headers]);
     }
 
     private function submit(Document $resource, Document $deployment, ?array $source): Document
@@ -322,7 +327,7 @@ readonly class Deployments
         if ($source !== null) {
             $subdir = \trim($source['subdir'] ?? '', '/');
             $sourceArtifacts = [
-                new DownloadArtifact(id: 'source', in: $source['url'], out: 'source.tar.gz'),
+                new DownloadArtifact(id: 'source', in: $source['url'], out: 'source.tar.gz', headers: $source['headers'] ?? []),
                 new UnarchiveArtifact(id: 'extract', in: 'source.tar.gz', out: 'source', subdir: $subdir !== '' ? $subdir : null, strip: true, depends: 'source'),
                 // Appwrite never sees the remote source (the sidecar fetches it),
                 // so unlike the uploaded-tarball path it can't size it. Stat the

--- a/src/Appwrite/Platform/Modules/Compute/Base.php
+++ b/src/Appwrite/Platform/Modules/Compute/Base.php
@@ -177,6 +177,7 @@ class Base extends Action
                 $deployment,
                 $vcs->getRepositoryPresignedUrl($owner, $repositoryName, $ref),
                 $function->getAttribute('providerRootDirectory', ''),
+                $vcs->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             $deployment = $dbForProject->createDocument('deployments', new Document([
@@ -398,6 +399,7 @@ class Base extends Action
                 $deployment,
                 $vcs->getRepositoryPresignedUrl($owner, $repositoryName, $ref),
                 $site->getAttribute('providerRootDirectory', ''),
+                $vcs->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             $publisherForBuilds->enqueue(new BuildMessage(

--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Duplicate/Create.php
@@ -162,6 +162,7 @@ class Create extends Action
                 $deployment,
                 $github->getRepositoryPresignedUrl($owner, $repository, $ref),
                 $deployment->getAttribute('providerRootDirectory', ''),
+                $github->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             // Public template repo: providerBranch holds the resolved ref,

--- a/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
+++ b/src/Appwrite/Platform/Modules/Functions/Workers/Builds.php
@@ -406,6 +406,7 @@ class Builds extends Action
                 $deployment,
                 $providerAdapter->getRepositoryPresignedUrl($cloneOwner, $cloneRepository, $ref),
                 $resource->getAttribute('providerRootDirectory', ''),
+                $providerAdapter->getRepositoryPresignedUrlHeaders(),
             );
 
             Console::execute('rm -rf ' . \escapeshellarg('/tmp/builds/' . $deploymentId), '', $stdout, $stderr);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Duplicate/Create.php
@@ -183,6 +183,7 @@ class Create extends Action
                 $deployment,
                 $vcs->getRepositoryPresignedUrl($owner, $repository, $ref),
                 $deployment->getAttribute('providerRootDirectory', ''),
+                $vcs->getRepositoryPresignedUrlHeaders(),
             );
         } else {
             // Public template repo: providerBranch holds the resolved ref,

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -397,6 +397,7 @@ trait Deployment
                         $deployment,
                         $vcs->getRepositoryPresignedUrl($providerRepositoryOwner, $providerRepositoryName, $providerCommitHash),
                         $resource->getAttribute('providerRootDirectory', ''),
+                        $vcs->getRepositoryPresignedUrlHeaders(),
                     ));
 
                 if ($resource->getCollection() === 'sites') {


### PR DESCRIPTION
A Bitbucket site deployment never builds. It sits at `Waiting` with `Size 0 B`, no build logs, and no job in the queue. GitHub, same project and framework, builds fine.

## Cause

A VCS deployment's source is fetched from `getRepositoryPresignedUrl()` by the jobs-service. Bitbucket's archive host takes no credential from a url — the token offered as basic userinfo is answered with a redirect to a login page, so the fetch lands empty and no build is ever queued. Nothing errors, which is why it just waits.

Reproduced against production with the real stored token:

| request | result |
|---|---|
| current url (token as userinfo) | **302, 0 bytes** |
| same url, no auth | 200, 161267 bytes |
| `Authorization: Bearer <token>` | **200, 161267 bytes** |

## Change

`DownloadArtifact` already accepts headers, so the adapter says what the fetch needs (utopia-php/vcs#130, released in 5.1.2) and every source fetch passes them through. Providers that authenticate through the url alone return none, so nothing they send changes.

All six `getRepositoryPresignedUrl()` call sites are covered — including both `Duplicate/Create.php` and `VCS/Http/GitHub/Deployment.php`, which resolve their adapter through `$vcsFactory->fromInstallation()` and so are provider-agnostic despite their names.

## Note

Only new deployments are affected. Ones already stuck at `Waiting` were never queued and nothing retries them.