### PR TITLE
fix(deployments): reset event queue on intermediate chunk uploads

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/Create.php
@@ -347,6 +347,8 @@ class Create extends Action
                     $queueForEvents
                         ->setParam('functionId', $function->getId())
                         ->setParam('deploymentId', $deployment->getId());
+                } else {
+                    $queueForEvents->reset();
                 }
 
                 $response

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/Create.php
@@ -420,6 +420,8 @@ class Create extends Action
                     $queueForEvents
                         ->setParam('siteId', $site->getId())
                         ->setParam('deploymentId', $deployment->getId());
+                } else {
+                    $queueForEvents->reset();
                 }
 
                 $response


### PR DESCRIPTION
## What does this PR do?

Fixes the high-volume Sentry issue `[siteId] is missing from the params.` on `sites.createDeployment` (27K events / 3 months), and its `[functionId]` twin on `functions.createDeployment`.

When a chunked deployment upload processes a **non-final** chunk, `Create.php` updates `sourceChunksUploaded` but sets no event params — those are only set behind `if ($chunksUploaded === $chunks)`. The route's event label is still populated, so the `api` shutdown hook calls `Event::generateEvents()` with empty params and throws `InvalidArgumentException` on every intermediate chunk of every >5MB deployment (~275 times/day in fra1 alone).

The client is unaffected — the 202 is flushed before shutdown hooks run (Loki shows the next chunk's request starting before the failing span even finishes) — but the throw aborts the remaining shutdown hooks (realtime, usage, audits) for the request and floods Sentry with phantom 500s.

Fix: reset the event queue when the upload is not yet complete, mirroring the existing idempotent-retry path a few lines above.

## Test Plan

Existing chunked-upload e2e tests cover the final-chunk event dispatch. Verified the failure mode in production Loki logs (tor1/fra1): every intermediate chunk logs the InvalidArgumentException from `shared/api.php:833`; with the reset, the shutdown hook takes its `empty(getEvent())` early return, which the completed-upload retry path already exercises.

## Related PRs and Issues

- Sentry issue 3e39f1e9 (sites.createDeployment, [siteId] is missing from the params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)