### PR TITLE
feat: add SAML request and metadata generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,7 @@
         "phpmailer/phpmailer": "6.9.*",
         "chillerlan/php-qrcode": "4.3.*",
         "adhocore/jwt": "1.1.*",
+        "robrichards/xmlseclibs": "3.1.*",
         "spomky-labs/otphp": "11.*",
         "webonyx/graphql-php": "15.32.*",
         "league/csv": "9.14.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8f482127f1d48cb4026f35a161b15f5",
+    "content-hash": "9eba58d61b8add4d15a884e791c52f7c",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -2224,6 +2224,48 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
             "time": "2026-06-18T03:57:49+00:00"
+        },
+        {
+            "name": "robrichards/xmlseclibs",
+            "version": "3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/robrichards/xmlseclibs.git",
+                "reference": "03062be78178cbb5e8f605cd255dc32a14981f92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/robrichards/xmlseclibs/zipball/03062be78178cbb5e8f605cd255dc32a14981f92",
+                "reference": "03062be78178cbb5e8f605cd255dc32a14981f92",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">= 5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RobRichards\\XMLSecLibs\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A PHP library for XML Security",
+            "homepage": "https://github.com/robrichards/xmlseclibs",
+            "keywords": [
+                "security",
+                "signature",
+                "xml",
+                "xmldsig"
+            ],
+            "support": {
+                "issues": "https://github.com/robrichards/xmlseclibs/issues",
+                "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.5"
+            },
+            "time": "2026-03-13T10:31:56+00:00"
         },
         {
             "name": "spomky-labs/otphp",

--- a/src/Appwrite/Auth/SAML/AuthnRequest.php
+++ b/src/Appwrite/Auth/SAML/AuthnRequest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Appwrite\Auth\SAML;
+
+use DOMDocument;
+
+/**
+ * Builds a SAML 2.0 `<AuthnRequest>` and encodes it for the HTTP-Redirect
+ * binding, which is how an SP-initiated sign-in starts.
+ *
+ * The request ID is retained by the caller and stored server side, so the
+ * matching `InResponseTo` on the way back can be checked against a request we
+ * actually issued. See Response::validate().
+ */
+class AuthnRequest
+{
+    /**
+     * @var string
+     */
+    private readonly string $id;
+
+    /**
+     * @var string
+     */
+    private readonly string $issueInstant;
+
+    /**
+     * @param Settings $settings
+     */
+    public function __construct(private readonly Settings $settings)
+    {
+        $this->id = self::generateId();
+        $this->issueInstant = \gmdate('Y-m-d\TH:i:s\Z');
+    }
+
+    /**
+     * SAML request IDs are xsd:ID, which is an XML NCName: it may not start
+     * with a digit. Prefixing the hex with an underscore satisfies that
+     * regardless of what the random bytes happen to be.
+     *
+     * @return string
+     */
+    private static function generateId(): string
+    {
+        return '_' . \bin2hex(\random_bytes(16));
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * The `<AuthnRequest>` as XML.
+     *
+     * `AssertionConsumerServiceURL` and `Destination` are both included: the
+     * former tells the IdP where to POST the assertion, the latter lets the IdP
+     * confirm the request was addressed to it.
+     *
+     * @return string
+     */
+    public function toXml(): string
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+
+        $request = $doc->createElementNS('urn:oasis:names:tc:SAML:2.0:protocol', 'samlp:AuthnRequest');
+        $request->setAttribute('ID', $this->id);
+        $request->setAttribute('Version', '2.0');
+        $request->setAttribute('IssueInstant', $this->issueInstant);
+        $request->setAttribute('Destination', $this->settings->getIdpSsoUrl());
+        $request->setAttribute('ProtocolBinding', 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST');
+        $request->setAttribute('AssertionConsumerServiceURL', $this->settings->getAcsUrl());
+        $doc->appendChild($request);
+
+        $issuer = $doc->createElementNS('urn:oasis:names:tc:SAML:2.0:assertion', 'saml:Issuer', $this->settings->getSpEntityId());
+        $request->appendChild($issuer);
+
+        $policy = $doc->createElementNS('urn:oasis:names:tc:SAML:2.0:protocol', 'samlp:NameIDPolicy');
+        $policy->setAttribute('Format', $this->settings->getNameIdFormat());
+        $policy->setAttribute('AllowCreate', 'true');
+        $request->appendChild($policy);
+
+        return $doc->saveXML();
+    }
+
+    /**
+     * Full IdP sign-in URL for the HTTP-Redirect binding.
+     *
+     * Per SAML 2.0 bindings, the request is deflated (raw, headerless), base64
+     * encoded, and URL encoded. `RelayState` is opaque to the IdP and echoed
+     * back to the ACS; the spec caps it at 80 bytes, so callers pass a lookup
+     * token rather than the state itself.
+     *
+     * @param string $relayState
+     *
+     * @return string
+     */
+    public function getRedirectUrl(string $relayState = ''): string
+    {
+        $deflated = \gzdeflate($this->toXml());
+
+        if ($deflated === false) {
+            throw new Exception('Failed to compress SAML authentication request.');
+        }
+
+        $query = ['SAMLRequest' => \base64_encode($deflated)];
+
+        if ($relayState !== '') {
+            $query['RelayState'] = $relayState;
+        }
+
+        $separator = \str_contains($this->settings->getIdpSsoUrl(), '?') ? '&' : '?';
+
+        return $this->settings->getIdpSsoUrl() . $separator . \http_build_query($query);
+    }
+}

--- a/src/Appwrite/Auth/SAML/Exception.php
+++ b/src/Appwrite/Auth/SAML/Exception.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Appwrite\Auth\SAML;
+
+use Appwrite\Extend\Exception as AppwriteException;
+
+/**
+ * Raised when a SAML configuration is invalid, or when an incoming SAML
+ * response fails validation.
+ *
+ * Messages on this exception surface to the project admin through the OAuth2
+ * failure redirect, so they should name the misconfiguration and, where
+ * possible, the fix. They must never echo attacker-controlled assertion
+ * content back to the caller.
+ */
+class Exception extends AppwriteException
+{
+    public function __construct(string $message, string $type = AppwriteException::USER_OAUTH2_PROVIDER_ERROR, ?\Throwable $previous = null)
+    {
+        parent::__construct($type, $message, previous: $previous);
+    }
+}

--- a/src/Appwrite/Auth/SAML/Metadata.php
+++ b/src/Appwrite/Auth/SAML/Metadata.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Appwrite\Auth\SAML;
+
+use DOMDocument;
+
+/**
+ * Generates the SP metadata document an IdP administrator imports to configure
+ * the trust relationship from their side.
+ *
+ * Publishing metadata is preferable to asking admins to copy individual fields:
+ * every IdP worth integrating can consume it, and it stays correct if the SP
+ * surface changes.
+ */
+class Metadata
+{
+    private const string NS_METADATA = 'urn:oasis:names:tc:SAML:2.0:metadata';
+    private const string BINDING_POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST';
+
+    /**
+     * @param Settings $settings
+     */
+    public function __construct(private readonly Settings $settings)
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function toXml(): string
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->formatOutput = true;
+
+        $entity = $doc->createElementNS(self::NS_METADATA, 'md:EntityDescriptor');
+        $entity->setAttribute('entityID', $this->settings->getSpEntityId());
+        $doc->appendChild($entity);
+
+        $descriptor = $doc->createElementNS(self::NS_METADATA, 'md:SPSSODescriptor');
+        $descriptor->setAttribute('protocolSupportEnumeration', 'urn:oasis:names:tc:SAML:2.0:protocol');
+        // We do not sign AuthnRequests yet, but we do require the assertion
+        // itself to be signed.
+        $descriptor->setAttribute('AuthnRequestsSigned', 'false');
+        $descriptor->setAttribute('WantAssertionsSigned', 'true');
+        $entity->appendChild($descriptor);
+
+        $nameIdFormat = $doc->createElementNS(self::NS_METADATA, 'md:NameIDFormat', $this->settings->getNameIdFormat());
+        $descriptor->appendChild($nameIdFormat);
+
+        $service = $doc->createElementNS(self::NS_METADATA, 'md:AssertionConsumerService');
+        $service->setAttribute('Binding', self::BINDING_POST);
+        $service->setAttribute('Location', $this->settings->getAcsUrl());
+        $service->setAttribute('index', '0');
+        $service->setAttribute('isDefault', 'true');
+        $descriptor->appendChild($service);
+
+        return $doc->saveXML();
+    }
+}

--- a/src/Appwrite/Auth/SAML/Settings.php
+++ b/src/Appwrite/Auth/SAML/Settings.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Appwrite\Auth\SAML;
+
+use Appwrite\Extend\Exception as AppwriteException;
+
+/**
+ * Immutable SAML Service Provider configuration.
+ *
+ * Holds both sides of the trust relationship: what the Identity Provider told
+ * us about itself (entity ID, sign-in URL, signing certificate) and what we
+ * publish about ourselves (entity ID, Assertion Consumer Service URL).
+ *
+ * Validation happens on construction so an invalid configuration is rejected
+ * when an admin saves it, rather than when a user first tries to sign in.
+ */
+class Settings
+{
+    /**
+     * Subset of SAML 2.0 NameID formats worth exposing. `unspecified` leaves
+     * the choice to the IdP, which is what most deployments want.
+     */
+    public const array NAME_ID_FORMATS = [
+        'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
+        'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+        'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+        'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+    ];
+
+    public const string DEFAULT_NAME_ID_FORMAT = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
+
+    /**
+     * Attribute names an IdP commonly uses for each claim, tried in order when
+     * the admin has not mapped the claim explicitly. Okta and Entra ID both
+     * emit either a bare name or the corresponding Claims schema URI.
+     */
+    public const array DEFAULT_ATTRIBUTE_MAP = [
+        'email' => [
+            'email',
+            'emailAddress',
+            'mail',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+        ],
+        'name' => [
+            'name',
+            'displayName',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name',
+        ],
+        'firstName' => [
+            'firstName',
+            'givenName',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
+        ],
+        'lastName' => [
+            'lastName',
+            'surname',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+        ],
+    ];
+
+    /**
+     * @var string
+     */
+    private string $x509Cert;
+
+    /**
+     * @param string $idpEntityId IdP entity ID, matched against the assertion Issuer.
+     * @param string $idpSsoUrl IdP sign-in URL the AuthnRequest is sent to.
+     * @param string $x509Cert IdP signing certificate, PEM or bare base64.
+     * @param string $spEntityId Our entity ID, matched against the assertion AudienceRestriction.
+     * @param string $acsUrl Our Assertion Consumer Service URL, matched against the SubjectConfirmationData Recipient.
+     * @param string $nameIdFormat Requested NameID format.
+     * @param array<string, string> $attributeMap Claim name to IdP attribute name, overriding DEFAULT_ATTRIBUTE_MAP.
+     *
+     * @throws Exception when any value is missing or malformed.
+     */
+    public function __construct(
+        private readonly string $idpEntityId,
+        private readonly string $idpSsoUrl,
+        string $x509Cert,
+        private readonly string $spEntityId,
+        private readonly string $acsUrl,
+        private readonly string $nameIdFormat = self::DEFAULT_NAME_ID_FORMAT,
+        private readonly array $attributeMap = [],
+    ) {
+        $this->x509Cert = self::normalizeCertificate($x509Cert);
+
+        if (empty($this->idpEntityId)) {
+            throw new Exception('SAML identity provider entity ID is required.', AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+
+        if (!\filter_var($this->idpSsoUrl, FILTER_VALIDATE_URL)) {
+            throw new Exception('SAML identity provider sign-in URL must be a valid URL.', AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+
+        if (empty($this->spEntityId)) {
+            throw new Exception('SAML service provider entity ID is required.', AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+
+        if (!\filter_var($this->acsUrl, FILTER_VALIDATE_URL)) {
+            throw new Exception('SAML assertion consumer service URL must be a valid URL.', AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+
+        if (!\in_array($this->nameIdFormat, self::NAME_ID_FORMATS, true)) {
+            throw new Exception('Unsupported SAML NameID format: ' . $this->nameIdFormat, AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+    }
+
+    /**
+     * Accept a certificate as a full PEM block, or as the bare base64 body that
+     * IdP setup screens and IdP metadata `<X509Certificate>` elements contain,
+     * and return a normalized PEM block.
+     *
+     * @param string $cert
+     *
+     * @return string
+     *
+     * @throws Exception when the value is not a certificate OpenSSL can parse.
+     */
+    private static function normalizeCertificate(string $cert): string
+    {
+        $cert = \trim($cert);
+
+        if (empty($cert)) {
+            throw new Exception('SAML identity provider signing certificate is required.', AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+
+        if (!\str_contains($cert, 'BEGIN CERTIFICATE')) {
+            $body = \preg_replace('/\s+/', '', $cert);
+            $cert = "-----BEGIN CERTIFICATE-----\n"
+                . \chunk_split($body, 64, "\n")
+                . "-----END CERTIFICATE-----\n";
+        }
+
+        // openssl_x509_read is the authority on whether this parses at all.
+        // Errors are queued by OpenSSL, so drain them to keep the queue from
+        // leaking into an unrelated call later in the request.
+        $parsed = @\openssl_x509_read($cert);
+        while (\openssl_error_string() !== false) {
+            // Discard.
+        }
+
+        if ($parsed === false) {
+            throw new Exception('SAML identity provider signing certificate could not be parsed. Provide the IdP X.509 signing certificate in PEM format.', AppwriteException::GENERAL_ARGUMENT_INVALID);
+        }
+
+        return $cert;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdpEntityId(): string
+    {
+        return $this->idpEntityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdpSsoUrl(): string
+    {
+        return $this->idpSsoUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getX509Cert(): string
+    {
+        return $this->x509Cert;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSpEntityId(): string
+    {
+        return $this->spEntityId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAcsUrl(): string
+    {
+        return $this->acsUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameIdFormat(): string
+    {
+        return $this->nameIdFormat;
+    }
+
+    /**
+     * Candidate IdP attribute names for a claim, most specific first. An
+     * explicit mapping wins outright; otherwise fall back to the common names.
+     *
+     * @param string $claim
+     *
+     * @return array<int, string>
+     */
+    public function getAttributeCandidates(string $claim): array
+    {
+        $configured = $this->attributeMap[$claim] ?? null;
+
+        if (!empty($configured)) {
+            return [$configured];
+        }
+
+        return self::DEFAULT_ATTRIBUTE_MAP[$claim] ?? [];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAttributeMap(): array
+    {
+        return $this->attributeMap;
+    }
+}

--- a/tests/unit/Auth/SAML/AuthnRequestTest.php
+++ b/tests/unit/Auth/SAML/AuthnRequestTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Auth\SAML;
+
+use Appwrite\Auth\SAML\AuthnRequest;
+use Appwrite\Auth\SAML\Exception;
+use Appwrite\Auth\SAML\Metadata;
+use Appwrite\Auth\SAML\Settings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the outbound half of the protocol: the settings a project stores, the
+ * authentication request sent to the identity provider, and the service
+ * provider metadata an administrator imports on their side.
+ *
+ * Nothing here parses input from an identity provider.
+ */
+final class AuthnRequestTest extends TestCase
+{
+    private const IDP_ENTITY_ID = 'https://idp.example.com/metadata';
+    private const IDP_SSO_URL = 'https://idp.example.com/sso';
+    private const SP_ENTITY_ID = 'https://appwrite.test/sp';
+    private const ACS_URL = 'https://appwrite.test/v1/account/sessions/saml/project/callback';
+
+    private string $certificate;
+
+    protected function setUp(): void
+    {
+        $key = \openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        $csr = \openssl_csr_new(['commonName' => 'saml-test-idp'], $key, ['digest_alg' => 'sha256']);
+        $x509 = \openssl_csr_sign($csr, null, $key, 1, ['digest_alg' => 'sha256']);
+
+        $certificate = '';
+        \openssl_x509_export($x509, $certificate);
+
+        $this->certificate = $certificate;
+    }
+
+    private function settings(string $ssoUrl = self::IDP_SSO_URL, ?string $cert = null): Settings
+    {
+        return new Settings(
+            idpEntityId: self::IDP_ENTITY_ID,
+            idpSsoUrl: $ssoUrl,
+            x509Cert: $cert ?? $this->certificate,
+            spEntityId: self::SP_ENTITY_ID,
+            acsUrl: self::ACS_URL,
+        );
+    }
+
+    // --- Settings ----------------------------------------------------------
+
+    /**
+     * Identity provider setup screens show the certificate body without the PEM
+     * header, so both forms have to be accepted.
+     */
+    public function testBareBase64CertificateIsNormalizedToPem(): void
+    {
+        $bare = \preg_replace('/-----[^-]+-----|\s/', '', $this->certificate);
+
+        $settings = $this->settings(cert: $bare);
+
+        $this->assertStringContainsString('BEGIN CERTIFICATE', $settings->getX509Cert());
+        $this->assertNotFalse(\openssl_x509_read($settings->getX509Cert()));
+    }
+
+    public function testUnparseableCertificateIsRejected(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/could not be parsed/i');
+
+        $this->settings(cert: 'not-a-certificate');
+    }
+
+    public function testInvalidSignOnUrlIsRejected(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/valid URL/i');
+
+        $this->settings('not a url');
+    }
+
+    public function testUnsupportedNameIdFormatIsRejected(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/NameID format/i');
+
+        new Settings(
+            idpEntityId: self::IDP_ENTITY_ID,
+            idpSsoUrl: self::IDP_SSO_URL,
+            x509Cert: $this->certificate,
+            spEntityId: self::SP_ENTITY_ID,
+            acsUrl: self::ACS_URL,
+            nameIdFormat: 'urn:example:not-a-real-format',
+        );
+    }
+
+    /**
+     * An explicit mapping wins outright; otherwise the common attribute names
+     * are tried in order.
+     */
+    public function testExplicitAttributeMappingOverridesTheDefaults(): void
+    {
+        $this->assertContains('email', $this->settings()->getAttributeCandidates('email'));
+
+        $mapped = new Settings(
+            idpEntityId: self::IDP_ENTITY_ID,
+            idpSsoUrl: self::IDP_SSO_URL,
+            x509Cert: $this->certificate,
+            spEntityId: self::SP_ENTITY_ID,
+            acsUrl: self::ACS_URL,
+            attributeMap: ['email' => 'urn:custom:mail'],
+        );
+
+        $this->assertSame(['urn:custom:mail'], $mapped->getAttributeCandidates('email'));
+    }
+
+    // --- AuthnRequest ------------------------------------------------------
+
+    /**
+     * The HTTP-Redirect binding requires the request to be deflated (raw,
+     * headerless), base64 encoded and URL encoded.
+     */
+    public function testRequestIsDeflatedAndBase64Encoded(): void
+    {
+        $request = new AuthnRequest($this->settings());
+        $url = $request->getRedirectUrl('relay-token');
+
+        $query = [];
+        \parse_str((string)\parse_url($url, PHP_URL_QUERY), $query);
+
+        $this->assertSame('relay-token', $query['RelayState']);
+        $this->assertSame($request->toXml(), \gzinflate(\base64_decode($query['SAMLRequest'], true)));
+    }
+
+    public function testRequestCarriesDestinationIssuerAndAcsUrl(): void
+    {
+        $xml = \simplexml_load_string((new AuthnRequest($this->settings()))->toXml());
+
+        $this->assertSame(self::IDP_SSO_URL, (string)$xml['Destination']);
+        $this->assertSame(self::ACS_URL, (string)$xml['AssertionConsumerServiceURL']);
+        $this->assertStringContainsString('HTTP-POST', (string)$xml['ProtocolBinding']);
+
+        $xml->registerXPathNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
+        $this->assertSame(self::SP_ENTITY_ID, (string)$xml->xpath('//saml:Issuer')[0]);
+    }
+
+    /**
+     * SAML request IDs are xsd:ID, which is an XML NCName and may not begin
+     * with a digit.
+     */
+    public function testRequestIdIsAValidNcName(): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $this->assertMatchesRegularExpression('/^_[0-9a-f]{32}$/', (new AuthnRequest($this->settings()))->getId());
+        }
+    }
+
+    /**
+     * Identity providers whose sign-in URL already carries a query string must
+     * still get a well-formed URL.
+     */
+    public function testExistingQueryStringOnTheSignOnUrlIsPreserved(): void
+    {
+        $url = (new AuthnRequest($this->settings(self::IDP_SSO_URL . '?tenant=42')))->getRedirectUrl();
+
+        $this->assertSame(1, \substr_count($url, '?'));
+        $this->assertStringContainsString('tenant=42', $url);
+    }
+
+    // --- Metadata ----------------------------------------------------------
+
+    public function testMetadataAdvertisesThePostBindingAndAcsUrl(): void
+    {
+        $xml = (new Metadata($this->settings()))->toXml();
+
+        $this->assertStringContainsString('AssertionConsumerService', $xml);
+        $this->assertStringContainsString(self::ACS_URL, $xml);
+        $this->assertStringContainsString('HTTP-POST', $xml);
+        $this->assertStringContainsString('WantAssertionsSigned="true"', $xml);
+        $this->assertNotFalse(\simplexml_load_string($xml));
+    }
+}


### PR DESCRIPTION
# feat: SAML request and metadata generation (1/4)

First of four parts adding SAML 2.0 sign-in.
**This part is outbound only.** It builds what Appwrite sends to an identity
provider and parses nothing. No routes, no configuration, no API surface — none
of it is reachable yet.

## What's here

| File | Does |
|---|---|
| `SAML/Settings.php` | A project's SAML configuration, validated on construction |
| `SAML/AuthnRequest.php` | Builds the authentication request, encoded for the HTTP-Redirect binding |
| `SAML/Metadata.php` | Generates the SP descriptor an IdP administrator imports |
| `SAML/Exception.php` | Namespace-local exception |

Validating in the `Settings` constructor means a bad certificate or URL is
rejected when an admin saves it, not when a user first tries to sign in.
Certificates are accepted either as a PEM block or as the bare base64 body that
IdP setup screens display — Okta shows the latter, and pasting it should work.

## New dependency

`robrichards/xmlseclibs` 3.1.x — MIT, no transitive packages, needs only
`ext-openssl` which is already required. It isn't used until part 2, where XML
signature verification happens; it's added here so the dependency change lands
on its own rather than inside a security review.

This is the first dependency outside the utopia-php ecosystem in this area.
 Hand-rolling XML-DSig is how
service providers get CVEs: canonicalisation, reference resolution and
signature-wrapping defence are the hard part, and the primitives are the easy
part.

## Review question

*Does this generate correct SAML 2.0 outbound XML?*

Nothing here handles untrusted input, so it doesn't need adversarial reading —
that's part 2.

## Tests

10 tests: request encoding round-trip, NCName ID validity, certificate
normalisation, settings validation, metadata contents.

## What follows

2. Assertion validation — signature verification, wrapping, XXE, conditions
3. Project configuration — the admin endpoint
4. Sign-in endpoints — the flow goes live