### PR TITLE
test(migrations): follow a migrated function execution to completion

### DIFF
--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -2223,7 +2223,14 @@ trait MigrationsBase
             'functionId' => ID::unique(),
             'name' => 'Test',
             'runtime' => 'node-22',
-            'entrypoint' => 'index.js'
+            'entrypoint' => 'index.js',
+            // The timeout is the executor's WHOLE budget, not the time the code gets: it is
+            // passed straight through as `timeout:` and the executor spends it starting a
+            // cold runtime before the handler runs. The migration copies it to the
+            // destination, where the execution below is that function's first ever run, so
+            // the default 15s is charged to a cold start on a docker-in-docker daemon --
+            // ten seconds was already measured as too little for that in CI.
+            'timeout' => 60
         ]);
 
         $deploymentId = $this->setupDeployment($functionId, [
@@ -2314,8 +2321,9 @@ trait MigrationsBase
             'body' => 'test'
         ]);
 
-        $this->assertEquals(201, $execution['headers']['status-code']);
-        $this->assertStringContainsString('body-is-test', $execution['body']['logs']);
+        $this->assertEquals(201, $execution['headers']['status-code'], 'Execution was not created: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
+        $this->assertSame('completed', $execution['body']['status'], 'Execution did not complete: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
+        $this->assertStringContainsString('body-is-test', (string) $execution['body']['logs'], 'Execution completed without the logs it printed: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
 
         // Cleanup
         $this->client->call(Client::METHOD_DELETE, '/functions/' . $functionId, [

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use Tests\E2E\Client;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Services\Functions\FunctionsBase;
+use Tests\E2E\Services\Realtime\RealtimeBase;
 use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
@@ -17,11 +18,14 @@ use Utopia\Database\Helpers\Role;
 use Utopia\Database\Query;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Sources\Appwrite;
+use WebSocket\ConnectionException;
+use WebSocket\TimeoutException;
 
 trait MigrationsBase
 {
     use ProjectCustom;
     use FunctionsBase;
+    use RealtimeBase;
 
     /**
      * @var array
@@ -56,6 +60,18 @@ trait MigrationsBase
         self::$project = $projectBackup;
 
         return self::$destinationProject;
+    }
+
+    public function getDestinationUser(bool $fresh = false): array
+    {
+        $project = self::$project;
+        self::$project = $this->getDestinationProject();
+
+        try {
+            return $this->getUser($fresh);
+        } finally {
+            self::$project = $project;
+        }
     }
 
     /**
@@ -2223,14 +2239,8 @@ trait MigrationsBase
             'functionId' => ID::unique(),
             'name' => 'Test',
             'runtime' => 'node-22',
-            'entrypoint' => 'index.js',
-            // The timeout is the executor's WHOLE budget, not the time the code gets: it is
-            // passed straight through as `timeout:` and the executor spends it starting a
-            // cold runtime before the handler runs. The migration copies it to the
-            // destination, where the execution below is that function's first ever run, so
-            // the default 15s is charged to a cold start on a docker-in-docker daemon --
-            // ten seconds was already measured as too little for that in CI.
-            'timeout' => 60
+            'execute' => [Role::users()->toString()],
+            'entrypoint' => 'index.js'
         ]);
 
         $deploymentId = $this->setupDeployment($functionId, [
@@ -2280,6 +2290,7 @@ trait MigrationsBase
         $this->assertEquals('Test', $response['body']['name']);
         $this->assertEquals('node-22', $response['body']['runtime']);
         $this->assertEquals('index.js', $response['body']['entrypoint']);
+        $this->assertSame([Role::users()->toString()], $response['body']['execute']);
 
 
         $this->assertEventually(function () use ($functionId) {
@@ -2312,18 +2323,84 @@ trait MigrationsBase
             );
         }, 100000, 500);
 
-        // Attempt execution
-        $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', [
-            'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getDestinationProject()['$id'],
-            'x-appwrite-key' => $this->getDestinationProject()['apiKey'],
-        ], [
-            'body' => 'test'
-        ]);
+        $destinationProject = $this->getDestinationProject();
+        $destinationUser = $this->getDestinationUser(true);
+        $realtime = $this->getWebsocket(
+            channels: ['executions'],
+            headers: [
+                'origin' => 'http://localhost',
+                'cookie' => 'a_session_' . $destinationProject['$id'] . '=' . $destinationUser['session'],
+            ],
+            projectId: $destinationProject['$id'],
+            timeout: 2,
+        );
+        $completedExecution = null;
+        $lastMessage = null;
 
-        $this->assertEquals(201, $execution['headers']['status-code'], 'Execution was not created: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
-        $this->assertSame('completed', $execution['body']['status'], 'Execution did not complete: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
-        $this->assertStringContainsString('body-is-test', (string) $execution['body']['logs'], 'Execution completed without the logs it printed: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
+        try {
+            $connected = json_decode($realtime->receive(), true);
+
+            $this->assertSame('connected', $connected['type'] ?? null, 'Realtime did not connect: ' . json_encode($connected, JSON_PRETTY_PRINT));
+            $this->assertContains('executions', $connected['data']['channels'] ?? [], 'Realtime did not subscribe to executions: ' . json_encode($connected, JSON_PRETTY_PRINT));
+
+            $execution = $this->client->call(Client::METHOD_POST, '/functions/' . $functionId . '/executions', [
+                'content-type' => 'application/json',
+                'origin' => 'http://localhost',
+                'x-appwrite-project' => $destinationProject['$id'],
+                'cookie' => 'a_session_' . $destinationProject['$id'] . '=' . $destinationUser['session'],
+            ], [
+                'async' => true,
+                'body' => 'test'
+            ]);
+
+            $this->assertSame(202, $execution['headers']['status-code'], 'Execution was not accepted: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
+            $this->assertSame('waiting', $execution['body']['status'], 'Execution was not queued: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
+            $this->assertNotEmpty($execution['body']['$id'], 'Accepted execution has no ID: ' . json_encode($execution['body'], JSON_PRETTY_PRINT));
+
+            $executionId = $execution['body']['$id'];
+            $deadline = microtime(true) + (int) $response['body']['timeout'] + 15;
+
+            while (microtime(true) < $deadline) {
+                try {
+                    $message = json_decode($realtime->receive(), true);
+                } catch (TimeoutException) {
+                    continue;
+                } catch (ConnectionException $exception) {
+                    $this->fail('Realtime closed before the execution completed: ' . $exception->getMessage());
+                }
+
+                if (!is_array($message)) {
+                    continue;
+                }
+
+                $lastMessage = $message;
+                if (
+                    ($message['type'] ?? null) === 'event'
+                    && in_array("functions.{$functionId}.executions.{$executionId}.update", $message['data']['events'] ?? [], true)
+                ) {
+                    $payload = $message['data']['payload'] ?? null;
+                    $this->assertIsArray($payload, 'Execution update has no payload: ' . json_encode($message, JSON_PRETTY_PRINT));
+                    $this->assertSame($executionId, $payload['$id'] ?? null, 'Realtime returned a different execution: ' . json_encode($payload, JSON_PRETTY_PRINT));
+                    $this->assertSame($functionId, $payload['functionId'] ?? null, 'Execution ran a different function: ' . json_encode($payload, JSON_PRETTY_PRINT));
+
+                    if (($payload['status'] ?? null) === 'failed') {
+                        $this->fail('Execution failed: ' . json_encode($payload['errors'] ?? $payload, JSON_PRETTY_PRINT));
+                    }
+
+                    if (($payload['status'] ?? null) === 'completed') {
+                        $completedExecution = $payload;
+                        break;
+                    }
+                }
+            }
+        } finally {
+            $realtime->close();
+        }
+
+        $this->assertIsArray($completedExecution, 'Timed out waiting for the terminal execution event. Last message: ' . json_encode($lastMessage, JSON_PRETTY_PRINT));
+        $this->assertSame('completed', $completedExecution['status'], 'Execution did not complete: ' . json_encode($completedExecution, JSON_PRETTY_PRINT));
+        $this->assertSame(200, $completedExecution['responseStatusCode'], 'Execution returned an unexpected status: ' . json_encode($completedExecution, JSON_PRETTY_PRINT));
+        $this->assertStringContainsString('body-is-test', (string) $completedExecution['logs'], 'Execution completed without the logs it printed: ' . json_encode($completedExecution, JSON_PRETTY_PRINT));
 
         // Cleanup
         $this->client->call(Client::METHOD_DELETE, '/functions/' . $functionId, [


### PR DESCRIPTION
## What

`Tests\E2E\Services\Migrations\MigrationsConsoleClientTest::testAppwriteMigrationFunction` intermittently fails in the downstream Cloud Kind lane after migrating a function to the destination project.

The genuine pre-fix red is Cloud workflow run `31589275737`, job `94090602962`, `Tests / CE / E2E / Migrations (dedicated)`. The function test ran for 31.647s and was the only failure in a 69-test / 3014-assertion lane:

```
Failed asserting that '' [ASCII](length: 0) contains "body-is-test" [ASCII](length: 12).
tests/e2e/Services/Migrations/MigrationsBase.php:2318
```

## Root cause

The earlier 60-second fixture-timeout approach did not match the API contract. The synchronous create-execution route always calls the executor with `requestTimeout: 30`, so increasing the function timeout cannot give that HTTP request a 60-second budget.

The supported cold-start-safe contract is asynchronous:

1. `POST /functions/{functionId}/executions` with `async=true` returns 202, a real execution ID, and `status=waiting` before dispatching the function worker.
2. The function worker calls the executor without the synchronous route's 30-second request override, so the executor uses the migrated function timeout plus its 15-second transport allowance.
3. Server CE exposes no execution-read route. For an authorized session, the worker publishes the exact terminal execution update over the public Realtime `executions` channel, including status, response status, logs, and errors. Asynchronous executions intentionally do not expose a response body.

An intermediate candidate incorrectly attempted the unavailable execution-read route. Exact-head workflow run `31708864484`, job `94476757868`, failed with the real 404 and drove the Realtime correction rather than a fallback or edition-specific branch.

## Change

- Preserve and assert the migrated `execute=[users]` permission needed for an authorized destination-project subscriber.
- Create a destination-project user session, subscribe to `executions`, and require the Realtime `connected` frame before submitting work.
- Require the async create response to be 202 / waiting with a non-empty execution ID.
- Wait only until the migrated function timeout plus the executor's 15-second transport allowance.
- Match the exact function/execution update event and validate both IDs in its payload.
- Fail immediately with execution errors on `failed`; otherwise require `completed`, response status 200, and the original `body-is-test` log.

There is no skip, blanket retry, timeout inflation, response-body fiction, product/controller change, or Cloud dependency change. The log assertion remains strict, so a real logs-loss regression still fails.

## Verification

Local focused gates on exact head `f230c64d62318f9c595b184d01d2ecc74aa17a29`:

- `php -l tests/e2e/Services/Migrations/MigrationsBase.php`
- `composer lint -- tests/e2e/Services/Migrations/MigrationsBase.php`
- `composer analyze -- tests/e2e/Services/Migrations/MigrationsBase.php`
- `composer refactor:check -- tests/e2e/Services/Migrations/MigrationsBase.php`
- `git diff --check`

All pass. Full-repository local gates are not claimed: full Pint exceeded Composer's 300-second process limit, full PHPStan reports 232 dependency/API baseline errors, and full Rector reports the unrelated existing `AttributesTest.php` `assertEquals`/`assertSame` change.

The mandatory runtime gate for this head is GitHub's `Tests / E2E / PostgreSQL (dedicated) / Migrations`, which runs this trait end-to-end on a 60GB runner. A fresh isolated Cloud Kind attempt could not start the test because the local Docker VM reached its 128GB disk cap while pulling the stack; that partial cluster was removed API-first and then deleted, with no Cloud source or Composer lock change committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
