### PR TITLE
docs(vcs): add the missing per-provider installation descriptions

### DIFF
--- a/docs/references/vcs/create-bitbucket-installation.md
+++ b/docs/references/vcs/create-bitbucket-installation.md
@@ -1,0 +1,1 @@
+Begin Appwrite's Bitbucket OAuth authorization to set up version control integration. This endpoint responds with a redirect URL to Bitbucket's authorization page. The Bitbucket OAuth consumer must be configured in your environment for this endpoint to work.

--- a/docs/references/vcs/create-gitea-installation.md
+++ b/docs/references/vcs/create-gitea-installation.md
@@ -1,0 +1,1 @@
+Begin Appwrite's Gitea OAuth authorization to set up version control integration. This endpoint responds with a redirect URL to Gitea's authorization page. The Gitea OAuth application must be configured in your environment for this endpoint to work.

--- a/docs/references/vcs/create-gitlab-installation.md
+++ b/docs/references/vcs/create-gitlab-installation.md
@@ -1,0 +1,1 @@
+Begin Appwrite's GitLab OAuth authorization to set up version control integration. This endpoint responds with a redirect URL to GitLab's authorization page. The GitLab OAuth application must be configured in your environment for this endpoint to work.


### PR DESCRIPTION
Unblocks SDK preview builds, which currently fail for every cloud bump past #13158.

## What breaks

`VCS/Http/Authorize/Base.php` names a description file per provider:

```php
description: '/docs/references/vcs/create-' . $key . '-installation.md',
```

Four providers have an authorize endpoint — github, gitlab, gitea, bitbucket — and only `create-github-installation.md` was ever written. GitLab's, Gitea's and Bitbucket's were each missed when those providers landed.

`hide: true` kept all of them out of the SDK surface, so the missing files never mattered. #13158 made hiding conditional on `_APP_SDK_PREVIEW`, and cloud's SDK jobs run `specs` with it enabled — so the endpoints now enter the console spec and generation stops at the first missing file:

```
Spec generation failed for console (open-api3):
  Documentation file not found or unreadable: /docs/references/vcs/create-gitea-installation.md
```

Client and server specs save; only console fails, and SDK generation then has no spec to read. Writing one file just moves the failure to the next provider.

Repro: `docker compose exec -e _APP_SDK_PREVIEW=enabled appwrite specs --version=latest --mode=normal --git=no`

## This change

The three missing files, matching the existing GitHub one in length and voice.

They aren't shared, because the flows differ: GitHub installs a **GitHub App**, while GitLab, Gitea and Bitbucket authorize through **OAuth**. One description for all four would be wrong for three of them.

Verified every path the authorize endpoints can build now resolves to a file that exists.