### PR TITLE
fix(oauth2): derive emailVerification from the provider instead of assuming it

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1807,8 +1807,8 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                             Permission::delete(Role::user($userId)),
                         ],
                         'email' => $email,
-                        'emailVerification' => true,
-                        'status' => true, // Email should already be authenticated by OAuth2 provider
+                        'emailVerification' => $isVerified, // Trust the provider's userinfo claim, not the mere fact an email was returned
+                        'status' => true,
                         'password' => null,
                         'hash' => $proofForPassword->getHash()->getName(),
                         'hashOptions' => $proofForPassword->getHash()->getOptions(),
@@ -1866,6 +1866,8 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                 'emailIsFree' => null,
             ];
 
+            $isVerified = $oauth2->isEmailVerified($accessToken);
+
             try {
                 $parsedEmail = new Email($providerEmail);
                 $canonical = $parsedEmail->getCanonical();
@@ -1874,7 +1876,7 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
                     || ($plan['supportsCanonicalEmailValidation'] ?? false)
                 )
                     && ($project->getAttribute('auths', [])['canonicalEmails'] ?? false)
-                    && $oauth2->isEmailVerified($accessToken);
+                    && $isVerified;
                 $email = $canonicalize ? $canonical : $providerEmail;
                 $emails = array_values(array_unique([$email, $providerEmail]));
                 $emailMetadata = [
@@ -1913,6 +1915,8 @@ Http::get('/v1/account/sessions/oauth2/:provider/redirect')
             }
 
             $user->setAttribute('email', $email);
+            // Never downgrade an already-verified user; only ever promote to verified
+            $user->setAttribute('emailVerification', $user->getAttribute('emailVerification', false) || $isVerified);
             $user->setAttribute('emailCanonical', $emailMetadata['emailCanonical']);
             $user->setAttribute('emailIsCanonical', $emailMetadata['emailIsCanonical']);
             $user->setAttribute('emailIsCorporate', $emailMetadata['emailIsCorporate']);

--- a/src/Appwrite/Auth/OAuth2/Amazon.php
+++ b/src/Appwrite/Auth/OAuth2/Amazon.php
@@ -149,9 +149,8 @@ class Amazon extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Bitly.php
+++ b/src/Appwrite/Auth/OAuth2/Bitly.php
@@ -157,7 +157,15 @@ class Bitly extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        return true;
+        $user = $this->getUser($accessToken);
+
+        foreach ($user['emails'] ?? [] as $email) {
+            if (($email['is_verified'] ?? false) === true) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Box.php
+++ b/src/Appwrite/Auth/OAuth2/Box.php
@@ -150,9 +150,8 @@ class Box extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Etsy.php
+++ b/src/Appwrite/Auth/OAuth2/Etsy.php
@@ -158,9 +158,8 @@ class Etsy extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Facebook.php
+++ b/src/Appwrite/Auth/OAuth2/Facebook.php
@@ -131,9 +131,8 @@ class Facebook extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Figma.php
+++ b/src/Appwrite/Auth/OAuth2/Figma.php
@@ -139,9 +139,8 @@ class Figma extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Kick.php
+++ b/src/Appwrite/Auth/OAuth2/Kick.php
@@ -147,7 +147,8 @@ class Kick extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        return !empty($this->getUserEmail($accessToken));
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Microsoft.php
+++ b/src/Appwrite/Auth/OAuth2/Microsoft.php
@@ -147,9 +147,8 @@ class Microsoft extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Microsoft explicitly does not verify emails in Graph /me, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Notion.php
+++ b/src/Appwrite/Auth/OAuth2/Notion.php
@@ -137,9 +137,8 @@ class Notion extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Slack.php
+++ b/src/Appwrite/Auth/OAuth2/Slack.php
@@ -131,9 +131,8 @@ class Slack extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // email_verified lives on openid.connect.userInfo, not users.identity; unverified is the safe default until we migrate
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Stripe.php
+++ b/src/Appwrite/Auth/OAuth2/Stripe.php
@@ -146,9 +146,8 @@ class Stripe extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Tradeshift.php
+++ b/src/Appwrite/Auth/OAuth2/Tradeshift.php
@@ -154,9 +154,8 @@ class Tradeshift extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUser($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Twitch.php
+++ b/src/Appwrite/Auth/OAuth2/Twitch.php
@@ -144,9 +144,8 @@ class Twitch extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // email_verified lives on the OIDC userinfo endpoint, not Helix /users; unverified is the safe default until we migrate
+        return false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/X.php
+++ b/src/Appwrite/Auth/OAuth2/X.php
@@ -142,7 +142,10 @@ class X extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        return !empty($this->getUserEmail($accessToken));
+        // X only populates confirmed_email once the address is confirmed, so its presence is the verification signal
+        $user = $this->getUser($accessToken);
+
+        return !empty($user['data']['confirmed_email']);
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Yahoo.php
+++ b/src/Appwrite/Auth/OAuth2/Yahoo.php
@@ -156,7 +156,9 @@ class Yahoo extends OAuth2
     /**
      * Check if the OAuth email is verified
      *
-     * If present, the email is verified. This was verfied through a manual Yahoo sign up process
+     * Yahoo is an OpenID Connect provider and advertises the `email_verified`
+     * claim on its userinfo endpoint, so use that instead of merely assuming a
+     * returned address is confirmed.
      *
      * @param string $accessToken
      *
@@ -164,9 +166,9 @@ class Yahoo extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
+        $user = $this->getUser($accessToken);
 
-        return !empty($email);
+        return $user['email_verified'] ?? false;
     }
 
     /**

--- a/src/Appwrite/Auth/OAuth2/Yammer.php
+++ b/src/Appwrite/Auth/OAuth2/Yammer.php
@@ -133,9 +133,8 @@ class Yammer extends OAuth2
      */
     public function isEmailVerified(string $accessToken): bool
     {
-        $email = $this->getUserEmail($accessToken);
-
-        return !empty($email);
+        // Provider exposes no email verification signal, so treat as unverified until one is confirmed
+        return false;
     }
 
     /**


### PR DESCRIPTION
## What

The OAuth2 callback hardcoded `'emailVerification' => true` for every new user, with the comment *"Email should already be authenticated by OAuth2 provider."* That assumption does not hold. Every user signing in through any provider was marked verified regardless of what that provider actually said.

`$isVerified` was already being computed at `account.php:1704`, and already trusted for the security-sensitive account-linking checks that refuse to merge into an existing account on an unverified email. It simply never reached the `emailVerification` attribute.

## Changes

**Callback (`app/controllers/api/account.php`)**

- New-user path: `'emailVerification' => $isVerified`.
- The branch where an existing account gains an email set `email` and all five `emailMetadata` fields but never touched `emailVerification`, leaving a stale value against a brand-new address. It now sets it, OR'd with the current value so an already-verified user is never downgraded — verification only ever gets promoted.

**Adapters that do report status**

| Adapter | Before | After |
|---|---|---|
| `Yahoo` | `!empty($email)` | `email_verified` claim from its OIDC userinfo endpoint |
| `Bitly` | `return true` | walks `emails[].is_verified` |
| `X` | `!empty(getUserEmail())` | reads `data.confirmed_email` directly |

**Adapters with no usable signal — now `return false`**

Amazon, Box, Etsy, Facebook, Figma, Kick, Microsoft, Notion, Slack, Stripe, Tradeshift, Twitch, Yammer.

These all inferred verification from `!empty($email)`, which conflates *"the provider returned a string"* with *"the provider vouched for the address."* Unverified is the safe default. `Tradeshift` was additionally testing the whole user array rather than an email, so it was true whenever the account existed.

Three got a specific comment because "no signal exists" would have been inaccurate: **Microsoft** does not verify emails in Graph `/me` at all, and **Slack**/**Twitch** do expose `email_verified` but only on OIDC endpoints these adapters don't call.

Untouched: the 24 adapters already reading a real field (`email_verified`, `emailVerified`, `is_confirmed`, `confirmed_at`, `verified_account`, `verified`).

## Reviewer notes

⚠️ **This is a behavior change on a security boundary.** New signups through Facebook, Microsoft, Slack, and Twitch will now land as unverified, so anything gated on `emailVerification` will start challenging users who previously sailed through. Existing accounts keep their current value. Worth a look from whoever owns Cloud, since `console` shares this path.

**Slack and Twitch are recoverable but not here.** Both expose `email_verified` on OIDC endpoints (`openid.connect.userInfo`, `id.twitch.tv/oauth2/userinfo`). Slack already declares `openid`/`email`/`profile` scopes while calling the legacy `users.identity`. Migrating changes the source field for `getUserID()` (`user.id` → `sub`), and that's the provider UID join key on the `identities` table — getting it wrong locks existing users out of their accounts. Needs its own PR with a migration plan.

**No test coverage added.** I found no existing test asserting `emailVerification` on the OAuth2 callback; the `Mock`/`MockUnverified` adapter pair suggests E2E is the right home for it. Happy to add in this PR or a follow-up.

## Verification

`php -l` clean across all touched files; `composer lint` passes on `app/controllers/api/account.php` and `src/Appwrite/Auth/OAuth2/`. Provider claims confirmed against live discovery documents (Yahoo, Twitch) and official API docs (Bitly, Slack, Facebook, Figma, Microsoft) rather than from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)