### PR TITLE
fix(sites): keep stored buildRuntime when update omits it

### DIFF
--- a/src/Appwrite/Deployment/Deployments.php
+++ b/src/Appwrite/Deployment/Deployments.php
@@ -3,6 +3,7 @@
 namespace Appwrite\Deployment;
 
 use Ahc\Jwt\JWT;
+use Appwrite\Extend\Exception;
 use OpenRuntimes\Orchestrator\Enum\CallbackEvent;
 use OpenRuntimes\Orchestrator\Enum\ReadFormat;
 use OpenRuntimes\Orchestrator\Jobs;
@@ -506,7 +507,7 @@ readonly class Deployments
         $key = $resource->getAttribute($resource->getCollection() === 'sites' ? 'buildRuntime' : 'runtime');
         $runtime = Config::getParam($version === 'v2' ? 'runtimes-v2' : 'runtimes', [])[$key] ?? null;
         if ($runtime === null) {
-            throw new \Exception('Runtime "' . $key . '" is not supported');
+            throw new Exception(Exception::FUNCTION_RUNTIME_UNSUPPORTED, 'Runtime "' . $key . '" is not supported');
         }
 
         return $runtime;

--- a/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Sites/Update.php
@@ -195,6 +195,10 @@ class Update extends Base
             $framework = $site->getAttribute('framework');
         }
 
+        if (empty($buildRuntime)) {
+            $buildRuntime = $site->getAttribute('buildRuntime');
+        }
+
         $buildSpecification ??= $site->getAttribute('buildSpecification', APP_SITES_BUILD_SPECIFICATION_DEFAULT);
 
         $repositoryId = $site->getAttribute('repositoryId', '');


### PR DESCRIPTION
## What does this PR do?

Fixes the production failure where every deployment upload for a site suddenly starts returning `500 general_unknown` with `Runtime "" is not supported` (thrown from `Deployments.php` while building the build-job spec on the final chunk).

**Root cause:** `Sites/Http/Sites/Update.php` declares `buildRuntime` as an optional param defaulting to `''` and writes it into the site unconditionally. `framework` and `buildSpecification` fall back to the stored document when omitted — `buildRuntime` did not. Any partial `PUT /v1/sites/:siteId` that omits `buildRuntime` (CLI, SDK, scripted callers) wipes the site's runtime; since builds moved to the orchestrator jobs path, the runtime is resolved synchronously inside the upload request, so the wiped value turns every subsequent deployment into a wire 500. Site *creation* whitelist-validates `buildRuntime`, so only updates can break a site this way.

**Production evidence (Loki, fra1, project `6a709cf7000d5c29d34e`, 2026-08-10):** repeated cycles of `PUT site → 200`, `POST deployments → 202` (healthy), then one `PUT site → 200` at 16:45:44 after which every `POST /v1/sites/:siteId/deployments` returns `500 Runtime "" is not supported` — for hours, including console duplicate-deployment attempts. Same signature in nyc3 (project `6a78dc6000138aae3944`).

**Changes:**
- `Sites/Update.php`: fall back to the stored `buildRuntime` when the param is omitted or empty — mirrors `Functions/Update.php:181`, which already does this for `runtime`.
- `Deployment/Deployments.php`: an unresolvable runtime now throws the typed `FUNCTION_RUNTIME_UNSUPPORTED` (404) — the same code Functions Create/Executions use for this exact message — instead of a bare `\Exception` that surfaces as `500 general_unknown`. A site already broken by the wipe now gets an actionable error instead of paging on 500s.

Note: `adapter` and `fallbackFile` have the same unconditional-write behavior in Sites Update. Left untouched here since empty may be a legitimate "clear" for those — needs a product decision.

## Test Plan

Verified against production Loki traces (timeline above). Existing sites e2e covers update + deploy with `buildRuntime` provided; the failure path required an update that omits it — reverting the `Update.php` hunk reproduces the wiped attribute on any partial update.

## Related PRs and Issues

- Helpscout 3414820971 (consecutive site deployments failing with 500 general_unknown during chunked upload)
- #13177 (separate telemetry-only 500 on the same endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)