### PR TITLE
Harden codeql-analysis.yml GITHUB_TOKEN permissions (1.5.x backport)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,8 +13,13 @@ on:
   schedule:
     - cron: '0 16 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      security-events: write
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Backports the `codeql-analysis.yml` permissions hardening already on `main` (f8b89b2294b4514d9d4be3096a9e92a2aabb503e) to this release branch, per #12716.

`main`'s `.github/workflows/codeql-analysis.yml` was fixed to scope down the default `GITHUB_TOKEN` permissions (flagged by [zizmor](https://github.com/woodruffw/zizmor) as `excessive-permissions`), but this branch never got the same fix and still runs with the broader default permissions.

This mirrors main's fix exactly:
```yaml
permissions:
  contents: read

jobs:
  analyze:
    permissions:
      security-events: write
```
- Top-level `contents: read` -- least-privilege default for the whole workflow.
- Job-level `security-events: write` -- the one elevated scope `analyze` actually needs, to upload CodeQL SARIF results.

Scoped to just the permissions fix (not the separate action-SHA-pinning hardening also present on `main`), to keep this backport minimal and reviewable.

**Note:** #12716 lists this same finding on two other branches (`release-sdks`, `1.4.x`). I opened this PR for `1.5.x` only; happy to open the equivalent PRs for the other two branches if that's wanted.

## Test plan

- [x] YAML parses (`yaml.safe_load`).
- [x] Diff matches `main`'s already-merged fix for the same file/finding line-for-line (aside from the file's own diverged content on this older branch).