### PR TITLE
Reject creating a session for a blocked user via the admin API

### DIFF
--- a/src/Appwrite/Platform/Modules/Users/Http/Users/Sessions/Create.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/Sessions/Create.php
@@ -78,6 +78,10 @@ class Create extends Action
             throw new Exception(Exception::USER_NOT_FOUND);
         }
 
+        if (false === $user->getAttribute('status')) { // Account is blocked
+            throw new Exception(Exception::USER_BLOCKED);
+        }
+
         $secret = $proofForToken->generate();
         $detector = new Detector($request->getUserAgent('UNKNOWN'));
         $duration = $project->getAttribute('auths', [])['duration'] ?? TOKEN_EXPIRATION_LOGIN_LONG;

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -627,6 +627,31 @@ trait UsersBase
         ]);
 
         $this->assertEquals(204, $response['headers']['status-code']);
+
+        /**
+         * Test for FAILURE: blocked users must not get a new session created
+         */
+        $this->client->call(Client::METHOD_PATCH, '/users/' . $data['userId'] . '/status', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'status' => false,
+        ]);
+
+        $response = $this->client->call(Client::METHOD_POST, '/users/' . $data['userId'] . '/sessions', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        $this->assertEquals(403, $response['headers']['status-code']);
+
+        // Reset status back to true for other tests
+        $this->client->call(Client::METHOD_PATCH, '/users/' . $data['userId'] . '/status', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'status' => true,
+        ]);
     }
 
 


### PR DESCRIPTION
## Summary

Fixes bug 2 from #12797.

`POST /v1/users/:userId/sessions` (`src/Appwrite/Platform/Modules/Users/Http/Users/Sessions/Create.php`) only checked that the target user exists, not whether they're blocked (`status: false`):

```php
$user = $dbForProject->getDocument('users', $userId);
if ($user->isEmpty()) {
    throw new Exception(Exception::USER_NOT_FOUND);
}
// no status check -- straight into session creation
```

Every other place a user's blocked status gates something already has this exact check -- self-service login in `app/controllers/api/account.php`:
```php
if (false === $profile->getAttribute('status')) { // Account is blocked
    throw new Exception(Exception::USER_BLOCKED); // User is in status blocked
}
```
and the shared request middleware that rejects *any* subsequent request made by a blocked user, in `app/controllers/shared/api.php` (`Step 10: Check if user is blocked`).

So this wasn't an auth bypass -- I confirmed the middleware still rejects any request made with a session created this way, since it checks the *current* user's status on every call, independent of how the session was created. But it's still a real inconsistency: an admin/API-key caller could create a session document for a blocked user that the codebase's own middleware guarantees can never be used, leaving an orphaned session record that could confuse session-count reporting or audit trails, exactly as described in the issue.

Fix: add the same `USER_BLOCKED` check used at the two other call sites, right after the existing `USER_NOT_FOUND` check.

## Test plan

- [x] Added a regression case to `testCreateSession` (`tests/e2e/Services/Users/UsersBase.php`): block the test user via `PATCH /users/:userId/status`, assert `POST /users/:userId/sessions` now returns 403, then reset status to `true` (existing tests in this suite depend on the user being unblocked).
- [x] `php -l`, Pint, and PHPStan (level 4) all pass on both changed files.
- [ ] Couldn't run the full E2E suite in this environment (needs the Docker/breeze stack); relying on CI.

This is a follow-up to #13143, which fixed bug 1 from the same issue (#12797) separately since the two bugs are unrelated.