### PR TITLE
Reuse existing repositories row on function VCS connect

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -246,10 +246,16 @@ class Update extends Base
             ]);
 
             if (!$existingRepository->isEmpty()) {
+                // Reset providerPullRequestIds: it tracks which external PR authors are
+                // authorized to deploy, keyed only by numeric PR ID (see VCS/Http/GitHub/
+                // Authorize/External/Update.php). Carrying over the old repository's list
+                // would let a PR on the *new* repository with the same numeric ID as one
+                // previously authorized on the *old* repository deploy without authorization.
                 $repository = $dbForPlatform->updateDocument('repositories', $existingRepository->getId(), new Document([
                     'installationId' => $installation->getId(),
                     'installationInternalId' => $installation->getSequence(),
                     'providerRepositoryId' => $providerRepositoryId,
+                    'providerPullRequestIds' => [],
                 ]));
             } else {
                 $repository = $dbForPlatform->createDocument('repositories', new Document([

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -7,6 +7,7 @@ use Appwrite\Event\Event;
 use Appwrite\Event\Publisher\Build as BuildPublisher;
 use Appwrite\Event\Validator\FunctionEvent;
 use Appwrite\Extend\Exception;
+use Appwrite\Locking\Lock;
 use Appwrite\Platform\Modules\Compute\Base;
 use Appwrite\Platform\Modules\Compute\Validator\Specification;
 use Appwrite\SDK\AuthType;
@@ -121,6 +122,7 @@ class Update extends Base
             ->inject('executor')
             ->inject('authorization')
             ->inject('platform')
+            ->inject('lock')
             ->callback($this->action(...));
     }
 
@@ -159,7 +161,8 @@ class Update extends Base
         RepositoryWebhooks $repositoryWebhooks,
         Executor $executor,
         Authorization $authorization,
-        array $platform
+        array $platform,
+        Lock $lock
     ) {
         // TODO: If only branch changes, re-deploy
         $function = $dbForProject->getDocument('functions', $functionId);
@@ -234,44 +237,58 @@ class Update extends Base
         // Git connect logic
         if (!$isConnected && !empty($providerRepositoryId)) {
             $teamId = $project->getAttribute('teamId', '');
+            $projectInternalId = (string) ($project->getSequence() ?: $project->getId());
 
-            // A stale row can be left over from a previous connect that raced with (or
-            // preceded) this function's providerRepositoryId being persisted. Reuse it
-            // instead of appending a duplicate, which would double-fire deployments on
-            // every subsequent push.
-            $existingRepository = $dbForPlatform->findOne('repositories', [
-                Query::equal('projectInternalId', [$project->getSequence()]),
-                Query::equal('resourceInternalId', [$function->getSequence()]),
-                Query::equal('resourceType', ['function']),
-            ]);
+            // The find-then-write below isn't atomic on its own: the (projectInternalId,
+            // resourceInternalId, resourceType) index on 'repositories' is a regular key
+            // index, not unique, so two concurrent connect requests for the same function
+            // could both pass the "no existing row" check and both create one -- the exact
+            // duplicate-row race this fix exists to close. Locking the whole find-or-create
+            // step serializes concurrent attempts for the same function.
+            $repository = $lock->withKey(
+                'lock:platform:' . $projectInternalId . ':repositories:function:' . $function->getSequence(),
+                function () use ($dbForPlatform, $project, $function, $installation, $providerRepositoryId, $teamId) {
+                    // A stale row can be left over from a previous connect that preceded
+                    // this function's providerRepositoryId being persisted. Reuse it instead
+                    // of appending a duplicate, which would double-fire deployments on every
+                    // subsequent push.
+                    $existingRepository = $dbForPlatform->findOne('repositories', [
+                        Query::equal('projectInternalId', [$project->getSequence()]),
+                        Query::equal('resourceInternalId', [$function->getSequence()]),
+                        Query::equal('resourceType', ['function']),
+                    ]);
 
-            if (!$existingRepository->isEmpty()) {
-                // Reset providerPullRequestIds: it tracks which external PR authors are
-                // authorized to deploy, keyed only by numeric PR ID (see VCS/Http/GitHub/
-                // Authorize/External/Update.php). Carrying over the old repository's list
-                // would let a PR on the *new* repository with the same numeric ID as one
-                // previously authorized on the *old* repository deploy without authorization.
-                $repository = $dbForPlatform->updateDocument('repositories', $existingRepository->getId(), new Document([
-                    'installationId' => $installation->getId(),
-                    'installationInternalId' => $installation->getSequence(),
-                    'providerRepositoryId' => $providerRepositoryId,
-                    'providerPullRequestIds' => [],
-                ]));
-            } else {
-                $repository = $dbForPlatform->createDocument('repositories', new Document([
-                    '$id' => ID::unique(),
-                    '$permissions' => $this->getPermissions($teamId, $project->getId()),
-                    'installationId' => $installation->getId(),
-                    'installationInternalId' => $installation->getSequence(),
-                    'projectId' => $project->getId(),
-                    'projectInternalId' => $project->getSequence(),
-                    'providerRepositoryId' => $providerRepositoryId,
-                    'resourceId' => $function->getId(),
-                    'resourceInternalId' => $function->getSequence(),
-                    'resourceType' => 'function',
-                    'providerPullRequestIds' => [],
-                ]));
-            }
+                    if (!$existingRepository->isEmpty()) {
+                        // Reset providerPullRequestIds: it tracks which external PR authors
+                        // are authorized to deploy, keyed only by numeric PR ID (see VCS/
+                        // Http/GitHub/Authorize/External/Update.php). Carrying over the old
+                        // repository's list would let a PR on the *new* repository with the
+                        // same numeric ID as one previously authorized on the *old*
+                        // repository deploy without authorization.
+                        return $dbForPlatform->updateDocument('repositories', $existingRepository->getId(), new Document([
+                            'installationId' => $installation->getId(),
+                            'installationInternalId' => $installation->getSequence(),
+                            'providerRepositoryId' => $providerRepositoryId,
+                            'providerPullRequestIds' => [],
+                        ]));
+                    }
+
+                    return $dbForPlatform->createDocument('repositories', new Document([
+                        '$id' => ID::unique(),
+                        '$permissions' => $this->getPermissions($teamId, $project->getId()),
+                        'installationId' => $installation->getId(),
+                        'installationInternalId' => $installation->getSequence(),
+                        'projectId' => $project->getId(),
+                        'projectInternalId' => $project->getSequence(),
+                        'providerRepositoryId' => $providerRepositoryId,
+                        'resourceId' => $function->getId(),
+                        'resourceInternalId' => $function->getSequence(),
+                        'resourceType' => 'function',
+                        'providerPullRequestIds' => [],
+                    ]));
+                },
+                target: 'repositories'
+            );
 
             $repositoryId = $repository->getId();
             $repositoryInternalId = $repository->getSequence();

--- a/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php
@@ -235,19 +235,37 @@ class Update extends Base
         if (!$isConnected && !empty($providerRepositoryId)) {
             $teamId = $project->getAttribute('teamId', '');
 
-            $repository = $dbForPlatform->createDocument('repositories', new Document([
-                '$id' => ID::unique(),
-                '$permissions' => $this->getPermissions($teamId, $project->getId()),
-                'installationId' => $installation->getId(),
-                'installationInternalId' => $installation->getSequence(),
-                'projectId' => $project->getId(),
-                'projectInternalId' => $project->getSequence(),
-                'providerRepositoryId' => $providerRepositoryId,
-                'resourceId' => $function->getId(),
-                'resourceInternalId' => $function->getSequence(),
-                'resourceType' => 'function',
-                'providerPullRequestIds' => [],
-            ]));
+            // A stale row can be left over from a previous connect that raced with (or
+            // preceded) this function's providerRepositoryId being persisted. Reuse it
+            // instead of appending a duplicate, which would double-fire deployments on
+            // every subsequent push.
+            $existingRepository = $dbForPlatform->findOne('repositories', [
+                Query::equal('projectInternalId', [$project->getSequence()]),
+                Query::equal('resourceInternalId', [$function->getSequence()]),
+                Query::equal('resourceType', ['function']),
+            ]);
+
+            if (!$existingRepository->isEmpty()) {
+                $repository = $dbForPlatform->updateDocument('repositories', $existingRepository->getId(), new Document([
+                    'installationId' => $installation->getId(),
+                    'installationInternalId' => $installation->getSequence(),
+                    'providerRepositoryId' => $providerRepositoryId,
+                ]));
+            } else {
+                $repository = $dbForPlatform->createDocument('repositories', new Document([
+                    '$id' => ID::unique(),
+                    '$permissions' => $this->getPermissions($teamId, $project->getId()),
+                    'installationId' => $installation->getId(),
+                    'installationInternalId' => $installation->getSequence(),
+                    'projectId' => $project->getId(),
+                    'projectInternalId' => $project->getSequence(),
+                    'providerRepositoryId' => $providerRepositoryId,
+                    'resourceId' => $function->getId(),
+                    'resourceInternalId' => $function->getSequence(),
+                    'resourceType' => 'function',
+                    'providerPullRequestIds' => [],
+                ]));
+            }
 
             $repositoryId = $repository->getId();
             $repositoryInternalId = $repository->getSequence();


### PR DESCRIPTION
## Summary

Fixes #11901.

Connecting a function to a repo (`src/Appwrite/Platform/Modules/Functions/Http/Functions/Update.php`) always did:

```php
if (!$isConnected && !empty($providerRepositoryId)) {
    $repository = $dbForPlatform->createDocument('repositories', new Document([...]));
    ...
}
```

guarded only by `$isConnected = !empty($function->getAttribute('providerRepositoryId', ''))` -- the *function's own* cached copy of whether it's connected. If that guard is stale for any reason (a race between two requests, a retried connect request from the client, or the function's `providerRepositoryId` update not having committed/propagated yet when a second connect request lands), the guard passes again and a **second** `repositories` row gets created for the same `(project, function)`.

Each row independently fans out a deployment on every push -- so the function deploys N times per push, where N is the row count. The reporter found this live: 9 of 13 connected functions holding 2 rows each, one holding 3, all pointing at the same `installationId`/`providerRepositoryId`.

The fix: before creating, look up an existing row by `(projectInternalId, resourceInternalId, resourceType)` -- the exact same three fields the *disconnect* logic a few lines up already queries by (`Query::equal('projectInternalId', ...)`, `resourceInternalId`, `resourceType`) -- and update it in place if found, instead of blindly appending. This makes the connect step idempotent regardless of what causes the guard to be stale, rather than chasing the exact reproduction sequence.

**Scope note:** `src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php` has the identical `createDocument('repositories', ...)` pattern for Sites. I scoped this PR to Functions only, matching the issue (which is specifically about functions), rather than bundling an equivalent change to a different resource type into the same PR. Happy to open a follow-up for Sites if wanted.

## Test plan

- [x] `php -l`, Pint, and PHPStan (level 4) pass on the changed file.
- [x] Traced the existing e2e VCS test coverage (`tests/e2e/Services/VCSGitHub/*`) -- it only exercises the installation-not-found error path (`testGetInstallation` with a random ID), since the suite has no real GitHub App installation fixture to drive a full connect flow against. I wasn't able to add or run an e2e regression test for the dedup behavior itself in this environment for that reason; the fix is scoped narrowly and mirrors the exact query the adjacent disconnect logic already uses, but a maintainer with VCS test credentials should double check the connect flow end-to-end.