### PR TITLE
fix(auth): reject JWT when linked session is expired

### DIFF
--- a/app/init/realtime/connection.php
+++ b/app/init/realtime/connection.php
@@ -288,14 +288,16 @@ return function (Container $container): void {
             $jwtUserId = $payload['userId'] ?? '';
             if (!empty($jwtUserId)) {
                 if ($mode === APP_MODE_ADMIN) {
+                    /** @var User $user */
                     $user = $dbForPlatform->getDocument('users', $jwtUserId);
                 } else {
+                    /** @var User $user */
                     $user = $dbForProject->getDocument('users', $jwtUserId);
                 }
             }
 
             $jwtSessionId = $payload['sessionId'] ?? '';
-            if (!empty($jwtSessionId) && empty($user->find('$id', $jwtSessionId, 'sessions'))) {
+            if (!empty($jwtSessionId) && !$user->sessionActive($jwtSessionId)) {
                 $user = new User([]);
             }
         }

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -448,16 +448,16 @@ return function (Container $context): void {
             $jwtUserId = $payload['userId'] ?? '';
             if (! empty($jwtUserId)) {
                 if ($mode === APP_MODE_ADMIN) {
+                    /** @var User $user */
                     $user = $dbForPlatform->getDocument('users', $jwtUserId);
                 } else {
+                    /** @var User $user */
                     $user = $dbForProject->getDocument('users', $jwtUserId);
                 }
             }
             $jwtSessionId = $payload['sessionId'] ?? '';
-            if (! empty($jwtSessionId)) {
-                if (empty($user->find('$id', $jwtSessionId, 'sessions'))) { // Match JWT to active token
-                    $user = new User([]);
-                }
+            if (! empty($jwtSessionId) && ! $user->sessionActive($jwtSessionId)) { // Match JWT to active session
+                $user = new User([]);
             }
         }
 

--- a/src/Appwrite/Utopia/Database/Documents/User.php
+++ b/src/Appwrite/Utopia/Database/Documents/User.php
@@ -174,4 +174,22 @@ class User extends Document
 
         return false;
     }
+
+    /**
+     * Check that a session exists on the user and has not expired.
+     *
+     * Used by JWT authentication, which binds to a session ID rather than a
+     * session secret.
+     */
+    public function sessionActive(string $sessionId): bool
+    {
+        $session = $this->find('$id', $sessionId, 'sessions');
+
+        if (empty($session)) {
+            return false;
+        }
+
+        return $session->isSet('expire')
+            && DateTime::formatTz(DateTime::format(new \DateTime($session->getAttribute('expire')))) >= DateTime::formatTz(DateTime::now());
+    }
 }

--- a/tests/unit/Utopia/Database/Documents/UserTest.php
+++ b/tests/unit/Utopia/Database/Documents/UserTest.php
@@ -97,6 +97,37 @@ final class UserTest extends TestCase
         $this->assertEquals(false, $user2->sessionVerify('false-secret', $proofForToken));
     }
 
+    public function testSessionActive(): void
+    {
+        $user = new User([
+            '$id' => ID::custom('user1'),
+            'sessions' => [
+                new Document([
+                    '$id' => ID::custom('active'),
+                    'secret' => 'secret',
+                    'provider' => SESSION_PROVIDER_EMAIL,
+                    'expire' => DateTime::addSeconds(new \DateTime(), 60 * 60),
+                ]),
+                new Document([
+                    '$id' => ID::custom('expired'),
+                    'secret' => 'secret',
+                    'provider' => SESSION_PROVIDER_EMAIL,
+                    'expire' => DateTime::addSeconds(new \DateTime(), -60),
+                ]),
+                new Document([
+                    '$id' => ID::custom('missing-expire'),
+                    'secret' => 'secret',
+                    'provider' => SESSION_PROVIDER_EMAIL,
+                ]),
+            ],
+        ]);
+
+        $this->assertTrue($user->sessionActive('active'));
+        $this->assertFalse($user->sessionActive('expired'));
+        $this->assertFalse($user->sessionActive('missing-expire'));
+        $this->assertFalse($user->sessionActive('missing'));
+    }
+
     public function testTokenVerify(): void
     {
         $proofForToken = new Token();


### PR DESCRIPTION
Backport of #13125 to `1.9.x` for self-hosted.

## What

JWT auth only checked that the session ID still existed on the user, not that the session was still within its expiry. `createJWT` takes a caller-supplied `duration` (default 900s, max 3600s) that is independent of the session's `expire`, so a JWT stayed usable after the session it was minted from had timed out.

`User::sessionActive()` applies the same expiry rule `sessionVerify()` already uses for cookie auth, so both paths now expire together.

Fixes #8000 on the release branch.

## Contents

Clean cherry-pick of the merged change — no adaptation was needed for `1.9.x`:

- `User::sessionActive()` plus its unit test
- JWT call sites in `app/init/resources/request.php` and `app/init/realtime/connection.php`
- `@var User` annotations on the JWT user lookups (`getDocument()` is declared as returning `Document`, so the `sessionActive()` calls trip PHPStan's `method.notFound` without them)

## Verification

- `composer lint` on the touched files — passed
- `composer analyze` — no errors in the touched files
- `testSessionActive` — passed

## Note for reviewers

This is a behavior change for JWT-only clients. JWT requests do not extend sessions — only `updateSession` does — so projects with a short `auths.duration` will start seeing 401s where a stale JWT previously worked. That is the intended fix, but it is worth a line in the release notes.

`app/controllers/general.php` has a third copy of the same existence-only check on the preview-auth path. It is deliberately **not** included here: it is unfixed on `main` too, and backporting a fix that `main` does not have would leave `1.9.x` ahead of the dev branch. It should be fixed on `main` first and backported on its own.