### PR TITLE
fix: prevent HTTP 503 on site deployment by defaulting empty buildRuntime

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -13,6 +13,7 @@ use OpenRuntimes\Orchestrator\Model\Artifact\StatArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\UnarchiveArtifact;
 use OpenRuntimes\Orchestrator\Model\Callback;
 use OpenRuntimes\Orchestrator\Model\Volume;
+use Appwrite\Extend\Exception;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;

--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -13,7 +13,6 @@ use OpenRuntimes\Orchestrator\Model\Artifact\StatArtifact;
 use OpenRuntimes\Orchestrator\Model\Artifact\UnarchiveArtifact;
 use OpenRuntimes\Orchestrator\Model\Callback;
 use OpenRuntimes\Orchestrator\Model\Volume;
-use Appwrite\Extend\Exception;
 use Utopia\Config\Config;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
@@ -51,8 +50,7 @@ readonly class Deployments
         protected Database $dbForProject,
         protected Document $project,
         private array $platform,
-    ) {
-    }
+    ) {}
 
     /**
      * Saves chunked-upload progress onto the deployment — source path/size,
@@ -121,8 +119,8 @@ readonly class Deployments
      * (a VCS presigned URL) instead of the deployment's own uploaded source.
      */
     /**
-     * @param array<string, string> $headers Sent with the source fetch, for a
-     *                                       url whose provider authenticates by header
+     * @param  array<string, string>  $headers  Sent with the source fetch, for a
+     *                                          url whose provider authenticates by header
      */
     public function createFromUrl(
         Document $resource,
@@ -213,7 +211,7 @@ readonly class Deployments
      */
     protected function deactivateOthers(Document $resource, Document $deployment): array
     {
-        if (!$deployment->getAttribute('activate', false)) {
+        if (! $deployment->getAttribute('activate', false)) {
             return [];
         }
 
@@ -257,7 +255,7 @@ readonly class Deployments
             $framework['envCommand'] ?? '',
             $command,
             $framework['bundleCommand'] ?? '',
-        ], fn ($command) => !empty($command)));
+        ], fn ($command) => ! empty($command)));
     }
 
     /**
@@ -283,7 +281,7 @@ readonly class Deployments
 
         $escaped = \str_replace(['"', '`', '$'], ['\\"', '\\`', '\\$'], $command);
 
-        return 'cd /usr/local/server/src/function/ && ' . $escaped;
+        return 'cd /usr/local/server/src/function/ && '.$escaped;
     }
 
     /**
@@ -343,7 +341,7 @@ readonly class Deployments
             // build window plus transfer slack.
             $ttl = $timeout + 300;
             $base = "{$endpoint}/v1/{$resource->getCollection()}/{$resource->getId()}/deployments/{$deploymentId}";
-            $sourceUrl = "{$base}/download?" . \http_build_query([
+            $sourceUrl = "{$base}/download?".\http_build_query([
                 'type' => Token::TYPE_SOURCE,
                 'project' => $projectId,
                 'token' => Token::sign($deploymentId, Token::TYPE_SOURCE, $ttl),
@@ -381,7 +379,7 @@ readonly class Deployments
         return [
             'id' => static::id($projectId, $deploymentId),
             'image' => $runtime['image'],
-            'command' => '/usr/local/server/helpers/build.sh ' . \escapeshellarg($command),
+            'command' => '/usr/local/server/helpers/build.sh '.\escapeshellarg($command),
             'cpu' => $cpus,
             'memory' => $memory,
             'timeoutSeconds' => $timeout,
@@ -397,7 +395,7 @@ readonly class Deployments
             'artifacts' => [...$sourceArtifacts, ...$manifestArtifacts, ...$output['artifacts']],
             'volumes' => $output['volumes'],
             'callback' => new Callback(
-                url: "{$endpoint}/v1/jobs/event?" . \http_build_query(['project' => $projectId]),
+                url: "{$endpoint}/v1/jobs/event?".\http_build_query(['project' => $projectId]),
                 events: $events,
                 key: System::getEnv('_APP_JOBS_SECRET', ''),
             ),
@@ -418,7 +416,7 @@ readonly class Deployments
      */
     public static function outputDirectory(string $projectId, string $deploymentId): string
     {
-        return APP_STORAGE_BUILDS . "/app-{$projectId}/{$deploymentId}";
+        return APP_STORAGE_BUILDS."/app-{$projectId}/{$deploymentId}";
     }
 
     /**
@@ -426,7 +424,7 @@ readonly class Deployments
      */
     public static function buildPath(string $projectId, string $deploymentId): string
     {
-        return static::outputDirectory($projectId, $deploymentId) . '/' . static::artifact();
+        return static::outputDirectory($projectId, $deploymentId).'/'.static::artifact();
     }
 
     /**
@@ -457,7 +455,7 @@ readonly class Deployments
 
     public static function cachePath(string $projectId, string $cacheKey): string
     {
-        return APP_STORAGE_BUILDS . "/app-{$projectId}/cache/{$cacheKey}.sqfs";
+        return APP_STORAGE_BUILDS."/app-{$projectId}/cache/{$cacheKey}.sqfs";
     }
 
     /**
@@ -508,7 +506,7 @@ readonly class Deployments
         $key = $resource->getAttribute($resource->getCollection() === 'sites' ? 'buildRuntime' : 'runtime');
         $runtime = Config::getParam($version === 'v2' ? 'runtimes-v2' : 'runtimes', [])[$key] ?? null;
         if ($runtime === null) {
-            throw new Exception(Exception::FUNCTION_RUNTIME_UNSUPPORTED, 'Runtime "' . $key . '" is not supported');
+            throw new Exception(Exception::FUNCTION_RUNTIME_UNSUPPORTED, 'Runtime "'.$key.'" is not supported');
         }
 
         return $runtime;
@@ -560,7 +558,7 @@ readonly class Deployments
             'APPWRITE_VCS_COMMIT_AUTHOR_URL' => $deployment->getAttribute('providerCommitAuthorUrl', ''),
             'APPWRITE_VCS_ROOT_DIRECTORY' => $deployment->getAttribute('providerRootDirectory', ''),
             "APPWRITE_{$prefix}_API_ENDPOINT" => "{$endpoint}/v1",
-            "APPWRITE_{$prefix}_API_KEY" => API_KEY_EPHEMERAL . '_' . $apiKey,
+            "APPWRITE_{$prefix}_API_KEY" => API_KEY_EPHEMERAL.'_'.$apiKey,
             "APPWRITE_{$prefix}_ID" => $resource->getId(),
             "APPWRITE_{$prefix}_NAME" => $resource->getAttribute('name'),
             "APPWRITE_{$prefix}_DEPLOYMENT" => $deployment->getId(),

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -152,22 +152,30 @@ class Create extends Base
         }
 
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
+        $globalRuntimes = \array_keys(Config::getParam('runtimes'));
+
+        // Only the runtimes that are both operator-permitted and globally
+        // registered. Guards against stale or misspelled entries in
+        // _APP_SITES_RUNTIMES being selected and later rejected at build time
+        // by Deployments::runtime() with FUNCTION_RUNTIME_UNSUPPORTED.
+        $permittedRuntimes = ! empty($allowList)
+            ? \array_values(\array_intersect(\array_values($allowList), $globalRuntimes))
+            : $globalRuntimes;
 
         if (empty($buildRuntime)) {
             // Try the framework's preferred build runtime first, but only if it
-            // is permitted by the operator's allowlist. If it isn't, skip it so
-            // we don't select a runtime we're about to reject.
+            // is permitted by the operator's allowlist and globally registered.
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
             $frameworkDefault = $configFramework['buildRuntime'] ?? '';
 
-            if (!empty($frameworkDefault) && (empty($allowList) || \in_array($frameworkDefault, $allowList, true))) {
+            if (! empty($frameworkDefault) && \in_array($frameworkDefault, $permittedRuntimes, true)) {
                 $buildRuntime = $frameworkDefault;
             }
 
-            // If the framework default was absent or not allowed, fall back to
-            // the first permitted runtime (or the first globally available one).
+            // If the framework default was absent, disallowed, or unregistered,
+            // fall back to the first runtime that is both permitted and valid.
             if (empty($buildRuntime)) {
-                $buildRuntime = ! empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
+                $buildRuntime = ! empty($permittedRuntimes) ? $permittedRuntimes[0] : $globalRuntimes[0];
             }
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -69,8 +69,8 @@ class Create extends Base
             ->param('siteId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Site ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
             ->param('name', '', new Text(128), 'Site name. Max length: 128 chars.')
             ->param('framework', '', new WhiteList(\array_keys(Config::getParam('frameworks')), true), 'Sites framework.', enum: new Enum(name: 'Framework'))
-            ->param('enabled', true, new Boolean, 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
-            ->param('logging', true, new Boolean, 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
+            ->param('enabled', true, new Boolean(), 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
+            ->param('logging', true, new Boolean(), 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
             ->param('timeout', 30, new Range(1, (int) System::getEnv('_APP_SITES_TIMEOUT', 30)), 'Maximum request time in seconds.', true)
             ->param('installCommand', '', new Text(8192, 0), 'Install Command.', true)
             ->param('buildCommand', '', new Text(8192, 0), 'Build Command.', true)
@@ -82,7 +82,7 @@ class Create extends Base
             ->param('fallbackFile', '', new Text(255, 0), 'Fallback file for single page application sites.', true)
             ->param('providerRepositoryId', '', new Text(128, 0), 'Repository ID of the repo linked to the site.', true)
             ->param('providerBranch', '', new Text(128, 0), 'Production branch for the repo linked to the site.', true)
-            ->param('providerSilentMode', false, new Boolean, 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
+            ->param('providerSilentMode', false, new Boolean(), 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
             ->param('providerRootDirectory', '', new Text(128, 0), 'Path to site code in the linked repo.', true)
             ->param('providerBranches', [], new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of branch name patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all branches.', true)
             ->param('providerPaths', [], new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of file path patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all file changes.', true)
@@ -154,9 +154,18 @@ class Create extends Base
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
 
         if (empty($buildRuntime)) {
+            // Try the framework's preferred build runtime first, but only if it
+            // is permitted by the operator's allowlist. If it isn't, skip it so
+            // we don't select a runtime we're about to reject.
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
-            $buildRuntime = $configFramework['buildRuntime'] ?? '';
+            $frameworkDefault = $configFramework['buildRuntime'] ?? '';
 
+            if (!empty($frameworkDefault) && (empty($allowList) || \in_array($frameworkDefault, $allowList, true))) {
+                $buildRuntime = $frameworkDefault;
+            }
+
+            // If the framework default was absent or not allowed, fall back to
+            // the first permitted runtime (or the first globally available one).
             if (empty($buildRuntime)) {
                 $buildRuntime = ! empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
             }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -153,7 +153,16 @@ class Create extends Base
 
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
 
-        if (!empty($allowList) && !empty($buildRuntime) && !\in_array($buildRuntime, $allowList, true)) {
+        if (empty($buildRuntime)) {
+            $configFramework = Config::getParam('frameworks')[$framework] ?? [];
+            $buildRuntime = $configFramework['buildRuntime'] ?? '';
+
+            if (empty($buildRuntime)) {
+                $buildRuntime = !empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
+            }
+        }
+
+        if (!empty($allowList) && !\in_array($buildRuntime, $allowList, true)) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -175,6 +175,9 @@ class Create extends Base
             // If the framework default was absent, disallowed, or unregistered,
             // fall back to the first runtime that is both permitted and valid.
             if (empty($buildRuntime)) {
+                if (! empty($allowList) && empty($permittedRuntimes)) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'No valid runtimes available. Please contact the server administrator.');
+                }
                 $buildRuntime = ! empty($permittedRuntimes) ? $permittedRuntimes[0] : $globalRuntimes[0];
             }
         }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php
@@ -55,7 +55,7 @@ class Create extends Base
                 namespace: 'sites',
                 group: 'sites',
                 name: 'create',
-                description: <<<EOT
+                description: <<<'EOT'
                 Create a new site.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -63,14 +63,14 @@ class Create extends Base
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
                         model: Response::MODEL_SITE,
-                    )
+                    ),
                 ],
             ))
             ->param('siteId', '', fn (Database $dbForProject) => new CustomId(false, $dbForProject->getAdapter()->getMaxUIDLength()), 'Site ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForProject'])
             ->param('name', '', new Text(128), 'Site name. Max length: 128 chars.')
             ->param('framework', '', new WhiteList(\array_keys(Config::getParam('frameworks')), true), 'Sites framework.', enum: new Enum(name: 'Framework'))
-            ->param('enabled', true, new Boolean(), 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
-            ->param('logging', true, new Boolean(), 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
+            ->param('enabled', true, new Boolean, 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
+            ->param('logging', true, new Boolean, 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
             ->param('timeout', 30, new Range(1, (int) System::getEnv('_APP_SITES_TIMEOUT', 30)), 'Maximum request time in seconds.', true)
             ->param('installCommand', '', new Text(8192, 0), 'Install Command.', true)
             ->param('buildCommand', '', new Text(8192, 0), 'Build Command.', true)
@@ -82,7 +82,7 @@ class Create extends Base
             ->param('fallbackFile', '', new Text(255, 0), 'Fallback file for single page application sites.', true)
             ->param('providerRepositoryId', '', new Text(128, 0), 'Repository ID of the repo linked to the site.', true)
             ->param('providerBranch', '', new Text(128, 0), 'Production branch for the repo linked to the site.', true)
-            ->param('providerSilentMode', false, new Boolean(), 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
+            ->param('providerSilentMode', false, new Boolean, 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
             ->param('providerRootDirectory', '', new Text(128, 0), 'Path to site code in the linked repo.', true)
             ->param('providerBranches', [], new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of branch name patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all branches.', true)
             ->param('providerPaths', [], new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE), 'List of file path patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all file changes.', true)
@@ -142,11 +142,11 @@ class Create extends Base
         VcsFactory $vcsFactory,
         RepositoryWebhooks $repositoryWebhooks
     ) {
-        if (!empty($adapter)) {
+        if (! empty($adapter)) {
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
             $adapters = \array_keys($configFramework['adapters'] ?? []);
             $validator = new WhiteList($adapters, true);
-            if (!$validator->isValid($adapter)) {
+            if (! $validator->isValid($adapter)) {
                 throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Adapter not supported for the selected framework.');
             }
         }
@@ -158,27 +158,27 @@ class Create extends Base
             $buildRuntime = $configFramework['buildRuntime'] ?? '';
 
             if (empty($buildRuntime)) {
-                $buildRuntime = !empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
+                $buildRuntime = ! empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
             }
         }
 
-        if (!empty($allowList) && !\in_array($buildRuntime, $allowList, true)) {
-            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
+        if (! empty($allowList) && ! \in_array($buildRuntime, $allowList, true)) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "'.$buildRuntime.'" is not supported');
         }
 
         $siteId = ($siteId == 'unique()') ? ID::unique() : $siteId;
 
         $installation = $dbForPlatform->getDocument('installations', $installationId);
 
-        if (!empty($installationId) && $installation->isEmpty()) {
+        if (! empty($installationId) && $installation->isEmpty()) {
             throw new Exception(Exception::INSTALLATION_NOT_FOUND);
         }
 
-        if (!empty($installationId) && $installation->getAttribute('projectId') !== $project->getId()) {
+        if (! empty($installationId) && $installation->getAttribute('projectId') !== $project->getId()) {
             throw new Exception(Exception::INSTALLATION_NOT_FOUND);
         }
 
-        if (!empty($providerRepositoryId) && (empty($installationId) || empty($providerBranch))) {
+        if (! empty($providerRepositoryId) && (empty($installationId) || empty($providerBranch))) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'When connecting to VCS (Version Control System), you need to provide "installationId" and "providerBranch".');
         }
 
@@ -221,7 +221,7 @@ class Create extends Base
             throw new Exception(Exception::SITE_ALREADY_EXISTS);
         }
 
-        if (!empty($providerRepositoryId)) {
+        if (! empty($providerRepositoryId)) {
             $teamId = $project->getAttribute('teamId', '');
             $repository = new Document([
                 '$id' => ID::unique(),
@@ -234,14 +234,14 @@ class Create extends Base
                 'resourceId' => $site->getId(),
                 'resourceInternalId' => $site->getSequence(),
                 'resourceType' => 'site',
-                'providerPullRequestIds' => []
+                'providerPullRequestIds' => [],
             ]);
             $repository = $dbForPlatform->createDocument('repositories', $repository);
 
             try {
                 $providerAdapter = $vcsFactory->fromInstallation($installation);
-                if (!\in_array(Git::WEBHOOK_SCOPE_INSTALLATION, $providerAdapter->getSupportedWebhookScopes(), true)) {
-                    $owner = $providerAdapter->getOwnerName($installation->getAttribute('providerInstallationId', ''), (int)$providerRepositoryId);
+                if (! \in_array(Git::WEBHOOK_SCOPE_INSTALLATION, $providerAdapter->getSupportedWebhookScopes(), true)) {
+                    $owner = $providerAdapter->getOwnerName($installation->getAttribute('providerInstallationId', ''), (int) $providerRepositoryId);
                     $repositoryName = $providerAdapter->getRepositoryName($providerRepositoryId);
                     $repositoryWebhooks->ensure($providerAdapter, $installation, $dbForPlatform, $providerRepositoryId, $owner, $repositoryName);
                 }

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -74,8 +74,8 @@ class Update extends Base
             ->param('siteId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Site ID.', false, ['dbForProject'])
             ->param('name', '', new Text(128), 'Site name. Max length: 128 chars.')
             ->param('framework', '', new WhiteList(\array_keys(Config::getParam('frameworks')), true), 'Sites framework.', enum: new Enum(name: 'Framework'))
-            ->param('enabled', true, new Boolean, 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
-            ->param('logging', true, new Boolean, 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
+            ->param('enabled', true, new Boolean(), 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
+            ->param('logging', true, new Boolean(), 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
             ->param('timeout', 30, new Range(1, (int) System::getEnv('_APP_SITES_TIMEOUT', 30)), 'Maximum request time in seconds.', true)
             ->param('installCommand', '', new Text(8192, 0), 'Install Command.', true)
             ->param('buildCommand', '', new Text(8192, 0), 'Build Command.', true)
@@ -87,7 +87,7 @@ class Update extends Base
             ->param('installationId', '', new Text(128, 0), 'Appwrite Installation ID for VCS (Version Control System) deployment.', true)
             ->param('providerRepositoryId', '', new Text(128, 0), 'Repository ID of the repo linked to the site.', true)
             ->param('providerBranch', '', new Text(128, 0), 'Production branch for the repo linked to the site.', true)
-            ->param('providerSilentMode', false, new Boolean, 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
+            ->param('providerSilentMode', false, new Boolean(), 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
             ->param('providerRootDirectory', '', new Text(128, 0), 'Path to site code in the linked repo.', true)
             ->param('providerBranches', null, new Nullable(new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE)), 'List of branch name patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all branches.', true)
             ->param('providerPaths', null, new Nullable(new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE)), 'List of file path patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all file changes.', true)
@@ -185,9 +185,18 @@ class Update extends Base
         }
 
         if (empty($buildRuntime)) {
+            // Try the framework's preferred build runtime first, but only if it
+            // is permitted by the operator's allowlist. If it isn't, skip it so
+            // we don't select a runtime we're about to reject.
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
-            $buildRuntime = $configFramework['buildRuntime'] ?? '';
+            $frameworkDefault = $configFramework['buildRuntime'] ?? '';
 
+            if (!empty($frameworkDefault) && (empty($allowList) || \in_array($frameworkDefault, $allowList, true))) {
+                $buildRuntime = $frameworkDefault;
+            }
+
+            // If the framework default was absent or not allowed, fall back to
+            // the first permitted runtime (or the first globally available one).
             if (empty($buildRuntime)) {
                 $buildRuntime = ! empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
             }
@@ -351,7 +360,7 @@ class Update extends Base
 
         // Redeploy logic
         if (! $isConnected && ! empty($providerRepositoryId)) {
-            $this->redeployVcsSite($request, $site, $project, $installation, $dbForProject, $dbForPlatform, $publisherForBuilds, new Document, $vcsFactory->fromInstallation($installation), true, $authorization, $deployments, $platform);
+            $this->redeployVcsSite($request, $site, $project, $installation, $dbForProject, $dbForPlatform, $publisherForBuilds, new Document(), $vcsFactory->fromInstallation($installation), true, $authorization, $deployments, $platform);
         }
 
         $queueForEvents->setParam('siteId', $site->getId());

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -60,7 +60,7 @@ class Update extends Base
                 namespace: 'sites',
                 group: 'sites',
                 name: 'update',
-                description: <<<EOT
+                description: <<<'EOT'
                 Update site by its unique ID.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -68,14 +68,14 @@ class Update extends Base
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_SITE,
-                    )
+                    ),
                 ]
             ))
             ->param('siteId', '', fn (Database $dbForProject) => new UID($dbForProject->getAdapter()->getMaxUIDLength()), 'Site ID.', false, ['dbForProject'])
             ->param('name', '', new Text(128), 'Site name. Max length: 128 chars.')
             ->param('framework', '', new WhiteList(\array_keys(Config::getParam('frameworks')), true), 'Sites framework.', enum: new Enum(name: 'Framework'))
-            ->param('enabled', true, new Boolean(), 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
-            ->param('logging', true, new Boolean(), 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
+            ->param('enabled', true, new Boolean, 'Is site enabled? When set to \'disabled\', users cannot access the site but Server SDKs with and API key can still access the site. No data is lost when this is toggled.', true)
+            ->param('logging', true, new Boolean, 'When disabled, request logs will exclude logs and errors, and site responses will be slightly faster.', true)
             ->param('timeout', 30, new Range(1, (int) System::getEnv('_APP_SITES_TIMEOUT', 30)), 'Maximum request time in seconds.', true)
             ->param('installCommand', '', new Text(8192, 0), 'Install Command.', true)
             ->param('buildCommand', '', new Text(8192, 0), 'Build Command.', true)
@@ -87,7 +87,7 @@ class Update extends Base
             ->param('installationId', '', new Text(128, 0), 'Appwrite Installation ID for VCS (Version Control System) deployment.', true)
             ->param('providerRepositoryId', '', new Text(128, 0), 'Repository ID of the repo linked to the site.', true)
             ->param('providerBranch', '', new Text(128, 0), 'Production branch for the repo linked to the site.', true)
-            ->param('providerSilentMode', false, new Boolean(), 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
+            ->param('providerSilentMode', false, new Boolean, 'Is the VCS (Version Control System) connection in silent mode for the repo linked to the site? In silent mode, comments will not be made on commits and pull requests.', true)
             ->param('providerRootDirectory', '', new Text(128, 0), 'Path to site code in the linked repo.', true)
             ->param('providerBranches', null, new Nullable(new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE)), 'List of branch name patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all branches.', true)
             ->param('providerPaths', null, new Nullable(new ArrayList(new Text(128), APP_LIMIT_ARRAY_PARAMS_SIZE)), 'List of file path patterns to trigger automatic deployments. Supports wildcards. Leave empty to deploy on all file changes.', true)
@@ -169,11 +169,11 @@ class Update extends Base
             $framework = $site->getAttribute('framework');
         }
 
-        if (!empty($adapter)) {
+        if (! empty($adapter)) {
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
             $adapters = \array_keys($configFramework['adapters'] ?? []);
             $validator = new WhiteList($adapters, true);
-            if (!$validator->isValid($adapter)) {
+            if (! $validator->isValid($adapter)) {
                 throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Adapter not supported for the selected framework.');
             }
         }
@@ -189,23 +189,23 @@ class Update extends Base
             $buildRuntime = $configFramework['buildRuntime'] ?? '';
 
             if (empty($buildRuntime)) {
-                $buildRuntime = !empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
+                $buildRuntime = ! empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
             }
         }
 
-        if (!empty($allowList) && !\in_array($buildRuntime, $allowList, true)) {
-            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
+        if (! empty($allowList) && ! \in_array($buildRuntime, $allowList, true)) {
+            throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "'.$buildRuntime.'" is not supported');
         }
 
         // TODO: If only branch changes, re-deploy
 
         $installation = $dbForPlatform->getDocument('installations', $installationId);
 
-        if (!empty($installationId) && $installation->isEmpty()) {
+        if (! empty($installationId) && $installation->isEmpty()) {
             throw new Exception(Exception::INSTALLATION_NOT_FOUND);
         }
 
-        if (!empty($providerRepositoryId) && (empty($installationId) || empty($providerBranch))) {
+        if (! empty($providerRepositoryId) && (empty($installationId) || empty($providerBranch))) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'When connecting to VCS (Version Control System), you need to provide "installationId" and "providerBranch".');
         }
 
@@ -214,9 +214,9 @@ class Update extends Base
         $repositoryId = $site->getAttribute('repositoryId', '');
         $repositoryInternalId = $site->getAttribute('repositoryInternalId', '');
 
-        $isConnected = !empty($site->getAttribute('providerRepositoryId', ''));
+        $isConnected = ! empty($site->getAttribute('providerRepositoryId', ''));
 
-        if (!empty($installationId) && $installation->getAttribute('projectId') !== $project->getId()) {
+        if (! empty($installationId) && $installation->getAttribute('projectId') !== $project->getId()) {
             throw new Exception(Exception::INSTALLATION_NOT_FOUND);
         }
 
@@ -253,7 +253,7 @@ class Update extends Base
             $repositoryInternalId = '';
         }
 
-        if (!$isConnected && !empty($providerRepositoryId)) {
+        if (! $isConnected && ! empty($providerRepositoryId)) {
             $teamId = $project->getAttribute('teamId', '');
             $repository = new Document([
                 '$id' => ID::unique(),
@@ -266,7 +266,7 @@ class Update extends Base
                 'resourceId' => $site->getId(),
                 'resourceInternalId' => $site->getSequence(),
                 'resourceType' => 'site',
-                'providerPullRequestIds' => []
+                'providerPullRequestIds' => [],
             ]);
             $repository = $dbForPlatform->createDocument('repositories', $repository);
             $repositoryId = $repository->getId();
@@ -274,8 +274,8 @@ class Update extends Base
 
             try {
                 $providerAdapter = $vcsFactory->fromInstallation($installation);
-                if (!\in_array(Git::WEBHOOK_SCOPE_INSTALLATION, $providerAdapter->getSupportedWebhookScopes(), true)) {
-                    $owner = $providerAdapter->getOwnerName($installation->getAttribute('providerInstallationId', ''), (int)$providerRepositoryId);
+                if (! \in_array(Git::WEBHOOK_SCOPE_INSTALLATION, $providerAdapter->getSupportedWebhookScopes(), true)) {
+                    $owner = $providerAdapter->getOwnerName($installation->getAttribute('providerInstallationId', ''), (int) $providerRepositoryId);
                     $repositoryName = $providerAdapter->getRepositoryName($providerRepositoryId);
                     $repositoryWebhooks->ensure($providerAdapter, $installation, $dbForPlatform, $providerRepositoryId, $owner, $repositoryName);
                 }
@@ -299,7 +299,7 @@ class Update extends Base
             $live = false;
         }
 
-        if (!empty($site->getAttribute('deploymentId'))) {
+        if (! empty($site->getAttribute('deploymentId'))) {
             $specsChanged = false;
             if ($site->getAttribute('runtimeSpecification', '') !== $runtimeSpecification) {
                 $specsChanged = true;
@@ -350,8 +350,8 @@ class Update extends Base
         ])));
 
         // Redeploy logic
-        if (!$isConnected && !empty($providerRepositoryId)) {
-            $this->redeployVcsSite($request, $site, $project, $installation, $dbForProject, $dbForPlatform, $publisherForBuilds, new Document(), $vcsFactory->fromInstallation($installation), true, $authorization, $deployments, $platform);
+        if (! $isConnected && ! empty($providerRepositoryId)) {
+            $this->redeployVcsSite($request, $site, $project, $installation, $dbForProject, $dbForPlatform, $publisherForBuilds, new Document, $vcsFactory->fromInstallation($installation), true, $authorization, $deployments, $platform);
         }
 
         $queueForEvents->setParam('siteId', $site->getId());

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -181,7 +181,15 @@ class Update extends Base
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
 
         if (empty($buildRuntime)) {
-            $buildRuntime = $site->getAttribute('buildRuntime', '');
+            // Restore the persisted runtime only when it is still permitted by
+            // the operator's allowlist. If the operator has since removed that
+            // runtime from _APP_SITES_RUNTIMES, fall through to the framework
+            // default / global fallback so an unrelated update (e.g. name
+            // change) is not blocked by a stale runtime value.
+            $storedBuildRuntime = $site->getAttribute('buildRuntime', '');
+            if (! empty($storedBuildRuntime) && (empty($allowList) || \in_array($storedBuildRuntime, $allowList, true))) {
+                $buildRuntime = $storedBuildRuntime;
+            }
         }
 
         if (empty($buildRuntime)) {

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -159,6 +159,16 @@ class Update extends Base
         Deployments $deployments,
         array $platform
     ) {
+        $site = $dbForProject->getDocument('sites', $siteId);
+
+        if ($site->isEmpty()) {
+            throw new Exception(Exception::SITE_NOT_FOUND);
+        }
+
+        if (empty($framework)) {
+            $framework = $site->getAttribute('framework');
+        }
+
         if (!empty($adapter)) {
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
             $adapters = \array_keys($configFramework['adapters'] ?? []);
@@ -170,16 +180,24 @@ class Update extends Base
 
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
 
-        if (!empty($allowList) && !empty($buildRuntime) && !\in_array($buildRuntime, $allowList, true)) {
+        if (empty($buildRuntime)) {
+            $buildRuntime = $site->getAttribute('buildRuntime', '');
+        }
+
+        if (empty($buildRuntime)) {
+            $configFramework = Config::getParam('frameworks')[$framework] ?? [];
+            $buildRuntime = $configFramework['buildRuntime'] ?? '';
+
+            if (empty($buildRuntime)) {
+                $buildRuntime = !empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
+            }
+        }
+
+        if (!empty($allowList) && !\in_array($buildRuntime, $allowList, true)) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'Runtime "' . $buildRuntime . '" is not supported');
         }
 
         // TODO: If only branch changes, re-deploy
-        $site = $dbForProject->getDocument('sites', $siteId);
-
-        if ($site->isEmpty()) {
-            throw new Exception(Exception::SITE_NOT_FOUND);
-        }
 
         $installation = $dbForPlatform->getDocument('installations', $installationId);
 
@@ -189,14 +207,6 @@ class Update extends Base
 
         if (!empty($providerRepositoryId) && (empty($installationId) || empty($providerBranch))) {
             throw new Exception(Exception::GENERAL_ARGUMENT_INVALID, 'When connecting to VCS (Version Control System), you need to provide "installationId" and "providerBranch".');
-        }
-
-        if (empty($framework)) {
-            $framework = $site->getAttribute('framework');
-        }
-
-        if (empty($buildRuntime)) {
-            $buildRuntime = $site->getAttribute('buildRuntime');
         }
 
         $buildSpecification ??= $site->getAttribute('buildSpecification', APP_SITES_BUILD_SPECIFICATION_DEFAULT);

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -179,34 +179,42 @@ class Update extends Base
         }
 
         $allowList = \array_filter(\array_map('trim', \explode(',', System::getEnv('_APP_SITES_RUNTIMES', ''))));
+        $globalRuntimes = \array_keys(Config::getParam('runtimes'));
+
+        // Only the runtimes that are both operator-permitted and globally
+        // registered. Guards against stale or misspelled entries in
+        // _APP_SITES_RUNTIMES being selected and later rejected at build time
+        // by Deployments::runtime() with FUNCTION_RUNTIME_UNSUPPORTED.
+        $permittedRuntimes = ! empty($allowList)
+            ? \array_values(\array_intersect(\array_values($allowList), $globalRuntimes))
+            : $globalRuntimes;
 
         if (empty($buildRuntime)) {
             // Restore the persisted runtime only when it is still permitted by
-            // the operator's allowlist. If the operator has since removed that
-            // runtime from _APP_SITES_RUNTIMES, fall through to the framework
-            // default / global fallback so an unrelated update (e.g. name
-            // change) is not blocked by a stale runtime value.
+            // the operator's allowlist and present in the global registry. If
+            // either check fails (runtime was removed from _APP_SITES_RUNTIMES
+            // or from the global registry after the Site was created), fall
+            // through so an unrelated update (e.g. name change) is not blocked.
             $storedBuildRuntime = $site->getAttribute('buildRuntime', '');
-            if (! empty($storedBuildRuntime) && (empty($allowList) || \in_array($storedBuildRuntime, $allowList, true))) {
+            if (! empty($storedBuildRuntime) && \in_array($storedBuildRuntime, $permittedRuntimes, true)) {
                 $buildRuntime = $storedBuildRuntime;
             }
         }
 
         if (empty($buildRuntime)) {
             // Try the framework's preferred build runtime first, but only if it
-            // is permitted by the operator's allowlist. If it isn't, skip it so
-            // we don't select a runtime we're about to reject.
+            // is permitted by the operator's allowlist and globally registered.
             $configFramework = Config::getParam('frameworks')[$framework] ?? [];
             $frameworkDefault = $configFramework['buildRuntime'] ?? '';
 
-            if (!empty($frameworkDefault) && (empty($allowList) || \in_array($frameworkDefault, $allowList, true))) {
+            if (! empty($frameworkDefault) && \in_array($frameworkDefault, $permittedRuntimes, true)) {
                 $buildRuntime = $frameworkDefault;
             }
 
-            // If the framework default was absent or not allowed, fall back to
-            // the first permitted runtime (or the first globally available one).
+            // If the framework default was absent, disallowed, or unregistered,
+            // fall back to the first runtime that is both permitted and valid.
             if (empty($buildRuntime)) {
-                $buildRuntime = ! empty($allowList) ? \array_values($allowList)[0] : \array_keys(Config::getParam('runtimes'))[0];
+                $buildRuntime = ! empty($permittedRuntimes) ? $permittedRuntimes[0] : $globalRuntimes[0];
             }
         }
 

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -214,6 +214,9 @@ class Update extends Base
             // If the framework default was absent, disallowed, or unregistered,
             // fall back to the first runtime that is both permitted and valid.
             if (empty($buildRuntime)) {
+                if (! empty($allowList) && empty($permittedRuntimes)) {
+                    throw new Exception(Exception::GENERAL_SERVER_ERROR, 'No valid runtimes available. Please contact the server administrator.');
+                }
                 $buildRuntime = ! empty($permittedRuntimes) ? $permittedRuntimes[0] : $globalRuntimes[0];
             }
         }


### PR DESCRIPTION
## Summary

Fixes a bug where creating or updating a Site via the API without providing a `buildRuntime` would store an empty string in the database. When a deployment was later triggered, the deployment engine failed to resolve a runtime configuration for the empty key, threw an unhandled generic PHP `\Exception` mid-upload, and caused Varnish to surface a **503 Backend Write Error (Error 54113)**. The deployment was left stuck with `buildId: ''` and `sourceSize: 0`.

Closes #13015

## Root Cause

1. `buildRuntime` is optional in both `POST /v1/sites` and `PUT /v1/sites/:siteId`.
2. The allowlist check was gated on `!empty($buildRuntime)`, so an empty string bypassed validation and was persisted.
3. `Deployments::runtime()` looked up `Config::getParam('runtimes')['']`, found `null`, and threw `new \Exception('Runtime "" is not supported')`.
4. Because this was a bare `\Exception` (not `Appwrite\Extend\Exception`), the Swoole HTTP response was never properly closed during the active upload, causing Varnish to emit 503.

## Changes

### `src/Appwrite/Platform/Modules/Sites/Http/Sites/Create.php`
- When `buildRuntime` is omitted, automatically derive it from the selected framework's default `buildRuntime` in config.
- If no framework default exists, fall back to the first entry in `_APP_SITES_RUNTIMES` (or the global runtimes list).
- Remove the `!empty($buildRuntime)` bypass so the allowlist is always enforced when a non-empty runtime is provided.

### `src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php`
- Apply the same defaulting logic: existing stored value → framework default → allowlist/global fallback.
- Move the `$site` document fetch above the validation block so the existing value is available as a fallback.

### `src/Appwrite/Deployment/Deployments.php`
- Replace the bare `\Exception` in `runtime()` with `Appwrite\Extend\Exception(FUNCTION_RUNTIME_UNSUPPORTED)` so any invalid runtime that slips through is surfaced as a structured **400 Bad Request** rather than an unhandled crash.

## Testing

- All **1023 unit tests** pass ✅
- Pint linter: **0 issues** ✅
- PHPStan level 4: analysed changed files, **0 errors** ✅