### PR TITLE
Restrict webhook and OAuth2 curl requests to http(s) protocols

### DIFF
--- a/src/Appwrite/Auth/OAuth2.php
+++ b/src/Appwrite/Auth/OAuth2.php
@@ -193,6 +193,9 @@ abstract class OAuth2
         \curl_setopt($ch, CURLOPT_HEADER, 0);
         \curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         \curl_setopt($ch, CURLOPT_USERAGENT, 'Appwrite OAuth2');
+        // Defense in depth: restrict curl to http(s) even though provider URLs are hardcoded per adapter.
+        \curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        \curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
         if (!empty($payload)) {
             \curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);

--- a/src/Appwrite/Platform/Workers/Webhooks.php
+++ b/src/Appwrite/Platform/Workers/Webhooks.php
@@ -144,6 +144,10 @@ class Webhooks extends Action
             ]
         );
         \curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
+        // The URL is validated at save time to be http(s) only; without these, a redirect
+        // response could still steer curl to a non-http(s) protocol (e.g. file://, gopher://).
+        \curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        \curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
         if (!$webhook->getAttribute('security', true)) {
             \curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);


### PR DESCRIPTION
## Summary

Addresses one layer of the SSRF report in #11845.

`POST /v1/webhooks` validates the `url` field is `http(s)` at save time (`URL(['http', 'https'])` composed with `PublicDomain`), but the webhook worker's curl call never enforced that restriction itself:

```php
curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
```

With `CURLOPT_MAXREDIRS` set but no `CURLOPT_PROTOCOLS` / `CURLOPT_REDIR_PROTOCOLS`, a webhook target that responds with a redirect can steer curl to a non-http(s) protocol on the redirect hop (`file://`, `gopher://`, `dict://`, ...), bypassing the save-time check entirely -- the validator only ever sees the original URL, not where a redirect sends the request.

This adds:
```php
curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
```
to `src/Appwrite/Platform/Workers/Webhooks.php`, and the same to `src/Appwrite/Auth/OAuth2.php`'s `request()` as defense in depth, since it shares the identical `curl_init`/`curl_setopt` pattern (OAuth2 provider URLs are adapter-hardcoded so the exposure there is narrower, but the fix is free).

**Scope note:** #11845 suggests three layers -- this PR is layer 2 only (protocol restriction). It does not implement layer 1 (delivery-time private-IP / DNS-rebinding filtering via `gethostbynamel` + `CURLOPT_RESOLVE`) or layer 3 (strengthening/renaming the `PublicDomain` validator), since both involve a product decision -- e.g. whether self-hosted deployments may legitimately target internal/RFC1918 hosts from a webhook -- that seemed better left to maintainers rather than have a first-time contributor bake in unilaterally. Happy to take a pass at those in a follow-up if maintainers confirm the desired behavior (hard block vs. configurable allowlist, etc.).

## Test plan

- [x] `php -l` on both changed files (no syntax errors).
- [x] Manually reviewed: neither file sets `CURLOPT_FOLLOWLOCATION`/relies on redirects for legitimate functionality being broken by this -- the protocol restriction only rejects protocol-switching redirects, not http\<->https redirects on the same scheme family.
- [ ] Wasn't able to run the PHP test suite in this environment (needs the full Docker/breeze-style stack); relying on CI here.