### PR TITLE
docs: update OAuth2 provider contribution guide

### DIFF
--- a/docs/tutorials/add-oauth2-provider.md
+++ b/docs/tutorials/add-oauth2-provider.md
@@ -248,12 +248,21 @@ Then wire the action in:
 
 ### 2.5 Response model
 
+For a standalone provider (the common case):
+
 1. Add `public const MODEL_OAUTH2_XXX = 'oAuth2Xxx';` in `src/Appwrite/Utopia/Response.php`
 2. Create `src/Appwrite/Utopia/Response/Model/OAuth2Xxx.php` extending `OAuth2Base` (see `OAuth2Yahoo.php`)
 3. Register it in `app/init/models.php` with `Response::setModel(new OAuth2Xxx());`
 4. Include `Response::MODEL_OAUTH2_XXX` in:
    - `OAuth2ProviderList.php`
    - `Project/Http/Project/OAuth2/Get.php`
+
+**Shared models for sandbox / alternate IDs:** Production and sandbox variants that expose the same response shape reuse one model. Do not create a second model class. Instead, list both provider ids in `$conditions['$id']`, and point both Update actions at the same `MODEL_OAUTH2_*` constant. Examples:
+
+- `paypal` / `paypalSandbox` → `OAuth2Paypal` with `'$id' => ['paypal', 'paypalSandbox']`
+- `tradeshift` / `tradeshiftBox` → `OAuth2Tradeshift` with `'$id' => ['tradeshift', 'tradeshiftBox']`
+
+You still need a separate adapter class, Update action, and `oAuthProviders.php` entry for each id; only the response model is shared. Each id must still appear in `Base::getProviderActions()` and in `OAuth2ProviderTest`.
 
 ### 2.6 Tests and changelog
 

--- a/docs/tutorials/add-oauth2-provider.md
+++ b/docs/tutorials/add-oauth2-provider.md
@@ -299,21 +299,14 @@ if (!isValueOfStringEnum(OAuthProvider, provider.key)) {
 
 Without an SDK that includes your provider, enabling it in the UI fails with **Invalid OAuth2 provider**, even when `PATCH /v1/project/oauth2/{providerId}` works via curl.
 
-After the backend endpoints and models land, regenerate specs and SDKs from a running Appwrite container (`bin/specs` and `bin/sdks` are thin wrappers around `php app/cli.php`):
+After the backend endpoints and models land, regenerate specs and SDKs from the repo root with PHP (no Docker stack required; `composer install` must already have been run):
 
 ```bash
 # 1. Regenerate API specs (writes under app/config/specs/)
-docker compose exec appwrite php app/cli.php specs --git=no
+php app/cli.php specs --git=no
 
 # 2. Generate the Console web SDK locally (for local Console development only)
-docker compose exec appwrite php app/cli.php sdks --platform=console --sdk=web --version=latest --git=no
-```
-
-Equivalent shortcuts:
-
-```bash
-docker compose exec appwrite specs --git=no
-docker compose exec appwrite sdks --platform=console --sdk=web --version=latest --git=no
+php app/cli.php sdks --platform=console --sdk=web --version=latest --git=no
 ```
 
 Omit the flags to run the interactive prompts instead. Commit the updated specs with the Appwrite PR; official SDK publishing is handled separately by maintainers.

--- a/docs/tutorials/add-oauth2-provider.md
+++ b/docs/tutorials/add-oauth2-provider.md
@@ -299,11 +299,31 @@ if (!isValueOfStringEnum(OAuthProvider, provider.key)) {
 
 Without an SDK that includes your provider, enabling it in the UI fails with **Invalid OAuth2 provider**, even when `PATCH /v1/project/oauth2/{providerId}` works via curl.
 
+After the backend endpoints and models land, regenerate specs and SDKs from a running Appwrite container (`bin/specs` and `bin/sdks` are thin wrappers around `php app/cli.php`):
+
+```bash
+# 1. Regenerate API specs (writes under app/config/specs/)
+docker compose exec appwrite php app/cli.php specs --git=no
+
+# 2. Generate the Console web SDK locally (for local Console development only)
+docker compose exec appwrite php app/cli.php sdks --platform=console --sdk=web --version=latest --git=no
+```
+
+Equivalent shortcuts:
+
+```bash
+docker compose exec appwrite specs --git=no
+docker compose exec appwrite sdks --platform=console --sdk=web --version=latest --git=no
+```
+
+Omit the flags to run the interactive prompts instead. Commit the updated specs with the Appwrite PR; official SDK publishing is handled separately by maintainers.
+
 The release sequence is:
 
-1. Land the backend endpoints and models in Appwrite, then regenerate API specs
-2. Wait for the official `@appwrite.io/console` package to be published with `OAuthProvider` and `updateOAuth2Xxx` for your provider
-3. Finish and undraft the Console PR once that published SDK is available
+1. Land the backend endpoints and models in Appwrite, regenerate specs (`php app/cli.php specs`), and open a **draft** Appwrite PR
+2. Generate a local Console SDK (`php app/cli.php sdks`) only to exercise Console changes locally
+3. Wait for the official `@appwrite.io/console` package to be published with `OAuthProvider` and `updateOAuth2Xxx` for your provider
+4. Finish and undraft the Console PR once that published SDK is available
 
 Linking or patching a local `@appwrite.io/console` build (or temporarily bypassing the enum check) is **only for local development**. Do not treat a local SDK as merge-ready. Open your Appwrite and Console PRs as **drafts** until the official Console SDK release includes your provider, then bump the Console dependency to that release and mark the PRs ready for review.
 

--- a/docs/tutorials/add-oauth2-provider.md
+++ b/docs/tutorials/add-oauth2-provider.md
@@ -8,11 +8,13 @@ OAuth2 providers help users to log in to the apps and websites without the need 
 
 As of the writing of these lines, we do not accept any minor OAuth2 providers. For us to accept some smaller and potentially unlimited number of OAuth2 providers, some product design and software architecture changes must be applied first.
 
+> **Tip:** Use an existing simple provider such as [Yahoo](https://github.com/search?q=repo%3Aappwrite%2Fappwrite+Yahoo&type=code) as a copy-paste reference. Search the Appwrite repository for that provider name and update every matching file for your new provider.
+
 ## 1. Prerequisites
 
 It's really easy to contribute to an open source project, but when using GitHub, there are a few steps we need to follow. This section will take you step-by-step through the process of preparing your own local version of Appwrite, where you can make any changes without affecting Appwrite right away.
 
-> If you are experienced with GitHub or have made a pull request before, you can skip to [Implement new provider](#2-implement-new-provider).
+> If you are experienced with GitHub or have made a pull request before, you can skip to [Implement new provider](#2-implement-new-provider-backend).
 
 ### 1.1 Fork the Appwrite repository
 
@@ -28,13 +30,41 @@ $ git clone COPIED_URL
 
 > To fork a repository, you will need a basic understanding of CLI and git-cli binaries installed. If you are a beginner, we recommend you to use `Github Desktop`. It is a really clean and simple visual Git client.
 
-Finally, you will need to create a `feat-XXX-YYY-oauth` branch based on the `master` branch and switch to it. The `XXX` should represent the issue ID and `YYY` the OAuth provider name.
+Finally, you will need to create a `feat-XXX-YYY-oauth` branch based on the `main` branch and switch to it. The `XXX` should represent the issue ID and `YYY` the OAuth provider name.
 
-## 2. Implement new provider
+Adding a provider usually spans **two repositories**:
 
-### 2.1 List your new provider
+1. **[appwrite/appwrite](https://github.com/appwrite/appwrite)** — backend adapter, config, Project OAuth2 API, response models, and tests
+2. **[appwrite/console](https://github.com/appwrite/console)** — Console UI list, update switch, and icons
 
-The first step in adding a new OAuth2 provider is to add it to the list of providers located at:
+The Console served by `docker compose` in this repository is a **prebuilt image** (`appwrite-console`). Local Console source changes are not picked up until you run the Console repo locally (or build and point compose at your own image).
+
+## 2. Implement new provider (backend)
+
+Throughout this guide, replace `XXX` / `Xxx` / `xxx` with your provider name in the correct casing (`Yahoo` / `yahoo`, `GitHub` / `github`, `paypalSandbox` / `PaypalSandbox`, and so on).
+
+### 2.1 Checklist
+
+| Step | File / location |
+|------|-----------------|
+| Config | `app/config/oAuthProviders.php` |
+| Adapter | `src/Appwrite/Auth/OAuth2/Xxx.php` |
+| Update action | `src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Xxx/Update.php` |
+| Provider registry | `src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Base.php` (`getProviderActions()`) |
+| HTTP registration | `src/Appwrite/Platform/Modules/Project/Services/Http.php` |
+| Get response models | `src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Get.php` |
+| Response model class | `src/Appwrite/Utopia/Response/Model/OAuth2Xxx.php` |
+| Response constant | `src/Appwrite/Utopia/Response.php` (`MODEL_OAUTH2_XXX`) |
+| Provider list model | `src/Appwrite/Utopia/Response/Model/OAuth2ProviderList.php` |
+| Model registration | `app/init/models.php` |
+| Unit test allow-list | `tests/unit/Platform/Modules/Project/OAuth2/OAuth2ProviderTest.php` |
+| Changelog | `CHANGES.md` |
+
+Do **not** invent a separate test class for the provider unless it needs adapter-specific unit coverage. Add the provider id to the existing `OAuth2ProviderTest` expected list so the registry stays complete.
+
+### 2.2 List your new provider
+
+Add an entry to:
 
 ```
 app/config/oAuthProviders.php
@@ -44,21 +74,34 @@ Make sure to fill in all data needed and that your provider array key name:
 
 - is in [`camelCase`](https://en.wikipedia.org/wiki/Camel_case) format for sentence, but lowercase for names. `github` must be all lowercased, but `paypalSandbox` should have uppercase S
 - has no spaces or special characters
+- matches `getName()` on your adapter class and `getProviderId()` on your Update action
 
-> Please make sure to keep the list of providers in `oAuthProviders.php` in the alphabetical order A-Z.
+Keep the list of providers in `oAuthProviders.php` in alphabetical order A–Z.
 
-### 2.2 Add Provider Logo
+Example shape:
 
-Add a logo image to your new provider in this path: `public/images/users`. Your logo should be a png 100×100px file with the name of your provider (all lowercase). Please make sure to leave about 30px padding around the logo to be consistent with other logos.
+```php
+'yahoo' => [
+    'name' => 'Yahoo',
+    'developers' => 'https://developer.yahoo.com/oauth2/guide/flows_authcode/',
+    'icon' => 'icon-yahoo',
+    'enabled' => true,
+    'sandbox' => false,
+    'form' => false,
+    'beta' => false,
+    'mock' => false,
+    'class' => 'Appwrite\\Auth\\OAuth2\\Yahoo',
+],
+```
+
+The `icon` value is metadata for the backend. Console icons live in the Console repository (see [section 3](#3-console-and-sdk)).
 
 ### 2.3 Add Provider Class
 
-Once you have finished setting up all the metadata for the new provider, you need to start coding.
-
-Create a new file `XXX.php` where `XXX` is the name of the OAuth provider in [`PascalCase`](https://stackoverflow.com/a/41769355/7659504) in this location
+Create a new file `Xxx.php` where `Xxx` is the name of the OAuth provider in [`PascalCase`](https://stackoverflow.com/a/41769355/7659504) in this location:
 
 ```bash
-src/Appwrite/Auth/OAuth2/XXX.php
+src/Appwrite/Auth/OAuth2/Xxx.php
 ```
 
 Inside this file, create a new class that extends the basic OAuth2 provider abstract class. Note that the class name should start with a capital letter, as PHP FIG standards suggest.
@@ -86,7 +129,7 @@ class [PROVIDER NAME] extends OAuth2
 
     public function getName(): string
     {
-        return '[PROVIDER NAME]';
+        return '[providerId]'; // must match oAuthProviders.php key, e.g. 'yahoo'
     }
 
     public function getLoginURL(): string
@@ -163,6 +206,13 @@ class [PROVIDER NAME] extends OAuth2
 
         return $this->user;
     }
+
+    /**
+     * Optional. Called when enabling the provider from the Console with
+     * credentials set. Throw \Exception if client id/secret are invalid.
+     * See Github::verifyCredentials() for a token-endpoint probe pattern.
+     */
+    // public function verifyCredentials(): void {}
 }
 
 ```
@@ -171,56 +221,120 @@ class [PROVIDER NAME] extends OAuth2
 
 > If your OAuth2 provider has different endpoints for getting username/email/id, you can fire specific requests from specific get-method, and stop using `getUser` method.
 
-Please mention in your documentation what resources or API docs you used to implement the provider's OAuth2 protocol.
+Please mention in your pull request what resources or API docs you used to implement the provider's OAuth2 protocol.
 
-## 3. Test your provider
+### 2.4 Project OAuth2 Update action
 
-After you finish adding your new provider to Appwrite, you should be able to see it in your Appwrite console. Navigate to 'Project > Users > Providers' and check your new provider's settings form.
+Each provider exposes `PATCH /v1/project/oauth2/{providerId}` through a dedicated Update action. Copy a simple provider such as Yahoo:
 
-> To start the Appwrite console from the source code, you can simply run `docker compose up -d'.
-
-Add credentials and check both a successful and a failed login (where the user denies integration on the provider page).
-
-You can test your OAuth2 provider by trying to login using the [OAuth2 method](https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session) when integrating the Appwrite Web SDK in a demo app.
-
-Pass your new adapter name as the provider parameter. If login is successful, you will be redirected to your success URL parameter. Otherwise, you will be redirected to your failure URL.
-
-If everything goes well, raise a pull request and be ready to respond to any feedback which can arise during our code review.
-
-## 4. Raise a pull request
-
-First of all, commit the changes with the message `Added XXX OAuth2 Provider` and push it. This will publish a new branch to your forked version of Appwrite. If you visit it at `github.com/YOUR_USERNAME/appwrite`, you will see a new alert saying you are ready to submit a pull request. Follow the steps GitHub provides, and at the end, you will have your pull request submitted.
-
-## 🤕 Stuck ?
-
-If you need any help with the contribution, feel free to head over to [our Discord channel](https://appwrite.io/discord) and we'll be happy to help you out.
-
-## 😉 Need more freedom
-
-If your OAuth provider requires special configuration apart from `clientId` and `clientSecret` you can create a custom form. Currently this is being realized through putting all custom fields as JSON into the `clientSecret` field to keep the project API stable. You can implement your custom form following these steps:
-
-1. Add your custom form in `app/views/console/users/oauth/[PROVIDER].phtml`. Below is a template you can use. Add the filename to `app/config/oAuthProviders.php`.
-
-```php
-<?php
-$provider = $this->getParam('provider', '');
-?>
-<label for="oauth2<?php echo $this->escape(ucfirst($provider)); ?>Appid">Application (Client) ID<span class="tooltip" data-tooltip="Provided by AzureAD"><i class="icon-info-circled"></i></span></label>
-<input name="appId" id="oauth2<?php echo $this->escape(ucfirst($provider)); ?>Appid" type="text" autocomplete="off" data-ls-bind="{{console-project.provider<?php echo $this->escape(ucfirst($provider)); ?>Appid}}" placeholder="Application ID" />
-<?php /*Hidden input for the final secret. Gets filled with a JSON via JS. */ ?>
-<input name="secret" data-forms-oauth-custom="<?php echo $this->escape(ucfirst($provider)); ?>" id="oauth2<?php echo $this->escape(ucfirst($provider)); ?>Secret" type="hidden" autocomplete="off" data-ls-bind="{{console-project.provider<?php echo $this->escape(ucfirst($provider)); ?>Secret}}" />
-<!-- [Your custom form inputs go here] -->
+```bash
+src/Appwrite/Platform/Modules/Project/Http/Project/OAuth2/Xxx/Update.php
 ```
 
-2. Add the config for creating the JSON in `public/scripts/views/forms/oauth-custom.js` using this template
+Implement at least:
 
-```js
-{
-    "[Provider]":{
-        "[JSON property name 1]":"[html element Id 1]",
-        "[JSON property name 2]":"[html element Id 2]"
-    }
+- `getProviderId()` — same key as in `oAuthProviders.php`
+- `getProviderClass()` — your adapter class
+- `getProviderLabel()` — human-readable name (e.g. `Yahoo`)
+- `getProviderSDKMethod()` — e.g. `updateOAuth2Yahoo`
+- `getResponseModel()` — e.g. `Response::MODEL_OAUTH2_YAHOO`
+- `getClientIdName()` / `getClientIdExample()`
+- `getClientSecretName()` / `getClientSecretExample()`
+
+Then wire the action in:
+
+1. `Base::getProviderActions()` — map `'xxx' => Xxx\Update::class`
+2. `Modules/Project/Services/Http.php` — `use` + `$this->addAction(...)`
+
+### 2.5 Response model
+
+1. Add `public const MODEL_OAUTH2_XXX = 'oAuth2Xxx';` in `src/Appwrite/Utopia/Response.php`
+2. Create `src/Appwrite/Utopia/Response/Model/OAuth2Xxx.php` extending `OAuth2Base` (see `OAuth2Yahoo.php`)
+3. Register it in `app/init/models.php` with `Response::setModel(new OAuth2Xxx());`
+4. Include `Response::MODEL_OAUTH2_XXX` in:
+   - `OAuth2ProviderList.php`
+   - `Project/Http/Project/OAuth2/Get.php`
+
+### 2.6 Tests and changelog
+
+1. Add your provider id to the `$expected` array in `OAuth2ProviderTest::testProviderRegistryIsExplicitAndComplete()`
+2. Add a line under the relevant section in `CHANGES.md`
+
+## 3. Console and SDK
+
+Backend-only changes are **not enough** for the provider to appear or save correctly in the Console.
+
+### 3.1 Console repository ([appwrite/console](https://github.com/appwrite/console))
+
+Open a companion PR that:
+
+1. Adds the provider to `src/lib/stores/oauth-providers.ts` (name, icon key, docs URL, usually `component: Main`). Auth settings **filters out** providers missing from this map.
+2. Adds a `case` in `src/routes/(console)/project-[region]-[project]/auth/updateOAuth.ts` that calls `projectSdk.updateOAuth2Xxx(...)`.
+3. Adds SVG icons under:
+   - `static/icons/light/color/{provider}.svg`
+   - `static/icons/light/grayscale/{provider}.svg`
+   - `static/icons/dark/color/{provider}.svg`
+   - `static/icons/dark/grayscale/{provider}.svg`
+
+Use an existing provider folder (for example `yahoo`) as the icon template.
+
+### 3.2 Specs and Console SDK
+
+The Console checks `OAuthProvider` from `@appwrite.io/console` before calling Update:
+
+```ts
+if (!isValueOfStringEnum(OAuthProvider, provider.key)) {
+    throw new Error(`Invalid OAuth2 provider: ${provider.key}`);
 }
 ```
 
-3. In your provider class `src/Appwrite/Auth/OAuth2/[Provider].php` add logic to decode the JSON using the same property names.
+Until the generated SDK enum includes your provider:
+
+1. Regenerate Appwrite API specs after the backend endpoints/models land
+2. Regenerate / bump the Console SDK so `OAuthProvider` and `updateOAuth2Xxx` exist
+3. Point local Console at that SDK build while developing
+
+Without the SDK update, enabling the provider in the UI fails with **Invalid OAuth2 provider**, even when `PATCH /v1/project/oauth2/{providerId}` works via curl.
+
+### 3.3 Local development tips
+
+- Rebuild / recreate the Appwrite containers after backend changes: `docker compose up -d --force-recreate --build`
+- Confirm the backend lists the provider, for example:
+  - `GET /v1/project/oauth2` (Network tab while on Auth settings), or
+  - `docker exec -it appwrite php -r "print_r(require '/usr/src/code/app/config/oAuthProviders.php');"`
+- To exercise Console UI changes, run the Console repository against your local Appwrite endpoint. The `appwrite-console` service in this repo’s compose file uses a published image and will not include your unreleased Console edits.
+- You can still validate the Project API without Console by calling `PATCH /v1/project/oauth2/{providerId}` directly.
+
+## 4. Test your provider
+
+1. Run unit coverage for the Project OAuth2 registry:
+
+   ```shell
+   docker compose exec appwrite test tests/unit/Platform/Modules/Project/OAuth2/
+   ```
+
+2. With backend + Console wired, open **Auth → Settings**, find your provider, save Client ID / Client Secret, and enable it.
+
+3. Exercise login with the [OAuth2 session API](https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session) (or a small Web SDK demo). Pass your provider id as the `provider` parameter. Confirm both success and failure (user denies consent) redirects.
+
+If everything goes well, raise pull requests for Appwrite and Console and be ready to respond to code review feedback.
+
+## 5. Raise a pull request
+
+Commit the changes with a clear message such as `Added XXX OAuth2 Provider` and push your branch. Open a PR from your fork. Link the related feature issue, and link the Console PR when you have one.
+
+## Stuck?
+
+If you need any help with the contribution, feel free to head over to [our Discord channel](https://appwrite.io/discord) and we'll be happy to help you out.
+
+## Providers with extra fields
+
+If your OAuth provider needs more than a single client id + client secret (domain, tenant, realm, Apple key material, OIDC discovery URLs, and so on), do **not** add legacy `.phtml` Console forms. Those paths are obsolete.
+
+Instead, follow an existing multi-field provider such as Auth0, Microsoft, Apple, or OIDC:
+
+1. Override `getParameters()` (and often the Update action constructor) in `.../OAuth2/Xxx/Update.php` so the Project API exposes the extra params.
+2. Store non-secret extras in the JSON blob under `{providerId}Secret` when that is the existing pattern for that style of provider (see Auth0 / Gitlab / Apple).
+3. Override `buildReadResponse()` when the Console needs those extras back (with secrets zeroed).
+4. In the Console, either reuse `mainOAuth.svelte` with parameters from the API, or add a dedicated component under `auth/(providers)/` when the UI is special-cased (Google and OIDC are examples).
+5. Extend the `updateOAuth.ts` switch to pass every field through to `updateOAuth2Xxx`.

--- a/docs/tutorials/add-oauth2-provider.md
+++ b/docs/tutorials/add-oauth2-provider.md
@@ -275,7 +275,7 @@ Backend-only changes are **not enough** for the provider to appear or save corre
 
 ### 3.1 Console repository ([appwrite/console](https://github.com/appwrite/console))
 
-Open a companion PR that:
+Open a companion **draft** PR that:
 
 1. Adds the provider to `src/lib/stores/oauth-providers.ts` (name, icon key, docs URL, usually `component: Main`). Auth settings **filters out** providers missing from this map.
 2. Adds a `case` in `src/routes/(console)/project-[region]-[project]/auth/updateOAuth.ts` that calls `projectSdk.updateOAuth2Xxx(...)`.
@@ -297,13 +297,15 @@ if (!isValueOfStringEnum(OAuthProvider, provider.key)) {
 }
 ```
 
-Until the generated SDK enum includes your provider:
+Without an SDK that includes your provider, enabling it in the UI fails with **Invalid OAuth2 provider**, even when `PATCH /v1/project/oauth2/{providerId}` works via curl.
 
-1. Regenerate Appwrite API specs after the backend endpoints/models land
-2. Regenerate / bump the Console SDK so `OAuthProvider` and `updateOAuth2Xxx` exist
-3. Point local Console at that SDK build while developing
+The release sequence is:
 
-Without the SDK update, enabling the provider in the UI fails with **Invalid OAuth2 provider**, even when `PATCH /v1/project/oauth2/{providerId}` works via curl.
+1. Land the backend endpoints and models in Appwrite, then regenerate API specs
+2. Wait for the official `@appwrite.io/console` package to be published with `OAuthProvider` and `updateOAuth2Xxx` for your provider
+3. Finish and undraft the Console PR once that published SDK is available
+
+Linking or patching a local `@appwrite.io/console` build (or temporarily bypassing the enum check) is **only for local development**. Do not treat a local SDK as merge-ready. Open your Appwrite and Console PRs as **drafts** until the official Console SDK release includes your provider, then bump the Console dependency to that release and mark the PRs ready for review.
 
 ### 3.3 Local development tips
 
@@ -326,11 +328,11 @@ Without the SDK update, enabling the provider in the UI fails with **Invalid OAu
 
 3. Exercise login with the [OAuth2 session API](https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session) (or a small Web SDK demo). Pass your provider id as the `provider` parameter. Confirm both success and failure (user denies consent) redirects.
 
-If everything goes well, raise pull requests for Appwrite and Console and be ready to respond to code review feedback.
+If everything goes well, open draft pull requests for Appwrite and Console (see [section 3.2](#32-specs-and-console-sdk) for when to mark them ready) and be ready to respond to code review feedback.
 
 ## 5. Raise a pull request
 
-Commit the changes with a clear message such as `Added XXX OAuth2 Provider` and push your branch. Open a PR from your fork. Link the related feature issue, and link the Console PR when you have one.
+Commit the changes with a clear message such as `Added XXX OAuth2 Provider` and push your branch. Open a **draft** PR from your fork. Link the related feature issue, and link the Console draft PR when you have one. Mark both ready for review only after the official `@appwrite.io/console` SDK includes your provider.
 
 ## Stuck?
 


### PR DESCRIPTION
## What does this PR do?

Updates `docs/tutorials/add-oauth2-provider.md` so it matches the current OAuth2 contribution flow. The previous tutorial still pointed at removed paths (`public/images/users`, legacy `.phtml` Console forms) and omitted the Project OAuth2 Update action, response models, Console store/SDK wiring, and the prebuilt `appwrite-console` image caveat that commonly blocks local testing.

## Test Plan

- [x] Reviewed the guide against a recent simple provider (Yahoo) file set
- [x] Confirmed Console icon paths and `updateOAuth.ts` / `oauth-providers.ts` requirements against `appwrite/console`
- [ ] Docs-only change; no runtime tests required

## Related PRs and Issues

- Related discussion: https://appwrite.io/threads/1534243135733891253
- Related to #13067 / #13123 (Hugging Face OAuth contribution friction)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
