### PR TITLE
fix(databases): type-guard the deprecated databases path like every other one

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Action.php
@@ -26,10 +26,10 @@ class Action extends AppwriteAction
      * the list filter ({@see getDatabaseTypeQueryFilters()}) and the by-id guard
      * ({@see isDatabaseTypeMismatch()}) so they cannot diverge.
      *
-     * TablesDB is the compatibility successor to the legacy databases API, so it
-     * also serves legacy-typed databases; the other product APIs are scoped to
-     * their own type. Every database carries a non-null `type` (set on create
-     * and backfilled to 'legacy' by migration V23), so null is not represented.
+     * TablesDB and the legacy databases API are the same product either side of a
+     * rename, so each serves both types; DocumentsDB and VectorsDB are scoped to
+     * their own. Every database carries a non-null `type` (set on create and
+     * backfilled to 'legacy' by migration V23), so null is not represented.
      *
      * @return string[]
      */
@@ -37,22 +37,23 @@ class Action extends AppwriteAction
     {
         return match ($this->getDatabaseType()) {
             DATABASE_TYPE_TABLESDB => [DATABASE_TYPE_TABLESDB, DATABASE_TYPE_LEGACY],
+            DATABASE_TYPE_LEGACY => [DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB],
             default => [$this->getDatabaseType()],
         };
     }
 
     /**
-     * A database resolved by id on a product-DB path must be one of the path's
-     * allowed types; otherwise it is treated as not-found rather than proceeding
-     * to a type-mismatched backend operation that surfaces as an opaque 500. The
-     * legacy /v1/databases API is intentionally not type-guarded.
+     * A database resolved by id must be one of the path's allowed types; otherwise
+     * it is treated as not-found rather than proceeding to a type-mismatched backend
+     * operation that surfaces as an opaque 500.
+     *
+     * The legacy path was previously exempt, which left it resolving by id what its
+     * own list refused to return: `GET /v1/databases/{id}` answered for a DocumentsDB
+     * or VectorsDB database that `GET /v1/databases` had never listed, and
+     * `/collections` on one then 500'd against a table shaped for another product.
      */
     protected function isDatabaseTypeMismatch(Document $database): bool
     {
-        if ($this->getDatabaseType() === DATABASE_TYPE_LEGACY) {
-            return false;
-        }
-
         return !in_array($database->getAttribute('type', ''), $this->getAllowedDatabaseTypes(), true);
     }
 

--- a/tests/unit/Platform/Modules/Databases/DatabaseTypeMismatchTest.php
+++ b/tests/unit/Platform/Modules/Databases/DatabaseTypeMismatchTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Unit\Platform\Modules\Databases;
 
 use Appwrite\Platform\Modules\Databases\Http\Databases\Action;
+use Appwrite\Platform\Modules\Databases\Http\Databases\XList;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Document;
+use Utopia\Database\Query;
 
 final class DatabaseTypeMismatchTest extends TestCase
 {
@@ -80,9 +82,73 @@ final class DatabaseTypeMismatchTest extends TestCase
         $this->assertTrue($vectors->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
     }
 
-    public function testLegacyDatabasesPathIsNeverTypeGuarded(): void
+    /**
+     * The legacy path is the mirror of the TablesDB one: same product either side of
+     * a rename, so it serves both types and refuses the other two.
+     *
+     * It was previously exempt from the guard entirely, which let it resolve by id
+     * what its own list refused to return — `GET /v1/databases/{id}` answered for a
+     * DocumentsDB or VectorsDB database that `GET /v1/databases` never listed, and
+     * `/collections` on one then 500'd against a table shaped for another product.
+     */
+    public function testLegacyPathServesTablesdbAndRefusesTheOtherProducts(): void
     {
-        $legacy = new class () extends Action {
+        $legacy = $this->legacyAction();
+
+        $this->assertSame([DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB], $legacy->exposeAllowedTypes());
+
+        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
+        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_TABLESDB])));
+        $this->assertTrue($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_DOCUMENTSDB])));
+        $this->assertTrue($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_VECTORSDB])));
+        $this->assertTrue($legacy->exposeMismatch(new Document([])));
+    }
+
+    /**
+     * The by-id guard and the list filter must select the same set, or the two
+     * disagree about which databases exist.
+     */
+    public function testLegacyListFilterAndByIdGuardSelectTheSameSet(): void
+    {
+        $legacy = $this->legacyAction();
+        $filters = $legacy->exposeQueryFilters();
+
+        $this->assertCount(1, $filters);
+        $this->assertSame('type', $filters[0]->getAttribute());
+
+        $listed = $filters[0]->getValues();
+        $this->assertSame($legacy->exposeAllowedTypes(), $listed);
+
+        foreach ([DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB, DATABASE_TYPE_DOCUMENTSDB, DATABASE_TYPE_VECTORSDB] as $type) {
+            $this->assertSame(
+                in_array($type, $listed, true),
+                !$legacy->exposeMismatch(new Document(['type' => $type])),
+                "list and get disagree about whether a '{$type}' database exists on /v1/databases",
+            );
+        }
+    }
+
+    /**
+     * The two paths over the same product must accept the same databases, so a caller
+     * migrating from /v1/databases to /v1/tablesdb never loses one.
+     */
+    public function testLegacyAndTablesdbPathsAcceptTheSameDatabases(): void
+    {
+        $legacy = $this->legacyAction();
+        $tablesdb = $this->tablesdbAction();
+
+        foreach ([DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB, DATABASE_TYPE_DOCUMENTSDB, DATABASE_TYPE_VECTORSDB] as $type) {
+            $this->assertSame(
+                $tablesdb->exposeMismatch(new Document(['type' => $type])),
+                $legacy->exposeMismatch(new Document(['type' => $type])),
+                "the deprecated and successor paths disagree about a '{$type}' database",
+            );
+        }
+    }
+
+    private function legacyAction(): object
+    {
+        $legacy = new class () extends XList {
             public static function getName(): string
             {
                 return 'testLegacyTypeGuard';
@@ -92,11 +158,39 @@ final class DatabaseTypeMismatchTest extends TestCase
             {
                 return $this->isDatabaseTypeMismatch($database);
             }
+
+            /** @return string[] */
+            public function exposeAllowedTypes(): array
+            {
+                return $this->getAllowedDatabaseTypes();
+            }
+
+            /** @return Query[] */
+            public function exposeQueryFilters(): array
+            {
+                return $this->getDatabaseTypeQueryFilters();
+            }
         };
         $legacy->setHttpPath('/v1/databases/:databaseId/collections');
-        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_LEGACY])));
-        $this->assertFalse($legacy->exposeMismatch(new Document([])));
-        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_TABLESDB])));
-        $this->assertFalse($legacy->exposeMismatch(new Document(['type' => DATABASE_TYPE_DOCUMENTSDB])));
+
+        return $legacy;
+    }
+
+    private function tablesdbAction(): object
+    {
+        $tablesdb = new class () extends Action {
+            public static function getName(): string
+            {
+                return 'testTablesdbMirrorGuard';
+            }
+
+            public function exposeMismatch(Document $database): bool
+            {
+                return $this->isDatabaseTypeMismatch($database);
+            }
+        };
+        $tablesdb->setHttpPath('/v1/tablesdb/:databaseId/tables');
+
+        return $tablesdb;
     }
 }

--- a/tests/unit/Platform/Modules/Databases/LegacyCollectionsRefusalTest.php
+++ b/tests/unit/Platform/Modules/Databases/LegacyCollectionsRefusalTest.php
@@ -23,6 +23,15 @@ use Utopia\Database\Validator\Authorization;
  */
 final class LegacyCollectionsRefusalTest extends TestCase
 {
+    /**
+     * Whether the action queried `database_{sequence}`.
+     *
+     * An instance property rather than a return value, because the call under test
+     * throws on the path this suite cares about — a returned flag would be lost with
+     * the stack, leaving the assertion to pass on the catch alone.
+     */
+    private bool $reached = false;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -32,11 +41,10 @@ final class LegacyCollectionsRefusalTest extends TestCase
 
     /**
      * @param array<string, mixed> $attributes
-     * @return array{reached: bool}
      */
-    private function listCollections(array $attributes): array
+    private function listCollections(array $attributes): void
     {
-        $reached = false;
+        $this->reached = false;
 
         $dbForProject = $this->createMock(Database::class);
         $dbForProject
@@ -44,15 +52,15 @@ final class LegacyCollectionsRefusalTest extends TestCase
             ->willReturn(new Document(['$id' => 'db', '$sequence' => '7', ...$attributes]));
         $dbForProject
             ->method('find')
-            ->willReturnCallback(function () use (&$reached): array {
-                $reached = true;
+            ->willReturnCallback(function (): array {
+                $this->reached = true;
 
                 return [];
             });
         $dbForProject
             ->method('count')
-            ->willReturnCallback(function () use (&$reached): int {
-                $reached = true;
+            ->willReturnCallback(function (): int {
+                $this->reached = true;
 
                 return 0;
             });
@@ -62,12 +70,10 @@ final class LegacyCollectionsRefusalTest extends TestCase
             [],
             '',
             false,
-            $this->createMock(UtopiaResponse::class),
+            $this->createStub(UtopiaResponse::class),
             $dbForProject,
             new Authorization(),
         );
-
-        return ['reached' => $reached];
     }
 
     public function testAVectorsDatabaseIsRefusedBeforeTheBackendIsQueried(): void
@@ -92,20 +98,18 @@ final class LegacyCollectionsRefusalTest extends TestCase
 
     /**
      * The mismatched call must not reach `database_{sequence}` at all — that query is
-     * where the 500 came from.
+     * where the 500 came from. Refusing and querying anyway would still 500.
      */
     public function testTheRefusedCallNeverReachesTheBackend(): void
     {
         foreach ([DATABASE_TYPE_VECTORSDB, DATABASE_TYPE_DOCUMENTSDB] as $type) {
-            $reached = true;
-
             try {
-                $reached = $this->listCollections(['type' => $type])['reached'];
+                $this->listCollections(['type' => $type]);
             } catch (Exception) {
-                $reached = false;
+                // The refusal is expected here; what it did on the way is the assertion.
             }
 
-            $this->assertFalse($reached, "a '{$type}' database must be refused before database_{sequence} is queried");
+            $this->assertFalse($this->reached, "a '{$type}' database must be refused before database_{sequence} is queried");
         }
     }
 
@@ -116,8 +120,10 @@ final class LegacyCollectionsRefusalTest extends TestCase
     public function testTheServedTypesStillReachTheBackend(): void
     {
         foreach ([DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB] as $type) {
+            $this->listCollections(['type' => $type]);
+
             $this->assertTrue(
-                $this->listCollections(['type' => $type])['reached'],
+                $this->reached,
                 "a '{$type}' database must still be served by /v1/databases/{id}/collections",
             );
         }

--- a/tests/unit/Platform/Modules/Databases/LegacyCollectionsRefusalTest.php
+++ b/tests/unit/Platform/Modules/Databases/LegacyCollectionsRefusalTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Databases;
+
+use Appwrite\Extend\Exception;
+use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\XList;
+use Appwrite\Utopia\Response as UtopiaResponse;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Validator\Authorization;
+
+/**
+ * `GET /v1/databases/{id}/collections` on a VectorsDB or DocumentsDB database used to
+ * reach the backend and query `database_{sequence}`, a table shaped for a different
+ * product, which surfaced as an opaque 500.
+ *
+ * The refusal has to happen before the backend is touched, so these tests assert the
+ * backend is never reached rather than pinning the wording of whatever the engine
+ * would have thrown.
+ */
+final class LegacyCollectionsRefusalTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once __DIR__ . '/../../../../../src/Appwrite/Platform/Modules/Databases/Constants.php';
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     * @return array{reached: bool}
+     */
+    private function listCollections(array $attributes): array
+    {
+        $reached = false;
+
+        $dbForProject = $this->createMock(Database::class);
+        $dbForProject
+            ->method('getDocument')
+            ->willReturn(new Document(['$id' => 'db', '$sequence' => '7', ...$attributes]));
+        $dbForProject
+            ->method('find')
+            ->willReturnCallback(function () use (&$reached): array {
+                $reached = true;
+
+                return [];
+            });
+        $dbForProject
+            ->method('count')
+            ->willReturnCallback(function () use (&$reached): int {
+                $reached = true;
+
+                return 0;
+            });
+
+        (new XList())->action(
+            'db',
+            [],
+            '',
+            false,
+            $this->createMock(UtopiaResponse::class),
+            $dbForProject,
+            new Authorization(),
+        );
+
+        return ['reached' => $reached];
+    }
+
+    public function testAVectorsDatabaseIsRefusedBeforeTheBackendIsQueried(): void
+    {
+        try {
+            $this->listCollections(['type' => DATABASE_TYPE_VECTORSDB]);
+            $this->fail('Listing collections of a VectorsDB database on /v1/databases must be refused, not served.');
+        } catch (Exception $exception) {
+            $this->assertSame(Exception::DATABASE_NOT_FOUND, $exception->getType());
+        }
+    }
+
+    public function testADocumentsDatabaseIsRefusedBeforeTheBackendIsQueried(): void
+    {
+        try {
+            $this->listCollections(['type' => DATABASE_TYPE_DOCUMENTSDB]);
+            $this->fail('Listing collections of a DocumentsDB database on /v1/databases must be refused, not served.');
+        } catch (Exception $exception) {
+            $this->assertSame(Exception::DATABASE_NOT_FOUND, $exception->getType());
+        }
+    }
+
+    /**
+     * The mismatched call must not reach `database_{sequence}` at all — that query is
+     * where the 500 came from.
+     */
+    public function testTheRefusedCallNeverReachesTheBackend(): void
+    {
+        foreach ([DATABASE_TYPE_VECTORSDB, DATABASE_TYPE_DOCUMENTSDB] as $type) {
+            $reached = true;
+
+            try {
+                $reached = $this->listCollections(['type' => $type])['reached'];
+            } catch (Exception) {
+                $reached = false;
+            }
+
+            $this->assertFalse($reached, "a '{$type}' database must be refused before database_{sequence} is queried");
+        }
+    }
+
+    /**
+     * The guard must not over-refuse: the products this path really serves still reach
+     * the backend.
+     */
+    public function testTheServedTypesStillReachTheBackend(): void
+    {
+        foreach ([DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB] as $type) {
+            $this->assertTrue(
+                $this->listCollections(['type' => $type])['reached'],
+                "a '{$type}' database must still be served by /v1/databases/{id}/collections",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes the remaining half of Appwrite [DAT-2219](https://linear.app/appwrite/issue/DAT-2219). Found during a production API verification sweep.

## The defect

The legacy `/v1/databases` path is exempt from the by-id type guard while its own list stays type-filtered, so the two disagree about which databases exist:

- `GET /v1/databases` lists only `legacy`-typed databases.
- `GET /v1/databases/{id}` resolves a database of **any** type — DocumentsDB, VectorsDB, TablesDB.
- `GET /v1/databases/{vectorsdb-id}/collections` then queries `database_{sequence}`, a table shaped for another product, and returns **500** rather than a typed refusal.

The sweep hit the disagreement 4 times out of 4.

`Action.php` already builds the guard and the list filter on one `getAllowedDatabaseTypes()` — its own docblock says "single source of truth ... so they cannot diverge". The legacy path simply opted out:

```php
if ($this->getDatabaseType() === DATABASE_TYPE_LEGACY) {
    return false;
}
```

## The fix

Remove the exemption, and give legacy the mirror of the set TablesDB already has:

```php
DATABASE_TYPE_TABLESDB => [DATABASE_TYPE_TABLESDB, DATABASE_TYPE_LEGACY],
DATABASE_TYPE_LEGACY   => [DATABASE_TYPE_LEGACY, DATABASE_TYPE_TABLESDB],
```

TablesDB and legacy are the same product either side of a rename, so each serves both types and refuses the other two. Two lines, and every route on the path inherits it — the guard is consulted by ~30 actions (get, delete, update, collections, attributes, indexes, documents, transactions).

Consequences:

| call | before | after |
|---|---|---|
| `GET /v1/databases` | `legacy` only | `legacy` + `tablesdb` |
| `GET /v1/databases/{tablesdb-id}` | 200 | 200 |
| `GET /v1/databases/{vectorsdb-id}` | 200 | 404 |
| `GET /v1/databases/{vectorsdb-id}/collections` | **500** | 404 |
| `DELETE /v1/databases/{vectorsdb-id}` | 204 | 404 |

Nothing the path served *correctly* starts being refused. `tablesdb` moves from "get-only" to "listed and get" — list catching up to what get already did. `documentsdb`/`vectorsdb` move from being served incorrectly to a typed not-found, and their own product routes remain the way to reach them.

### Why widen list rather than narrow get

The other direction — restricting the by-id routes to `legacy` only — would also make the two agree, but it would stop the deprecated path resolving TablesDB databases at all, which is the migration path this API is deprecated *in favour of*. It would also regress DAT-2170, where `GET /v1/databases/{id}` was fixed to report a dedicated database's real `specification`/`engine`/`replicas`.

## Regression tests, seen red

### Red — fix reverted (`git checkout origin/main -- Action.php`)

```
Tests: 17, Assertions: 36, Failures: 6.

2) DatabaseTypeMismatchTest::testLegacyListFilterAndByIdGuardSelectTheSameSet
list and get disagree about whether a 'tablesdb' database exists on /v1/databases
Failed asserting that true is identical to false.

3) DatabaseTypeMismatchTest::testLegacyAndTablesdbPathsAcceptTheSameDatabases
the deprecated and successor paths disagree about a 'documentsdb' database
Failed asserting that false is identical to true.

4) LegacyCollectionsRefusalTest::testAVectorsDatabaseIsRefusedBeforeTheBackendIsQueried
Listing collections of a VectorsDB database on /v1/databases must be refused, not served.

6) LegacyCollectionsRefusalTest::testTheRefusedCallNeverReachesTheBackend
a 'vectorsdb' database must be refused before database_{sequence} is queried
Failed asserting that true is false.

1) DatabaseTypeMismatchTest::testLegacyPathServesTablesdbAndRefusesTheOtherProducts
Failed asserting that two arrays are identical.
 Array &0 [
     0 => 'legacy',
-    1 => 'tablesdb',
 ]
```

### Green

```
Tests: 17, Assertions: 45.
```

`LegacyCollectionsRefusalTest` drives `Collections\XList::action()` and asserts the backend is **never reached** for a mismatched type, rather than pinning the wording of whatever the engine would have thrown — the 500 came from that query, so not making it is the property that matters. It also asserts the guard does not over-refuse: `legacy` and `tablesdb` still reach the backend.

`testLegacyListFilterAndByIdGuardSelectTheSameSet` compares the list filter's `Query::equal('type', ...)` values against the by-id guard's verdict for every type, so the two cannot silently diverge again.

`testLegacyDatabasesPathIsNeverTypeGuarded` is replaced — it pinned the exempt behaviour this PR removes.

## Verification

- `composer lint` (Pint) — passed
- `composer check` (PHPStan) on the changed path — no errors
- `--testsuite unit` — no Databases-related failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
