### PR TITLE
chore(deps): allow utopia-php/lock 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "utopia-php/validators": "^0.4",
         "utopia-php/image": "0.8.*",
         "utopia-php/locale": "0.8.*",
-        "utopia-php/lock": "0.2.*",
+        "utopia-php/lock": "0.3.*",
         "utopia-php/logger": "0.8.*",
         "utopia-php/messaging": "^2.0",
         "utopia-php/migration": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8f482127f1d48cb4026f35a161b15f5",
+    "content-hash": "4ad47c6924e38efc505314c491e8315e",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -4204,16 +4204,16 @@
         },
         {
             "name": "utopia-php/lock",
-            "version": "0.2.4",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/lock.git",
-                "reference": "49352091b93cc0400eeb2464c2aceb4203da14a3"
+                "reference": "ee39f161b79f79d6959b8f8c9502376b4e6f8575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/lock/zipball/49352091b93cc0400eeb2464c2aceb4203da14a3",
-                "reference": "49352091b93cc0400eeb2464c2aceb4203da14a3",
+                "url": "https://api.github.com/repos/utopia-php/lock/zipball/ee39f161b79f79d6959b8f8c9502376b4e6f8575",
+                "reference": "ee39f161b79f79d6959b8f8c9502376b4e6f8575",
                 "shasum": ""
             },
             "require": {
@@ -4246,9 +4246,9 @@
             "description": "A simple lock library to coordinate access to shared resources across coroutines, processes and hosts",
             "support": {
                 "issues": "https://github.com/utopia-php/lock/issues",
-                "source": "https://github.com/utopia-php/lock/tree/0.2.4"
+                "source": "https://github.com/utopia-php/lock/tree/0.3.0"
             },
-            "time": "2026-08-05T09:16:12+00:00"
+            "time": "2026-08-12T06:54:16+00:00"
         },
         {
             "name": "utopia-php/logger",
@@ -4725,22 +4725,22 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "ade5660eadcd042a313d1ed4aa25d260a2737b5c"
+                "reference": "869a75dbcfee027657e7fd61211d48120099985f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/ade5660eadcd042a313d1ed4aa25d260a2737b5c",
-                "reference": "ade5660eadcd042a313d1ed4aa25d260a2737b5c",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/869a75dbcfee027657e7fd61211d48120099985f",
+                "reference": "869a75dbcfee027657e7fd61211d48120099985f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.5",
                 "utopia-php/di": "^0.3",
-                "utopia-php/lock": "^0.2",
+                "utopia-php/lock": "^0.3",
                 "utopia-php/pools": "^2.0",
                 "utopia-php/servers": "^0.4",
                 "utopia-php/telemetry": "^0.4",
@@ -4783,9 +4783,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/1.1.4"
+                "source": "https://github.com/utopia-php/queue/tree/1.1.5"
             },
-            "time": "2026-08-10T04:51:03+00:00"
+            "time": "2026-08-12T11:57:15+00:00"
         },
         {
             "name": "utopia-php/registry",
@@ -5124,16 +5124,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "61832b7c863831466ccdeccd4e4f76a43765fbbf"
+                "reference": "a5b7b78b789e5af0a30f96da8355bbf48fb56699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/61832b7c863831466ccdeccd4e4f76a43765fbbf",
-                "reference": "61832b7c863831466ccdeccd4e4f76a43765fbbf",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/a5b7b78b789e5af0a30f96da8355bbf48fb56699",
+                "reference": "a5b7b78b789e5af0a30f96da8355bbf48fb56699",
                 "shasum": ""
             },
             "require": {
@@ -5158,9 +5158,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.4.1"
+                "source": "https://github.com/utopia-php/validators/tree/0.4.2"
             },
-            "time": "2026-08-10T04:15:37+00:00"
+            "time": "2026-08-11T07:43:49+00:00"
         },
         {
             "name": "utopia-php/vcs",


### PR DESCRIPTION
## Why

`utopia-php/lock` 0.3.0 added `DistributedLock::adopt()`, which lets a holder delegate token-guarded commands such as `refresh()` to an instance backed by a **different Redis connection**.

`appwrite/cloud` needs it to close a defect live in production: its lock refresher coroutine shares the action's borrowed Redis connection with the action itself, so two coroutines command one socket. That is a Swoole fatal which takes the worker process down with every in-flight message already popped, and the observed consequence is an acknowledged delete that tore nothing down, leaving compute running and billing.

Composer resolves the **intersection** of every constraint, so cloud cannot reach 0.3.0 while anything in its tree pins `0.2`. Three things did: cloud's root, this package, and `utopia-php/queue`. queue was widened in utopia-php/monorepo#128 and released as **1.1.5**. This is the second of the three.

## Why it is safe

`git diff 0.2.4 0.3.0` on the lock package is **123 insertions, 0 deletions**, across `README.md`, `src/Distributed.php` and `tests/DistributedTest.php`. The only functional change is the new `adopt()` method; nothing that already existed changed signature or behaviour.

## What moves

| Package | Before | After |
| --- | --- | --- |
| `utopia-php/lock` | 0.2.4 | 0.3.0 |
| `utopia-php/queue` | 1.1.4 | 1.1.5 |
| `utopia-php/validators` | 0.4.1 | 0.4.2 |

`queue` 1.1.5 is exactly 1.1.4 plus the same constraint widen. `validators` 0.4.1 to 0.4.2 makes `Identifier` reject a trailing newline.

## Verification

```
composer validate --no-check-publish --no-check-all
composer update utopia-php/lock utopia-php/queue -W
No security vulnerability advisories found.
```

Resolution required `--ignore-platform-req` for `ext-scrypt`, `ext-mongodb` and `ext-swoole`, which this host lacks; those are narrow per-extension ignores, never the blanket flag, so the runtime PHP version guard stays in place. CI is the gate for the suites.

## What follows

`appwrite/cloud` widens the same constraint and runs `composer update`. It tracks `appwrite/server-ce: main-dev`, so this merging to `main` is enough and no release is required here.