### PR TITLE
Fix TablesDB create action parameter names

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables;
 
+use Appwrite\Event\Event;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Create as CollectionCreate;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
@@ -10,6 +11,7 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response as UtopiaResponse;
 use Utopia\Database\Database;
+use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Permissions;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
@@ -72,5 +74,10 @@ class Create extends CollectionCreate
             ->inject('queueForEvents')
             ->inject('authorization')
             ->callback($this->action(...));
+    }
+
+    public function action(string $databaseId, string $tableId, string $name, ?array $permissions, bool $rowSecurity, bool $enabled, array $columns, array $indexes, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, Event $queueForEvents, Authorization $authorization): void
+    {
+        parent::action($databaseId, $tableId, $name, $permissions, $rowSecurity, $enabled, $columns, $indexes, $response, $dbForProject, $getDatabasesDB, $queueForEvents, $authorization);
     }
 }

--- a/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\Platform\Modules\Databases\Http\TablesDB\Tables\Indexes;
 
+use Appwrite\Event\Event;
+use Appwrite\Event\Publisher\Database as DatabasePublisher;
 use Appwrite\Platform\Modules\Databases\Http\Databases\Collections\Indexes\Create as IndexCreate;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
@@ -9,6 +11,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response as UtopiaResponse;
 use Utopia\Database\Database;
+use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Key;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
@@ -73,4 +76,8 @@ class Create extends IndexCreate
             ->callback($this->action(...));
     }
 
+    public function action(string $databaseId, string $tableId, string $key, string $type, array $columns, array $orders, array $lengths, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, DatabasePublisher $publisherForDatabase, Event $queueForEvents, Authorization $authorization): void
+    {
+        parent::action($databaseId, $tableId, $key, $type, $columns, $orders, $lengths, $response, $dbForProject, $getDatabasesDB, $publisherForDatabase, $queueForEvents, $authorization);
+    }
 }

--- a/tests/unit/Platform/Modules/Databases/ActionParameterNamesTest.php
+++ b/tests/unit/Platform/Modules/Databases/ActionParameterNamesTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Modules\Databases;
+
+use PHPUnit\Framework\TestCase;
+
+final class ActionParameterNamesTest extends TestCase
+{
+    private const ALLOWED_INHERITED_RENAMES = [
+        'column' => 'attribute',
+        'relatedTableId' => 'relatedCollectionId',
+        'rowId' => 'documentId',
+        'rows' => 'documents',
+        'rowSecurity' => 'documentSecurity',
+        'tableId' => 'collectionId',
+        'total' => 'includeTotal',
+    ];
+
+    public function testInheritedActionCallbacksDoNotHideUnexpectedParameterRenames(): void
+    {
+        $errors = [];
+
+        foreach ($this->phpFiles($this->root() . '/src/Appwrite/Platform/Modules/Databases/Http') as $file) {
+            $source = \file_get_contents($file);
+            if ($source === false || !\str_contains($source, '->callback($this->action(...))')) {
+                continue;
+            }
+
+            if ($this->declaresAction($source)) {
+                continue;
+            }
+
+            $parent = $this->parentPath($source);
+            if ($parent === null || !\is_file($parent)) {
+                continue;
+            }
+
+            $parentSource = \file_get_contents($parent);
+            if ($parentSource === false) {
+                continue;
+            }
+
+            $parentParameters = $this->actionParameters($parentSource);
+            if ($parentParameters === []) {
+                continue;
+            }
+
+            foreach ($this->declaredParameters($source) as $index => $parameter) {
+                $parentParameter = $parentParameters[$index] ?? null;
+                if ($parentParameter === null || $parameter === $parentParameter) {
+                    continue;
+                }
+
+                if ((self::ALLOWED_INHERITED_RENAMES[$parameter] ?? null) === $parentParameter) {
+                    continue;
+                }
+
+                $errors[] = \sprintf(
+                    '%s inherits action() but declares param #%d as $%s; parent expects $%s. Override action() and delegate explicitly, or add an intentional allowlist entry.',
+                    $this->relative($file),
+                    $index + 1,
+                    $parameter,
+                    $parentParameter,
+                );
+            }
+        }
+
+        $this->assertSame([], $errors);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function phpFiles(string $directory): array
+    {
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory));
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        \sort($files);
+
+        return $files;
+    }
+
+    private function declaresAction(string $source): bool
+    {
+        return \preg_match('/function\s+action\s*\(/', $source) === 1;
+    }
+
+    private function parentPath(string $source): ?string
+    {
+        if (\preg_match('/class\s+\w+\s+extends\s+(?<parent>\\?\w+)/', $source, $match) !== 1) {
+            return null;
+        }
+
+        $parent = $match['parent'];
+        $uses = $this->uses($source);
+        $fqcn = $uses[$parent] ?? null;
+
+        if ($fqcn === null) {
+            return null;
+        }
+
+        $prefix = 'Appwrite\\';
+        if (!\str_starts_with($fqcn, $prefix)) {
+            return null;
+        }
+
+        return $this->root() . '/src/Appwrite/' . \str_replace('\\', '/', \substr($fqcn, \strlen($prefix))) . '.php';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function uses(string $source): array
+    {
+        $uses = [];
+        \preg_match_all('/^use\s+(?<fqcn>[^;]+);/m', $source, $matches);
+
+        foreach ($matches['fqcn'] as $fqcn) {
+            $parts = \preg_split('/\s+as\s+/i', \trim($fqcn));
+            if ($parts === false) {
+                continue;
+            }
+
+            if (\count($parts) === 2) {
+                $uses[$parts[1]] = $parts[0];
+                continue;
+            }
+
+            $segments = \explode('\\', $parts[0]);
+            $uses[\end($segments)] = $parts[0];
+        }
+
+        return $uses;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function declaredParameters(string $source): array
+    {
+        \preg_match_all("/->param\\('(?<name>[^']+)'/", $source, $matches);
+
+        return $matches['name'];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function actionParameters(string $source): array
+    {
+        if (\preg_match('/function\s+action\s*\((?<parameters>.*?)\)\s*:/s', $source, $match) !== 1) {
+            return [];
+        }
+
+        $parameters = [];
+        foreach ($this->splitArguments($match['parameters']) as $argument) {
+            if (\preg_match('/\$(?<name>[A-Za-z_][A-Za-z0-9_]*)/', $argument, $argumentMatch) === 1) {
+                $parameters[] = $argumentMatch['name'];
+            }
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function splitArguments(string $arguments): array
+    {
+        $parts = [];
+        $current = '';
+        $depth = 0;
+
+        foreach (\str_split($arguments) as $character) {
+            if ($character === '(' || $character === '[') {
+                ++$depth;
+            }
+
+            if ($character === ')' || $character === ']') {
+                --$depth;
+            }
+
+            if ($character === ',' && $depth === 0) {
+                $parts[] = $current;
+                $current = '';
+                continue;
+            }
+
+            $current .= $character;
+        }
+
+        if (\trim($current) !== '') {
+            $parts[] = $current;
+        }
+
+        return $parts;
+    }
+
+    private function root(): string
+    {
+        return \dirname(__DIR__, 5);
+    }
+
+    private function relative(string $path): string
+    {
+        return \substr($path, \strlen($this->root()) + 1);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds explicit TablesDB action adapters where the public API uses TablesDB terms but the shared Databases implementation still uses legacy collection/attribute terms.

```php
// public TablesDB params
array $columns

// shared Databases implementation
parent::action(..., $columns, ...); // parent receives this as $attributes
```

This covers:
- `tablesDB.createTable`: `columns` -> parent `$attributes`
- `tablesDB.createIndex`: `columns` -> parent `$attributes`

It also adds a unit guard that scans Databases HTTP actions and fails on future inherited callbacks with unexpected param-name renames unless they either override `action()` or are explicitly allowlisted.

## Test Plan

```text
php -l src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
composer lint src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
composer analyze src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Create.php
php -l src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
composer lint src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
composer analyze src/Appwrite/Platform/Modules/Databases/Http/TablesDB/Tables/Indexes/Create.php
composer test -- tests/unit/Platform/Modules/Databases/ActionParameterNamesTest.php
composer analyze tests/unit/Platform/Modules/Databases/ActionParameterNamesTest.php
```

Could not run Docker e2e locally because the Docker daemon was unavailable.

## Related PRs and Issues

- #XXXX

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
