### PR TITLE
Use resource ID in execution responses

### DIFF
--- a/src/Appwrite/Messaging/Adapter/Realtime.php
+++ b/src/Appwrite/Messaging/Adapter/Realtime.php
@@ -915,7 +915,7 @@ class Realtime extends MessagingAdapter
                         $channels[] = 'projects.' . $project->getId();
                         $channels[] = 'executions';
                         $channels[] = 'executions.' . $payload->getId();
-                        $channels[] = 'functions.' . $payload->getAttribute('functionId');
+                        $channels[] = 'functions.' . $payload->getAttribute('resourceId');
                         $roles = $payload->getRead();
                     }
                 } elseif ($parts[2] === 'deployments') {

--- a/src/Appwrite/Utopia/Response/Filters/V27.php
+++ b/src/Appwrite/Utopia/Response/Filters/V27.php
@@ -11,10 +11,22 @@ class V27 extends Filter
     public function parse(array $content, string $model): array
     {
         return match ($model) {
+            Response::MODEL_EXECUTION => $this->parseExecution($content),
+            Response::MODEL_EXECUTION_LIST => $this->handleList($content, 'executions', fn ($item) => $this->parseExecution($item)),
             Response::MODEL_MIGRATION => $this->parseMigration($content),
             Response::MODEL_MIGRATION_LIST => $this->handleList($content, 'migrations', fn ($item) => $this->parseMigration($item)),
             default => $content,
         };
+    }
+
+    protected function parseExecution(array $content): array
+    {
+        if (isset($content['resourceId'])) {
+            $content['functionId'] = $content['resourceId'];
+            unset($content['resourceId']);
+        }
+
+        return $content;
     }
 
     protected function parseMigration(array $content): array

--- a/src/Appwrite/Utopia/Response/Filters/V27.php
+++ b/src/Appwrite/Utopia/Response/Filters/V27.php
@@ -26,6 +26,8 @@ class V27 extends Filter
             unset($content['resourceId']);
         }
 
+        unset($content['resourceType']);
+
         return $content;
     }
 

--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -38,29 +38,36 @@ class Execution extends Model
                 'example' => [Role::any()->toString()],
                 'array' => true,
             ])
-            // TODO: Sites listLogs will not have this, and will need siteId instead
             ->addRule('functionId', [
                 'type' => self::TYPE_STRING,
                 'description' => 'Function ID.',
+                'required' => false,
+                'default' => '',
+                'example' => '5e5ea6g16897e',
+            ])
+            ->addRule('siteId', [
+                'type' => self::TYPE_STRING,
+                'description' => 'Site ID.',
+                'required' => false,
                 'default' => '',
                 'example' => '5e5ea6g16897e',
             ])
             ->addRule('deploymentId', [
                 'type' => self::TYPE_STRING,
-                'description' => 'Function\'s deployment ID used to create the execution.',
+                'description' => 'Deployment ID used to create the execution.',
                 'default' => '',
                 'example' => '5e5ea5c16897e',
             ])
             ->addRule('trigger', [
                 'type' => self::TYPE_ENUM,
-                'description' => 'The trigger that caused the function to execute. Possible values can be: `http`, `schedule`, or `event`.',
+                'description' => 'The trigger that caused the resource to execute. Possible values can be: `http`, `schedule`, or `event`.',
                 'default' => '',
                 'example' => 'http',
                 'enum' => ['http', 'schedule', 'event'],
             ])
             ->addRule('status', [
                 'type' => self::TYPE_ENUM,
-                'description' => 'The status of the function execution. Possible values can be: `waiting`, `processing`, `completed`, `failed`, or `scheduled`.',
+                'description' => 'The status of the resource execution. Possible values can be: `waiting`, `processing`, `completed`, `failed`, or `scheduled`.',
                 'default' => '',
                 'example' => 'processing',
                 'enum' => ['waiting', 'processing', 'completed', 'failed', 'scheduled'],
@@ -104,14 +111,14 @@ class Execution extends Model
             ])
             ->addRule('logs', [
                 'type' => self::TYPE_STRING,
-                'description' => 'Function logs. Includes the last 4,000 characters. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'description' => 'Resource logs. Includes the last 4,000 characters. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
                 'default' => '',
                 'example' => '',
                 'sensitive' => true,
             ])
             ->addRule('errors', [
                 'type' => self::TYPE_STRING,
-                'description' => 'Function errors. Includes the last 4,000 characters. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
+                'description' => 'Resource errors. Includes the last 4,000 characters. This will return an empty string unless the response is returned using an API key or as part of a webhook payload.',
                 'default' => '',
                 'example' => '',
                 'sensitive' => true,
@@ -160,9 +167,18 @@ class Execution extends Model
      */
     public function filter(Document $document): Document
     {
+        $resourceType = $document->getAttribute('resourceType', 'functions');
+        $resourceId = $document->getAttribute('resourceId', '');
+
+        if ($resourceType === 'sites') {
+            $document->setAttribute('siteId', $resourceId);
+        } else {
+            $document->setAttribute('functionId', $resourceId);
+        }
+
         $document->removeAttribute('resourceType');
-        $document->setAttribute('functionId', $document->getAttribute('resourceId', ''));
         $document->removeAttribute('resourceId');
+
         return $document;
     }
 }

--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -38,17 +38,9 @@ class Execution extends Model
                 'example' => [Role::any()->toString()],
                 'array' => true,
             ])
-            ->addRule('functionId', [
+            ->addRule('resourceId', [
                 'type' => self::TYPE_STRING,
-                'description' => 'Function ID.',
-                'required' => false,
-                'default' => '',
-                'example' => '5e5ea6g16897e',
-            ])
-            ->addRule('siteId', [
-                'type' => self::TYPE_STRING,
-                'description' => 'Site ID.',
-                'required' => false,
+                'description' => 'Function or site ID.',
                 'default' => '',
                 'example' => '5e5ea6g16897e',
             ])
@@ -167,17 +159,7 @@ class Execution extends Model
      */
     public function filter(Document $document): Document
     {
-        $resourceType = $document->getAttribute('resourceType', 'functions');
-        $resourceId = $document->getAttribute('resourceId', '');
-
-        if ($resourceType === 'sites') {
-            $document->setAttribute('siteId', $resourceId);
-        } else {
-            $document->setAttribute('functionId', $resourceId);
-        }
-
         $document->removeAttribute('resourceType');
-        $document->removeAttribute('resourceId');
 
         return $document;
     }

--- a/src/Appwrite/Utopia/Response/Model/Execution.php
+++ b/src/Appwrite/Utopia/Response/Model/Execution.php
@@ -5,7 +5,6 @@ namespace Appwrite\Utopia\Response\Model;
 use Appwrite\Utopia\Response;
 use Appwrite\Utopia\Response\Model;
 use Utopia\Database\DateTime;
-use Utopia\Database\Document;
 use Utopia\Database\Helpers\Role;
 
 class Execution extends Model
@@ -43,6 +42,13 @@ class Execution extends Model
                 'description' => 'Function or site ID.',
                 'default' => '',
                 'example' => '5e5ea6g16897e',
+            ])
+            ->addRule('resourceType', [
+                'type' => self::TYPE_ENUM,
+                'description' => 'Execution resource type.',
+                'default' => 'functions',
+                'example' => 'functions',
+                'enum' => ['functions', 'sites'],
             ])
             ->addRule('deploymentId', [
                 'type' => self::TYPE_STRING,
@@ -149,18 +155,5 @@ class Execution extends Model
     public function getType(): string
     {
         return Response::MODEL_EXECUTION;
-    }
-
-
-    /**
-     * Convert DB structure to response model
-     *
-     * @return Document
-     */
-    public function filter(Document $document): Document
-    {
-        $document->removeAttribute('resourceType');
-
-        return $document;
     }
 }

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1848,12 +1848,12 @@ final class FunctionsCustomServerTest extends Scope
         $this->assertEquals($execution['body']['$id'], $executionIdHeader);
 
         $this->assertNotEmpty($execution['body']['$id']);
-        $this->assertNotEmpty($execution['body']['functionId']);
+        $this->assertNotEmpty($execution['body']['resourceId']);
         $this->assertEquals(true, (new DatetimeValidator())->isValid($execution['body']['$createdAt']));
-        $this->assertEquals($data['functionId'], $execution['body']['functionId']);
+        $this->assertEquals($data['functionId'], $execution['body']['resourceId']);
         $this->assertEquals('completed', $execution['body']['status']);
         $this->assertEquals(200, $execution['body']['responseStatusCode']);
-        $this->assertStringContainsString($execution['body']['functionId'], (string) $execution['body']['responseBody']);
+        $this->assertStringContainsString($execution['body']['resourceId'], (string) $execution['body']['responseBody']);
         $this->assertStringContainsString($data['deploymentId'], (string) $execution['body']['responseBody']);
         $this->assertStringContainsString('Test1', (string) $execution['body']['responseBody']);
         $this->assertStringContainsString('http', (string) $execution['body']['responseBody']);

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1851,6 +1851,7 @@ final class FunctionsCustomServerTest extends Scope
         $this->assertNotEmpty($execution['body']['resourceId']);
         $this->assertEquals(true, (new DatetimeValidator())->isValid($execution['body']['$createdAt']));
         $this->assertEquals($data['functionId'], $execution['body']['resourceId']);
+        $this->assertEquals('functions', $execution['body']['resourceType']);
         $this->assertEquals('completed', $execution['body']['status']);
         $this->assertEquals(200, $execution['body']['responseStatusCode']);
         $this->assertStringContainsString($execution['body']['resourceId'], (string) $execution['body']['responseBody']);

--- a/tests/e2e/Services/GraphQL/Base.php
+++ b/tests/e2e/Services/GraphQL/Base.php
@@ -2254,7 +2254,7 @@ trait Base
                 return 'query getExecution($functionId: String!$executionId: String!) {
                     functionsGetExecution(functionId: $functionId, executionId: $executionId) {
                         _id
-                        functionId
+                        resourceId
                         status
                         logs
                         errors
@@ -2266,7 +2266,7 @@ trait Base
                         total
                         executions {
                             _id
-                            functionId
+                            resourceId
                             status
                             logs
                             errors
@@ -2277,7 +2277,7 @@ trait Base
                 return 'mutation createExecution($functionId: String!, $body: String, $async: Boolean) {
                     functionsCreateExecution(functionId: $functionId, body: $body, async: $async) {
                         _id
-                        functionId
+                        resourceId
                         status
                         logs
                         errors

--- a/tests/e2e/Services/GraphQL/Base.php
+++ b/tests/e2e/Services/GraphQL/Base.php
@@ -2255,6 +2255,7 @@ trait Base
                     functionsGetExecution(functionId: $functionId, executionId: $executionId) {
                         _id
                         resourceId
+                        resourceType
                         status
                         logs
                         errors
@@ -2267,6 +2268,7 @@ trait Base
                         executions {
                             _id
                             resourceId
+                            resourceType
                             status
                             logs
                             errors
@@ -2278,6 +2280,7 @@ trait Base
                     functionsCreateExecution(functionId: $functionId, body: $body, async: $async) {
                         _id
                         resourceId
+                        resourceType
                         status
                         logs
                         errors

--- a/tests/unit/Messaging/MessagingTest.php
+++ b/tests/unit/Messaging/MessagingTest.php
@@ -858,7 +858,7 @@ final class MessagingTest extends TestCase
             event: 'functions.function_id.executions.execution_id.create',
             payload: new Document([
                 '$id' => ID::custom('execution_id'),
-                'functionId' => 'function_id',
+                'resourceId' => 'function_id',
                 '$read' => [Role::any()->toString()],
                 '$permissions' => [Permission::read(Role::any())],
             ]),

--- a/tests/unit/Utopia/Response/Filters/V27Test.php
+++ b/tests/unit/Utopia/Response/Filters/V27Test.php
@@ -17,6 +17,7 @@ final class V27Test extends TestCase
         $result = $filter->parse([
             '$id' => 'execution',
             'resourceId' => 'function',
+            'resourceType' => 'functions',
         ], Response::MODEL_EXECUTION);
 
         $this->assertSame([
@@ -34,6 +35,7 @@ final class V27Test extends TestCase
             'executions' => [[
                 '$id' => 'execution',
                 'resourceId' => 'function',
+                'resourceType' => 'functions',
             ]],
         ], Response::MODEL_EXECUTION_LIST);
 

--- a/tests/unit/Utopia/Response/Filters/V27Test.php
+++ b/tests/unit/Utopia/Response/Filters/V27Test.php
@@ -10,6 +10,42 @@ use PHPUnit\Framework\TestCase;
 
 final class V27Test extends TestCase
 {
+    public function testRestoresLegacyExecutionFunctionId(): void
+    {
+        $filter = new V27();
+
+        $result = $filter->parse([
+            '$id' => 'execution',
+            'resourceId' => 'function',
+        ], Response::MODEL_EXECUTION);
+
+        $this->assertSame([
+            '$id' => 'execution',
+            'functionId' => 'function',
+        ], $result);
+    }
+
+    public function testRestoresLegacyExecutionListFunctionId(): void
+    {
+        $filter = new V27();
+
+        $result = $filter->parse([
+            'total' => 1,
+            'executions' => [[
+                '$id' => 'execution',
+                'resourceId' => 'function',
+            ]],
+        ], Response::MODEL_EXECUTION_LIST);
+
+        $this->assertSame([
+            'total' => 1,
+            'executions' => [[
+                '$id' => 'execution',
+                'functionId' => 'function',
+            ]],
+        ], $result);
+    }
+
     public function testRestoresLegacyMigrationResourceShape(): void
     {
         $filter = new V27();

--- a/tests/unit/Utopia/Response/Model/ExecutionTest.php
+++ b/tests/unit/Utopia/Response/Model/ExecutionTest.php
@@ -10,37 +10,21 @@ use Utopia\Database\Document;
 
 final class ExecutionTest extends TestCase
 {
-    public function testFunctionExecutionUsesFunctionId(): void
-    {
-        $execution = (new Execution())->filter(new Document([
-            'resourceType' => 'functions',
-            'resourceId' => 'function-id',
-        ]));
-
-        $this->assertSame('function-id', $execution->getAttribute('functionId'));
-        $this->assertFalse($execution->isSet('siteId'));
-        $this->assertFalse($execution->isSet('resourceType'));
-        $this->assertFalse($execution->isSet('resourceId'));
-    }
-
-    public function testSiteExecutionUsesSiteId(): void
+    public function testPreservesResourceId(): void
     {
         $execution = (new Execution())->filter(new Document([
             'resourceType' => 'sites',
             'resourceId' => 'site-id',
         ]));
 
-        $this->assertSame('site-id', $execution->getAttribute('siteId'));
-        $this->assertFalse($execution->isSet('functionId'));
+        $this->assertSame('site-id', $execution->getAttribute('resourceId'));
         $this->assertFalse($execution->isSet('resourceType'));
-        $this->assertFalse($execution->isSet('resourceId'));
     }
 
-    public function testResourceIdsAreOptional(): void
+    public function testResourceIdIsRequired(): void
     {
         $rules = (new Execution())->getRules();
 
-        $this->assertFalse($rules['functionId']['required']);
-        $this->assertFalse($rules['siteId']['required']);
+        $this->assertTrue($rules['resourceId']['required']);
     }
 }

--- a/tests/unit/Utopia/Response/Model/ExecutionTest.php
+++ b/tests/unit/Utopia/Response/Model/ExecutionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Response\Model;
+
+use Appwrite\Utopia\Response\Model\Execution;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Document;
+
+final class ExecutionTest extends TestCase
+{
+    public function testFunctionExecutionUsesFunctionId(): void
+    {
+        $execution = (new Execution())->filter(new Document([
+            'resourceType' => 'functions',
+            'resourceId' => 'function-id',
+        ]));
+
+        $this->assertSame('function-id', $execution->getAttribute('functionId'));
+        $this->assertFalse($execution->isSet('siteId'));
+        $this->assertFalse($execution->isSet('resourceType'));
+        $this->assertFalse($execution->isSet('resourceId'));
+    }
+
+    public function testSiteExecutionUsesSiteId(): void
+    {
+        $execution = (new Execution())->filter(new Document([
+            'resourceType' => 'sites',
+            'resourceId' => 'site-id',
+        ]));
+
+        $this->assertSame('site-id', $execution->getAttribute('siteId'));
+        $this->assertFalse($execution->isSet('functionId'));
+        $this->assertFalse($execution->isSet('resourceType'));
+        $this->assertFalse($execution->isSet('resourceId'));
+    }
+
+    public function testResourceIdsAreOptional(): void
+    {
+        $rules = (new Execution())->getRules();
+
+        $this->assertFalse($rules['functionId']['required']);
+        $this->assertFalse($rules['siteId']['required']);
+    }
+}

--- a/tests/unit/Utopia/Response/Model/ExecutionTest.php
+++ b/tests/unit/Utopia/Response/Model/ExecutionTest.php
@@ -10,7 +10,7 @@ use Utopia\Database\Document;
 
 final class ExecutionTest extends TestCase
 {
-    public function testPreservesResourceId(): void
+    public function testPreservesResourceIdentity(): void
     {
         $execution = (new Execution())->filter(new Document([
             'resourceType' => 'sites',
@@ -18,13 +18,14 @@ final class ExecutionTest extends TestCase
         ]));
 
         $this->assertSame('site-id', $execution->getAttribute('resourceId'));
-        $this->assertFalse($execution->isSet('resourceType'));
+        $this->assertSame('sites', $execution->getAttribute('resourceType'));
     }
 
-    public function testResourceIdIsRequired(): void
+    public function testResourceIdentityIsRequired(): void
     {
         $rules = (new Execution())->getRules();
 
         $this->assertTrue($rules['resourceId']['required']);
+        $this->assertTrue($rules['resourceType']['required']);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Makes the shared execution response model use a generic resource identifier for both Functions executions and Sites request logs.

```json
// before
{"functionId":"function-id"}

// after
{"resourceId":"function-or-site-id"}
```

The response model now preserves the stored `resourceId` and removes only the internal `resourceType`. A response-format filter maps `resourceId` back to `functionId` for SDKs targeting versions before 2.0.0.

## Test Plan

```text
vendor/bin/phpunit tests/unit/Utopia/Response/Model/ExecutionTest.php tests/unit/Utopia/Response/Filters/V27Test.php
composer lint src/Appwrite/Utopia/Response/Model/Execution.php src/Appwrite/Utopia/Response/Filters/V27.php tests/unit/Utopia/Response/Model/ExecutionTest.php tests/unit/Utopia/Response/Filters/V27Test.php
composer check -- src/Appwrite/Utopia/Response/Model/Execution.php src/Appwrite/Utopia/Response/Filters/V27.php tests/unit/Utopia/Response/Model/ExecutionTest.php tests/unit/Utopia/Response/Filters/V27Test.php
php app/cli.php specs --git=no
```

Verified the generated Console spec requires `resourceId` and no longer contains `functionId` or `siteId` on the execution model.

## Related PRs and Issues

- Follow-up to appwrite/mcp#103

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
