### PR TITLE
fix(databases): bump utopia-php/mongo to 1.5.3 and utopia-php/database to 7.2.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4416,16 +4416,16 @@
         },
         {
             "name": "utopia-php/mongo",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/mongo.git",
-                "reference": "20f9a644a356599fdd6265ba48696fc42a1f1881"
+                "reference": "be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/20f9a644a356599fdd6265ba48696fc42a1f1881",
-                "reference": "20f9a644a356599fdd6265ba48696fc42a1f1881",
+                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4",
+                "reference": "be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4",
                 "shasum": ""
             },
             "require": {
@@ -4471,9 +4471,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/mongo/issues",
-                "source": "https://github.com/utopia-php/mongo/tree/1.5.2"
+                "source": "https://github.com/utopia-php/mongo/tree/1.5.3"
             },
-            "time": "2026-08-12T06:57:25+00:00"
+            "time": "2026-08-13T01:55:11+00:00"
         },
         {
             "name": "utopia-php/platform",

--- a/composer.lock
+++ b/composer.lock
@@ -3638,16 +3638,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "7.1.4",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "b2b136a3827ccee2ea4eb83626348db4992286e1"
+                "reference": "38181c98e23b28c753f35cba6f03086a37033389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/b2b136a3827ccee2ea4eb83626348db4992286e1",
-                "reference": "b2b136a3827ccee2ea4eb83626348db4992286e1",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/38181c98e23b28c753f35cba6f03086a37033389",
+                "reference": "38181c98e23b28c753f35cba6f03086a37033389",
                 "shasum": ""
             },
             "require": {
@@ -3692,9 +3692,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/7.1.4"
+                "source": "https://github.com/utopia-php/database/tree/7.2.1"
             },
-            "time": "2026-08-12T09:39:29+00:00"
+            "time": "2026-08-13T02:26:08+00:00"
         },
         {
             "name": "utopia-php/detector",


### PR DESCRIPTION
Fixes #13175 — *BigInt[] Breaks MongoDb*.

## What users hit

Store an integer outside the int32 range in an array column on MongoDB, for example `[-3408048000]`, and the write succeeds. Every subsequent `listRows` on that table returns:

```json
{ "message": "Server Error", "code": 500, "type": "general_unknown" }
```

with `Cannot use object of type MongoDB\BSON\Int64 as array` in the logs. The table stays unusable in the Console until it is deleted. `[-42]` works, which is what made this look value-dependent rather than like a type bug.

## Cause

`MongoDB\BSON\Document::toPHP()` decodes every 64-bit BSON integer as a `MongoDB\BSON\Int64` wrapper, on all platforms. A small value encodes as int32 and decodes to a plain `int`; anything past int32 encodes as int64 and comes back as an object. utopia-php/mongo was handing those objects to callers.

Fixed at the decode boundary in utopia-php/mongo#49.

## What this bumps

Lock only, two packages, no `composer.json` change:

| Package | From | To | Why |
|---|---|---|---|
| `utopia-php/mongo` | 1.5.2 | 1.5.3 | the fix itself (utopia-php/mongo#49) |
| `utopia-php/database` | 7.1.4 | 7.2.1 | regression coverage (utopia-php/database#936) |

Both references match their tags: `be29ee2d` is #49's merge commit, `38181c98` is the 7.2.1 tag and the merge of #936.

**Wider than the int64 fix, worth a reviewer's attention:** 7.1.4 → 7.2.1 also carries utopia-php/database#733, which classifies unique violations by the violated key instead of matching on the driver's message string. That touches `src` across MariaDB, MySQL, Postgres, SQLite, Memory and Redis adapters. It is unrelated to this issue and rides along with the version bump.

## On the reported "write should have been rejected"

The issue also expected `-3408048000` to be rejected by an `integer` column. That part is not a bug. An integer column created without explicit `min`/`max` gets `size = 8`, so it is a 64-bit column and the value is legal. `Structure` does range-validate array elements when a narrower `max` is set. Only the read path was broken, so no validation change here.

## Where the regression tests live

Deliberately not in this repo: utopia-php/database#936, now shipped in 7.2.1. Two tests there, both **seen red** before 1.5.3 and green after:

- `sum()` returned the aggregate total raw against a `float|int` return type, so any total past int32 was a `TypeError`.
- Object attributes have no per-key schema to cast against, so the wrapper reached the response and serialised as `{"$numberLong":"-3408048000"}` instead of a number.

Typed `integer`/`bigint` attributes were already surviving, because `castingAfter()` applies `(int)` and ext-mongodb 2.x gives `Int64` a numeric cast handler. The two paths above were the real leaks, and they are adapter-level behaviour, so the adapter suite is where they belong. Duplicating that as an appwrite e2e test would be slower coverage of a dependency bug at the most expensive layer.

## Not verified

- **No local e2e run.** Lock-only change; I did not stand up the full appwrite stack and am relying on CI. End-to-end proof for the int64 fix is in utopia-php/database#936, run against the real released 1.5.3: full `MongoDBTest`, 663 tests, 4997 assertions, 0 failures, plus the two new tests green on all six adapters and in schemaless and shared-tables modes.
- **The unique-violation change from #733.** I did not review or exercise it; it arrives with the version bump and its own CI passed in the database repo.
- **32-bit PHP.** 1.5.3 keeps the wrapper there on purpose, as the only lossless representation. No repo in the chain has a 32-bit CI target.