### PR TITLE
Make the hardcoded PHP memory_limit configurable

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -44,6 +44,15 @@ return [
                 'filter' => ''
             ],
             [
+                'name' => '_APP_MEMORY_LIMIT',
+                'description' => 'PHP memory limit applied to every Appwrite process (API, workers, and CLI tasks). By default, set to \'512M\'. Uploading or processing files close to this size can exhaust it, since the request body and any in-memory buffering during storage device I/O count against it. If you raise _APP_STORAGE_LIMIT to allow larger file uploads, raise this accordingly. Accepts any value PHP\'s memory_limit ini directive accepts (e.g. \'1024M\', \'2G\'); \'-1\' disables the limit entirely.',
+                'introduction' => '1.9.6',
+                'default' => '512M',
+                'required' => false,
+                'question' => '',
+                'filter' => ''
+            ],
+            [
                 'name' => '_APP_LOCKING_ENABLED',
                 'description' => 'Enable distributed locking for platform writes. Locks coordinate concurrent updates across API pods so read-modify-write operations on shared documents do not lose updates. By default, set to \'enabled\'. Set to \'disabled\' as an emergency kill switch; locks become no-ops and concurrent writes will race.',
                 'introduction' => '1.9.3',

--- a/app/init.php
+++ b/app/init.php
@@ -14,7 +14,7 @@ if (\file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once __DIR__ . '/../vendor/autoload.php';
 }
 
-\ini_set('memory_limit', '512M');
+\ini_set('memory_limit', System::getEnv('_APP_MEMORY_LIMIT', '512M'));
 \ini_set('display_errors', 1);
 \ini_set('display_startup_errors', 1);
 \ini_set('default_socket_timeout', -1);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       - appwrite-geo
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_EDITION
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
@@ -282,6 +283,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKER_PER_CORE
       - _APP_OPTIONS_ABUSE
       - _APP_OPTIONS_ROUTER_PROTECTION
@@ -326,6 +328,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -371,6 +374,7 @@ services:
       - appwrite-certificates:/storage/certificates:rw
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -433,6 +437,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=1
       - _APP_WORKER_PER_CORE
@@ -479,6 +484,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -575,6 +581,7 @@ services:
       - ${_APP_DB_HOST:-postgresql}
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -619,6 +626,7 @@ services:
       - _APP_WORKER_SCREENSHOTS_ROUTER
       - _APP_OPTIONS_FORCE_HTTPS
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -681,6 +689,7 @@ services:
       - appwrite-certificates:/storage/certificates:rw
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -725,6 +734,7 @@ services:
       - redis
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
@@ -771,6 +781,7 @@ services:
       - ${_APP_DB_HOST:-postgresql}
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=1
       - _APP_WORKER_PER_CORE
@@ -817,6 +828,7 @@ services:
       - ${_APP_DB_HOST:-postgresql}
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
@@ -861,6 +873,7 @@ services:
       - redis
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=1
       - _APP_WORKER_PER_CORE
@@ -923,6 +936,7 @@ services:
       - ${_APP_DB_HOST:-postgresql}
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_WORKERS_NUM=1
       - _APP_WORKER_MAX_COROUTINES=1
       - _APP_WORKER_PER_CORE
@@ -969,6 +983,7 @@ services:
       - redis
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_LOGGING_FORMAT
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
@@ -1019,6 +1034,7 @@ services:
       - redis
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_LOGGING_FORMAT
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
@@ -1063,6 +1079,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_LOGGING_FORMAT
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
@@ -1104,6 +1121,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_LOGGING_FORMAT
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
@@ -1144,6 +1162,7 @@ services:
       - appwrite-embedding
     environment:
       - _APP_ENV
+      - _APP_MEMORY_LIMIT
       - _APP_LOGGING_FORMAT
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER


### PR DESCRIPTION
## Summary

Fixes #12643.

`app/init.php` -- the bootstrap loaded by every Appwrite process (API, workers, CLI tasks) -- has:

```php
\ini_set('memory_limit', '512M');
```

with no way to override it. The reported error is:

```
Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 5242880 bytes)
in /usr/src/code/vendor/utopia-php/storage/src/Storage/Device/S3.php on line 228
```

`536870912` bytes is exactly `512M` -- not a PHP default coincidence, this repo's own bootstrap sets it. The reporter's own testing confirms it's not a host resource issue: identical failure on a 4GB DigitalOcean droplet *and* a 64GB desktop VM with 12GB+ free throughout the upload.

This is also an internal inconsistency: `_APP_STORAGE_LIMIT` (max upload size, `app/config/variables.php`) is independently configurable and self-hosters commonly raise it well past 512MB for large-file use cases (the reporter tested 578MB and 1.3GB files). Raising `_APP_STORAGE_LIMIT` alone doesn't help, since this separate, undocumented PHP-level ceiling silently caps what can actually be processed regardless.

## Fix

Read it from a new `_APP_MEMORY_LIMIT` env var, documented in `app/config/variables.php` alongside the other `_APP_*` settings, defaulting to the same `512M` so existing deployments see no behavior change unless they opt in:

```php
\ini_set('memory_limit', System::getEnv('_APP_MEMORY_LIMIT', '512M'));
```

Self-hosters who raise `_APP_STORAGE_LIMIT` for large files can now also raise this to match (or set it to `-1` to disable the limit entirely, standard PHP `memory_limit` syntax).

## Test plan

- [x] `php -l`, Pint, and PHPStan (level 4) pass on both changed files.
- [x] Verified the actual runtime behavior directly (not just read the code): with `_APP_MEMORY_LIMIT` unset, `ini_get('memory_limit')` after the call is `512M` (unchanged default). With `_APP_MEMORY_LIMIT=2048M`, it's `2048M`. With `_APP_MEMORY_LIMIT=-1`, it's `-1`.