### PR TITLE
fix(specs): fail the task when a spec cannot be generated

### DIFF
--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -779,7 +779,12 @@ class Specs extends Action
                     $parsedSpecs = $specs->parse();
                     $this->verifyParsedSpec($parsedSpecs);
                 } catch (\RuntimeException $e) {
-                    throw new \RuntimeException("Spec generation failed for {$platform} ({$format}): " . $e->getMessage(), 0, $e);
+                    // The CLI reports a throw and carries on, so a spec that
+                    // failed to generate leaves the task reporting success and
+                    // the missing file is met further down the pipeline, where
+                    // it reads as specs never having been run.
+                    Console::error("Spec generation failed for {$platform} ({$format}): " . $e->getMessage());
+                    Console::exit(1);
                 }
 
                 $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -779,10 +779,7 @@ class Specs extends Action
                     $parsedSpecs = $specs->parse();
                     $this->verifyParsedSpec($parsedSpecs);
                 } catch (\RuntimeException $e) {
-                    // The CLI reports a throw and carries on, so a spec that
-                    // failed to generate leaves the task reporting success and
-                    // the missing file is met further down the pipeline, where
-                    // it reads as specs never having been run.
+                    // A throw is reported and carried on from, so stop here
                     Console::error("Spec generation failed for {$platform} ({$format}): " . $e->getMessage());
                     Console::exit(1);
                 }

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -782,6 +782,7 @@ class Specs extends Action
                     // A throw is reported and carried on from, so stop here
                     Console::error("Spec generation failed for {$platform} ({$format}): " . $e->getMessage());
                     Console::exit(1);
+                    return;
                 }
 
                 $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);


### PR DESCRIPTION
Followup, which fixed the missing docs files. 

