### PR TITLE
Fix unique constraint duplicate errors

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -839,6 +839,11 @@ return [
         'description' => 'Document with the requested ID \'%s\' already exists. Try again with a different ID or use ID.unique() to generate a unique ID.',
         'code' => 409,
     ],
+    Exception::DOCUMENT_UNIQUE_CONSTRAINT_VIOLATION => [
+        'name' => Exception::DOCUMENT_UNIQUE_CONSTRAINT_VIOLATION,
+        'description' => 'Document violates a unique attribute constraint. Try again with different value(s).',
+        'code' => 409,
+    ],
     Exception::DOCUMENT_UPDATE_CONFLICT => [
         'name' => Exception::DOCUMENT_UPDATE_CONFLICT,
         'description' => 'Remote document is newer than local.',
@@ -874,6 +879,11 @@ return [
     Exception::ROW_ALREADY_EXISTS => [
         'name' => Exception::ROW_ALREADY_EXISTS,
         'description' => 'Row with the requested ID \'%s\' already exists. Try again with a different ID or use ID.unique() to generate a unique ID.',
+        'code' => 409,
+    ],
+    Exception::ROW_UNIQUE_CONSTRAINT_VIOLATION => [
+        'name' => Exception::ROW_UNIQUE_CONSTRAINT_VIOLATION,
+        'description' => 'Row violates a unique column constraint. Try again with different value(s).',
         'code' => 409,
     ],
     Exception::ROW_UPDATE_CONFLICT => [

--- a/composer.lock
+++ b/composer.lock
@@ -3638,16 +3638,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "7.1.3",
+            "version": "7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "ce4e14e11cf8f9e6897015d5a7f8bb44a4b74949"
+                "reference": "a8e8386686a650f6e87a4fab244fafc06b698807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/ce4e14e11cf8f9e6897015d5a7f8bb44a4b74949",
-                "reference": "ce4e14e11cf8f9e6897015d5a7f8bb44a4b74949",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/a8e8386686a650f6e87a4fab244fafc06b698807",
+                "reference": "a8e8386686a650f6e87a4fab244fafc06b698807",
                 "shasum": ""
             },
             "require": {
@@ -3692,9 +3692,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/7.1.3"
+                "source": "https://github.com/utopia-php/database/tree/7.2.0"
             },
-            "time": "2026-08-10T12:17:57+00:00"
+            "time": "2026-08-13T00:53:05+00:00"
         },
         {
             "name": "utopia-php/detector",
@@ -4416,16 +4416,16 @@
         },
         {
             "name": "utopia-php/mongo",
-            "version": "1.5.1",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/mongo.git",
-                "reference": "3ece830d1d72d2c9f68c656738e285629b5c72a9"
+                "reference": "be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/3ece830d1d72d2c9f68c656738e285629b5c72a9",
-                "reference": "3ece830d1d72d2c9f68c656738e285629b5c72a9",
+                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4",
+                "reference": "be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4",
                 "shasum": ""
             },
             "require": {
@@ -4471,9 +4471,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/mongo/issues",
-                "source": "https://github.com/utopia-php/mongo/tree/1.5.1"
+                "source": "https://github.com/utopia-php/mongo/tree/1.5.3"
             },
-            "time": "2026-08-02T00:46:11+00:00"
+            "time": "2026-08-13T01:55:11+00:00"
         },
         {
             "name": "utopia-php/platform",

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -232,6 +232,7 @@ class Exception extends \Exception
     public const string DOCUMENT_MISSING_DATA = 'document_missing_data';
     public const string DOCUMENT_MISSING_PAYLOAD = 'document_missing_payload';
     public const string DOCUMENT_ALREADY_EXISTS = 'document_already_exists';
+    public const string DOCUMENT_UNIQUE_CONSTRAINT_VIOLATION = 'document_unique_constraint_violation';
     public const string DOCUMENT_UPDATE_CONFLICT = 'document_update_conflict';
     public const string DOCUMENT_DELETE_RESTRICTED = 'document_delete_restricted';
 
@@ -241,6 +242,7 @@ class Exception extends \Exception
     public const string ROW_MISSING_DATA = 'row_missing_data';
     public const string ROW_MISSING_PAYLOAD = 'row_missing_payload';
     public const string ROW_ALREADY_EXISTS = 'row_already_exists';
+    public const string ROW_UNIQUE_CONSTRAINT_VIOLATION = 'row_unique_constraint_violation';
     public const string ROW_UPDATE_CONFLICT = 'row_update_conflict';
     public const string ROW_DELETE_RESTRICTED = 'row_delete_restricted';
 

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php
@@ -165,6 +165,16 @@ abstract class Action extends DatabasesAction
     }
 
     /**
+     * Get the appropriate unique constraint exception.
+     */
+    protected function getUniqueConstraintException(): string
+    {
+        return $this->isCollectionsAPI()
+            ? Exception::DOCUMENT_UNIQUE_CONSTRAINT_VIOLATION
+            : Exception::ROW_UNIQUE_CONSTRAINT_VIOLATION;
+    }
+
+    /**
      * Get the appropriate conflict exception.
      */
     protected function getConflictException(): string

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php
@@ -20,6 +20,7 @@ use Utopia\Database\Exception\Conflict as ConflictException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Relationship as RelationshipException;
 use Utopia\Database\Exception\Structure as StructureException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\UID;
 use Utopia\Http\Adapter\Swoole\Response as SwooleResponse;
@@ -169,12 +170,13 @@ class Upsert extends Action
         }
 
         $dbForDatabases = $getDatabasesDB($database);
+        $collectionTableId = 'database_' . $database->getSequence() . '_collection_' . $collection->getSequence();
         $upserted = [];
 
         try {
-            $modified = $dbForDatabases->withPreserveDates(function () use ($dbForDatabases, $database, $collection, $documents, $plan, &$upserted) {
+            $modified = $dbForDatabases->withPreserveDates(function () use ($dbForDatabases, $collectionTableId, $documents, $plan, &$upserted) {
                 return $dbForDatabases->upsertDocuments(
-                    'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),
+                    $collectionTableId,
                     $documents,
                     onNext: function (Document $document) use ($plan, &$upserted) {
                         if (\count($upserted) < ($plan['databasesBatchSize'] ?? APP_LIMIT_DATABASE_BATCH)) {
@@ -185,8 +187,10 @@ class Upsert extends Action
             });
         } catch (ConflictException) {
             throw new Exception($this->getConflictException());
-        } catch (DuplicateException) {
-            throw new Exception($this->getDuplicateException(), params: ['multiple']);
+        } catch (UniqueException $e) {
+            throw new Exception($this->getUniqueConstraintException(), previous: $e);
+        } catch (DuplicateException $e) {
+            throw new Exception($this->getDuplicateException(), previous: $e, params: ['multiple']);
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -22,6 +22,7 @@ use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Exception\Relationship as RelationshipException;
 use Utopia\Database\Exception\Structure as StructureException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
@@ -469,12 +470,13 @@ class Create extends Action
         }
 
         $dbForDatabases = $getDatabasesDB($database);
+        $collectionTableId = 'database_' . $database->getSequence() . '_collection_' . $collection->getSequence();
         try {
             $created = [];
             $dbForDatabases->withPreserveDates(
-                function () use (&$created, $dbForDatabases, $database, $collection, $documents) {
+                function () use (&$created, $dbForDatabases, $collectionTableId, $documents) {
                     $dbForDatabases->createDocuments(
-                        'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),
+                        $collectionTableId,
                         $documents,
                         onNext: function ($doc) use (&$created) {
                             $created[] = $doc;
@@ -482,8 +484,10 @@ class Create extends Action
                     );
                 }
             );
-        } catch (DuplicateException) {
-            throw new Exception($this->getDuplicateException(), params: [$documentId]);
+        } catch (UniqueException $e) {
+            throw new Exception($this->getUniqueConstraintException(), previous: $e);
+        } catch (DuplicateException $e) {
+            throw new Exception($this->getDuplicateException(), previous: $e, params: [$documentId]);
         } catch (NotFoundException) {
             throw new Exception($this->getParentNotFoundException(), params: [$collectionId]);
         } catch (RelationshipException $e) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php
@@ -19,6 +19,7 @@ use Utopia\Database\Exception\Conflict as ConflictException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Relationship as RelationshipException;
 use Utopia\Database\Exception\Structure as StructureException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
@@ -326,15 +327,17 @@ class Update extends Action
             $document = $dbForDatabases->withRequestTimestamp(
                 $requestTimestamp,
                 fn () => $dbForDatabases->withPreserveDates(fn () => $dbForDatabases->updateDocument(
-                    'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),
+                    $collectionTableId,
                     $document->getId(),
                     $newDocument
                 ))
             );
         } catch (ConflictException) {
             throw new Exception($this->getConflictException());
-        } catch (DuplicateException) {
-            throw new Exception($this->getDuplicateException(), params: [$documentId]);
+        } catch (UniqueException $e) {
+            throw new Exception($this->getUniqueConstraintException(), previous: $e);
+        } catch (DuplicateException $e) {
+            throw new Exception($this->getDuplicateException(), previous: $e, params: [$documentId]);
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {

--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php
@@ -20,6 +20,7 @@ use Utopia\Database\Exception\Conflict as ConflictException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Relationship as RelationshipException;
 use Utopia\Database\Exception\Structure as StructureException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
@@ -333,9 +334,9 @@ class Upsert extends Action
 
         $upserted = [];
         try {
-            $dbForDatabases->withPreserveDates(function () use (&$upserted, $dbForDatabases, $database, $collection, $newDocument) {
+            $dbForDatabases->withPreserveDates(function () use (&$upserted, $dbForDatabases, $collectionTableId, $newDocument) {
                 return $dbForDatabases->upsertDocuments(
-                    'database_' . $database->getSequence() . '_collection_' . $collection->getSequence(),
+                    $collectionTableId,
                     [$newDocument],
                     onNext: function (Document $document) use (&$upserted) {
                         $upserted[] = $document;
@@ -344,8 +345,10 @@ class Upsert extends Action
             });
         } catch (ConflictException) {
             throw new Exception($this->getConflictException());
-        } catch (DuplicateException) {
-            throw new Exception($this->getDuplicateException(), params: [$documentId]);
+        } catch (UniqueException $e) {
+            throw new Exception($this->getUniqueConstraintException(), previous: $e);
+        } catch (DuplicateException $e) {
+            throw new Exception($this->getDuplicateException(), previous: $e, params: [$documentId]);
         } catch (RelationshipException $e) {
             throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
         } catch (StructureException $e) {

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -6262,6 +6262,8 @@ trait DatabasesBase
         ]);
 
         $this->assertEquals(409, $duplicate['headers']['status-code']);
+        $this->assertEquals($this->getUniqueConstraintException(), $duplicate['body']['type']);
+        $this->assertStringNotContainsString('requested ID', $duplicate['body']['message']);
 
         // Test for exception when inserting new doc and then updating to conflict
         $document = $this->client->call(Client::METHOD_POST, $this->getRecordUrl($databaseId, $collectionId), array_merge([
@@ -6298,6 +6300,16 @@ trait DatabasesBase
         ]);
 
         $this->assertEquals(409, $duplicate['headers']['status-code']);
+        $this->assertEquals($this->getUniqueConstraintException(), $duplicate['body']['type']);
+        $this->assertStringNotContainsString('requested ID', $duplicate['body']['message']);
+
+    }
+
+    private function getUniqueConstraintException(): string
+    {
+        return $this->getRecordResource() === 'rows'
+            ? Exception::ROW_UNIQUE_CONSTRAINT_VIOLATION
+            : Exception::DOCUMENT_UNIQUE_CONSTRAINT_VIOLATION;
     }
 
     public function testPersistentCreatedAt(): void


### PR DESCRIPTION
## What does this PR do?

Splits document/row ID collisions from unique index violations so unique column collisions no longer tell users to change a valid row ID. This now relies on `utopia-php/database` 7.2.0, where `UniqueException` extends `DuplicateException` and is thrown for non-`_uid` unique-index violations.

```text
before: row_already_exists: Row with the requested ID 'dup3' already exists...
after:  row_unique_constraint_violation: Row violates a unique column constraint...
```

Actual ID collisions still return `document_already_exists` / `row_already_exists`.

## Test Plan

```text
composer lint app/config/errors.php src/Appwrite/Extend/Exception.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php tests/e2e/Services/Databases/DatabasesBase.php
composer analyze src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Action.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Update.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Upsert.php src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Bulk/Upsert.php tests/e2e/Services/Databases/DatabasesBase.php
```

Not run locally: Docker e2e suite.

## Related PRs and Issues

- Uses https://github.com/utopia-php/database/pull/733

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
