### PR TITLE
fix(tests): retry transient request catcher failures

### DIFF
--- a/tests/e2e/Scopes/Scope.php
+++ b/tests/e2e/Scopes/Scope.php
@@ -343,9 +343,12 @@ abstract class Scope extends TestCase
         }
 
         $query = http_build_query($queryParams);
+        $url = 'http://' . $hostname . ':5000/__find_request__?' . $query;
 
-        for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
-            $requests = json_decode(file_get_contents('http://' . $hostname . ':5000/__find_request__?' . $query), true);
+        for ($attempt = 0; $attempt <= $maxAttempts; $attempt++) {
+            $response = @file_get_contents($url);
+            $requests = is_string($response) ? json_decode($response, true) : [];
+
             if (is_array($requests)) {
                 for ($i = count($requests) - 1; $i >= 0; $i--) {
                     $request = $this->decodeRequestData($requests[$i]);
@@ -369,30 +372,8 @@ abstract class Scope extends TestCase
                 }
             }
 
-            usleep($delayMs * 1000);
-        }
-
-        $requests = json_decode(file_get_contents('http://' . $hostname . ':5000/__find_request__?' . $query), true);
-        if (is_array($requests)) {
-            for ($i = count($requests) - 1; $i >= 0; $i--) {
-                $request = $this->decodeRequestData($requests[$i]);
-                if ($probe !== null) {
-                    try {
-                        $probe($request);
-                        return $request;
-                    } catch (\Throwable $error) {
-                        continue;
-                    }
-                }
-
-                if ($enforceProjectId) {
-                    $requestProjectId = $request['headers']['X-Appwrite-Webhook-Project-Id'] ?? '';
-                    if ($requestProjectId === $projectId) {
-                        return $request;
-                    }
-                } else {
-                    return $request;
-                }
+            if ($attempt < $maxAttempts) {
+                usleep($delayMs * 1000);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Makes request-catcher polling tolerate transient HTTP failures. `file_get_contents()` can return `false`; passing that value directly to `json_decode()` caused webhook E2E tests to fail before their retry loop could continue.

```text
before: transient read failure -> TypeError
now:    transient read failure -> next polling attempt
```

It also removes the duplicated final polling pass while preserving the same 11 total attempts.

## Test Plan

- `php -l tests/e2e/Scopes/Scope.php`
- `composer lint tests/e2e/Scopes/Scope.php`
- `composer refactor:check`

## Related PRs and Issues

- Follow-up to the flaky ProjectWebhooks failure observed on #13127: https://github.com/appwrite/appwrite/actions/runs/31673716088/job/94363863575

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
