### PR TITLE
fix(account): deny JWT creation for JWT-authorized requests

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -397,6 +397,11 @@ return [
         'description' => 'JWT and cookie used in the same request. Use either `setJWT` or `setCookie`. Learn about which authentication method to use in the SSR docs: https://appwrite.io/docs/products/auth/server-side-rendering',
         'code' => 403,
     ],
+    Exception::USER_JWT_CREATION_DENIED => [
+        'name' => Exception::USER_JWT_CREATION_DENIED,
+        'description' => 'A JWT cannot be created from a request authorized with a JWT. Authenticate with a session cookie or session header instead.',
+        'code' => 403,
+    ],
     Exception::API_KEY_EXPIRED => [
         'name' => Exception::API_KEY_EXPIRED,
         'description' => 'The ephemeral API key has expired. Please don\'t use ephemeral API keys for more than duration of the execution.',

--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3219,7 +3219,7 @@ Http::post('/v1/account/jwts')
         group: 'tokens',
         name: 'createJWT',
         description: '/docs/references/account/create-jwt.md',
-        auth: [AuthType::ADMIN, AuthType::SESSION, AuthType::JWT],
+        auth: [AuthType::ADMIN, AuthType::SESSION],
         responses: [
             new SDKResponse(
                 code: Response::STATUS_CODE_CREATED,
@@ -3232,11 +3232,16 @@ Http::post('/v1/account/jwts')
     ->label('abuse-limit', APP_LIMIT_WRITE_RATE_DEFAULT * 2)
     ->label('abuse-time', APP_LIMIT_WRITE_RATE_PERIOD_DEFAULT)
     ->label('abuse-key', 'url:{url},userId:{userId}')
+    ->inject('request')
     ->inject('response')
     ->inject('user')
     ->inject('store')
     ->inject('proofForToken')
-    ->action(function (int $duration, Response $response, User $user, Store $store, ProofsToken $proofForToken) {
+    ->action(function (int $duration, Request $request, Response $response, User $user, Store $store, ProofsToken $proofForToken) {
+        if (!empty($request->getHeaderLine('x-appwrite-jwt', ''))) {
+            throw new Exception(Exception::USER_JWT_CREATION_DENIED);
+        }
+
         $sessionId = $user->sessionVerify($store->getProperty('secret', ''), $proofForToken);
 
         if (!$sessionId) {

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -116,6 +116,7 @@ class Exception extends \Exception
     public const string USER_TARGET_ALREADY_EXISTS = 'user_target_already_exists';
     public const string USER_API_KEY_AND_SESSION_SET = 'user_api_key_and_session_set';
     public const string USER_JWT_AND_COOKIE_SET = 'user_jwt_and_cookie_set';
+    public const string USER_JWT_CREATION_DENIED = 'user_jwt_creation_denied';
     public const string USER_ID_MISSING = 'user_id_missing';
 
     public const string API_KEY_EXPIRED = 'api_key_expired';

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -2762,6 +2762,17 @@ final class AccountCustomClientTest extends Scope
 
         $this->assertEquals(200, $response['headers']['status-code']);
 
+        // Ensure a JWT cannot be created from a request authorized with a JWT
+        $response = $this->client->call(Client::METHOD_POST, '/account/jwt', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-jwt' => $jwt,
+        ]));
+
+        $this->assertEquals(403, $response['headers']['status-code']);
+        $this->assertEquals('user_jwt_creation_denied', $response['body']['type']);
+
         $response = $this->client->call(Client::METHOD_DELETE, '/account/sessions/' . $sessionId, array_merge([
             'origin' => 'http://localhost',
             'content-type' => 'application/json',


### PR DESCRIPTION
## What does this PR do?

Rejects `POST /v1/account/jwts` when the request itself is authorized with a JWT (`X-Appwrite-JWT` header). Creating a JWT requires session authentication (cookie or session header); allowing a JWT to mint new JWTs would enable indefinite chaining past the original session's intent.

Previously this case failed anyway — a JWT-authorized request carries no session secret, so `sessionVerify` failed — but with a misleading `user_session_not_found` (404-style) error. It now fails explicitly:

- New exception `user_jwt_creation_denied` (403): "A JWT cannot be created from a request authorized with a JWT. Authenticate with a session cookie or session header instead."
- The endpoint checks for the `X-Appwrite-JWT` header before session verification.
- Removed `AuthType::JWT` from the endpoint's SDK auth types, since JWT auth is now explicitly unsupported here (it never worked).

Ordering with existing resource-level checks stays intact: an invalid JWT still yields `user_jwt_invalid` (401), JWT + cookie together still yields `user_jwt_and_cookie_set` (403), and a valid JWT alone now yields the new error.

## Test Plan

Extended `testCreateJWT` in `tests/e2e/Services/Account/AccountCustomClientTest.php`: after confirming a freshly created JWT authenticates `GET /account`, it attempts `POST /account/jwt` with that JWT and asserts a 403 with type `user_jwt_creation_denied`.

Run with:
```
docker compose exec appwrite test tests/e2e/Services/Account --filter=testCreateJWT
```

Pint and PHPStan pass on all changed files.

## Related PRs and Issues

None.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)