### PR TITLE
Fix empty-string password silently getting hashed and stored

### DIFF
--- a/src/Appwrite/Platform/Modules/Users/Http/Users/Password/Update.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/Password/Update.php
@@ -95,6 +95,7 @@ class Update extends Action
             ]));
             $queueForEvents->setParam('userId', $user->getId());
             $response->dynamic($user, Response::MODEL_USER);
+            return;
         }
 
         $hooks->trigger('passwordValidator', [$dbForProject, $project, $password, &$user, true]);

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -1463,6 +1463,16 @@ trait UsersBase
         $this->assertNotEmpty($user['body']['$id']);
         $this->assertEmpty($user['body']['password']);
 
+        // Clearing the password must not fall through to hashing and storing the empty
+        // string as a real password afterwards.
+        $user = $this->client->call(Client::METHOD_GET, '/users/' . $data['userId'], array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals($user['headers']['status-code'], 200);
+        $this->assertEmpty($user['body']['password']);
+
         $this->assertEventually(function () {
             $session = $this->client->call(Client::METHOD_POST, '/account/sessions/email', [
                 'content-type' => 'application/json',


### PR DESCRIPTION
## Summary

Fixes bug 1 from #12797.

`PATCH /v1/users/:userId/password` intentionally allows an empty password (the param validator is constructed with `allowEmpty: true` on both `PasswordStrength` and `PasswordDictionary`) as a way to clear a user's password -- useful for e.g. converting an account to OAuth-only.

The empty-password branch in `src/Appwrite/Platform/Modules/Users/Http/Users/Password/Update.php` correctly clears the password and sends the response:

```php
if (\strlen($password) === 0) {
    $user
        ->setAttribute('password', '')
        ->setAttribute('passwordUpdate', DateTime::now());

    $user = $dbForProject->updateDocument('users', $user->getId(), new Document([
        'password' => $user->getAttribute('password'),
        'passwordUpdate' => $user->getAttribute('passwordUpdate'),
    ]));
    $queueForEvents->setParam('userId', $user->getId());
    $response->dynamic($user, Response::MODEL_USER);
}
// <-- no return here
$hooks->trigger('passwordValidator', ...);
$hasher = new Argon2();
$newPassword = $hasher->hash($password); // hashes the empty string
...
$user = $dbForProject->updateDocument('users', $user->getId(), new Document([
    'password' => $user->getAttribute('password'), // now a real Argon2 hash of ""
    ...
]));
```

There's no `return` after the empty-password branch, so execution falls through unconditionally. The empty string then gets hashed with Argon2 and written back to the user in a second `updateDocument` call. The client's response looked correct (`password: ""`), but the database ended up with a valid Argon2 hash of an empty string moments later -- so the account could subsequently authenticate with an empty-string password, exactly as described in the linked issue.

Fix: add the missing `return;`.

## Test plan

- [x] Added a regression assertion in `testUpdateUserPassword` (`tests/e2e/Services/Users/UsersBase.php`): after clearing the password, re-fetch the user via `GET /users/:userId` and assert `password` is still empty. Verified this is the right check by tracing that the fall-through bug's second `updateDocument` call is what would make this fail (a hash string instead of `""`), not anything visible in the immediate response.
- [x] `php -l`, Pint, and PHPStan (level 4) all pass on both changed files.
- [ ] Couldn't run the full E2E suite in this environment (needs the Docker/breeze stack); relying on CI.

Note: this PR only addresses bug 1 from #12797. Bug 2 (session creation succeeding for a blocked user via the admin API) is a separate, lower-severity issue -- the reporter notes the session is likely unusable since auth middleware checks user status at request time -- and I didn't want to bundle an unrelated behavior change into this fix. Happy to open a follow-up for it if wanted.