### PR TITLE
fix(tests): restore the e2e helpers appwrite/cloud still calls

### DIFF
--- a/phpstan-deadcode.neon
+++ b/phpstan-deadcode.neon
@@ -25,6 +25,10 @@ parameters:
         - tests/resources
     ignoreErrors:
         # Referenced in appwrite/cloud.
+        # Test helpers: appwrite/cloud's e2e suites extend these traits.
+        - '#^Unused Tests\\E2E\\Services\\Functions\\FunctionsBase::getExecution$#'
+        - '#^Unused Tests\\E2E\\Services\\Functions\\FunctionsBase::listExecutions$#'
+        - '#^Unused Tests\\E2E\\Services\\Sites\\SitesBase::listLogs$#'
         - '#^Unused Appwrite\\Auth\\MFA\\Challenge::challenge$#'
         - '#^Unused Appwrite\\Auth\\MFA\\Challenge::verify$#'
         - '#^Unused Appwrite\\Certificates\\Adapter::getCertificateStatus$#'

--- a/tests/e2e/Services/Functions/FunctionsBase.php
+++ b/tests/e2e/Services/Functions/FunctionsBase.php
@@ -215,6 +215,26 @@ trait FunctionsBase
         return $deployment;
     }
 
+    protected function getExecution(string $functionId, $executionId): mixed
+    {
+        $execution = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions/' . $executionId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()));
+
+        return $execution;
+    }
+
+    protected function listExecutions(string $functionId, mixed $params = []): mixed
+    {
+        $executions = $this->client->call(Client::METHOD_GET, '/functions/' . $functionId . '/executions', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), $params);
+
+        return $executions;
+    }
+
     protected function listFunctions(mixed $params = []): mixed
     {
         $functions = $this->client->call(Client::METHOD_GET, '/functions', array_merge([

--- a/tests/e2e/Services/Sites/SitesBase.php
+++ b/tests/e2e/Services/Sites/SitesBase.php
@@ -210,6 +210,18 @@ trait SitesBase
         return $deployment;
     }
 
+    protected function listLogs(string $siteId, array $queries = []): mixed
+    {
+        $logs = $this->client->call(Client::METHOD_GET, '/sites/' . $siteId . '/logs', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'queries' => $queries
+        ]);
+
+        return $logs;
+    }
+
     protected function listSites(mixed $params = []): mixed
     {
         $sites = $this->client->call(Client::METHOD_GET, '/sites', array_merge([


### PR DESCRIPTION
Restores three e2e test helpers that [#13207](https://github.com/appwrite/appwrite/pull/13207) removed and `appwrite/cloud` still calls.

## How it surfaced

Bumping `appwrite/server-ce` in cloud to pick up [#13212](https://github.com/appwrite/appwrite/pull/13212) fails static analysis there with nine undefined-method errors:

| Helper | Call sites in cloud |
| --- | --- |
| `FunctionsBase::getExecution` | 7 |
| `FunctionsBase::listExecutions` | 1 |
| `SitesBase::listLogs` | 1 |

```
tests/e2e/Services/Functions/FunctionsCustomServerTest.php:72,106,144,183,194,223,235,269
tests/e2e/Services/Sites/SitesCustomServerTest.php:27
```

## Why the sweep missed them

That PR set out to avoid exactly this, and says so:

> Anything listed under ignoreErrors is dead as far as this repository can see, but must not be removed — each group explains why. Appwrite is the base server for appwrite/cloud, so a symbol unused here may still be consumed there; check that repository before deleting anything this reports.

`phpstan-deadcode.neon` already carries sixty-one entries for that reason. These three were missed because they are consumed from cloud's **tests**, which use these traits, rather than from its source.

## What this does

Puts the three methods back exactly as they were, and adds them to the allowlist under their own heading so the next sweep leaves them alone for a stated reason rather than rediscovering them.

```
# Test helpers: appwrite/cloud's e2e suites extend these traits.
- '#^Unused Tests\\E2E\\Services\\Functions\\FunctionsBase::getExecution$#'
- '#^Unused Tests\\E2E\\Services\\Functions\\FunctionsBase::listExecutions$#'
- '#^Unused Tests\\E2E\\Services\\Sites\\SitesBase::listLogs$#'
```

Nothing in this repository calls them, so nothing here changes behaviour.

## Checks

- `composer dead-code` — no errors, with the three allowlisted
- `phpstan.neon` — no errors
- `pint --test` on both files — passed

## Note for the next sweep

The cross-check that missed these looked at cloud's source. Cloud extends these test traits, so a symbol can be dead here, absent from cloud's `src/`, and still required by cloud's `tests/`. Worth running the detector against a cloud checkout with the candidate removed, rather than grepping, before the next removal.
