### PR TITLE
Address a created Bitbucket repository by its slug

### DIFF
--- a/src/Appwrite/Auth/OAuth2/Bitbucket.php
+++ b/src/Appwrite/Auth/OAuth2/Bitbucket.php
@@ -219,8 +219,10 @@ class Bitbucket extends OAuth2
         $repository = \json_decode($repository, true) ?? [];
 
         // Normalize to the GitHub/Gitea/GitLab field shape ProviderRepository expects.
-        if (isset($repository['uuid'])) {
-            $repository['id'] = $repository['uuid'];
+        // The id is the "workspace/slug" every later lookup routes on, which is
+        // what listing reports too -- a uuid resolves to no repository.
+        if (isset($repository['full_name'])) {
+            $repository['id'] = $repository['full_name'];
         }
 
         if (isset($repository['is_private'])) {


### PR DESCRIPTION
## What does this PR do?

Creating a Bitbucket repository from the console returned Bitbucket's uuid as the repository id. Every later lookup routes on the `workspace/slug` id that listing reports, so connecting the new repository failed.

Observed in production as a 500 on `POST /v1/sites`:

```
error.type    Utopia\VCS\Exception\RepositoryNotFound
error.message Repository {f0c09aab-3cfe-4e85-93ee-150b028919bf} not found
error.file    vendor/utopia-php/vcs/src/VCS/Adapter/Git/Bitbucket.php:333
trace         Sites/Http/Sites/Create.php:236 getRepositoryName()
```

`Bitbucket::getRepositoryName()` splits the id on `/` and throws when there is none, which a braced uuid never has.

`searchRepositories()` in the adapter already normalizes listing ids to `full_name`, so creation was the only path reporting a different id for the same repository.

## Test Plan

- `composer lint` passes on the changed file
- `composer analyze` reports 89 errors both with and without this change, none in the changed file
- Create a site from a template against a Bitbucket installation and confirm the repository connects instead of returning 500

## Related PRs and Issues

None.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/main/CONTRIBUTING.md)?

Yes.