### PR TITLE
Respect _APP_SDK_PREVIEW in SDK exclusion logic

### DIFF
--- a/.github/workflows/sdk-preview.yml
+++ b/.github/workflows/sdk-preview.yml
@@ -48,11 +48,11 @@ jobs:
 
       - name: Generate Specs
         run: |
-          docker compose exec appwrite specs --version=latest --mode=normal --git=no
+          docker compose exec -e _APP_SDK_PREVIEW=enabled appwrite specs --version=latest --mode=normal --git=no
 
       - name: Generate SDK
         run: |
-          docker compose exec appwrite sdks --platform=${{ steps.set-sdk.outputs.platform }} --sdk=${{ steps.set-sdk.outputs.sdk_type }} --version=latest --git=no
+          docker compose exec -e _APP_SDK_PREVIEW=enabled appwrite sdks --platform=${{ steps.set-sdk.outputs.platform }} --sdk=${{ steps.set-sdk.outputs.sdk_type }} --version=latest --git=no
           sudo chown -R $USER:$USER ./app/sdks/${{ steps.set-sdk.outputs.platform }}-${{ steps.set-sdk.outputs.sdk_type }}
 
       - name: Build and Publish SDK

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,24 @@ Register new injections alongside existing ones in `app/init/resources.php` and 
 
 Use `snake_case`; dots only for parent/child relationships (`project.id`, `storage.bucket.id`). See [Tracing with Utopia Span](#tracing-with-utopia-span) for full rules.
 
+## SDK generation exclusions
+
+Two independent mechanisms keep an endpoint out of a generated SDK:
+
+1. **`exclude` in `app/config/sdks.php`** -- per-SDK `services` / `methods` lists, applied at generation time.
+2. **`hide:` on `Appwrite\SDK\Method`** -- `true` drops the endpoint from every spec, an array drops it from the listed platforms only. An endpoint dropped from the spec cannot be recovered at generation time.
+
+Both are lifted when `_APP_SDK_PREVIEW=enabled`. Preview SDKs are built from a PR so a reviewer can see the whole API surface that PR produces, and they publish nothing. Only `.github/workflows/sdk-preview.yml` sets the flag, on **both** the `specs` and `sdks` steps -- setting it on `sdks` alone leaves anything hidden at layer 2 silently missing. Every other run, releases included, leaves it unset and keeps every rule.
+
+Read the flag inline at each call site with a comment, never behind a helper:
+
+```php
+// Preview SDK builds show the whole surface, so they do not hide.
+hide: System::getEnv('_APP_SDK_PREVIEW', 'disabled') !== 'enabled',
+```
+
+A new `hide:` must respect the flag. `->label('docs', false)` is a separate mechanism for routes that are not part of the public API at all (mocks, OAuth callbacks) and stays unconditional.
+
 ## Tracing with Utopia Span
 
 In handlers, only call `Span::add($key, $value)`. **Never** call `Span::init`, `setError`, or `Span::finish` -- lifecycle is owned by the entry-point harness (`app/http.php`, `app/worker.php`, `app/realtime.php`, `Bus::dispatch`). For selective export, filter in the sampler in `app/init/span.php`.

--- a/app/config/sdks.php
+++ b/app/config/sdks.php
@@ -1,6 +1,8 @@
 <?php
 
-return [
+use Utopia\System\System;
+
+$platforms = [
     APP_SDK_PLATFORM_CLIENT => [
         'key' => APP_SDK_PLATFORM_CLIENT,
         'name' => 'Client',
@@ -589,3 +591,18 @@ return [
         ],
     ],
 ];
+
+// A preview SDK is built from a PR to show the whole API surface that PR produces
+// and publishes nothing, so none of the exclusions above apply to it. Only the
+// preview workflow sets _APP_SDK_PREVIEW; every other run, releases included,
+// leaves it unset and keeps every rule. The per-endpoint counterpart is the `hide`
+// argument on Appwrite\SDK\Method, lifted under the same flag at its call sites.
+if (System::getEnv('_APP_SDK_PREVIEW', 'disabled') === 'enabled') {
+    foreach ($platforms as $platformKey => $platform) {
+        foreach (\array_keys($platform['sdks']) as $index) {
+            unset($platforms[$platformKey]['sdks'][$index]['exclude']);
+        }
+    }
+}
+
+return $platforms;

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -1320,7 +1320,8 @@ Http::get('/v1/account/sessions/oauth2/:provider')
             )
         ],
         contentType: ContentType::HTML,
-        hide: [APP_SDK_PLATFORM_SERVER],
+        // Preview SDK builds show the whole surface, so they do not hide.
+        hide: System::getEnv('_APP_SDK_PREVIEW', 'disabled') === 'enabled' ? false : [APP_SDK_PLATFORM_SERVER],
     ))
     ->label('abuse-limit', 50)
     ->label('abuse-key', 'ip:{ip}')

--- a/app/controllers/api/graphql.php
+++ b/app/controllers/api/graphql.php
@@ -54,7 +54,8 @@ Http::get('/v1/graphql')
         group: 'graphql',
         name: 'get',
         auth: [AuthType::ADMIN, AuthType::KEY, AuthType::SESSION, AuthType::JWT],
-        hide: true,
+        // Preview SDK builds show the whole surface, so they do not hide.
+        hide: System::getEnv('_APP_SDK_PREVIEW', 'disabled') !== 'enabled',
         description: '/docs/references/graphql/get.md',
         responses: [
             new SDKResponse(

--- a/src/Appwrite/Platform/Modules/VCS/Http/Authorize/Base.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/Authorize/Base.php
@@ -67,7 +67,8 @@ abstract class Base extends Action
                 ],
                 contentType: ContentType::HTML,
                 type: MethodType::WEBAUTH,
-                hide: true,
+                // Preview SDK builds show the whole surface, so they do not hide.
+                hide: System::getEnv('_APP_SDK_PREVIEW', 'disabled') !== 'enabled',
             ))
             ->param('success', '', fn ($redirectValidator) => $redirectValidator, 'URL to redirect back to console after a successful installation attempt.', true, ['redirectValidator'])
             ->param('failure', '', fn ($redirectValidator) => $redirectValidator, 'URL to redirect back to console after a failed installation attempt.', true, ['redirectValidator'])

--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Authorize/Get.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Authorize/Get.php
@@ -46,7 +46,8 @@ class Get extends Action
                 ],
                 contentType: ContentType::HTML,
                 type: MethodType::WEBAUTH,
-                hide: true,
+                // Preview SDK builds show the whole surface, so they do not hide.
+                hide: System::getEnv('_APP_SDK_PREVIEW', 'disabled') !== 'enabled',
             ))
             ->param('success', '', fn ($redirectValidator) => $redirectValidator, 'URL to redirect back to console after a successful installation attempt.', true, ['redirectValidator'])
             ->param('failure', '', fn ($redirectValidator) => $redirectValidator, 'URL to redirect back to console after a failed installation attempt.', true, ['redirectValidator'])


### PR DESCRIPTION
## What

Companion to [appwrite-labs/cloud#5213](https://github.com/appwrite-labs/cloud/pull/5213), which introduced `_APP_SDK_PREVIEW=enabled` so a preview SDK shows the whole API surface the PR produces instead of a released SDK's trimmed one.

That PR gated the exclusion rules that live in `cloud`. The same two mechanisms exist here and the flag did not reach them, so a cloud preview build still dropped every CE endpoint listed below, and this repo's own `sdk-preview.yml` did not set the flag at all.

## Two layers, both gated

1. **`exclude` in `app/config/sdks.php`** — a gate at the end of the file drops them under the flag. **None of the exclusion logic above it changed**; the list is byte-for-byte identical (console-cli: `assistant`, `avatars`).
2. **`hide:` on `Appwrite\SDK\Method`** — drops the endpoint from the *spec*, so unlike layer 1 it cannot be recovered at generation time. The flag is therefore set on the **specs** step too, not just `sdks`. Four call sites:

   | Endpoint | Was | Now visible in preview to |
   |---|---|---|
   | `account.createOAuth2Session` | `hide: [server]` | server SDKs |
   | `graphql.get` | `hide: true` | all platforms |
   | `vcs.createGitHubInstallation` | `hide: true` | all platforms |
   | `vcs.create{Bitbucket,Gitea,GitLab}Installation` (`Authorize/Base.php`) | `hide: true` | all platforms |

`->label('docs', false)` is deliberately left alone — that marks routes that are not part of the public API in any build (mocks, OAuth callbacks, cloud cards), not SDK-level exclusions.

Following the convention cloud's PR established, the flag is read inline at each call site with a comment rather than behind a helper. `AGENTS.md` documents both layers and the "gate the specs step too" rule.

## Verification

Resolved `app/config/sdks.php` under all three states and counted the exclusion rules that survive:

| `_APP_SDK_PREVIEW` | exclusion rules across all SDKs |
|---|---|
| unset | 2 |
| `disabled` | 2 |
| `enabled` | 0 |

2 matches the pre-change baseline exactly (console-cli `services`: `assistant`, `avatars`), so no non-preview run changes behaviour.

The four unhidden methods are all reachable by the templates that build them: `MethodType::WEBAUTH` is handled in `templates/node` and `templates/web`, which cover the `server-nodejs`, `client-web` and `console-web` previews.

Pint passes. PHPStan level 4 clean on all five changed files.

## Testing

No automated test covers SDK generation. Verified by resolving the config directly, as above.

## Notes

- CE's only `exclude` is two console-cli services, so unlike cloud's 44 compiler-driven CLI method exclusions there is no known `sdks --sdk=cli` build hazard from lifting it here.
- This repo's `sdk-preview.yml` is `workflow_dispatch` only, so it is unaffected by the `paths: ['composer.lock']` trigger problem noted on the cloud PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)