### PR TITLE
Generate a unified OpenAPI specification

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -73,8 +73,9 @@ jobs:
           # Create or checkout the feature branch
           git checkout -b "${GIT_BRANCH}" || git checkout "${GIT_BRANCH}"
 
-          # Copy spec files
+          # Replace the legacy platform specs with the unified spec
           mkdir -p "specs/${VERSION}"
+          rm -f specs/${VERSION}/open-api3-${VERSION}-*.json
           cp ${GITHUB_WORKSPACE}/${SPECS_DIR}/*${VERSION}*.json "specs/${VERSION}/" 2>/dev/null || true
 
           # Copy latest specs if version is latest

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -26,6 +26,7 @@ use Appwrite\SDK\Language\Swift;
 use Appwrite\SDK\Language\Unity;
 use Appwrite\SDK\Language\Web;
 use Appwrite\SDK\SDK;
+use Appwrite\SDK\Specification\Platform as PlatformSpecification;
 use Appwrite\Spec\OpenAPI3;
 use Appwrite\Spec\StaticSpec;
 use CzProject\GitPhp\Git;
@@ -311,13 +312,26 @@ class SDKs extends Action
                 } else {
                     Console::log('  Fetching API spec...');
 
-                    $specPath = __DIR__ . '/../../../../app/config/specs/open-api3-' . $version . '-' . $language['family'] . '.json';
+                    $specPath = __DIR__ . '/../../../../app/config/specs/open-api3-' . $version . '.json';
 
                     if (!file_exists($specPath)) {
                         throw new \Exception('Spec file not found: ' . $specPath . '. Please run "docker compose exec appwrite specs --version=' . $version . '" first to generate the specs.');
                     }
 
-                    $spec = file_get_contents($specPath);
+                    $contents = file_get_contents($specPath);
+                    if ($contents === false) {
+                        throw new \Exception('Failed to read spec file: ' . $specPath . '.');
+                    }
+
+                    $decoded = \json_decode($contents, true);
+                    if (!\is_array($decoded)) {
+                        throw new \Exception('Failed to decode spec file: ' . $specPath . '.');
+                    }
+
+                    $spec = \json_encode(PlatformSpecification::filter($decoded, $language['family']));
+                    if ($spec === false) {
+                        throw new \Exception('Failed to encode spec file: ' . $specPath . '.');
+                    }
                 }
 
                 $cover = 'https://github.com/appwrite/appwrite/raw/main/public/images/github.png';

--- a/src/Appwrite/Platform/Tasks/Specs.php
+++ b/src/Appwrite/Platform/Tasks/Specs.php
@@ -81,7 +81,7 @@ class Specs extends Action
     }
 
     /**
-     * Platforms to include in PR creation.
+     * SDK example platforms to include in PR creation.
      * Override in a subclass to exclude specific platforms.
      *
      * @return array<string>
@@ -577,6 +577,54 @@ class Specs extends Action
         return $sdkPlatforms;
     }
 
+    /**
+     * @return array<string>
+     */
+    protected function getSDKPlatformsForMethod(Method $method): array
+    {
+        $platforms = \array_values(\array_unique($this->getSDKPlatformsForRouteSecurity($method->getAuth())));
+        $hide = $method->isHidden();
+
+        if ($hide === true) {
+            return [];
+        }
+
+        if (\is_array($hide)) {
+            $platforms = \array_values(\array_diff($platforms, $hide));
+        }
+
+        return $platforms;
+    }
+
+    /**
+     * Merge platform security schemes into the canonical OpenAPI component.
+     * Platform-specific definitions are retained as extension overrides when
+     * two platforms use the same scheme name differently.
+     *
+     * @param array<string, array<string, array<string, mixed>>> $platformKeys
+     * @return array<string, array<string, mixed>>
+     */
+    protected function mergeKeys(array $platformKeys): array
+    {
+        $keys = [];
+        $definitions = [];
+
+        foreach ($platformKeys as $platform => $schemes) {
+            foreach ($schemes as $name => $scheme) {
+                if (!isset($keys[$name])) {
+                    $keys[$name] = $scheme;
+                    $definitions[$name] = $scheme;
+                } elseif ($definitions[$name] !== $scheme) {
+                    $keys[$name]['x-appwrite']['overrides'][$platform] = $scheme;
+                }
+
+                $keys[$name]['x-appwrite']['platforms'][] = $platform;
+            }
+        }
+
+        return $keys;
+    }
+
     public function action(string $version, string $mode, ?string $git, ?string $message, ?string $branch): void
     {
         if (\is_null($git)) {
@@ -612,7 +660,104 @@ class Specs extends Action
 
         $platforms = static::getPlatforms();
         $authCounts = $this->getAuthCounts();
-        $keys = $this->getKeys();
+        $platformKeys = $this->getKeys();
+        $keys = $this->mergeKeys($platformKeys);
+        $routes = [];
+        $services = [];
+        $routeNamespaces = [];
+
+        foreach ($appRoutes as $method) {
+            foreach ($method as $route) {
+                $sdks = $route->getLabel('sdk', false);
+
+                if (empty($sdks) || !$route->getLabel('docs', true)) {
+                    continue;
+                }
+
+                if ($route->getLabel('mock', false) !== $mocks) {
+                    continue;
+                }
+
+                if (!\is_array($sdks)) {
+                    $sdks = [$sdks];
+                }
+
+                $include = false;
+                foreach ($sdks as $sdk) {
+                    /** @var Method $sdk */
+                    if (empty($sdk->getNamespace()) || empty($this->getSDKPlatformsForMethod($sdk))) {
+                        continue;
+                    }
+
+                    $include = true;
+                    $routeNamespaces[$sdk->getNamespace()] = true;
+                }
+
+                if ($include) {
+                    $routes[] = $route;
+                }
+            }
+        }
+
+        /**
+         * Tag names must match Method namespaces (path tags), e.g. tablesDB.
+         * Service config keys stay lowercase (tablesdb); descriptions resolve
+         * case-insensitively from services.php.
+         */
+        $serviceDescriptions = [];
+        $configuredServices = [];
+
+        foreach (Config::getParam('services', []) as $service) {
+            $serviceKey = $service['key'] ?? '';
+            if ($serviceKey === '') {
+                continue;
+            }
+
+            $serviceDescriptions[\strtolower($serviceKey)] = $service['subtitle'] ?? '';
+
+            if (
+                !isset($service['docs'])
+                || !isset($service['sdk'])
+                || !$service['docs']
+                || !$service['sdk']
+                || empty(\array_intersect($platforms, $service['platforms'] ?? []))
+            ) {
+                continue;
+            }
+
+            $configuredServices[$serviceKey] = $service['subtitle'] ?? '';
+        }
+
+        $seenServices = [];
+        foreach (\array_keys($routeNamespaces) as $namespace) {
+            $services[] = [
+                'name' => $namespace,
+                'description' => $serviceDescriptions[\strtolower($namespace)] ?? '',
+            ];
+            $seenServices[\strtolower($namespace)] = true;
+        }
+
+        foreach ($configuredServices as $serviceKey => $description) {
+            if (isset($seenServices[\strtolower($serviceKey)])) {
+                continue;
+            }
+
+            $services[] = [
+                'name' => $serviceKey,
+                'description' => $description,
+            ];
+        }
+
+        $arguments = [
+            $specsContainer,
+            $services,
+            $routes,
+            $response->getModels(),
+            $keys,
+            0,
+            '',
+            fn (array $security): array => $this->getSDKPlatformsForRouteSecurity($security),
+        ];
 
         $generatedFiles = [];
         $endpoint = System::getEnv('_APP_HOME', 'https://appwrite.io');
@@ -623,187 +768,59 @@ class Specs extends Action
             throw new Exception('Failed to create specs directory: ' . $specsDir);
         }
 
-        foreach ($platforms as $platform) {
-            $routes = [];
-            $models = [];
-            $services = [];
-            $routeNamespaces = [];
+        foreach (['open-api3'] as $format) {
+            $formatInstance = $this->getFormatInstance($format, $arguments);
+            $specs = new Specification($formatInstance);
 
-            foreach ($appRoutes as $key => $method) {
-                foreach ($method as $route) {
-                    $sdks = $route->getLabel('sdk', false);
+            $formatInstance
+                ->setParam('name', APP_NAME)
+                ->setParam('description', 'Appwrite backend as a service cuts up to 70% of the time and costs required for building a modern application. We abstract and simplify common development tasks behind a REST APIs, to help you develop your app in a fast and secure way. For full API documentation and tutorials go to [https://appwrite.io/docs](https://appwrite.io/docs)')
+                ->setParam('endpoint', 'https://cloud.appwrite.io/v1')
+                ->setParam('endpoint.docs', 'https://<REGION>.cloud.appwrite.io/v1')
+                ->setParam('version', APP_VERSION_STABLE)
+                ->setParam('terms', $endpoint . '/policy/terms')
+                ->setParam('support.email', $email)
+                ->setParam('support.url', $endpoint . '/support')
+                ->setParam('contact.name', APP_NAME . ' Team')
+                ->setParam('contact.email', $email)
+                ->setParam('contact.url', $endpoint . '/support')
+                ->setParam('license.name', 'BSD-3-Clause')
+                ->setParam('license.url', 'https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE')
+                ->setParam('docs.description', 'Full API docs, specs and tutorials')
+                ->setParam('docs.url', $endpoint . '/docs');
 
-                    if (empty($sdks)) {
-                        continue;
-                    }
+            $path = $mocks
+                ? $specsDir . '/' . $format . '-mocks.json'
+                : $specsDir . '/' . $format . '-' . $version . '.json';
 
-                    if (!\is_array($sdks)) {
-                        $sdks = [$sdks];
-                    }
-
-                    foreach ($sdks as $sdk) {
-                        /** @var Method $sdk */
-                        $hide = $sdk->isHidden();
-
-                        if ($hide === true || (\is_array($hide) && \in_array($platform, $hide))) {
-                            continue;
-                        }
-
-                        $routeSecurity = $sdk->getAuth();
-                        $sdkPlatforms = $this->getSDKPlatformsForRouteSecurity($routeSecurity);
-
-                        if (!$route->getLabel('docs', true)) {
-                            continue;
-                        }
-
-                        if ($route->getLabel('mock', false) && !$mocks) {
-                            continue;
-                        }
-
-                        if (!$route->getLabel('mock', false) && $mocks) {
-                            continue;
-                        }
-
-                        if (empty($sdk->getNamespace())) {
-                            continue;
-                        }
-
-                        if (!\in_array($platform, $sdkPlatforms)) {
-                            continue;
-                        }
-
-                        $routes[] = $route;
-                        $routeNamespaces[$sdk->getNamespace()] = true;
-                    }
-                }
+            try {
+                $parsedSpecs = $specs->parse();
+                $parsedSpecs['x-appwrite']['platforms'] = \array_map(
+                    fn (string $platform): array => [
+                        'authCount' => $authCounts[$platform] ?? 0,
+                        'securitySchemes' => \array_keys($platformKeys[$platform] ?? []),
+                    ],
+                    \array_combine($platforms, $platforms),
+                );
+                $this->verifyParsedSpec($parsedSpecs);
+            } catch (\RuntimeException $e) {
+                Console::error("Spec generation failed ({$format}): " . $e->getMessage());
+                Console::exit(1);
+                return;
             }
 
-            /**
-             * Tag names must match Method namespaces (path tags), e.g. tablesDB.
-             * Service config keys stay lowercase (tablesdb); descriptions resolve
-             * case-insensitively from services.php.
-             */
-            $serviceDescriptions = [];
-            $configuredServices = [];
+            $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);
 
-            foreach (Config::getParam('services', []) as $service) {
-                $serviceKey = $service['key'] ?? '';
-                if ($serviceKey === '') {
-                    continue;
-                }
-
-                $serviceDescriptions[\strtolower($serviceKey)] = $service['subtitle'] ?? '';
-
-                if (
-                    !isset($service['docs']) // Skip service if not part of the public API
-                    || !isset($service['sdk'])
-                    || !$service['docs']
-                    || !$service['sdk']
-                ) {
-                    continue;
-                }
-
-                // Check if current platform is included in service's platforms
-                if (!\in_array($platform, $service['platforms'] ?? [])) {
-                    continue;
-                }
-
-                $configuredServices[$serviceKey] = $service['subtitle'] ?? '';
+            if ($encodedSpecs === false) {
+                throw new Exception('Failed to encode ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . \json_last_error_msg());
             }
 
-            $seenServices = [];
-
-            foreach (\array_keys($routeNamespaces) as $namespace) {
-                $services[] = [
-                    'name' => $namespace,
-                    'description' => $serviceDescriptions[\strtolower($namespace)] ?? '',
-                ];
-                $seenServices[\strtolower($namespace)] = true;
+            if (\file_put_contents($path, $encodedSpecs) === false) {
+                throw new Exception('Failed to save ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . $path);
             }
 
-            foreach ($configuredServices as $serviceKey => $description) {
-                if (isset($seenServices[\strtolower($serviceKey)])) {
-                    continue;
-                }
-
-                $services[] = [
-                    'name' => $serviceKey,
-                    'description' => $description,
-                ];
-            }
-
-            $models = $response->getModels();
-
-            foreach ($models as $key => $value) {
-                if ($platform !== APP_SDK_PLATFORM_CONSOLE && !$value->isPublic()) {
-                    unset($models[$key]);
-                }
-            }
-
-            $arguments = [
-                $specsContainer,
-                $services,
-                $routes,
-                $models,
-                $keys[$platform],
-                $authCounts[$platform] ?? 0,
-                $platform
-            ];
-
-            foreach (['open-api3'] as $format) {
-                $formatInstance = $this->getFormatInstance($format, $arguments);
-                $specs = new Specification($formatInstance);
-
-                $formatInstance
-                    ->setParam('name', APP_NAME)
-                    ->setParam('description', 'Appwrite backend as a service cuts up to 70% of the time and costs required for building a modern application. We abstract and simplify common development tasks behind a REST APIs, to help you develop your app in a fast and secure way. For full API documentation and tutorials go to [https://appwrite.io/docs](https://appwrite.io/docs)')
-                    ->setParam('endpoint', 'https://cloud.appwrite.io/v1')
-                    ->setParam('endpoint.docs', 'https://<REGION>.cloud.appwrite.io/v1')
-                    ->setParam('version', APP_VERSION_STABLE)
-                    ->setParam('terms', $endpoint . '/policy/terms')
-                    ->setParam('support.email', $email)
-                    ->setParam('support.url', $endpoint . '/support')
-                    ->setParam('contact.name', APP_NAME . ' Team')
-                    ->setParam('contact.email', $email)
-                    ->setParam('contact.url', $endpoint . '/support')
-                    ->setParam('license.name', 'BSD-3-Clause')
-                    ->setParam('license.url', 'https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE')
-                    ->setParam('docs.description', 'Full API docs, specs and tutorials')
-                    ->setParam('docs.url', $endpoint . '/docs');
-
-                $path = $mocks
-                    ? $specsDir . '/' . $format . '-mocks-' . $platform . '.json'
-                    : $specsDir . '/' . $format . '-' . $version . '-' . $platform . '.json';
-
-                try {
-                    $parsedSpecs = $specs->parse();
-                    $this->verifyParsedSpec($parsedSpecs);
-                } catch (\RuntimeException $e) {
-                    // A throw is reported and carried on from, so stop here
-                    Console::error("Spec generation failed for {$platform} ({$format}): " . $e->getMessage());
-                    Console::exit(1);
-                    return;
-                }
-
-                $encodedSpecs = \json_encode($parsedSpecs, JSON_PRETTY_PRINT);
-
-                unset($parsedSpecs);
-
-                if ($encodedSpecs === false) {
-                    throw new Exception('Failed to encode ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . \json_last_error_msg());
-                }
-
-                if (\file_put_contents($path, $encodedSpecs) === false) {
-                    throw new Exception('Failed to save ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . $path);
-                }
-
-                $generatedFiles[] = realpath($path);
-                Console::success('Saved ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . realpath($path));
-
-                unset($encodedSpecs, $specs, $formatInstance);
-            }
-
-            unset($arguments, $models, $routes, $services);
+            $generatedFiles[] = realpath($path);
+            Console::success('Saved ' . ($mocks ? 'mocks ' : '') . 'spec file: ' . realpath($path));
         }
 
         if ($git === 'yes') {
@@ -833,18 +850,13 @@ class Specs extends Action
 
             // Copy generated spec files into specs/{version}/ subdirectory
             $prPlatforms = static::getPlatformsForPR();
-            $prFiles = \array_filter(
-                $generatedFiles,
-                fn (string $file) => \in_array(
-                    \substr(\basename($file, '.json'), \strrpos(\basename($file, '.json'), '-') + 1),
-                    $prPlatforms,
-                    true
-                )
-            );
-
             $specsSubDir = $mocks ? 'mocks' : $version;
             \exec('mkdir -p ' . \escapeshellarg("{$target}/specs/{$specsSubDir}"));
-            foreach ($prFiles as $file) {
+            $legacyPattern = $mocks ? 'open-api3-mocks-*.json' : "open-api3-{$version}-*.json";
+            foreach (\glob("{$target}/specs/{$specsSubDir}/{$legacyPattern}") ?: [] as $legacyFile) {
+                \unlink($legacyFile);
+            }
+            foreach ($generatedFiles as $file) {
                 $fileName = \basename($file);
                 \exec('cp ' . \escapeshellarg($file) . ' ' . \escapeshellarg("{$target}/specs/{$specsSubDir}/{$fileName}"));
                 Console::success("Copied spec file to repo: specs/{$specsSubDir}/{$fileName}");

--- a/src/Appwrite/SDK/Specification/Format.php
+++ b/src/Appwrite/SDK/Specification/Format.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK\Specification;
 
+use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\Utopia\Response\Model;
 use Utopia\DI\Container;
@@ -25,6 +26,8 @@ abstract class Format
     protected array $keys;
     protected int $authCount;
     protected string $platform;
+    /** @var callable(array): array<string> */
+    protected $platformsForSecurity;
     protected array $params = [
         'name' => '',
         'description' => '',
@@ -41,8 +44,16 @@ abstract class Format
         'license.url' => '',
     ];
 
-    public function __construct(Container $container, array $services, array $routes, array $models, array $keys, int $authCount, string $platform)
-    {
+    public function __construct(
+        Container $container,
+        array $services,
+        array $routes,
+        array $models,
+        array $keys,
+        int $authCount,
+        string $platform,
+        ?callable $platformsForSecurity = null,
+    ) {
         $this->container = $container;
         $this->services = $services;
         $this->routes = $routes;
@@ -50,6 +61,34 @@ abstract class Format
         $this->keys = $keys;
         $this->authCount = $authCount;
         $this->platform = $platform;
+        $this->platformsForSecurity = $platformsForSecurity ?? function (array $security): array {
+            $platforms = [];
+
+            foreach ($security as $type) {
+                switch ($type) {
+                    case AuthType::SESSION:
+                        $platforms[] = APP_SDK_PLATFORM_CLIENT;
+                        break;
+                    case AuthType::JWT:
+                    case AuthType::KEY:
+                        $platforms[] = APP_SDK_PLATFORM_SERVER;
+                        break;
+                    case AuthType::ADMIN:
+                        $platforms[] = APP_SDK_PLATFORM_CONSOLE;
+                        break;
+                }
+            }
+
+            return $platforms;
+        };
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getPlatformsForSecurity(array $security): array
+    {
+        return ($this->platformsForSecurity)($security);
     }
 
     /**

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -2,7 +2,6 @@
 
 namespace Appwrite\SDK\Specification\Format;
 
-use Appwrite\Platform\Tasks\Specs;
 use Appwrite\SDK\AuthType;
 use Appwrite\SDK\ContentType;
 use Appwrite\SDK\Method;
@@ -128,10 +127,8 @@ class OpenAPI3 extends Format
             $produces = ($sdk->getContentType())->value;
             $routeSecurity = $sdk->getAuth();
 
-            $specs = new Specs();
-            $sdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($routeSecurity);
-
-            $sdkPlatforms = array_values(array_unique($sdkPlatforms));
+            $sdkPlatforms = \array_values(\array_unique($this->getPlatformsForSecurity($sdk->getAuth())));
+            $availablePlatforms = $this->getMethodPlatforms($sdk);
             $namespace = $sdk->getNamespace();
 
             $descContents = $this->getDescriptionContents($desc);
@@ -159,6 +156,14 @@ class OpenAPI3 extends Format
                 ],
             ];
 
+            if ($availablePlatforms !== $sdkPlatforms) {
+                $temp['x-appwrite']['available-platforms'] = $availablePlatforms;
+            }
+
+            if ($sdk->getType() === MethodType::LOCATION && !empty($sdk->getLocationAuth())) {
+                $temp['x-appwrite']['location-auth'] = $sdk->getLocationAuth();
+            }
+
             if ($sdk->getDescriptionFilePath() !== null) {
                 $temp['x-appwrite']['edit'] = 'https://github.com/appwrite/appwrite/edit/master' . $sdk->getDescription();
             }
@@ -176,10 +181,10 @@ class OpenAPI3 extends Format
                     /** @var Method $methodObj */
                     $desc = $methodObj->getDescriptionFilePath();
 
-                    $methodSecurities = $methodObj->getAuth();
-                    $methodSdkPlatforms = $specs->getSDKPlatformsForRouteSecurity($methodSecurities);
+                    $methodSdkPlatforms = \array_values(\array_unique($this->getPlatformsForSecurity($methodObj->getAuth())));
+                    $methodAvailablePlatforms = $this->getMethodPlatforms($methodObj);
 
-                    if (!\in_array($this->platform, $methodSdkPlatforms)) {
+                    if (empty($methodAvailablePlatforms)) {
                         continue;
                     }
 
@@ -194,7 +199,8 @@ class OpenAPI3 extends Format
                         'name' => $methodObj->getMethodName(),
                         'namespace' => $methodObj->getNamespace(),
                         'desc' => $methodObj->getDesc(),
-                        'auth' => \array_slice($methodSecurities, 0, $this->authCount),
+                        'auth' => $methodSecurities,
+                        'platforms' => $methodSdkPlatforms,
                         'parameters' => [],
                         'required' => [],
                         'responses' => [],
@@ -202,6 +208,10 @@ class OpenAPI3 extends Format
                         'demo' => \strtolower($namespace) . '/' . Template::fromCamelCaseToDash($methodObj->getMethodName()) . '.md',
                         'public' => $methodObj->isPublic(),
                     ];
+
+                    if ($methodAvailablePlatforms !== $methodSdkPlatforms) {
+                        $additionalMethod['available-platforms'] = $methodAvailablePlatforms;
+                    }
 
                     // add deprecation only if method has it!
                     if ($methodObj->getDeprecated()) {
@@ -267,6 +277,16 @@ class OpenAPI3 extends Format
                     }
 
                     $temp['x-appwrite']['methods'][] = $additionalMethod;
+                    $availablePlatforms = \array_values(\array_unique(\array_merge(
+                        $temp['x-appwrite']['available-platforms'] ?? $temp['x-appwrite']['platforms'],
+                        $methodAvailablePlatforms,
+                    )));
+
+                    if ($availablePlatforms !== $temp['x-appwrite']['platforms']) {
+                        $temp['x-appwrite']['available-platforms'] = $availablePlatforms;
+                    } else {
+                        unset($temp['x-appwrite']['available-platforms']);
+                    }
                 }
             }
 
@@ -407,7 +427,7 @@ class OpenAPI3 extends Format
                     }
                 }
 
-                $temp['x-appwrite']['auth'] = array_slice($securities, 0, $this->authCount);
+                $temp['x-appwrite']['auth'] = $securities;
 
                 if ($sdk->getType() === MethodType::LOCATION) {
                     foreach ($sdk->getLocationAuth() as $key) {
@@ -1116,5 +1136,24 @@ class OpenAPI3 extends Format
         \ksort($output['paths']);
 
         return $output;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMethodPlatforms(Method $method): array
+    {
+        $platforms = \array_values(\array_unique($this->getPlatformsForSecurity($method->getAuth())));
+        $hide = $method->isHidden();
+
+        if ($hide === true) {
+            return [];
+        }
+
+        if (\is_array($hide)) {
+            $platforms = \array_values(\array_diff($platforms, $hide));
+        }
+
+        return $platforms;
     }
 }

--- a/src/Appwrite/SDK/Specification/Platform.php
+++ b/src/Appwrite/SDK/Specification/Platform.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Appwrite\SDK\Specification;
+
+class Platform
+{
+    private const HTTP_METHODS = [
+        'delete',
+        'get',
+        'head',
+        'options',
+        'patch',
+        'post',
+        'put',
+        'trace',
+    ];
+
+    /**
+     * Create the platform view consumed by existing SDK generator releases.
+     *
+     * @param array<string, mixed> $spec
+     * @return array<string, mixed>
+     */
+    public static function filter(array $spec, string $platform): array
+    {
+        $platformConfig = $spec['x-appwrite']['platforms'][$platform] ?? [];
+        $authCount = $platformConfig['authCount'] ?? 0;
+        $securitySchemes = [];
+        $schemes = $spec['components']['securitySchemes'] ?? [];
+        $schemeNames = $platformConfig['securitySchemes'] ?? \array_keys($schemes);
+
+        foreach ($schemeNames as $name) {
+            $scheme = $schemes[$name] ?? null;
+            if (!\is_array($scheme)) {
+                continue;
+            }
+
+            $platforms = $scheme['x-appwrite']['platforms'] ?? [];
+            if (!\in_array($platform, $platforms, true)) {
+                continue;
+            }
+
+            $override = $scheme['x-appwrite']['overrides'][$platform] ?? null;
+            if (\is_array($override)) {
+                $metadata = $scheme['x-appwrite'];
+                unset($metadata['platforms'], $metadata['overrides']);
+                if (!empty($metadata)) {
+                    $override['x-appwrite'] = \array_merge($metadata, $override['x-appwrite'] ?? []);
+                }
+                $scheme = $override;
+            } else {
+                unset($scheme['x-appwrite']['platforms'], $scheme['x-appwrite']['overrides']);
+                if (empty($scheme['x-appwrite'])) {
+                    unset($scheme['x-appwrite']);
+                }
+            }
+
+            $securitySchemes[$name] = $scheme;
+        }
+
+        $spec['components']['securitySchemes'] = $securitySchemes;
+        $securityNames = \array_fill_keys(\array_keys($securitySchemes), true);
+
+        foreach ($spec['paths'] ?? [] as $path => $pathItem) {
+            foreach ($pathItem as $method => $operation) {
+                if (!\in_array($method, self::HTTP_METHODS, true)) {
+                    continue;
+                }
+
+                $platforms = $operation['x-appwrite']['available-platforms']
+                    ?? $operation['x-appwrite']['platforms']
+                    ?? [];
+                if (!empty($platforms) && !\in_array($platform, $platforms, true)) {
+                    unset($spec['paths'][$path][$method]);
+                    continue;
+                }
+                unset($operation['x-appwrite']['available-platforms']);
+
+                $methods = $operation['x-appwrite']['methods'] ?? null;
+                if (\is_array($methods)) {
+                    $methods = \array_values(\array_filter(
+                        $methods,
+                        fn (array $item): bool => \in_array(
+                            $platform,
+                            $item['available-platforms'] ?? $item['platforms'] ?? [],
+                            true,
+                        ),
+                    ));
+
+                    if (empty($methods)) {
+                        unset($spec['paths'][$path][$method]);
+                        continue;
+                    }
+
+                    foreach ($methods as &$item) {
+                        $item['auth'] = self::filterAuth($item['auth'] ?? [], $securityNames, $authCount);
+                        unset($item['platforms'], $item['available-platforms']);
+                    }
+                    unset($item);
+
+                    $operation['x-appwrite']['methods'] = $methods;
+                }
+
+                $operation['x-appwrite']['auth'] = self::filterAuth(
+                    $operation['x-appwrite']['auth'] ?? [],
+                    $securityNames,
+                    $authCount,
+                );
+
+                foreach ($operation['x-appwrite']['location-auth'] ?? [] as $name) {
+                    if (isset($securityNames[$name])) {
+                        $operation['x-appwrite']['auth'][$name] = [];
+                    }
+                }
+                unset($operation['x-appwrite']['location-auth']);
+
+                foreach ($operation['security'] ?? [] as $index => $security) {
+                    $operation['security'][$index] = \array_intersect_key($security, $securityNames);
+                }
+
+                $spec['paths'][$path][$method] = $operation;
+            }
+
+            if (empty($spec['paths'][$path])) {
+                unset($spec['paths'][$path]);
+            }
+        }
+
+        return $spec;
+    }
+
+    /**
+     * @param array<string, mixed> $auth
+     * @param array<string, bool> $securityNames
+     * @return array<string, mixed>
+     */
+    private static function filterAuth(array $auth, array $securityNames, int $count): array
+    {
+        return \array_slice(\array_intersect_key($auth, $securityNames), 0, $count, true);
+    }
+}

--- a/tests/unit/SDK/Specification/PlatformTest.php
+++ b/tests/unit/SDK/Specification/PlatformTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Unit\SDK\Specification;
+
+use Appwrite\SDK\Specification\Platform;
+use PHPUnit\Framework\TestCase;
+
+final class PlatformTest extends TestCase
+{
+    public function testFiltersOperationsMethodsAuthenticationAndSecuritySchemes(): void
+    {
+        $spec = [
+            'x-appwrite' => [
+                'platforms' => [
+                    'client' => [
+                        'authCount' => 1,
+                        'securitySchemes' => ['Project', 'Session'],
+                    ],
+                    'server' => [
+                        'authCount' => 2,
+                        'securitySchemes' => ['Project', 'Key'],
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/account' => [
+                    'get' => [
+                        'x-appwrite' => [
+                            'platforms' => ['client', 'server'],
+                            'auth' => [
+                                'Project' => [],
+                                'Session' => [],
+                                'Key' => [],
+                            ],
+                            'methods' => [
+                                [
+                                    'name' => 'get',
+                                    'platforms' => ['client'],
+                                    'auth' => [
+                                        'Project' => [],
+                                        'Session' => [],
+                                    ],
+                                ],
+                                [
+                                    'name' => 'get',
+                                    'platforms' => ['server'],
+                                    'auth' => [
+                                        'Project' => [],
+                                        'Key' => [],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'security' => [[
+                            'Project' => [],
+                            'Session' => [],
+                            'Key' => [],
+                        ]],
+                    ],
+                ],
+                '/users' => [
+                    'get' => [
+                        'x-appwrite' => [
+                            'platforms' => ['server'],
+                            'auth' => [
+                                'Project' => [],
+                                'Key' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'Session' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Appwrite-Session',
+                        'x-appwrite' => ['platforms' => ['client']],
+                    ],
+                    'Project' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Appwrite-Project',
+                        'x-appwrite' => ['platforms' => ['client', 'server']],
+                    ],
+                    'Key' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Appwrite-Key',
+                        'x-appwrite' => ['platforms' => ['server']],
+                    ],
+                ],
+            ],
+        ];
+
+        $client = Platform::filter($spec, 'client');
+        $operation = $client['paths']['/account']['get'];
+
+        $this->assertArrayNotHasKey('/users', $client['paths']);
+        $this->assertSame(['Project', 'Session'], \array_keys($client['components']['securitySchemes']));
+        $this->assertSame(['Project'], \array_keys($operation['x-appwrite']['auth']));
+        $this->assertSame(['Project', 'Session'], \array_keys($operation['security'][0]));
+        $this->assertCount(1, $operation['x-appwrite']['methods']);
+        $this->assertSame('get', $operation['x-appwrite']['methods'][0]['name']);
+        $this->assertSame(['Project'], \array_keys($operation['x-appwrite']['methods'][0]['auth']));
+    }
+
+    public function testAppliesPlatformSecuritySchemeOverride(): void
+    {
+        $spec = [
+            'x-appwrite' => [
+                'platforms' => [
+                    'manager' => ['authCount' => 1],
+                ],
+            ],
+            'paths' => [],
+            'components' => [
+                'securitySchemes' => [
+                    'Key' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Appwrite-Key',
+                        'x-appwrite' => [
+                            'platforms' => ['server', 'manager'],
+                            'overrides' => [
+                                'manager' => [
+                                    'type' => 'http',
+                                    'scheme' => 'bearer',
+                                    'bearerFormat' => 'JWT',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $manager = Platform::filter($spec, 'manager');
+
+        $this->assertSame([
+            'type' => 'http',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT',
+        ], $manager['components']['securitySchemes']['Key']);
+    }
+}

--- a/tests/unit/SDK/Specification/PlatformTest.php
+++ b/tests/unit/SDK/Specification/PlatformTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\SDK\Specification;
 
 use Appwrite\SDK\Specification\Platform;


### PR DESCRIPTION
## What does this PR do?

Generates one canonical OpenAPI document and keeps platform differences in `x-appwrite` metadata. Existing SDK generation projects the document to the requested platform before passing it to the current SDK generator.

```text
before: open-api3-latest-{client,server,console}.json
after:  open-api3-latest.json
```

The specs workflow also removes the legacy platform files when publishing the unified document.

## Test Plan

- Generated normal and mock specs locally.
- Validated the unified document with `swagger-cli`.
- Compared SDK generator snapshots for client, server, and console; all inputs matched the legacy specs.
- Compared generated Web, Node, and PHP SDK output; no differences.
- Generated Cloud specs and the manager PHP SDK using the platform security override.
- Ran PHPUnit, Pint, and PHPStan on the changed specification code.

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
