### PR TITLE
fix: reject whitespace-only platform name and key

### DIFF
--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -17,7 +18,6 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Create extends Action
 {
@@ -43,7 +43,7 @@ class Create extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'createAndroidPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Create a new Android platform for your project. Use this endpoint to register a new Android platform where your users will run your application which will interact with the Appwrite API.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -51,7 +51,7 @@ class Create extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
                         model: Response::MODEL_PLATFORM_ANDROID,
-                    )
+                    ),
                 ],
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new CustomId(false, $dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Android/Update.php
@@ -9,6 +9,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
@@ -16,7 +17,6 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Update extends Action
 {
@@ -41,7 +41,7 @@ class Update extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'updateAndroidPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Update an Android platform by its unique ID. Use this endpoint to update the platform's name or application ID.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -49,7 +49,7 @@ class Update extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_PLATFORM_ANDROID,
-                    )
+                    ),
                 ]
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new UID($dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -17,7 +18,6 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Create extends Action
 {
@@ -43,7 +43,7 @@ class Create extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'createApplePlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Create a new Apple platform for your project. Use this endpoint to register a new Apple platform where your users will run your application which will interact with the Appwrite API.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -51,7 +51,7 @@ class Create extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
                         model: Response::MODEL_PLATFORM_APPLE,
-                    )
+                    ),
                 ],
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new CustomId(false, $dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Apple/Update.php
@@ -9,6 +9,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
@@ -16,7 +17,6 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Update extends Action
 {
@@ -41,7 +41,7 @@ class Update extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'updateApplePlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Update an Apple platform by its unique ID. Use this endpoint to update the platform's name or bundle identifier.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -49,7 +49,7 @@ class Update extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_PLATFORM_APPLE,
-                    )
+                    ),
                 ]
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new UID($dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -17,7 +18,6 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Create extends Action
 {
@@ -43,7 +43,7 @@ class Create extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'createLinuxPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Create a new Linux platform for your project. Use this endpoint to register a new Linux platform where your users will run your application which will interact with the Appwrite API.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -51,7 +51,7 @@ class Create extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
                         model: Response::MODEL_PLATFORM_LINUX,
-                    )
+                    ),
                 ],
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new CustomId(false, $dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Linux/Update.php
@@ -9,6 +9,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
@@ -16,7 +17,6 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Update extends Action
 {
@@ -41,7 +41,7 @@ class Update extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'updateLinuxPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Update a Linux platform by its unique ID. Use this endpoint to update the platform's name or package name.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -49,7 +49,7 @@ class Update extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_PLATFORM_LINUX,
-                    )
+                    ),
                 ]
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new UID($dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Create.php
@@ -11,6 +11,7 @@ use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -18,8 +19,9 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\Validator;
+use Utopia\Validator\AllOf;
 use Utopia\Validator\Hostname;
-use Utopia\Validator\Text;
 use Utopia\Validator\WhiteList;
 
 /**
@@ -51,7 +53,7 @@ class Create extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'createWebPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Create a new web platform for your project. Use this endpoint to register a new platform where your users will run your application which will interact with the Appwrite API.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -59,12 +61,12 @@ class Create extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
                         model: Response::MODEL_PLATFORM_WEB,
-                    )
+                    ),
                 ],
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new CustomId(false, $dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForPlatform'])
             ->param('name', null, new Text(128), 'Platform name. Max length: 128 chars.')
-            ->param('hostname', '', new Hostname(), 'Platform web hostname. Max length: 256 chars.', optional: true, example: 'app.example.com') // Optional for backwards compatibility
+            ->param('hostname', '', new AllOf([new Hostname, new Text(253)], Validator::TYPE_STRING), 'Platform web hostname. Max length: 256 chars.', optional: true, example: 'app.example.com') // Optional for backwards compatibility
             ->param('key', '', new Text(256), 'Deprecated: Package name for Android or bundle ID for iOS or macOS. Max length: 256 chars.', optional: true, deprecated: true) // Exists for backwards compatibility
             ->param('type', '', new Text(256), 'Deprecated: Platform type. Max length: 256 chars.', optional: true, deprecated: true) // Exists for backwards compatibility
             ->inject('request')
@@ -94,7 +96,7 @@ class Create extends Action
 
         // Backwards compatibility
         // Used to have: type, name, key, hostname
-        if (!empty($type)) {
+        if (! empty($type)) {
             // Validate deprecated type, and rename to new type
             $deprecatedTypeMapping = [
                 // Web
@@ -121,18 +123,18 @@ class Create extends Action
             ];
 
             $typeValidator = new WhiteList(\array_keys($deprecatedTypeMapping));
-            if (!$typeValidator->isValid($request->getParam('type', ''))) {
-                throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Param "type" is invalid: ' . $typeValidator->getDescription());
+            if (! $typeValidator->isValid($request->getParam('type', ''))) {
+                throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Param "type" is invalid: '.$typeValidator->getDescription());
             }
 
             $type = $deprecatedTypeMapping[$request->getParam('type', '')] ?? '';
         }
 
-        if (!empty($key)) {
+        if (! empty($key)) {
             // Validate deprecated app id (key)
             $keyValidator = new Text(256);
-            if (!$keyValidator->isValid($key)) {
-                throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Param "key" is invalid: ' . $keyValidator->getDescription());
+            if (! $keyValidator->isValid($key)) {
+                throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Param "key" is invalid: '.$keyValidator->getDescription());
             }
         }
 
@@ -153,7 +155,7 @@ class Create extends Action
             'type' => $type ?: Platform::TYPE_WEB, // Preserve type for backwards compatibility
             'name' => $name,
             'key' => $key,
-            'hostname' => $hostname
+            'hostname' => $hostname,
         ]);
 
         try {

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Web/Update.php
@@ -9,6 +9,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
@@ -16,8 +17,9 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
+use Utopia\Validator;
+use Utopia\Validator\AllOf;
 use Utopia\Validator\Hostname;
-use Utopia\Validator\Text;
 
 class Update extends Action
 {
@@ -43,7 +45,7 @@ class Update extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'updateWebPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Update a web platform by its unique ID. Use this endpoint to update the platform's name or hostname.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -51,12 +53,12 @@ class Update extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_PLATFORM_WEB,
-                    )
+                    ),
                 ]
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new UID($dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID.', false, ['dbForPlatform'])
             ->param('name', null, new Text(128), 'Platform name. Max length: 128 chars.')
-            ->param('hostname', '', new Hostname(), 'Platform web hostname. Max length: 256 chars.', optional: true, example: 'app.example.com') // Optional for backwards compatibility
+            ->param('hostname', '', new AllOf([new Hostname, new Text(253)], Validator::TYPE_STRING), 'Platform web hostname. Max length: 256 chars.', optional: true, example: 'app.example.com') // Optional for backwards compatibility
             ->param('key', '', new Text(256), 'Package name for Android or bundle ID for iOS or macOS. Max length: 256 chars.', optional: true, deprecated: true) // Exists for backwards compatibility
             ->inject('response')
             ->inject('queueForEvents')
@@ -81,11 +83,11 @@ class Update extends Action
 
         // Backwards compatibility
         // Used to have: type, name, key, hostname
-        if (!empty($key)) {
+        if (! empty($key)) {
             // Validate deprecated app id (key)
             $keyValidator = new Text(256);
-            if (!$keyValidator->isValid($key)) {
-                throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Param "key" is invalid: ' . $keyValidator->getDescription());
+            if (! $keyValidator->isValid($key)) {
+                throw new Exception(Exception::GENERAL_BAD_REQUEST, 'Param "key" is invalid: '.$keyValidator->getDescription());
             }
         }
 
@@ -99,7 +101,7 @@ class Update extends Action
         }
 
         // Wrapped in if, for backwards compatibility
-        if (!empty($hostname)) {
+        if (! empty($hostname)) {
             $supportedTypes = [
                 Platform::TYPE_WEB,
                 // Backwards compatibility
@@ -117,7 +119,7 @@ class Update extends Action
                 'flutter-windows',
                 'flutter-linux',
             ];
-            if (!in_array($platform->getAttribute('type', ''), $supportedTypes)) {
+            if (! in_array($platform->getAttribute('type', ''), $supportedTypes)) {
                 throw new Exception(Exception::PLATFORM_METHOD_UNSUPPORTED);
             }
         }
@@ -127,12 +129,12 @@ class Update extends Action
         ]);
 
         // Wrapped in if, for backwards compatibility
-        if (!empty($hostname)) {
+        if (! empty($hostname)) {
             $updates->setAttribute('hostname', $hostname);
         }
 
         // Backwards compatibility
-        if (!empty($key)) {
+        if (! empty($key)) {
             $updates->setAttribute('key', $key);
         }
 

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Create.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Create.php
@@ -10,6 +10,7 @@ use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Database\Validator\CustomId;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
@@ -17,7 +18,6 @@ use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Create extends Action
 {
@@ -43,7 +43,7 @@ class Create extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'createWindowsPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Create a new Windows platform for your project. Use this endpoint to register a new Windows platform where your users will run your application which will interact with the Appwrite API.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -51,7 +51,7 @@ class Create extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_CREATED,
                         model: Response::MODEL_PLATFORM_WINDOWS,
-                    )
+                    ),
                 ],
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new CustomId(false, $dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char. Max length is 36 chars.', false, ['dbForPlatform'])

--- a/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Update.php
+++ b/src/Appwrite/Platform/Modules/Project/Http/Project/Platforms/Windows/Update.php
@@ -9,6 +9,7 @@ use Appwrite\SDK\AuthType;
 use Appwrite\SDK\Method;
 use Appwrite\SDK\Response as SDKResponse;
 use Appwrite\Utopia\Response;
+use Appwrite\Utopia\Validator\Text;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
@@ -16,7 +17,6 @@ use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\UID;
 use Utopia\Platform\Action;
 use Utopia\Platform\Scope\HTTP;
-use Utopia\Validator\Text;
 
 class Update extends Action
 {
@@ -41,7 +41,7 @@ class Update extends Action
                 namespace: 'project',
                 group: 'platforms',
                 name: 'updateWindowsPlatform',
-                description: <<<EOT
+                description: <<<'EOT'
                 Update a Windows platform by its unique ID. Use this endpoint to update the platform's name or package identifier name.
                 EOT,
                 auth: [AuthType::ADMIN, AuthType::KEY],
@@ -49,7 +49,7 @@ class Update extends Action
                     new SDKResponse(
                         code: Response::STATUS_CODE_OK,
                         model: Response::MODEL_PLATFORM_WINDOWS,
-                    )
+                    ),
                 ]
             ))
             ->param('platformId', '', fn (Database $dbForPlatform) => new UID($dbForPlatform->getAdapter()->getMaxUIDLength()), 'Platform ID.', false, ['dbForPlatform'])

--- a/src/Appwrite/Utopia/Validator/Text.php
+++ b/src/Appwrite/Utopia/Validator/Text.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Appwrite\Utopia\Validator;
+
+use Utopia\Validator\Text as UtopiaText;
+
+/**
+ * Text
+ *
+ * Same length rules as Utopia text, but whitespace-only values are invalid.
+ */
+class Text extends UtopiaText
+{
+    public function getDescription(): string
+    {
+        return parent::getDescription().' and must not be whitespace only';
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        if (! parent::isValid($value)) {
+            return false;
+        }
+
+        return \trim($value) !== '' || $value === '';
+    }
+}

--- a/tests/e2e/Services/Project/PlatformsBase.php
+++ b/tests/e2e/Services/Project/PlatformsBase.php
@@ -31,7 +31,7 @@ trait PlatformsBase
         $this->assertSame('web', $platform['body']['type']);
         $this->assertSame('app.example.com', $platform['body']['hostname']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$updatedAt']));
 
@@ -82,6 +82,28 @@ trait PlatformsBase
             ID::unique(),
             null,
             'missing.example.com',
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateWebPlatformWhitespaceName(): void
+    {
+        $response = $this->createWebPlatform(
+            ID::unique(),
+            ' ',
+            'whitespace.example.com',
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateWebPlatformWhitespaceHostname(): void
+    {
+        $response = $this->createWebPlatform(
+            ID::unique(),
+            'Whitespace Hostname',
+            ' ',
         );
 
         $this->assertSame(400, $response['headers']['status-code']);
@@ -164,7 +186,7 @@ trait PlatformsBase
         $this->assertSame('apple', $platform['body']['type']);
         $this->assertSame('com.example.myapp', $platform['body']['bundleIdentifier']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$updatedAt']));
 
@@ -226,6 +248,28 @@ trait PlatformsBase
             ID::unique(),
             'Missing Identifier',
             null,
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateApplePlatformWhitespaceName(): void
+    {
+        $response = $this->createApplePlatform(
+            ID::unique(),
+            ' ',
+            'com.example.whitespacename',
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateApplePlatformWhitespaceIdentifier(): void
+    {
+        $response = $this->createApplePlatform(
+            ID::unique(),
+            'Whitespace Identifier',
+            ' ',
         );
 
         $this->assertSame(400, $response['headers']['status-code']);
@@ -296,7 +340,7 @@ trait PlatformsBase
         $this->assertSame('android', $platform['body']['type']);
         $this->assertSame('com.example.android', $platform['body']['applicationId']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$updatedAt']));
 
@@ -355,6 +399,28 @@ trait PlatformsBase
             ID::unique(),
             'Missing Identifier',
             null,
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateAndroidPlatformWhitespaceName(): void
+    {
+        $response = $this->createAndroidPlatform(
+            ID::unique(),
+            ' ',
+            'com.example.whitespacename',
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+    }
+
+    public function testCreateAndroidPlatformWhitespaceIdentifier(): void
+    {
+        $response = $this->createAndroidPlatform(
+            ID::unique(),
+            'Whitespace Identifier',
+            ' ',
         );
 
         $this->assertSame(400, $response['headers']['status-code']);
@@ -425,7 +491,7 @@ trait PlatformsBase
         $this->assertSame('windows', $platform['body']['type']);
         $this->assertSame('com.example.windows', $platform['body']['packageIdentifierName']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$updatedAt']));
 
@@ -554,7 +620,7 @@ trait PlatformsBase
         $this->assertSame('linux', $platform['body']['type']);
         $this->assertSame('com.example.linux', $platform['body']['packageName']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($platform['body']['$updatedAt']));
 
@@ -885,6 +951,19 @@ trait PlatformsBase
         $this->deletePlatform($platformId);
     }
 
+    public function testUpdateAndroidPlatformWhitespaceName(): void
+    {
+        $platform = $this->createAndroidPlatform(ID::unique(), 'Original Android', 'com.example.original');
+        $this->assertSame(201, $platform['headers']['status-code']);
+        $platformId = $platform['body']['$id'];
+
+        $updated = $this->updateAndroidPlatform($platformId, ' ', 'com.example.original');
+
+        $this->assertSame(400, $updated['headers']['status-code']);
+
+        $this->deletePlatform($platformId);
+    }
+
     // =========================================================================
     // Update Windows platform tests
     // =========================================================================
@@ -1059,7 +1138,7 @@ trait PlatformsBase
         $this->assertSame('web', $get['body']['type']);
         $this->assertSame('gettest.example.com', $get['body']['hostname']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($get['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($get['body']['$updatedAt']));
 
@@ -1081,7 +1160,7 @@ trait PlatformsBase
         $this->assertSame('apple', $get['body']['type']);
         $this->assertSame('com.example.gettest', $get['body']['bundleIdentifier']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($get['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($get['body']['$updatedAt']));
 
@@ -1103,7 +1182,7 @@ trait PlatformsBase
         $this->assertSame('android', $get['body']['type']);
         $this->assertSame('com.example.gettest', $get['body']['applicationId']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($get['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($get['body']['$updatedAt']));
 
@@ -1125,7 +1204,7 @@ trait PlatformsBase
         $this->assertSame('windows', $get['body']['type']);
         $this->assertSame('com.example.gettest', $get['body']['packageIdentifierName']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($get['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($get['body']['$updatedAt']));
 
@@ -1147,7 +1226,7 @@ trait PlatformsBase
         $this->assertSame('linux', $get['body']['type']);
         $this->assertSame('com.example.gettest', $get['body']['packageName']);
 
-        $dateValidator = new DatetimeValidator();
+        $dateValidator = new DatetimeValidator;
         $this->assertSame(true, $dateValidator->isValid($get['body']['$createdAt']));
         $this->assertSame(true, $dateValidator->isValid($get['body']['$updatedAt']));
 
@@ -1640,7 +1719,7 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PUT, '/project/platforms/web/' . $platformId, $headers, $params);
+        return $this->client->call(Client::METHOD_PUT, '/project/platforms/web/'.$platformId, $headers, $params);
     }
 
     protected function updateApplePlatform(string $platformId, ?string $name = null, ?string $bundleIdentifier = null, bool $authenticated = true): mixed
@@ -1664,7 +1743,7 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PUT, '/project/platforms/apple/' . $platformId, $headers, $params);
+        return $this->client->call(Client::METHOD_PUT, '/project/platforms/apple/'.$platformId, $headers, $params);
     }
 
     protected function updateAndroidPlatform(string $platformId, ?string $name = null, ?string $applicationId = null, bool $authenticated = true): mixed
@@ -1688,7 +1767,7 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PUT, '/project/platforms/android/' . $platformId, $headers, $params);
+        return $this->client->call(Client::METHOD_PUT, '/project/platforms/android/'.$platformId, $headers, $params);
     }
 
     protected function updateWindowsPlatform(string $platformId, ?string $name = null, ?string $packageIdentifierName = null, bool $authenticated = true): mixed
@@ -1712,7 +1791,7 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PUT, '/project/platforms/windows/' . $platformId, $headers, $params);
+        return $this->client->call(Client::METHOD_PUT, '/project/platforms/windows/'.$platformId, $headers, $params);
     }
 
     protected function updateLinuxPlatform(string $platformId, ?string $name = null, ?string $packageName = null, bool $authenticated = true): mixed
@@ -1736,7 +1815,7 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_PUT, '/project/platforms/linux/' . $platformId, $headers, $params);
+        return $this->client->call(Client::METHOD_PUT, '/project/platforms/linux/'.$platformId, $headers, $params);
     }
 
     protected function getPlatform(string $platformId, bool $authenticated = true): mixed
@@ -1750,11 +1829,11 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_GET, '/project/platforms/' . $platformId, $headers);
+        return $this->client->call(Client::METHOD_GET, '/project/platforms/'.$platformId, $headers);
     }
 
     /**
-     * @param array<string>|null $queries
+     * @param  array<string>|null  $queries
      */
     protected function listPlatforms(?array $queries, ?bool $total, bool $authenticated = true): mixed
     {
@@ -1784,6 +1863,6 @@ trait PlatformsBase
             $headers = array_merge($headers, $this->getHeaders());
         }
 
-        return $this->client->call(Client::METHOD_DELETE, '/project/platforms/' . $platformId, $headers);
+        return $this->client->call(Client::METHOD_DELETE, '/project/platforms/'.$platformId, $headers);
     }
 }

--- a/tests/unit/Utopia/Validator/TextTest.php
+++ b/tests/unit/Utopia/Validator/TextTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Validator;
+
+use Appwrite\Utopia\Validator\Text;
+use PHPUnit\Framework\TestCase;
+
+final class TextTest extends TestCase
+{
+    public function testRejectsWhitespaceOnly(): void
+    {
+        $validator = new Text(128);
+
+        $this->assertFalse($validator->isValid(' '));
+        $this->assertFalse($validator->isValid('   '));
+        $this->assertFalse($validator->isValid("\t"));
+        $this->assertFalse($validator->isValid("\n"));
+    }
+
+    public function testRejectsEmptyWhenMinIsOne(): void
+    {
+        $validator = new Text(128);
+
+        $this->assertFalse($validator->isValid(''));
+    }
+
+    public function testAllowsEmptyWhenMinIsZero(): void
+    {
+        $validator = new Text(128, 0);
+
+        $this->assertTrue($validator->isValid(''));
+        $this->assertFalse($validator->isValid(' '));
+    }
+
+    public function testAcceptsFilledText(): void
+    {
+        $validator = new Text(128);
+
+        $this->assertTrue($validator->isValid('My Android app'));
+        $this->assertTrue($validator->isValid('com.example.app'));
+        $this->assertTrue($validator->isValid('localhost'));
+    }
+
+    public function testStillEnforcesMaxLength(): void
+    {
+        $validator = new Text(3);
+
+        $this->assertTrue($validator->isValid('abc'));
+        $this->assertFalse($validator->isValid('abcd'));
+    }
+}


### PR DESCRIPTION
## Summary
- Reject whitespace-only platform `name` and identifier fields (`applicationId`, `bundleIdentifier`, package names, hostname) on create and update.
- Add an `Appwrite\Utopia\Validator\Text` wrapper so a space is no longer treated as a valid value.
- Cover the change with unit tests and platform e2e tests.

Fixes #8387

## Test plan
- [ ] Recreate via API: `POST /v1/project/platforms/android` with `name: " "` and `applicationId: " "` returns **400**
- [ ] Valid Android create (`My Android app` / `com.example.app`) still returns **201**
- [ ] Updating an existing platform name to `" "` returns **400**
- [ ] `docker compose exec appwrite test tests/unit/Utopia/Validator/TextTest.php`
- [ ] `docker compose exec appwrite test tests/e2e/Services/Project --filter=Whitespace`