### PR TITLE
Fix doctor CLI's update check hitting a dead endpoint

### DIFF
--- a/src/Appwrite/Platform/Tasks/Doctor.php
+++ b/src/Appwrite/Platform/Tasks/Doctor.php
@@ -299,13 +299,22 @@ class Doctor extends Action
         try {
             if (Http::isProduction()) {
                 Console::log('');
-                $version = \json_decode(@\file_get_contents(System::getEnv('_APP_HOME', 'http://localhost') . '/version'), true);
+                $context = \stream_context_create([
+                    'http' => [
+                        'method' => 'GET',
+                        'header' => 'User-Agent: Appwrite-Doctor',
+                        'timeout' => 5,
+                        'ignore_errors' => true,
+                    ],
+                ]);
+                $release = \json_decode(@\file_get_contents('https://api.github.com/repos/appwrite/appwrite/releases/latest', false, $context), true);
+                $latestVersion = $release['tag_name'] ?? null;
 
-                if ($version && isset($version['version'])) {
-                    if (\version_compare($version['version'], System::getEnv('_APP_VERSION', 'UNKNOWN')) === 0) {
+                if ($latestVersion) {
+                    if (\version_compare($latestVersion, System::getEnv('_APP_VERSION', 'UNKNOWN')) === 0) {
                         Console::info('You are running the latest version of ' . APP_NAME . '! 🥳');
                     } else {
-                        Console::info('A new version (' . $version['version'] . ') is available! 🥳' . "\n");
+                        Console::info('A new version (' . $latestVersion . ') is available! 🥳' . "\n");
                     }
                 } else {
                     Console::error('Failed to check for a newer version' . "\n");


### PR DESCRIPTION
## Summary

Fixes #7717.

`doctor`'s update-availability check does:

```php
$version = \json_decode(@\file_get_contents(System::getEnv('_APP_HOME', 'http://localhost') . '/version'), true);
```

`_APP_HOME` defaults to `https://appwrite.io`, so this fetches `https://appwrite.io/version`. That URL currently 404s -- it serves the marketing site's SPA shell (a "Not Found" page), not a JSON version payload:

```
$ curl -sL -w "%{http_code} %{content_type}\n" https://appwrite.io/version
404 text/html
```

So `json_decode` on that HTML always returns `null`, and `doctor` unconditionally prints "Failed to check for a newer version" regardless of whether an update is actually available.

Fix: use GitHub's releases API instead, which is a stable, public, versioned source appwrite/appwrite already controls:

```php
$release = \json_decode(@\file_get_contents('https://api.github.com/repos/appwrite/appwrite/releases/latest', false, $context), true);
$latestVersion = $release['tag_name'] ?? null;
```

Verified `_APP_VERSION`/`APP_VERSION_STABLE` (`app/init/constants.php`) and GitHub's `tag_name` use the same format (e.g. `"1.9.6"`, no `v` prefix), so `version_compare()` keeps working without any parsing changes.

Also added a `User-Agent` header (GitHub's API 403s anonymous requests without one) and a 5s timeout on the request (the original had no timeout at all, so a slow/unreachable host could hang the whole `doctor` command).

## Test plan

- [x] `php -l`, Pint, and PHPStan (level 4) pass on the changed file.
- [x] Ran the new fetch+compare logic standalone against the real GitHub API:
  ```
  string(5) "1.9.6"      // tag_name
  int(0)                  // version_compare("1.9.6", "1.9.6") -- "latest"
  int(1)                  // version_compare("1.9.6", "1.9.5") -- "update available"
  ```
- [ ] Didn't run `doctor` end-to-end inside a container in this environment (no Docker available here); relying on CI / a maintainer to confirm inside the real container.