### PR TITLE
Keep base operation ID for first HTTP method

### DIFF
--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -808,15 +808,10 @@ class OpenAPI3 extends Format
             $methods = \array_values($route->getMethods());
             foreach ($methods as $index => $method) {
                 $methodTemp = $temp;
-                if (\count($methods) > 1) {
+                if (\count($methods) > 1 && $index > 0) {
                     $suffix = \ucfirst(\strtolower($method));
                     $methodTemp['operationId'] .= $suffix;
-
-                    // Keep the first method's SDK name stable while ensuring
-                    // additional HTTP methods generate unique SDK methods.
-                    if ($index > 0) {
-                        $methodTemp['x-appwrite']['method'] .= $suffix;
-                    }
+                    $methodTemp['x-appwrite']['method'] .= $suffix;
                 }
                 $body = [
                     'content' => [

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -271,7 +271,7 @@ final class FormatTest extends TestCase
         $get = $openApi['paths']['/tests/{testId}']['get'];
         $post = $openApi['paths']['/tests/{testId}']['post'];
 
-        $this->assertSame('testGetOrUpdateTestGet', $get['operationId']);
+        $this->assertSame('testGetOrUpdateTest', $get['operationId']);
         $this->assertSame('testGetOrUpdateTestPost', $post['operationId']);
         $this->assertSame('getOrUpdateTest', $get['x-appwrite']['method']);
         $this->assertSame('getOrUpdateTestPost', $post['x-appwrite']['method']);


### PR DESCRIPTION
## What does this PR do?

Keeps the base OpenAPI `operationId` for the first HTTP method on a multi-method route. Additional methods still receive an HTTP method suffix so every operation remains unique.

```text
before: GET testGetOrUpdateTestGet, POST testGetOrUpdateTestPost
after:  GET testGetOrUpdateTest,    POST testGetOrUpdateTestPost
```

`x-appwrite.method` behavior remains unchanged.

## Test Plan

```text
vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php
composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php
git diff --check
```

## Related PRs and Issues

- N/A

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
