### PR TITLE
Include schema in table creation response

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Create.php
@@ -258,6 +258,9 @@ class Create extends Action
         $dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $collection->getId());
         $dbForProject->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $collection->getSequence());
 
+        // Reload the collection so its subquery filters include the schema created above.
+        $collection = $authorization->skip(fn () => $dbForProject->getDocument($databaseKey, $collection->getId()));
+
         $queueForEvents
             ->setContext('database', $database)
             ->setParam('databaseId', $databaseId)

--- a/tests/e2e/Services/Databases/TablesDB/TablesDBColumnsTest.php
+++ b/tests/e2e/Services/Databases/TablesDB/TablesDBColumnsTest.php
@@ -55,9 +55,22 @@ final class TablesDBColumnsTest extends Scope
                 ['key' => 'address', 'type' => 'ip'],
                 ['key' => 'status', 'type' => 'enum', 'elements' => ['on', 'off'], 'default' => 'on'],
             ],
+            'indexes' => [
+                ['key' => 'slug_unique', 'type' => 'unique', 'attributes' => ['slug']],
+            ],
         ]);
 
         $this->assertEquals(201, $table['headers']['status-code']);
+        $this->assertCount(9, $table['body']['columns']);
+        $columnKeys = array_column($table['body']['columns'], 'key');
+        sort($columnKeys);
+        $this->assertEquals(
+            ['address', 'archive', 'email', 'modulePath', 'slug', 'status', 'summary', 'title', 'website'],
+            $columnKeys,
+        );
+        $this->assertCount(1, $table['body']['indexes']);
+        $this->assertEquals('slug_unique', $table['body']['indexes'][0]['key']);
+        $this->assertEquals('available', $table['body']['indexes'][0]['status']);
         $tableId = $table['body']['$id'];
 
         $columns = $this->client->call(Client::METHOD_GET, '/tablesdb/' . $databaseId . '/tables/' . $tableId . '/columns', $headers);


### PR DESCRIPTION
## What does this PR do?

Reloads a newly created table after writing its inline column and index metadata. This lets the schema subquery filters hydrate the create response instead of returning empty arrays.

```text
before: create table -> "columns": [], "indexes": []
after:  create table -> requested columns and indexes
```

Adds regression coverage for inline columns and a unique index in the immediate response.

## Test Plan

- Pint formatting check
- PHP syntax checks
- PHPStan analysis
- Added E2E assertions for the create-table response; the local E2E suite was not run because the API container was stopped

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
