### PR TITLE
fix(response): match model defaults to their declared JSON type

### DIFF
--- a/src/Appwrite/Utopia/Response/Model/AlgoArgon2.php
+++ b/src/Appwrite/Utopia/Response/Model/AlgoArgon2.php
@@ -24,19 +24,19 @@ class AlgoArgon2 extends Model
             ->addRule('memoryCost', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Memory used to compute hash.',
-                'default' => '',
+                'default' => 0,
                 'example' => 65536,
             ])
             ->addRule('timeCost', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Amount of time consumed to compute hash',
-                'default' => '',
+                'default' => 0,
                 'example' => 4,
             ])
             ->addRule('threads', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Number of threads used to compute hash.',
-                'default' => '',
+                'default' => 0,
                 'example' => 3,
             ])
         ;

--- a/src/Appwrite/Utopia/Response/Model/Collection.php
+++ b/src/Appwrite/Utopia/Response/Model/Collection.php
@@ -31,7 +31,7 @@ class Collection extends Model
             ->addRule('$permissions', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Collection permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => [],
                 'example' => ['read("any")'],
                 'array' => true
             ])
@@ -56,7 +56,7 @@ class Collection extends Model
             ->addRule('documentSecurity', [
                 'type' => self::TYPE_BOOLEAN,
                 'description' => 'Whether document-level permissions are enabled. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => false,
                 'example' => true,
             ])
             ->addRule('attributes', [

--- a/src/Appwrite/Utopia/Response/Model/ConsoleVariables.php
+++ b/src/Appwrite/Utopia/Response/Model/ConsoleVariables.php
@@ -25,7 +25,7 @@ class ConsoleVariables extends Model
             ->addRule('_APP_COMPUTE_BUILD_TIMEOUT', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Maximum build timeout in seconds.',
-                'default' => '',
+                'default' => 0,
                 'example' => 900,
             ])
             ->addRule('_APP_DOMAIN_TARGET_AAAA', [
@@ -43,13 +43,13 @@ class ConsoleVariables extends Model
             ->addRule('_APP_STORAGE_LIMIT', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Maximum file size allowed for file upload in bytes.',
-                'default' => '',
+                'default' => 0,
                 'example' => '30000000',
             ])
             ->addRule('_APP_COMPUTE_SIZE_LIMIT', [
                 'type' => self::TYPE_INTEGER,
                 'description' => 'Maximum file size allowed for deployment in bytes.',
-                'default' => '',
+                'default' => 0,
                 'example' => '30000000',
             ])
             ->addRule('_APP_USAGE_STATS', [

--- a/src/Appwrite/Utopia/Response/Model/Document.php
+++ b/src/Appwrite/Utopia/Response/Model/Document.php
@@ -72,7 +72,7 @@ class Document extends Any
             ->addRule('$permissions', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Document permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => [],
                 'example' => ['read("any")'],
                 'array' => true,
             ]);

--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -34,7 +34,7 @@ class Execution extends Model
             ->addRule('$permissions', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Execution roles.',
-                'default' => '',
+                'default' => [],
                 'example' => [Role::any()->toString()],
                 'array' => true,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Framework.php
+++ b/src/Appwrite/Utopia/Response/Model/Framework.php
@@ -31,14 +31,14 @@ class Framework extends Model
             ->addRule('runtimes', [
                 'type' => self::TYPE_STRING,
                 'description' => 'List of supported runtime versions.',
-                'default' => '',
+                'default' => [],
                 'example' => ['static-1', 'node-22'],
                 'array' => true,
             ])
             ->addRule('adapters', [
                 'type' => Response::MODEL_FRAMEWORK_ADAPTER,
                 'description' => 'List of supported adapters.',
-                'default' => '',
+                'default' => [],
                 'example' => [[ 'key' => 'static', 'buildRuntime' => 'node-22', 'buildCommand' => 'npm run build', 'installCommand' => 'npm install', 'outputDirectory' => './dist' ]],
                 'array' => true,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Installation.php
+++ b/src/Appwrite/Utopia/Response/Model/Installation.php
@@ -31,14 +31,14 @@ class Installation extends Model
             ->addRule('provider', [
                 'type' => self::TYPE_STRING,
                 'description' => 'VCS (Version Control System) provider name.',
-                'default' => [],
+                'default' => '',
                 'example' => 'github',
                 'array' => false,
             ])
             ->addRule('organization', [
                 'type' => self::TYPE_STRING,
                 'description' => 'VCS (Version Control System) organization name.',
-                'default' => [],
+                'default' => '',
                 'example' => 'appwrite',
                 'array' => false,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Message.php
+++ b/src/Appwrite/Utopia/Response/Model/Message.php
@@ -39,21 +39,21 @@ class Message extends Model
             ->addRule('topics', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Topic IDs set as recipients.',
-                'default' => '',
+                'default' => [],
                 'array' => true,
                 'example' => ['5e5ea5c16897e'],
             ])
             ->addRule('users', [
                 'type' => self::TYPE_STRING,
                 'description' => 'User IDs set as recipients.',
-                'default' => '',
+                'default' => [],
                 'array' => true,
                 'example' => ['5e5ea5c16897e'],
             ])
             ->addRule('targets', [
                 'type' => self::TYPE_ENUM,
                 'description' => 'Target IDs set as recipients.',
-                'default' => '',
+                'default' => [],
                 'array' => true,
                 'example' => ['5e5ea5c16897e'],
             ])
@@ -75,7 +75,7 @@ class Message extends Model
                 'type' => self::TYPE_STRING,
                 'description' => 'Delivery errors if any.',
                 'required' => false,
-                'default' => '',
+                'default' => [],
                 'array' => true,
                 'example' => ['Failed to send message to target 5e5ea5c16897e: Credentials not valid.'],
             ])
@@ -88,7 +88,7 @@ class Message extends Model
             ->addRule('data', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Data of the message.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => [
                     'subject' => 'Welcome to Appwrite',
                     'content' => 'Hi there, welcome to Appwrite family.',

--- a/src/Appwrite/Utopia/Response/Model/Migration.php
+++ b/src/Appwrite/Utopia/Response/Model/Migration.php
@@ -126,13 +126,13 @@ class Migration extends Model
             ->addRule('statusCounters', [
                 'type' => self::TYPE_JSON,
                 'description' => 'A group of counters that represent the total progress of the migration.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => '{"Database": {"PENDING": 0, "SUCCESS": 1, "ERROR": 0, "SKIP": 0, "PROCESSING": 0, "WARNING": 0}}',
             ])
             ->addRule('resourceData', [
                 'type' => self::TYPE_JSON,
                 'description' => 'An array of objects containing the report data of the resources that were migrated.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => '[{"resource":"Database","id":"public","status":"SUCCESS","message":""}]',
             ])
             ->addRule('errors', [
@@ -145,7 +145,7 @@ class Migration extends Model
             ->addRule('options', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Migration options used during the migration process.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => '{"bucketId": "exports", "notify": false}',
             ])
         ;

--- a/src/Appwrite/Utopia/Response/Model/Presence.php
+++ b/src/Appwrite/Utopia/Response/Model/Presence.php
@@ -42,7 +42,7 @@ class Presence extends Model
             ->addRule('$permissions', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Presence permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => [],
                 'example' => ['read("any")'],
                 'array' => true,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Project.php
+++ b/src/Appwrite/Utopia/Response/Model/Project.php
@@ -156,7 +156,7 @@ class Project extends Model
             ->addRule('onboarding', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Stage progress (completed or skipped) with timestamps and actor types, keyed by stage id.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => [],
             ])
 

--- a/src/Appwrite/Utopia/Response/Model/Provider.php
+++ b/src/Appwrite/Utopia/Response/Model/Provider.php
@@ -55,7 +55,7 @@ class Provider extends Model
             ->addRule('credentials', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Provider credentials.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => [
                     'key' => '123456789'
                 ],
@@ -63,7 +63,7 @@ class Provider extends Model
             ->addRule('options', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Provider options.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'required' => false,
                 'example' => [
                     'from' => 'sender-email@mydomain'

--- a/src/Appwrite/Utopia/Response/Model/ProviderRepository.php
+++ b/src/Appwrite/Utopia/Response/Model/ProviderRepository.php
@@ -25,7 +25,7 @@ class ProviderRepository extends Model
             ->addRule('organization', [
                 'type' => self::TYPE_STRING,
                 'description' => 'VCS (Version Control System) organization name',
-                'default' => [],
+                'default' => '',
                 'example' => 'appwrite',
                 'array' => false,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Row.php
+++ b/src/Appwrite/Utopia/Response/Model/Row.php
@@ -72,7 +72,7 @@ class Row extends Any
             ->addRule('$permissions', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Row permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => [],
                 'example' => ['read("any")'],
                 'array' => true,
             ]);

--- a/src/Appwrite/Utopia/Response/Model/Runtime.php
+++ b/src/Appwrite/Utopia/Response/Model/Runtime.php
@@ -55,7 +55,7 @@ class Runtime extends Model
             ->addRule('supports', [
                 'type' => self::TYPE_STRING,
                 'description' => 'List of supported architectures.',
-                'default' => '',
+                'default' => [],
                 'example' => 'amd64',
                 'array' => true,
             ])

--- a/src/Appwrite/Utopia/Response/Model/Schedule.php
+++ b/src/Appwrite/Utopia/Response/Model/Schedule.php
@@ -61,7 +61,7 @@ class Schedule extends Model
             ->addRule('data', [
                 'type' => self::TYPE_JSON,
                 'description' => 'Schedule data used to store resource-specific context needed for execution.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => [],
             ])
             ->addRule('active', [

--- a/src/Appwrite/Utopia/Response/Model/Subscriber.php
+++ b/src/Appwrite/Utopia/Response/Model/Subscriber.php
@@ -37,7 +37,7 @@ class Subscriber extends Model
             ->addRule('target', [
                 'type' => Response::MODEL_TARGET,
                 'description' => 'Target.',
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => [
                     '$id' => '259125845563242502',
                     '$createdAt' => self::TYPE_DATETIME_EXAMPLE,

--- a/src/Appwrite/Utopia/Response/Model/Table.php
+++ b/src/Appwrite/Utopia/Response/Model/Table.php
@@ -32,7 +32,7 @@ class Table extends Model
             ->addRule('$permissions', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Table permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => [],
                 'example' => ['read("any")'],
                 'array' => true
             ])
@@ -57,7 +57,7 @@ class Table extends Model
             ->addRule('rowSecurity', [
                 'type' => self::TYPE_BOOLEAN,
                 'description' => 'Whether row-level permissions are enabled. [Learn more about permissions](https://appwrite.io/docs/permissions).',
-                'default' => '',
+                'default' => false,
                 'example' => true,
             ])
             ->addRule('columns', [

--- a/src/Appwrite/Utopia/Response/Model/UsageFunctions.php
+++ b/src/Appwrite/Utopia/Response/Model/UsageFunctions.php
@@ -79,7 +79,7 @@ class UsageFunctions extends Model
             ->addRule('functions', [
                 'type' => Response::MODEL_METRIC,
                 'description' => 'Aggregated number of functions per period.',
-                'default' => 0,
+                'default' => [],
                 'example' => 0,
                 'array' => true
             ])

--- a/src/Appwrite/Utopia/Response/Model/User.php
+++ b/src/Appwrite/Utopia/Response/Model/User.php
@@ -61,7 +61,7 @@ class User extends Model
                 ],
                 'description' => 'Password hashing algorithm configuration.',
                 'required' => false,
-                'default' => [],
+                'default' => new \stdClass(),
                 'example' => new \stdClass(),
                 'array' => false,
             ])

--- a/tests/unit/Utopia/Response/ModelDefaultTest.php
+++ b/tests/unit/Utopia/Response/ModelDefaultTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Response;
+
+use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Response\Model;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swoole\Http\Response as SwooleResponse;
+
+/**
+ * Every response model default must encode as the JSON type its rule declares.
+ *
+ * A rule's default is emitted whenever the attribute is absent from the
+ * document, so it ships to clients on freshly created resources. PHP encodes an
+ * empty array as `[]`, which means an object-shaped rule defaulting to `[]`
+ * sends a JSON array where the OpenAPI spec promises an object. Clients
+ * generated from that spec then fail to deserialize a response even though the
+ * request succeeded — this is what broke project creation, where a new project
+ * returned `"onboarding": []` for a field typed as an object.
+ *
+ * The check is deliberately shape-based rather than PHP-type-based: it encodes
+ * the default and compares the resulting JSON token to the shape the rule
+ * declares. That handles the cases a type check gets wrong, such as a non-empty
+ * associative array correctly encoding as an object.
+ */
+final class ModelDefaultTest extends TestCase
+{
+    private static ?Response $response = null;
+
+    /**
+     * Maps each scalar rule type to the JSON token its default must produce.
+     * Anything absent from this map is a model reference or a union of model
+     * references, both of which encode as objects.
+     */
+    private const SHAPES = [
+        Model::TYPE_STRING => 'string',
+        Model::TYPE_DATETIME => 'string',
+        Model::TYPE_ENUM => 'string',
+        Model::TYPE_ID => 'string',
+        Model::TYPE_PAYLOAD => 'string',
+        Model::TYPE_INTEGER => 'number',
+        Model::TYPE_FLOAT => 'number',
+        Model::TYPE_BOOLEAN => 'boolean',
+        Model::TYPE_JSON => 'object',
+        Model::TYPE_RELATIONSHIP => 'object',
+        Model::TYPE_ARRAY => 'array',
+    ];
+
+    #[DataProvider('provideModels')]
+    public function testRuleDefaultsMatchDeclaredJsonType(Model $model): void
+    {
+        $violations = [];
+
+        foreach ($model->getRules() as $name => $rule) {
+            if (! \array_key_exists('default', $rule)) {
+                continue;
+            }
+
+            $default = $rule['default'];
+
+            // A null default marks an optional field and encodes as null.
+            if ($default === null) {
+                continue;
+            }
+
+            $expected = self::expectedShape($rule);
+            $actual = self::jsonShape($default);
+
+            if ($actual !== $expected) {
+                $violations[] = \sprintf(
+                    '%s::%s declares %s so its default must encode as a JSON %s, but %s encodes as %s',
+                    $model->getName(),
+                    $name,
+                    self::describeType($rule['type'] ?? 'unknown'),
+                    $expected,
+                    \json_encode($default),
+                    $actual
+                );
+            }
+        }
+
+        $this->assertSame([], $violations, \sprintf(
+            "Response model defaults must encode as the JSON type they declare.\n" .
+            "Use new \\stdClass() for object-shaped rules so they encode as {} rather than [].\n\n%s\n",
+            \implode("\n", $violations)
+        ));
+    }
+
+    /**
+     * Guards the provider itself: an empty or partial model registry would let
+     * every case above pass without inspecting anything.
+     */
+    public function testProviderCoversTheModelRegistry(): void
+    {
+        $models = \iterator_to_array(self::provideModels());
+
+        $this->assertGreaterThan(100, \count($models), 'Expected the full response model registry.');
+        $this->assertArrayHasKey('project', $models);
+    }
+
+    /**
+     * Keyed by registry key rather than model name: names are not unique, as
+     * both Error/ErrorDev and the two Index models report the same name.
+     *
+     * @return iterable<string, array{Model}>
+     */
+    public static function provideModels(): iterable
+    {
+        foreach (self::response()->getModels() as $key => $model) {
+            // "Any" models carry no rules to validate.
+            if ($model->isAny()) {
+                continue;
+            }
+
+            yield $key => [$model];
+        }
+    }
+
+    /**
+     * The JSON token a rule's default is required to produce.
+     *
+     * @param array<string, mixed> $rule
+     */
+    private static function expectedShape(array $rule): string
+    {
+        if (($rule['array'] ?? false) === true) {
+            return 'array';
+        }
+
+        $type = $rule['type'] ?? null;
+
+        // A union of model references, e.g. user.hashOptions.
+        if (! \is_string($type)) {
+            return 'object';
+        }
+
+        // Unmapped types are model references, which encode as objects.
+        return self::SHAPES[$type] ?? 'object';
+    }
+
+    /**
+     * The JSON token a value actually encodes to.
+     */
+    private static function jsonShape(mixed $value): string
+    {
+        $encoded = \json_encode($value);
+
+        return match (true) {
+            \str_starts_with($encoded, '{') => 'object',
+            \str_starts_with($encoded, '[') => 'array',
+            \str_starts_with($encoded, '"') => 'string',
+            $encoded === 'true', $encoded === 'false' => 'boolean',
+            $encoded === 'null' => 'null',
+            default => 'number',
+        };
+    }
+
+    private static function describeType(mixed $type): string
+    {
+        return \is_array($type)
+            ? 'a union of ' . \count($type) . ' models'
+            : (string) $type;
+    }
+
+    private static function response(): Response
+    {
+        return self::$response ??= new Response(new SwooleResponse());
+    }
+}


### PR DESCRIPTION
## What

Response model rule defaults now encode as the JSON type their rule declares. Adds a generic test over every registered model so the class of bug cannot come back.

## Why

A rule's `default` is emitted whenever the attribute is absent from the document, so it ships to clients on freshly created resources. PHP encodes an empty array as `[]`, so an object-shaped rule defaulting to `[]` sends a JSON array where the spec promises an object.

Creating a project returned `"onboarding": []`, because a new project has no `onboarding` attribute yet and `Project::onboarding` is typed `TYPE_JSON` but defaulted to `[]`. Clients generated from the spec type that field as an object and fail to deserialize, so a request that Appwrite had already accepted surfaces to the caller as an error — which invites a retry of a completed mutation.

The tell is that the same project parses fine once any onboarding stage completes and the field becomes a real map. It only reproduces on freshly created resources, which is why it slipped through.

## Audit

Rather than grepping, this walks the live registry — all **289 registered models, 1203 rules** — and compares each default against its declared type. That also caught two inherited cases (`ProviderRepositoryFramework`, `ProviderRepositoryRuntime`) that static parsing missed.

**35 defaults across 20 models**, three variants of one mistake:

| Variant | Was | Now | Examples |
|---|---|---|---|
| Object-shaped rule | `[]` | `new \stdClass()` | `project.onboarding`, `message.data`, `schedule.data`, `provider.credentials`/`options`, `migration.statusCounters`/`resourceData`/`options`, `subscriber.target`, `user.hashOptions` |
| Array rule | `''` / `0` | `[]` | `$permissions` on Collection/Table/Row/Document/Execution/Presence, `message.topics`/`users`/`targets`/`deliveryErrors`, `runtime.supports`, `framework.runtimes`/`adapters`, `usageFunctions.functions` |
| Scalar rule | `''` | `false` / `0` | `collection.documentSecurity`, `table.rowSecurity`, `algoArgon2.memoryCost`/`timeCost`/`threads`, three `ConsoleVariables` integers |

## The test

`tests/unit/Utopia/Response/ModelDefaultTest.php` enforces one invariant: **a rule's default must encode as the JSON type it declares.**

The check is shape-based rather than PHP-type-based — it runs `json_encode` on the default and compares the resulting token to the shape the rule declares. That handles cases a type check gets wrong, such as a non-empty associative array correctly encoding as an object, with no special-casing.

It runs as a `#[DataProvider]` over models (286 cases, ~0.2s) so a failure names the offending model directly. A companion test asserts the registry actually loaded, so the cases cannot pass vacuously against an empty provider.

Verified it is not a rubber stamp — reintroducing both defect shapes fails with:

```
Project::onboarding declares json so its default must encode as a JSON object, but [] encodes as array
Table::rowSecurity declares boolean so its default must encode as a JSON boolean, but "" encodes as string
```

## Verification

- Rendering a `Project` response with no onboarding now emits `"onboarding":{}`, and that PHP-generated JSON hydrates in the generated client; previously it raised a validation error on `[]`.
- Full unit suite: 1336 tests pass. The two failures on this machine (`maxminddb` extension missing, unset JWT signing key) reproduce identically on a clean tree and are environmental.
- `composer lint` and `composer check` clean.
- **No spec regeneration required** — defaults are not emitted into the OpenAPI specs (verified: zero spec properties carry a `default`), so no generated SDK output changes.

## Follow-up, not fixed here

`migration.resourceData` is typed as an object and every creation path seeds it `'{}'`, so the default is correct — but its description and example still describe an array of objects. That is stale documentation worth a separate look.
