### PR TITLE
fix(project): deny key creation for key-authorized requests

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1216,6 +1216,11 @@ return [
         'description' => 'Key with the same ID already exists. Try again with a different ID.',
         'code' => 409,
     ],
+    Exception::KEY_CREATION_DENIED => [
+        'name' => Exception::KEY_CREATION_DENIED,
+        'description' => 'An API key cannot be created from a request authorized with an API key. Authenticate with a session instead. To create a short-lived key from a server, use the ephemeral key endpoint.',
+        'code' => 403,
+    ],
     Exception::DEV_KEY_GONE => [
         'name' => Exception::DEV_KEY_GONE,
         'description' => 'Dev key creation is no longer available.',

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -335,6 +335,7 @@ class Exception extends \Exception
     /** Keys */
     public const string KEY_NOT_FOUND = 'key_not_found';
     public const string KEY_ALREADY_EXISTS = 'key_already_exists';
+    public const string KEY_CREATION_DENIED = 'key_creation_denied';
 
     /** Dev Keys */
     public const string DEV_KEY_GONE = 'dev_key_gone';

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Keys/Create.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Platform\Modules\Project\Http\Project\Keys;
 
+use Appwrite\Auth\Key;
 use Appwrite\Event\Event as QueueEvent;
 use Appwrite\Extend\Exception;
 use Appwrite\Platform\Action;
@@ -55,7 +56,7 @@ class Create extends Base
                 
                 You can also create an ephemeral API key if you need a short-lived key instead.
                 EOT,
-                auth: [AuthType::ADMIN, AuthType::KEY],
+                auth: [AuthType::ADMIN],
                 responses: [
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
@@ -72,6 +73,7 @@ class Create extends Base
             ->inject('dbForPlatform')
             ->inject('project')
             ->inject('authorization')
+            ->inject('apiKey')
             ->callback($this->action(...));
     }
 
@@ -85,7 +87,13 @@ class Create extends Base
         Database $dbForPlatform,
         Document $project,
         Authorization $authorization,
+        ?Key $apiKey,
     ) {
+        // Dynamic supported for backwards compatibility
+        if ($apiKey !== null && \in_array($apiKey->getType(), [API_KEY_STANDARD, API_KEY_EPHEMERAL, 'dynamic'], true)) {
+            throw new Exception(Exception::KEY_CREATION_DENIED);
+        }
+
         $keyId = ($keyId == 'unique()') ? ID::unique() : $keyId;
 
         $key = new Document([

--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -2575,8 +2575,11 @@ trait MigrationsBase
             'x-appwrite-key' => $this->getDestinationProject()['apiKey'],
         ];
 
-        // Create API key on source project
-        $response = $this->client->call(Client::METHOD_POST, '/project/keys', $sourceHeaders, [
+        // Create API key on source project (key creation is denied for key-authorized requests)
+        $response = $this->client->call(Client::METHOD_POST, '/project/keys', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
             'keyId' => ID::unique(),
             'name' => 'Test API Key',
             'scopes' => ['databases.read', 'databases.write'],

--- a/tests/e2e/Services/Project/KeysBase.php
+++ b/tests/e2e/Services/Project/KeysBase.php
@@ -99,8 +99,11 @@ trait KeysBase
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
             'x-appwrite-response-format' => '1.9.0',
+            // Key creation is denied for key-authorized requests, so always use a console session
+            'origin' => 'http://localhost',
+            'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+            'x-appwrite-mode' => 'admin',
         ];
-        $headers = array_merge($headers, $this->getHeaders());
 
         $key = $this->client->call(Client::METHOD_POST, '/project/keys', $headers, [
             'keyId' => ID::unique(),
@@ -237,6 +240,40 @@ trait KeysBase
 
         // Cleanup
         $this->deleteKey($customId);
+    }
+
+    public function testCreateKeyRequiresSession(): void
+    {
+        // A request authorized with a standard API key cannot create a key
+        $response = $this->client->call(Client::METHOD_POST, '/project/keys', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'keyId' => ID::unique(),
+            'name' => 'Key Made By Key',
+            'scopes' => ['users.read'],
+        ]);
+
+        $this->assertSame(403, $response['headers']['status-code']);
+        $this->assertSame('key_creation_denied', $response['body']['type']);
+
+        // A request authorized with an ephemeral key cannot create a key either
+        $ephemeral = $this->createEphemeralKey(['keys.read', 'keys.write'], 900);
+        $this->assertSame(201, $ephemeral['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/project/keys', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $ephemeral['body']['secret'],
+        ], [
+            'keyId' => ID::unique(),
+            'name' => 'Key Made By Ephemeral Key',
+            'scopes' => ['users.read'],
+        ]);
+
+        $this->assertSame(403, $response['headers']['status-code']);
+        $this->assertSame('key_creation_denied', $response['body']['type']);
     }
 
     // =========================================================================
@@ -890,7 +927,12 @@ trait KeysBase
         ];
 
         if ($authenticated) {
-            $headers = array_merge($headers, $this->getHeaders());
+            // Key creation is denied for key-authorized requests, so always use a console session
+            $headers = array_merge($headers, [
+                'origin' => 'http://localhost',
+                'cookie' => 'a_session_console=' . $this->getRoot()['session'],
+                'x-appwrite-mode' => 'admin',
+            ]);
         }
 
         return $this->client->call(Client::METHOD_POST, '/project/keys', $headers, $params);


### PR DESCRIPTION
## What does this PR do?

Rejects `POST /v1/project/keys` (and its `POST /v1/projects/:projectId/keys` alias) when the request itself is authorized with a project API key (`X-Appwrite-Key` header). Creating a persistent API key now requires session authentication (console session in admin mode); allowing a key holding the `keys.write` scope to mint new keys would enable indefinite credential chaining — including an ephemeral key escalating itself into a persistent one.

Inspired by #13190, which applied the same rule to JWTs on `POST /v1/account/jwts`.

- New exception `key_creation_denied` (403): "An API key cannot be created from a request authorized with an API key. Authenticate with a session instead. To create a short-lived key from a server, use the ephemeral key endpoint."
- The endpoint checks the injected `apiKey` and denies project key types (`standard`, `ephemeral`, and the legacy `dynamic`). Organization and account keys are unaffected, as they are team/user credentials rather than project keys.
- Removed `AuthType::KEY` from the endpoint's SDK auth types, since key auth is now explicitly unsupported here.
- `POST /v1/project/keys/ephemeral` intentionally keeps key auth — that is the supported way for a server to derive short-lived credentials, and ephemeral keys cannot outlive or out-scope their origin.

## Test Plan

- Added `testCreateKeyRequiresSession` to `tests/e2e/Services/Project/KeysBase.php`: attempts key creation authorized with a standard key and with an ephemeral key (both holding `keys.write`), asserting 403 with type `key_creation_denied`. Runs in both the console and server suites.
- Updated the `createKey` helper (and the v22 backward-compat test) in `KeysBase` to always create keys with a console session, so the rest of the suite keeps its coverage under `KeysCustomServerTest`.
- Updated `testAppwriteMigrationApiKey` in `tests/e2e/Services/Migrations/MigrationsBase.php` to create the source key with a session; the migration itself and key listing via key auth are unchanged (the migration worker writes destination keys directly to the platform database, so migrations are unaffected by this change).

Run with:
```
docker compose exec appwrite test tests/e2e/Services/Project/KeysConsoleClientTest.php
docker compose exec appwrite test tests/e2e/Services/Project/KeysCustomServerTest.php
docker compose exec appwrite test tests/e2e/Services/Migrations --filter=testAppwriteMigrationApiKey
```

All pass locally. Pint, PHPStan, and Rector pass on all changed files.

## Related PRs and Issues

- #13190

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)