### PR TITLE
refactor(sdks): consume utopia-php/openapi specification models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,6 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/utopia-php/openapi"
-        },
-        {
-            "type": "vcs",
             "url": "https://github.com/utopia-php/auth"
         },
         {

--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "appwrite/sdk-generator": "3.0.*",
+        "appwrite/sdk-generator": "^3.0",
         "brianium/paratest": "7.*",
         "phpunit/phpunit": "12.*",
         "swoole/ide-helper": "6.*",

--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "appwrite/sdk-generator": "dev-refactor/use-utopia-openapi",
+        "appwrite/sdk-generator": "3.0.*",
         "brianium/paratest": "7.*",
         "phpunit/phpunit": "12.*",
         "swoole/ide-helper": "6.*",

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,10 @@
     "repositories": [
         {
             "type": "vcs",
+            "url": "https://github.com/utopia-php/openapi"
+        },
+        {
+            "type": "vcs",
             "url": "https://github.com/utopia-php/auth"
         },
         {
@@ -113,7 +117,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "appwrite/sdk-generator": "^2.0",
+        "appwrite/sdk-generator": "dev-refactor/use-utopia-openapi",
         "brianium/paratest": "7.*",
         "phpunit/phpunit": "12.*",
         "swoole/ide-helper": "6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a754a426ffcd90d3538709e3af3b96bc",
+    "content-hash": "4ca087676c3a1fdd1786d6e683050e81",
     "packages": [
         {
             "name": "adhocore/jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a09624e00c32904563af366e73687200",
+    "content-hash": "a659874ee101f4e69bad038bc3449175",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5287,16 +5287,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "dev-refactor/use-utopia-openapi",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "2c165902a8b18740a2bdae554e6c525d8f059983"
+                "reference": "31c03de12bd01bff37795f8bbbae836d6f622fae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/2c165902a8b18740a2bdae554e6c525d8f059983",
-                "reference": "2c165902a8b18740a2bdae554e6c525d8f059983",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/31c03de12bd01bff37795f8bbbae836d6f622fae",
+                "reference": "31c03de12bd01bff37795f8bbbae836d6f622fae",
                 "shasum": ""
             },
             "require": {
@@ -5333,9 +5333,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/refactor/use-utopia-openapi"
+                "source": "https://github.com/appwrite/sdk-generator/tree/3.0.0"
             },
-            "time": "2026-08-14T07:25:59+00:00"
+            "time": "2026-08-14T08:18:40+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8400,7 +8400,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "appwrite/sdk-generator": 20,
         "utopia-php/http": 5,
         "utopia-php/platform": 5
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3057fe6af1bcf76bd921a6a3d80155da",
+    "content-hash": "a09624e00c32904563af366e73687200",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5291,12 +5291,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "2bd9f697fe7f90fb0ae5692ca2b04d75d3e9997b"
+                "reference": "2c165902a8b18740a2bdae554e6c525d8f059983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/2bd9f697fe7f90fb0ae5692ca2b04d75d3e9997b",
-                "reference": "2bd9f697fe7f90fb0ae5692ca2b04d75d3e9997b",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/2c165902a8b18740a2bdae554e6c525d8f059983",
+                "reference": "2c165902a8b18740a2bdae554e6c525d8f059983",
                 "shasum": ""
             },
             "require": {
@@ -5306,7 +5306,7 @@
                 "matthiasmullie/minify": "^1.3",
                 "php": ">=8.5",
                 "twig/twig": "^3.28",
-                "utopia-php/openapi": "dev-main"
+                "utopia-php/openapi": "0.1.*"
             },
             "require-dev": {
                 "brianium/paratest": "^7",
@@ -5335,7 +5335,7 @@
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
                 "source": "https://github.com/appwrite/sdk-generator/tree/refactor/use-utopia-openapi"
             },
-            "time": "2026-08-14T07:16:17+00:00"
+            "time": "2026-08-14T07:25:59+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8358,7 +8358,7 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "dev-main",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
@@ -8379,51 +8379,20 @@
                 "phpunit/phpunit": "^13.3",
                 "rector/rector": "^2.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Utopia\\OpenAPI\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Utopia\\OpenAPI\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ],
-                "lint": [
-                    "find src tests -name '*.php' -print0 | xargs -0 -n1 php -l"
-                ],
-                "format": [
-                    "pint"
-                ],
-                "format:check": [
-                    "pint --test"
-                ],
-                "rector": [
-                    "rector process"
-                ],
-                "rector:check": [
-                    "rector process --dry-run"
-                ],
-                "check": [
-                    "@lint",
-                    "@format:check",
-                    "@rector:check",
-                    "@test"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
-                "source": "https://github.com/utopia-php/openapi/tree/0.1.0",
-                "issues": "https://github.com/utopia-php/openapi/issues"
+                "issues": "https://github.com/utopia-php/openapi/issues",
+                "source": "https://github.com/utopia-php/openapi/tree/0.1.0"
             },
             "time": "2026-08-14T07:11:54+00:00"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c078590044c76e96a511d220a852b1a",
+    "content-hash": "3057fe6af1bcf76bd921a6a3d80155da",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5287,16 +5287,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "2.11.1",
+            "version": "dev-refactor/use-utopia-openapi",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "4bf377c6b8c4f9620d8e5fd525ab6160bdc95a41"
+                "reference": "2bd9f697fe7f90fb0ae5692ca2b04d75d3e9997b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/4bf377c6b8c4f9620d8e5fd525ab6160bdc95a41",
-                "reference": "4bf377c6b8c4f9620d8e5fd525ab6160bdc95a41",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/2bd9f697fe7f90fb0ae5692ca2b04d75d3e9997b",
+                "reference": "2bd9f697fe7f90fb0ae5692ca2b04d75d3e9997b",
                 "shasum": ""
             },
             "require": {
@@ -5305,7 +5305,8 @@
                 "ext-mbstring": "*",
                 "matthiasmullie/minify": "^1.3",
                 "php": ">=8.5",
-                "twig/twig": "^3.28"
+                "twig/twig": "^3.28",
+                "utopia-php/openapi": "dev-main"
             },
             "require-dev": {
                 "brianium/paratest": "^7",
@@ -5316,8 +5317,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Appwrite\\SDK\\": "src/SDK/",
-                    "Appwrite\\Spec\\": "src/Spec/"
+                    "Appwrite\\SDK\\": "src/SDK/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5333,9 +5333,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/2.11.1"
+                "source": "https://github.com/appwrite/sdk-generator/tree/refactor/use-utopia-openapi"
             },
-            "time": "2026-08-10T11:13:18+00:00"
+            "time": "2026-08-14T07:16:17+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -8355,11 +8355,83 @@
                 }
             ],
             "time": "2026-07-03T20:44:34+00:00"
+        },
+        {
+            "name": "utopia-php/openapi",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/utopia-php/openapi.git",
+                "reference": "5962baf44f339ae0919ec751bcbf1a96828f0038"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/5962baf44f339ae0919ec751bcbf1a96828f0038",
+                "reference": "5962baf44f339ae0919ec751bcbf1a96828f0038",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=8.5"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.0",
+                "phpunit/phpunit": "^13.3",
+                "rector/rector": "^2.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Utopia\\OpenAPI\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Utopia\\OpenAPI\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "lint": [
+                    "find src tests -name '*.php' -print0 | xargs -0 -n1 php -l"
+                ],
+                "format": [
+                    "pint"
+                ],
+                "format:check": [
+                    "pint --test"
+                ],
+                "rector": [
+                    "rector process"
+                ],
+                "rector:check": [
+                    "rector process --dry-run"
+                ],
+                "check": [
+                    "@lint",
+                    "@format:check",
+                    "@rector:check",
+                    "@test"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
+            "support": {
+                "source": "https://github.com/utopia-php/openapi/tree/0.1.0",
+                "issues": "https://github.com/utopia-php/openapi/issues"
+            },
+            "time": "2026-08-14T07:11:54+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "appwrite/sdk-generator": 20,
         "utopia-php/http": 5,
         "utopia-php/platform": 5
     },

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -26,8 +26,6 @@ use Appwrite\SDK\Language\Swift;
 use Appwrite\SDK\Language\Unity;
 use Appwrite\SDK\Language\Web;
 use Appwrite\SDK\SDK;
-use Appwrite\Spec\OpenAPI3;
-use Appwrite\Spec\StaticSpec;
 use CzProject\GitPhp\Git;
 use Utopia\Agents\Adapters\OpenAI;
 use Utopia\Agents\DiffCheck\DiffCheck;
@@ -37,6 +35,7 @@ use Utopia\Agents\Schema;
 use Utopia\Agents\Schema\SchemaObject;
 use Utopia\Config\Config;
 use Utopia\Console;
+use Utopia\OpenAPI\Parser;
 use Utopia\Platform\Action;
 use Utopia\System\System;
 use Utopia\Validator\Nullable;
@@ -471,14 +470,20 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                 $sdk = new SDK(
                     $config,
                     $specFormat === 'static'
-                        ? new StaticSpec(
-                            title: 'Appwrite',
-                            description: 'Appwrite backend as a service',
-                            version: $version,
-                            licenseName: 'BSD-3-Clause',
-                            licenseURL: 'https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE',
-                        )
-                        : new OpenAPI3($spec)
+                        ? Parser::parse([
+                            'openapi' => '3.0.0',
+                            'info' => [
+                                'title' => 'Appwrite',
+                                'description' => 'Appwrite backend as a service',
+                                'version' => $version,
+                                'license' => [
+                                    'name' => 'BSD-3-Clause',
+                                    'url' => 'https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE',
+                                ],
+                            ],
+                            'paths' => [],
+                        ])
+                        : Parser::parse($spec)
                 );
 
                 $sdk


### PR DESCRIPTION
Companion to [appwrite/sdk-generator#1789](https://github.com/appwrite/sdk-generator/pull/1789), which removes `src/Spec/*` and the `Appwrite\Spec` autoload namespace from the generator in favour of the canonical typed models in `utopia-php/openapi`.

`src/Appwrite/Platform/Tasks/SDKs.php` is the caller that constructs those spec objects, so without this change `php app/cli.php sdks` fatals on the generator branch:

```text
Fatal error: Uncaught Error: Class "Appwrite\Spec\OpenAPI3" not found in src/Appwrite/Platform/Tasks/SDKs.php on line 481
```

## What's Changed

- `new OpenAPI3($spec)` becomes `Parser::parse($spec)`.
- `new StaticSpec(title: …, description: …, version: …, licenseName: …, licenseURL: …)` becomes `Parser::parse([...])` over an equivalent minimal OpenAPI 3 document, matching the static-spec example in the generator's README.
- Dropped the `Appwrite\Spec\OpenAPI3` and `Appwrite\Spec\StaticSpec` imports, added `Utopia\OpenAPI\Parser`.
- Pinned `appwrite/sdk-generator` to the tagged `3.0.*` release. No repository entry needed: `utopia-php/openapi` resolves from Packagist as `0.1.0`.

## Verification

Generated every server SDK against `open-api3-1.9.x-server.json` through `appwrite-labs/cloud`, which vendors this branch as `appwrite/server-ce`.
