### PR TITLE
Make combined worker and scheduler containers the Compose default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ _Note: When running `composer check` or `composer analyze`, be aware that runnin
 
 ## Project layout
 
+- **src/Utopia/** -- Composer PSR-4 overrides of Utopia libraries (same pattern as `Bus`). `Queue` and `Platform` currently carry the combined-worker APIs until they land in [utopia-php/monorepo](https://github.com/utopia-php/monorepo) `packages/queue` and `packages/platform`.
 - **src/Appwrite/Platform/Modules/** -- feature modules (Account, Avatars, Compute, Console, Databases, Functions, Health, Project, Projects, Proxy, Sites, Storage, Teams, Tokens, Users, VCS, Webhooks)
 - **src/Appwrite/Platform/Workers/** -- background job workers
 - **src/Appwrite/Platform/Tasks/** -- CLI tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ Self-hosted Backend-as-a-Service platform. Hybrid monolithic-microservice archit
 
 | Command | Purpose |
 |---------|---------|
-| `docker compose up -d --force-recreate --build` | Build and start all services |
+| `docker compose up -d --force-recreate --build` | Build and start all services (combined worker + scheduler by default) |
+| `docker compose -f docker-compose.yml -f docker-compose.separate.yml --profile separate up -d` | Start per-queue worker and scheduler containers instead |
 | `docker compose exec appwrite test tests/e2e/Services/[Service]` | Run E2E tests for a service |
 | `docker compose exec appwrite test tests/e2e/Services/[Service] --filter=[Method]` | Run a single test method |
 | `docker compose exec appwrite test tests/unit/` | Run unit tests |
@@ -36,7 +37,7 @@ _Note: When running `composer check` or `composer analyze`, be aware that runnin
 - **src/Appwrite/Platform/Tasks/** -- CLI tasks
 - **app/init.php** -- bootstrap (registers services, resources, listeners)
 - **app/init/** -- configs, constants, locales, models, registers, resources, span, database filters/formats
-- **bin/** -- CLI entry points: `worker-*` (14 workers), `schedule-*`, `queue-*`, plus `doctor`, `install`, `migrate`, `realtime`, `upgrade`, `ssl`, `vars`, `maintenance`, `interval`, `specs`, `sdks`, etc.
+- **bin/** -- CLI entry points: `worker` (combined), `worker-*` (per-queue), `schedule` (combined), `schedule-*`, `queue-*`, plus `doctor`, `install`, `migrate`, `realtime`, `upgrade`, `ssl`, `vars`, `maintenance`, `interval`, `specs`, `sdks`, etc.
 - **tests/e2e/** -- end-to-end tests per service
 - **tests/unit/** -- unit tests
 - **public/** -- static assets and generated SDKs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Notable changes
 
+* Combined worker and scheduler containers are the default Docker Compose topology. Separate per-queue containers remain available via `--profile separate` / `--background=separate`.
 * Add PostgreSQL database adapter in [#9772](https://github.com/appwrite/appwrite/pull/9772) and [#11293](https://github.com/appwrite/appwrite/pull/11293)
 * Add MongoDB support in [#11312](https://github.com/appwrite/appwrite/pull/11312)
 * Add new webhooks API in [#11033](https://github.com/appwrite/appwrite/pull/11033) and [#11566](https://github.com/appwrite/appwrite/pull/11566)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Notable changes
 
-* Combined worker and scheduler containers are the default Docker Compose topology. Separate per-queue containers remain available via `--profile separate` / `--background=separate`.
+* Combined worker and scheduler containers are the default Docker Compose topology. Separate per-queue containers remain available via `--profile separate` / `--background=separate`. Queue/platform APIs for per-queue coroutine caps live as in-tree Utopia overrides (`src/Utopia/Queue`, `src/Utopia/Platform`) until they land in [utopia-php/monorepo](https://github.com/utopia-php/monorepo).
 * Add PostgreSQL database adapter in [#9772](https://github.com/appwrite/appwrite/pull/9772) and [#11293](https://github.com/appwrite/appwrite/pull/11293)
 * Add MongoDB support in [#11312](https://github.com/appwrite/appwrite/pull/11312)
 * Add new webhooks API in [#11033](https://github.com/appwrite/appwrite/pull/11033) and [#11566](https://github.com/appwrite/appwrite/pull/11566)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,15 @@ docker compose build
 docker compose up -d
 ```
 
+By default the stack runs a **combined** worker (`appwrite-worker`) and scheduler (`appwrite-task-scheduler`). To run one container per queue instead:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.separate.yml --profile separate up -d
+```
+
+Do not start combined and separate workers at the same time — they would consume the same queues twice.
+
+
 ### Code Autocompletion
 
 To get proper autocompletion for all the different functions and classes in the codebase, you'll need to install Appwrite dependencies on your local machine. You can easily do that with PHP's package manager, [Composer](https://getcomposer.org/). If you don't have Composer installed, you can use the Docker Hub image to get the same result:
@@ -175,7 +184,9 @@ Learn more at our [Technology Stack](#technology-stack) section.
 ##### Container Namespace Conventions
 To keep our services easy to understand within Docker we follow a naming convention for all our containers depending on its intended use.
 
-`appwrite-worker-X` - Workers (`src/Appwrite/Platform/Workers/*`)
+`appwrite-worker` - Combined worker (all queues; the Compose default)
+`appwrite-worker-X` - Separate per-queue workers (`src/Appwrite/Platform/Workers/*`)
+`appwrite-task-scheduler` - Combined scheduler (functions + executions + messages)
 `appwrite-task-X` - Tasks (`src/Appwrite/Platform/Tasks/*`)
 
 Other containers should be named the same as their service, for example `redis` should just be called `redis`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN chmod +x /usr/local/bin/doctor && \
     chmod +x /usr/local/bin/maintenance &&  \
     chmod +x /usr/local/bin/migrate && \
     chmod +x /usr/local/bin/realtime && \
+    chmod +x /usr/local/bin/schedule && \
     chmod +x /usr/local/bin/schedule-functions && \
     chmod +x /usr/local/bin/schedule-executions && \
     chmod +x /usr/local/bin/schedule-messages && \
@@ -84,6 +85,7 @@ RUN chmod +x /usr/local/bin/doctor && \
     chmod +x /usr/local/bin/queue-count-failed && \
     chmod +x /usr/local/bin/queue-count-processing && \
     chmod +x /usr/local/bin/queue-count-success && \
+    chmod +x /usr/local/bin/worker && \
     chmod +x /usr/local/bin/worker-builds && \
     chmod +x /usr/local/bin/worker-jobs && \
     chmod +x /usr/local/bin/worker-screenshots && \

--- a/app/views/install/installer/js/modules/progress.js
+++ b/app/views/install/installer/js/modules/progress.js
@@ -368,6 +368,7 @@
             httpPort: normalizedHttpPort,
             httpsPort: normalizedHttpsPort,
             database: formState?.database || 'postgresql',
+            background: formState?.background || 'combined',
             appDomain: normalizedDomain,
             emailCertificates: normalizedEmail,
             opensslKey: (formState?.opensslKey || '').trim(),

--- a/app/views/install/installer/js/modules/state.js
+++ b/app/views/install/installer/js/modules/state.js
@@ -18,6 +18,7 @@
         emailCertificates: null,
         opensslKey: null,
         assistantOpenAIKey: null,
+        background: 'combined',
         accountEmail: null,
         accountPassword: null
     };

--- a/app/views/install/installer/js/modules/ui.js
+++ b/app/views/install/installer/js/modules/ui.js
@@ -90,7 +90,8 @@
 
     const updateDatabaseSelection = (radio, root) => {
         if (!radio || !root) return;
-        const allOptions = root.querySelectorAll('.selector-card');
+        const group = radio.closest('.selector-group') || root;
+        const allOptions = group.querySelectorAll('.selector-card');
         allOptions.forEach((option) => option.classList.remove('selected'));
         const selectedOption = radio.closest('.selector-card');
         if (selectedOption) {

--- a/app/views/install/installer/js/steps.js
+++ b/app/views/install/installer/js/steps.js
@@ -106,6 +106,7 @@
     const hydrateStep1State = (root) => {
         State.setStateIfEmpty?.('appDomain', root.querySelector('#hostname')?.value);
         State.setStateIfEmpty?.('database', root.querySelector('input[name="database"]:checked')?.value);
+        State.setStateIfEmpty?.('background', root.querySelector('input[name="background"]:checked')?.value || 'combined');
         State.setStateIfEmpty?.('httpPort', root.querySelector('#http-port')?.value);
         State.setStateIfEmpty?.('httpsPort', root.querySelector('#https-port')?.value);
         State.setStateIfEmpty?.('emailCertificates', root.querySelector('#ssl-email')?.value);
@@ -137,6 +138,16 @@
                 updateDatabaseSelection?.(radio, root);
             }
         }
+
+        if (formState.background) {
+            const radio = root.querySelector(`input[name="background"][value="${formState.background}"]`);
+            if (radio) {
+                radio.checked = true;
+                const group = radio.closest('.selector-group');
+                group?.querySelectorAll('.selector-card').forEach((card) => card.classList.remove('selected'));
+                radio.closest('.selector-card')?.classList.add('selected');
+            }
+        }
     };
 
     const initStep1 = (root) => {
@@ -161,6 +172,16 @@
         } else {
             bindDatabaseSelection(root);
         }
+
+        const backgroundRadios = root.querySelectorAll('input[name="background"]');
+        backgroundRadios.forEach((radio) => {
+            radio.addEventListener('change', () => {
+                formState.background = radio.value;
+                const group = radio.closest('.selector-group');
+                group?.querySelectorAll('.selector-card').forEach((card) => card.classList.remove('selected'));
+                radio.closest('.selector-card')?.classList.add('selected');
+            });
+        });
 
         const hostname = root.querySelector('#hostname');
         const httpPort = root.querySelector('#http-port');

--- a/app/views/install/installer/templates/steps/step-1.phtml
+++ b/app/views/install/installer/templates/steps/step-1.phtml
@@ -103,6 +103,26 @@ $assistantOpenAIKeyValue = htmlspecialchars((string) $defaultAssistantOpenAIKey,
                     </span>
                 </button>
                 <div class="accordion-content">
+                    <div class="input-group stack-xs">
+                        <label class="label-text typography-text-m-500 text-neutral-secondary">Workers and schedulers</label>
+                        <div class="selector-group">
+                            <label class="selector-card selected">
+                                <input type="radio" name="background" value="combined" checked class="sr-only">
+                                <div class="selector-content">
+                                    <div class="typography-text-m-500 text-neutral-primary">Combined</div>
+                                    <div class="typography-text-xs-400 text-neutral-secondary">One worker and one scheduler (recommended)</div>
+                                </div>
+                            </label>
+                            <label class="selector-card">
+                                <input type="radio" name="background" value="separate" class="sr-only">
+                                <div class="selector-content">
+                                    <div class="typography-text-m-500 text-neutral-primary">Separate</div>
+                                    <div class="typography-text-xs-400 text-neutral-secondary">One container per queue for scale-out</div>
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+
                     <div class="input-row">
                         <div class="input-group stack-xs">
                             <label for="http-port" class="label-text typography-text-m-500 text-neutral-secondary">HTTP port</label>

--- a/app/worker.php
+++ b/app/worker.php
@@ -5,6 +5,7 @@ $registerWorkerMessageResources = require __DIR__ . '/init/worker/message.php';
 
 use Appwrite\Certificates\LetsEncrypt;
 use Appwrite\Platform\Appwrite;
+use Appwrite\Worker\Config as WorkerConfig;
 use Swoole\Runtime;
 use Utopia\Console;
 use Utopia\Database\Document;
@@ -51,42 +52,67 @@ $container->set('certificates', function () {
 $platform = new Appwrite();
 $args = $_SERVER['argv'] ?? [];
 
-if (! isset($args[1])) {
-    Console::error('Missing worker name');
-    Console::exit(1);
-}
-
 \array_shift($args);
-$workerName = $args[0];
-
-if (\str_starts_with($workerName, 'databases')) {
-    $queueName = System::getEnv('_APP_QUEUE_NAME', 'database_db_main');
-} else {
-    $queueName = System::getEnv('_APP_QUEUE_NAME', 'v1-' . strtolower($workerName));
+$requested = [];
+foreach ($args as $arg) {
+    if (!\is_string($arg) || $arg === '' || \str_starts_with($arg, '-')) {
+        continue;
+    }
+    foreach (\preg_split('/[,\s]+/', strtolower($arg), -1, PREG_SPLIT_NO_EMPTY) ?: [] as $name) {
+        $requested[] = $name;
+    }
 }
+
+if ($requested === [] || \in_array('all', $requested, true)) {
+    $workerNames = WorkerConfig::NAMES;
+    $workerName = 'all';
+} else {
+    $unknown = \array_values(\array_diff($requested, WorkerConfig::NAMES));
+    if ($unknown !== []) {
+        Console::error('Unknown worker: ' . \implode(', ', $unknown) . '. Valid: ' . \implode(', ', WorkerConfig::NAMES));
+        Console::exit(1);
+    }
+    $workerNames = $requested;
+    $workerName = $workerNames[0];
+}
+
+$workerJobs = WorkerConfig::jobs($workerNames, allowEnvOverride: $workerName !== 'all');
+$firstJob = \reset($workerJobs);
+$queueName = $firstJob['queue'] ?? WorkerConfig::queueName($workerName);
+$adapterMaxCoroutines = $workerName === 'all'
+    ? 1
+    : ($firstJob['maxCoroutines'] ?? 1);
 
 $redisHost = System::getEnv('_APP_REDIS_HOST', 'redis');
 $redisPort = (int) System::getEnv('_APP_REDIS_PORT', 6379);
+$commands = new Locking(new RedisConnection($redisHost, $redisPort));
+
+$createConsumer = static function () use ($redisHost, $redisPort, $commands): BrokerRedis {
+    return new BrokerRedis(
+        receive: new RedisConnection($redisHost, $redisPort),
+        commands: $commands,
+    );
+};
 
 // A dedicated connection drives the blocking receive loop; a lock-guarded one
 // serializes acks/publishes from the per-message coroutines.
 $adapter = new Swoole(
-    new BrokerRedis(
-        receive: new RedisConnection($redisHost, $redisPort),
-        commands: new Locking(new RedisConnection($redisHost, $redisPort)),
-    ),
+    $createConsumer(),
     System::getEnv('_APP_WORKERS_NUM', 1),
     $queueName,
-    maxCoroutines: (int) System::getEnv('_APP_WORKER_MAX_COROUTINES', 1),
+    maxCoroutines: $adapterMaxCoroutines,
     resources: $container,
 );
 
 $worker = new Server($adapter);
+$worker->setConsumerFactory(fn (string $name) => $createConsumer());
 
 try {
-    $worker->init()->action(function () use ($worker, $registerWorkerMessageResources, $queueName) {
+    $worker->init()->action(function () use ($worker, $registerWorkerMessageResources) {
         $registerWorkerMessageResources($worker->context());
-        Span::init("worker.{$queueName}");
+        $message = $worker->context()->get('message');
+        $spanQueue = $message instanceof \Utopia\Queue\Message ? $message->getQueue() : 'worker';
+        Span::init("worker.{$spanQueue}");
     });
 
     $worker->shutdown()->action(function () {
@@ -101,7 +127,9 @@ try {
 
     $platform->setWorker($worker);
     $platform->init(Service::TYPE_WORKER, [
-        'workerName' => strtolower($workerName),
+        'workerName' => $workerName,
+        'workerNames' => $workerName === 'all' ? ['all'] : $workerNames,
+        'workerJobs' => $workerJobs,
     ]);
 } catch (\Throwable $e) {
     Console::error($e->getMessage() . ', File: ' . $e->getFile() . ', Line: ' . $e->getLine());
@@ -115,7 +143,7 @@ $worker
     ->inject('log')
     ->inject('project')
     ->inject('authorization')
-    ->action(function (Throwable $error, ?Logger $logger, Log $log, Document $project, Authorization $authorization) use ($queueName) {
+    ->action(function (Throwable $error, ?Logger $logger, Log $log, Document $project, Authorization $authorization) {
         $version = System::getEnv('_APP_VERSION', 'UNKNOWN');
 
         Span::current()?->setError($error);
@@ -126,7 +154,7 @@ $worker
             $log->setVersion($version);
             $log->setType(Log::TYPE_ERROR);
             $log->setMessage($error->getMessage());
-            $log->setAction('appwrite-queue-' . $queueName);
+            $log->setAction('appwrite-queue-worker');
             $log->addTag('verboseType', get_class($error));
             $log->addTag('code', $error->getCode());
             $log->addTag('projectId', $project->getId());

--- a/bin/schedule
+++ b/bin/schedule
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec php /usr/src/code/app/cli.php schedule "$@"

--- a/bin/worker
+++ b/bin/worker
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec php /usr/src/code/app/worker.php all "$@"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
             "Appwrite\\": "src/Appwrite",
             "Executor\\": "src/Executor",
             "Utopia\\Bus\\": "src/Utopia/Bus",
-            "Utopia\\Queue\\": "src/Utopia/Queue"
+            "Utopia\\Queue\\": "src/Utopia/Queue",
+            "Utopia\\Platform\\": "src/Utopia/Platform"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "psr-4": {
             "Appwrite\\": "src/Appwrite",
             "Executor\\": "src/Executor",
-            "Utopia\\Bus\\": "src/Utopia/Bus"
+            "Utopia\\Bus\\": "src/Utopia/Bus",
+            "Utopia\\Queue\\": "src/Utopia/Queue"
         }
     },
     "autoload-dev": {

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -50,6 +50,33 @@ services:
       - ./src:/usr/src/code/src
     ports:
       - 9502:80
+  appwrite-worker:
+    build:
+      context: .
+      target: development
+      args:
+        DEBUG: false
+        TESTING: true
+        VERSION: dev
+    image: appwrite-dev
+    volumes:
+      - ./app:/usr/src/code/app
+      - ./src:/usr/src/code/src
+    depends_on:
+      - request-catcher-sms
+      - request-catcher-webhook
+  appwrite-task-scheduler:
+    build:
+      context: .
+      target: development
+      args:
+        DEBUG: false
+        TESTING: true
+        VERSION: dev
+    image: appwrite-dev
+    volumes:
+      - ./app:/usr/src/code/app
+      - ./src:/usr/src/code/src
   appwrite-worker-webhooks:
     build:
       context: .

--- a/docker-compose.separate.yml
+++ b/docker-compose.separate.yml
@@ -1,0 +1,13 @@
+# Combined worker/scheduler stay unprofiled in docker-compose.yml so
+# `docker compose up` is the small stack. This override hides them when
+# the `separate` profile is enabled, so per-queue containers can run
+# without double-consuming queues.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.separate.yml --profile separate up -d
+services:
+  appwrite-worker:
+    profiles:
+      - combined
+  appwrite-task-scheduler:
+    profiles:
+      - combined

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,7 +309,194 @@ services:
       - _APP_DATABASE_SHARED_TABLES
       - _APP_POOL_ADAPTER=swoole
 
+  appwrite-worker:
+    entrypoint: worker
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: "5"
+        max-size: 10m
+    container_name: appwrite-worker
+    image: ${_APP_IMAGE:-appwrite/appwrite}:${_APP_VERSION:-latest}
+    networks:
+      - appwrite
+    depends_on:
+      - redis
+      - ${_APP_DB_HOST:-postgresql}
+      - appwrite-embedding
+    volumes:
+      - appwrite-uploads:/storage/uploads:rw
+      - appwrite-cache:/storage/cache:rw
+      - appwrite-functions:/storage/functions:rw
+      - appwrite-sites:/storage/sites:rw
+      - appwrite-builds:/storage/builds:rw
+      - appwrite-certificates:/storage/certificates:rw
+      - appwrite-config:/storage/config:rw
+      - appwrite-imports:/storage/imports:rw
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      - _APP_ENV
+      - _APP_WORKERS_NUM=1
+      # Pool sizing only (sum of per-queue caps). Each queue keeps its own maxCoroutines in PHP; databases stays at 1.
+      - _APP_WORKER_MAX_COROUTINES=61
+      - _APP_WORKER_PER_CORE
+      - _APP_POOL_ADAPTER
+      - _APP_OPENSSL_KEY_V1
+      - _APP_EMAIL_SECURITY
+      - _APP_EMAIL_CERTIFICATES
+      - _APP_DB_ADAPTER
+      - _APP_DB_HOST
+      - _APP_DB_PORT
+      - _APP_DB_SCHEMA
+      - _APP_DB_USER
+      - _APP_DB_PASS
+      - _APP_DB_ADAPTER_VECTORSDB
+      - _APP_DB_HOST_VECTORSDB
+      - _APP_DB_PORT_VECTORSDB
+      - _APP_DB_SCHEMA_VECTORSDB
+      - _APP_DB_USER_VECTORSDB
+      - _APP_DB_PASS_VECTORSDB
+      - _APP_REDIS_HOST
+      - _APP_REDIS_PORT
+      - _APP_REDIS_USER
+      - _APP_REDIS_PASS
+      - _APP_LOGGING_CONFIG
+      - _APP_LOGGING_FORMAT
+      - _APP_LOGGING_PROVIDER
+      - _APP_QUEUE_NAME
+      - _APP_DATABASE_SHARED_TABLES
+      - _APP_CONSOLE_URL_SCHEME=root
+      - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_TRUSTED_PROJECTS
+      - _APP_DOMAIN
+      - _APP_DOMAIN_TARGET_CNAME
+      - _APP_DOMAIN_TARGET_AAAA
+      - _APP_DOMAIN_TARGET_A
+      - _APP_DOMAIN_TARGET_CAA
+      - _APP_DNS
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_OPTIONS_ROUTER_FORCE_HTTPS
+      - _APP_WEBHOOK_MAX_FAILED_ATTEMPTS
+      - _APP_STORAGE_DEVICE
+      - _APP_STORAGE_S3_ACCESS_KEY
+      - _APP_STORAGE_S3_SECRET
+      - _APP_STORAGE_S3_REGION
+      - _APP_STORAGE_S3_BUCKET
+      - _APP_STORAGE_S3_ENDPOINT
+      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
+      - _APP_STORAGE_DO_SPACES_SECRET
+      - _APP_STORAGE_DO_SPACES_REGION
+      - _APP_STORAGE_DO_SPACES_BUCKET
+      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
+      - _APP_STORAGE_BACKBLAZE_SECRET
+      - _APP_STORAGE_BACKBLAZE_REGION
+      - _APP_STORAGE_BACKBLAZE_BUCKET
+      - _APP_STORAGE_LINODE_ACCESS_KEY
+      - _APP_STORAGE_LINODE_SECRET
+      - _APP_STORAGE_LINODE_REGION
+      - _APP_STORAGE_LINODE_BUCKET
+      - _APP_STORAGE_WASABI_ACCESS_KEY
+      - _APP_STORAGE_WASABI_SECRET
+      - _APP_STORAGE_WASABI_REGION
+      - _APP_STORAGE_WASABI_BUCKET
+      - _APP_EXECUTOR_SECRET
+      - _APP_EXECUTOR_HOST
+      - _APP_DOCKER_HUB_USERNAME
+      - _APP_DOCKER_HUB_PASSWORD
+      - _APP_FUNCTIONS_TIMEOUT
+      - _APP_SITES_TIMEOUT
+      - _APP_COMPUTE_BUILD_TIMEOUT
+      - _APP_COMPUTE_CPUS
+      - _APP_COMPUTE_MEMORY
+      - _APP_OPEN_RUNTIMES_NFT
+      - _APP_COMPUTE_SIZE_LIMIT
+      - _APP_VCS_GITHUB_APP_NAME
+      - _APP_VCS_GITHUB_PRIVATE_KEY
+      - _APP_VCS_GITHUB_APP_ID
+      - _APP_VCS_GITEA_ENDPOINT
+      - _APP_VCS_GITEA_BROWSER_ENDPOINT
+      - _APP_VCS_GITEA_CLIENT_ID
+      - _APP_VCS_GITEA_CLIENT_SECRET
+      - _APP_VCS_GITEA_WEBHOOK_SECRET
+      - _APP_VCS_GITLAB_CLIENT_ID
+      - _APP_VCS_GITLAB_CLIENT_SECRET
+      - _APP_VCS_GITLAB_WEBHOOK_SECRET
+      - _APP_VCS_BITBUCKET_CLIENT_ID
+      - _APP_VCS_BITBUCKET_CLIENT_SECRET
+      - _APP_VCS_BITBUCKET_WEBHOOK_SECRET
+      - _APP_VCS_WEBHOOK_URL
+      - _APP_BUILDS_VOLUME
+      - _APP_JOBS_HOST
+      - _APP_JOBS_SECRET
+      - _APP_JOBS_ENDPOINT
+      - _APP_BROWSER_HOST
+      - _APP_WORKER_SCREENSHOTS_ROUTER
+      - _APP_NOTIFICATIONS_TRACKING_SECRET
+      - _APP_SYSTEM_EMAIL_NAME
+      - _APP_SYSTEM_EMAIL_ADDRESS
+      - _APP_SMTP_HOST
+      - _APP_SMTP_PORT
+      - _APP_SMTP_SECURE
+      - _APP_SMTP_USERNAME
+      - _APP_SMTP_PASSWORD
+      - _APP_SMS_FROM
+      - _APP_SMS_PROVIDER
+      - _APP_SMS_PROJECTS_DENY_LIST
+      - _APP_MIGRATIONS_FIREBASE_CLIENT_ID
+      - _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET
+      - _APP_MIGRATION_HOST
+      - _APP_MAINTENANCE_RETENTION_AUDIT
+      - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
+
+  appwrite-task-scheduler:
+    entrypoint: schedule
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: "5"
+        max-size: 10m
+    container_name: appwrite-task-scheduler
+    image: ${_APP_IMAGE:-appwrite/appwrite}:${_APP_VERSION:-latest}
+    networks:
+      - appwrite
+    depends_on:
+      - ${_APP_DB_HOST:-postgresql}
+      - redis
+      - appwrite-embedding
+    environment:
+      - _APP_ENV
+      - _APP_LOGGING_FORMAT
+      - _APP_WORKER_PER_CORE
+      - _APP_POOL_ADAPTER
+      - _APP_OPENSSL_KEY_V1
+      - _APP_OPTIONS_FORCE_HTTPS
+      - _APP_DOMAIN
+      - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_SCHEMA
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
+      - _APP_MIGRATION_HOST
+      - _APP_REDIS_HOST
+      - _APP_REDIS_PORT
+      - _APP_REDIS_USER
+      - _APP_REDIS_PASS
+      - _APP_DB_ADAPTER
+      - _APP_DB_HOST
+      - _APP_DB_PORT
+      - _APP_DB_SCHEMA
+      - _APP_DB_USER
+      - _APP_DB_PASS
+      - _APP_DATABASE_SHARED_TABLES
+      - _APP_FUNCTIONS_SCHEDULE_SPREAD
+
   appwrite-worker-webhooks:
+    profiles:
+      - separate
     entrypoint: worker-webhooks
     logging:
       driver: json-file
@@ -348,6 +535,8 @@ services:
       - _APP_DATABASE_SHARED_TABLES
       - _APP_CONSOLE_URL_SCHEME=root
   appwrite-worker-deletes:
+    profiles:
+      - separate
     entrypoint: worker-deletes
     logging:
       driver: json-file
@@ -417,6 +606,8 @@ services:
       - _APP_MAINTENANCE_RETENTION_AUDIT
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
   appwrite-worker-databases:
+    profiles:
+      - separate
     entrypoint: worker-databases
     logging:
       driver: json-file
@@ -459,6 +650,8 @@ services:
       - _APP_QUEUE_NAME
       - _APP_DATABASE_SHARED_TABLES
   appwrite-worker-builds:
+    profiles:
+      - separate
     entrypoint: worker-builds
     logging:
       driver: json-file
@@ -558,6 +751,8 @@ services:
       - host.docker.internal:host-gateway
 
   appwrite-worker-jobs:
+    profiles:
+      - separate
     entrypoint: worker-jobs
     logging:
       driver: json-file
@@ -599,6 +794,8 @@ services:
       - host.docker.internal:host-gateway
 
   appwrite-worker-screenshots:
+    profiles:
+      - separate
     entrypoint: worker-screenshots
     logging:
       driver: json-file
@@ -662,6 +859,8 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
   appwrite-worker-certificates:
+    profiles:
+      - separate
     entrypoint: worker-certificates
     logging:
       driver: json-file
@@ -710,6 +909,8 @@ services:
       - _APP_DATABASE_SHARED_TABLES
 
   appwrite-worker-functions:
+    profiles:
+      - separate
     entrypoint: worker-functions
     logging:
       driver: json-file
@@ -756,6 +957,8 @@ services:
       - _APP_LOGGING_PROVIDER
       - _APP_DATABASE_SHARED_TABLES
   appwrite-worker-mails:
+    profiles:
+      - separate
     entrypoint: worker-mails
     logging:
       driver: json-file
@@ -801,6 +1004,8 @@ services:
       - _APP_DATABASE_SHARED_TABLES
 
   appwrite-worker-notifications:
+    profiles:
+      - separate
     entrypoint: worker-notifications
     logging:
       driver: json-file
@@ -844,6 +1049,8 @@ services:
       - _APP_OPTIONS_FORCE_HTTPS
       - _APP_DATABASE_SHARED_TABLES
   appwrite-worker-messaging:
+    profiles:
+      - separate
     entrypoint: worker-messaging
     logging:
       driver: json-file
@@ -905,6 +1112,8 @@ services:
       - _APP_STORAGE_WASABI_BUCKET
       - _APP_DATABASE_SHARED_TABLES
   appwrite-worker-migrations:
+    profiles:
+      - separate
     entrypoint: worker-migrations
     logging:
       driver: json-file
@@ -1046,6 +1255,8 @@ services:
       - _APP_INTERVAL_CLEANUP_STALE_EXECUTIONS
 
   appwrite-task-scheduler-functions:
+    profiles:
+      - separate
     entrypoint: schedule-functions
     restart: unless-stopped
     logging:
@@ -1087,6 +1298,8 @@ services:
       - _APP_DATABASE_SHARED_TABLES
       - _APP_FUNCTIONS_SCHEDULE_SPREAD
   appwrite-task-scheduler-executions:
+    profiles:
+      - separate
     entrypoint: schedule-executions
     restart: unless-stopped
     logging:
@@ -1127,6 +1340,8 @@ services:
       - _APP_DB_PASS
       - _APP_DATABASE_SHARED_TABLES
   appwrite-task-scheduler-messages:
+    profiles:
+      - separate
     entrypoint: schedule-messages
     restart: unless-stopped
     logging:

--- a/src/Appwrite/Docker/Compose/Generator.php
+++ b/src/Appwrite/Docker/Compose/Generator.php
@@ -29,6 +29,35 @@ class Generator
         'enableAssistant' => 'appwrite-assistant',
     ];
 
+    private const array BACKGROUND_SERVICE_GROUPS = [
+        'background' => [
+            'default' => 'combined',
+            'modes' => [
+                'combined' => [
+                    'appwrite-worker',
+                    'appwrite-task-scheduler',
+                ],
+                'separate' => [
+                    'appwrite-worker-webhooks',
+                    'appwrite-worker-deletes',
+                    'appwrite-worker-databases',
+                    'appwrite-worker-builds',
+                    'appwrite-worker-jobs',
+                    'appwrite-worker-screenshots',
+                    'appwrite-worker-certificates',
+                    'appwrite-worker-functions',
+                    'appwrite-worker-mails',
+                    'appwrite-worker-notifications',
+                    'appwrite-worker-messaging',
+                    'appwrite-worker-migrations',
+                    'appwrite-task-scheduler-functions',
+                    'appwrite-task-scheduler-executions',
+                    'appwrite-task-scheduler-messages',
+                ],
+            ],
+        ],
+    ];
+
     private const array LOCAL_VOLUME_PREPENDS = [
         'appwrite' => [
             'param' => 'hostPath',
@@ -46,6 +75,7 @@ class Generator
         'database' => 'postgresql',
         'hostPath' => '',
         'enableAssistant' => false,
+        'background' => 'combined',
     ];
 
     private const array DEPENDENCY_SELECTORS = [
@@ -132,6 +162,12 @@ class Generator
             }
         }
 
+        foreach (self::BACKGROUND_SERVICE_GROUPS as $param => $config) {
+            if (!\array_key_exists($params[$param], $config['modes'])) {
+                $params[$param] = $config['default'];
+            }
+        }
+
         $params['hostPath'] = \rtrim((string)$params['hostPath'], '/');
 
         return $params;
@@ -170,6 +206,25 @@ class Generator
                 unset($services[$service]);
             }
         }
+
+        foreach (self::BACKGROUND_SERVICE_GROUPS as $param => $config) {
+            $selected = $this->params[$param];
+            foreach ($config['modes'] as $mode => $names) {
+                if ($mode === $selected) {
+                    continue;
+                }
+                foreach ($names as $name) {
+                    unset($services[$name]);
+                }
+            }
+        }
+
+        foreach ($services as &$service) {
+            if (\is_array($service)) {
+                unset($service['profiles']);
+            }
+        }
+        unset($service);
 
         return $services;
     }

--- a/src/Appwrite/Platform/Appwrite.php
+++ b/src/Appwrite/Platform/Appwrite.php
@@ -24,23 +24,10 @@ use Appwrite\Platform\Modules\Tokens;
 use Appwrite\Platform\Modules\Users;
 use Appwrite\Platform\Modules\VCS;
 use Appwrite\Platform\Modules\Webhooks;
-use Appwrite\Worker\Config as WorkerConfig;
-use Utopia\Platform\Action;
 use Utopia\Platform\Platform;
-use Utopia\Platform\Service;
 
 class Appwrite extends Platform
 {
-    /**
-     * @var list<string>
-     */
-    private array $workerNames = [];
-
-    /**
-     * @var array<string, array{queue: string, maxCoroutines: int}>
-     */
-    private array $workerJobs = [];
-
     public function __construct()
     {
         parent::__construct(new Core());
@@ -65,89 +52,5 @@ class Appwrite extends Platform
         $this->addModule(new Organization\Module());
         $this->addModule(new Project\Module());
         $this->addModule(new Advisor\Module());
-    }
-
-    public function init(string $type, array $params = []): void
-    {
-        if ($type === Service::TYPE_WORKER) {
-            $names = $params['workerNames'] ?? [];
-            if ($names === [] && isset($params['workerName'])) {
-                $names = [$params['workerName']];
-            }
-            $this->workerNames = array_map('strtolower', $names);
-            $this->workerJobs = $params['workerJobs'] ?? [];
-        }
-
-        parent::init($type, $params);
-    }
-
-    /**
-     * @param array<int|string, \Utopia\Platform\Service> $services
-     */
-    protected function initWorker(array $services, string $workerName): void
-    {
-        $worker = $this->worker;
-        $names = $this->workerNames !== [] ? $this->workerNames : [strtolower($workerName)];
-        $all = \in_array('all', $names, true);
-
-        foreach ($services as $service) {
-            foreach ($service->getActions() as $key => $action) {
-                if ($action->getType() == Action::TYPE_DEFAULT) {
-                    $name = strtolower((string) $key);
-                    if (!$all && !\in_array($name, $names, true)) {
-                        continue;
-                    }
-                }
-
-                switch ($action->getType()) {
-                    case Action::TYPE_INIT:
-                        $hook = $worker->init();
-                        break;
-                    case Action::TYPE_ERROR:
-                        $hook = $worker->error();
-                        break;
-                    case Action::TYPE_SHUTDOWN:
-                        $hook = $worker->shutdown();
-                        break;
-                    case Action::TYPE_WORKER_START:
-                        $hook = $worker->workerStart();
-                        break;
-                    case Action::TYPE_WORKER_STOP:
-                        $hook = $worker->workerStop();
-                        break;
-                    case Action::TYPE_DEFAULT:
-                    default:
-                        $name = strtolower((string) $key);
-                        $config = $this->workerJobs[$name] ?? [
-                            'queue' => WorkerConfig::queueName($name),
-                            'maxCoroutines' => WorkerConfig::maxCoroutines($name),
-                        ];
-                        $hook = $worker->job($config['queue'], $config['maxCoroutines']);
-                        break;
-                }
-
-                $hook
-                    ->groups($action->getGroups())
-                    ->desc($action->getDesc() ?? '');
-
-                foreach ($action->getOptions() as $optionKey => $option) {
-                    switch ($option['type']) {
-                        case 'param':
-                            $optionKey = substr((string) $optionKey, stripos((string) $optionKey, ':') + 1);
-                            $hook->param($optionKey, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
-                            break;
-                        case 'injection':
-                            $hook->inject($option['name']);
-                            break;
-                    }
-                }
-
-                foreach ($action->getLabels() as $labelKey => $label) {
-                    $hook->label($labelKey, $label);
-                }
-
-                $hook->action($action->getCallback());
-            }
-        }
     }
 }

--- a/src/Appwrite/Platform/Appwrite.php
+++ b/src/Appwrite/Platform/Appwrite.php
@@ -24,10 +24,23 @@ use Appwrite\Platform\Modules\Tokens;
 use Appwrite\Platform\Modules\Users;
 use Appwrite\Platform\Modules\VCS;
 use Appwrite\Platform\Modules\Webhooks;
+use Appwrite\Worker\Config as WorkerConfig;
+use Utopia\Platform\Action;
 use Utopia\Platform\Platform;
+use Utopia\Platform\Service;
 
 class Appwrite extends Platform
 {
+    /**
+     * @var list<string>
+     */
+    private array $workerNames = [];
+
+    /**
+     * @var array<string, array{queue: string, maxCoroutines: int}>
+     */
+    private array $workerJobs = [];
+
     public function __construct()
     {
         parent::__construct(new Core());
@@ -52,5 +65,89 @@ class Appwrite extends Platform
         $this->addModule(new Organization\Module());
         $this->addModule(new Project\Module());
         $this->addModule(new Advisor\Module());
+    }
+
+    public function init(string $type, array $params = []): void
+    {
+        if ($type === Service::TYPE_WORKER) {
+            $names = $params['workerNames'] ?? [];
+            if ($names === [] && isset($params['workerName'])) {
+                $names = [$params['workerName']];
+            }
+            $this->workerNames = array_map('strtolower', $names);
+            $this->workerJobs = $params['workerJobs'] ?? [];
+        }
+
+        parent::init($type, $params);
+    }
+
+    /**
+     * @param array<int|string, \Utopia\Platform\Service> $services
+     */
+    protected function initWorker(array $services, string $workerName): void
+    {
+        $worker = $this->worker;
+        $names = $this->workerNames !== [] ? $this->workerNames : [strtolower($workerName)];
+        $all = \in_array('all', $names, true);
+
+        foreach ($services as $service) {
+            foreach ($service->getActions() as $key => $action) {
+                if ($action->getType() == Action::TYPE_DEFAULT) {
+                    $name = strtolower((string) $key);
+                    if (!$all && !\in_array($name, $names, true)) {
+                        continue;
+                    }
+                }
+
+                switch ($action->getType()) {
+                    case Action::TYPE_INIT:
+                        $hook = $worker->init();
+                        break;
+                    case Action::TYPE_ERROR:
+                        $hook = $worker->error();
+                        break;
+                    case Action::TYPE_SHUTDOWN:
+                        $hook = $worker->shutdown();
+                        break;
+                    case Action::TYPE_WORKER_START:
+                        $hook = $worker->workerStart();
+                        break;
+                    case Action::TYPE_WORKER_STOP:
+                        $hook = $worker->workerStop();
+                        break;
+                    case Action::TYPE_DEFAULT:
+                    default:
+                        $name = strtolower((string) $key);
+                        $config = $this->workerJobs[$name] ?? [
+                            'queue' => WorkerConfig::queueName($name),
+                            'maxCoroutines' => WorkerConfig::maxCoroutines($name),
+                        ];
+                        $hook = $worker->job($config['queue'], $config['maxCoroutines']);
+                        break;
+                }
+
+                $hook
+                    ->groups($action->getGroups())
+                    ->desc($action->getDesc() ?? '');
+
+                foreach ($action->getOptions() as $optionKey => $option) {
+                    switch ($option['type']) {
+                        case 'param':
+                            $optionKey = substr((string) $optionKey, stripos((string) $optionKey, ':') + 1);
+                            $hook->param($optionKey, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
+                            break;
+                        case 'injection':
+                            $hook->inject($option['name']);
+                            break;
+                    }
+                }
+
+                foreach ($action->getLabels() as $labelKey => $label) {
+                    $hook->label($labelKey, $label);
+                }
+
+                $hook->action($action->getCallback());
+            }
+        }
     }
 }

--- a/src/Appwrite/Platform/Installer/Http/Installer/Install.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/Install.php
@@ -41,6 +41,7 @@ class Install extends Action
             ->param('accountEmail', '', new Email(allowEmpty: true), 'Account email address', true)
             ->param('accountPassword', '', new Password(allowEmpty: true), 'Account password', true)
             ->param('database', '', new WhiteList(['postgresql', 'mariadb', 'mongodb']), 'Database adapter', true)
+            ->param('background', 'combined', new WhiteList(['combined', 'separate']), 'Worker and scheduler topology', true)
             ->param('installId', '', new Text(64, 0), 'Installation ID', true)
             ->param('retryStep', null, new Nullable(new WhiteList([
                 Server::STEP_CONFIG_FILES,
@@ -70,6 +71,7 @@ class Install extends Action
         string $accountEmail,
         string $accountPassword,
         string $database,
+        string $background,
         string $installId,
         ?string $retryStep,
         bool $migrate,
@@ -212,6 +214,7 @@ class Install extends Action
         try {
             $state->ensureBootstrapped();
             $installer = new \Appwrite\Platform\Tasks\Install();
+            $installer->setBackground($background);
 
             if ($wantsStream) {
                 $this->writeSseEvent($swooleResponse, 'install-id', ['installId' => $installId]);

--- a/src/Appwrite/Platform/Services/Tasks.php
+++ b/src/Appwrite/Platform/Services/Tasks.php
@@ -8,6 +8,7 @@ use Appwrite\Platform\Tasks\Interval;
 use Appwrite\Platform\Tasks\Maintenance;
 use Appwrite\Platform\Tasks\Migrate;
 use Appwrite\Platform\Tasks\QueueRetry;
+use Appwrite\Platform\Tasks\Schedule;
 use Appwrite\Platform\Tasks\ScheduleExecutions;
 use Appwrite\Platform\Tasks\ScheduleFunctions;
 use Appwrite\Platform\Tasks\ScheduleMessages;
@@ -36,6 +37,7 @@ class Tasks extends Service
             ->addAction(SDKs::getName(), new SDKs())
             ->addAction(SSL::getName(), new SSL())
             ->addAction(Screenshot::getName(), new Screenshot())
+            ->addAction(Schedule::getName(), new Schedule())
             ->addAction(ScheduleFunctions::getName(), new ScheduleFunctions())
             ->addAction(ScheduleExecutions::getName(), new ScheduleExecutions())
             ->addAction(ScheduleMessages::getName(), new ScheduleMessages())

--- a/src/Appwrite/Platform/Tasks/Install.php
+++ b/src/Appwrite/Platform/Tasks/Install.php
@@ -44,6 +44,7 @@ class Install extends Action
     protected ?bool $isLocalInstall = null;
     protected ?array $installerConfig = null;
     protected string $path = '/usr/src/code/appwrite';
+    protected string $background = 'combined';
 
     public static function getName(): string
     {
@@ -61,6 +62,7 @@ class Install extends Action
             ->param('interactive', 'Y', new Text(1), 'Run an interactive session', true)
             ->param('no-start', false, new Boolean(true), 'Run an interactive session', true)
             ->param('database', 'postgresql', new WhiteList(['postgresql', 'mariadb', 'mongodb']), 'Database to use (postgresql|mariadb|mongodb)', true)
+            ->param('background', 'combined', new WhiteList(['combined', 'separate']), 'Worker and scheduler topology (combined|separate)', true)
             ->callback($this->action(...));
     }
 
@@ -71,7 +73,8 @@ class Install extends Action
         string $image,
         string $interactive,
         bool $noStart,
-        string $database
+        string $database,
+        string $background
     ): void {
         $isUpgrade = $this->isUpgrade;
         $defaultHttpPort = '80';
@@ -113,6 +116,12 @@ class Install extends Action
             Console::info('Compose file found, creating backup: ' . $composeFileName . '.' . $time . '.backup');
             file_put_contents($this->path . '/' . $composeFileName . '.' . $time . '.backup', $data);
             $compose = new Compose($data);
+            if (!$this->hasExplicitBackgroundParam()) {
+                $detected = $this->detectBackgroundFromCompose($compose);
+                if ($detected !== null) {
+                    $background = $detected;
+                }
+            }
             $appwrite = $compose->getService('appwrite');
             $oldVersion = $appwrite->getImageVersion();
             try {
@@ -209,6 +218,8 @@ class Install extends Action
             Console::error("Database '{$database}' is not available. Available options: " . implode(', ', $enabledDatabases));
             Console::exit(1);
         }
+
+        $this->setBackground($background);
 
         // If interactive and web mode enabled, start web server
         // Skip the web installer when explicit CLI params are provided
@@ -574,6 +585,7 @@ class Install extends Action
             'database' => $database,
             'hostPath' => $this->hostPath,
             'enableAssistant' => $enableAssistant,
+            'background' => $this->background,
         ]);
 
         $templateForEnv->setParam('vars', $input);
@@ -1534,6 +1546,37 @@ class Install extends Action
             if ($host !== null && in_array($host, $dbServices, true)) {
                 return $host;
             }
+        }
+
+        return null;
+    }
+
+    public function setBackground(string $background): void
+    {
+        $this->background = \in_array($background, ['combined', 'separate'], true)
+            ? $background
+            : 'combined';
+    }
+
+    private function hasExplicitBackgroundParam(): bool
+    {
+        foreach ($_SERVER['argv'] ?? [] as $arg) {
+            if (\str_starts_with((string) $arg, '--background')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function detectBackgroundFromCompose(Compose $compose): ?string
+    {
+        $names = array_keys($compose->getServices());
+        if (\in_array('appwrite-worker', $names, true)) {
+            return 'combined';
+        }
+        if (\in_array('appwrite-worker-functions', $names, true)) {
+            return 'separate';
         }
 
         return null;

--- a/src/Appwrite/Platform/Tasks/Schedule.php
+++ b/src/Appwrite/Platform/Tasks/Schedule.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Appwrite\Platform\Tasks;
+
+use Swoole\Coroutine as Co;
+use Utopia\Console;
+use Utopia\Database\Database;
+use Utopia\Platform\Action;
+use Utopia\Queue\Broker\Pool as BrokerPool;
+use Utopia\Telemetry\Adapter as Telemetry;
+
+class Schedule extends Action
+{
+    public static function getName(): string
+    {
+        return 'schedule';
+    }
+
+    public function __construct()
+    {
+        $this
+            ->desc('Execute functions, executions, and messages scheduled in Appwrite')
+            ->inject('publisher')
+            ->inject('publisherMigrations')
+            ->inject('publisherFunctions')
+            ->inject('publisherMessaging')
+            ->inject('getIsResourceBlocked')
+            ->inject('dbForPlatform')
+            ->inject('getProjectDB')
+            ->inject('telemetry')
+            ->callback($this->action(...));
+    }
+
+    public function action(
+        BrokerPool $publisher,
+        BrokerPool $publisherMigrations,
+        BrokerPool $publisherFunctions,
+        BrokerPool $publisherMessaging,
+        callable $getIsResourceBlocked,
+        Database $dbForPlatform,
+        callable $getProjectDB,
+        Telemetry $telemetry,
+    ): never {
+        Console::title('Scheduler V1');
+        Console::success(APP_NAME . ' combined scheduler v1 has started');
+
+        $tasks = [
+            new ScheduleFunctions(),
+            new ScheduleExecutions(),
+            new ScheduleMessages(),
+        ];
+
+        foreach ($tasks as $task) {
+            Co::create(function () use (
+                $task,
+                $publisher,
+                $publisherMigrations,
+                $publisherFunctions,
+                $publisherMessaging,
+                $getIsResourceBlocked,
+                $dbForPlatform,
+                $getProjectDB,
+                $telemetry,
+            ): void {
+                $task->action(
+                    $publisher,
+                    $publisherMigrations,
+                    $publisherFunctions,
+                    $publisherMessaging,
+                    $getIsResourceBlocked,
+                    $dbForPlatform,
+                    $getProjectDB,
+                    $telemetry,
+                );
+            });
+        }
+
+        while (true) {
+            sleep(3600);
+        }
+    }
+}

--- a/src/Appwrite/Platform/Tasks/ScheduleBase.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleBase.php
@@ -119,15 +119,23 @@ abstract class ScheduleBase extends Action
             $this->collectSchedules($dbForPlatform, $getProjectDB, $lastSyncUpdate, $getIsResourceBlocked);
         });
 
+        $this->listen($dbForPlatform, $getProjectDB);
+    }
+
+    /**
+     * Blocking enqueue loop. Extracted so a combined scheduler can run each
+     * resource type's action() (including this loop) in its own coroutine.
+     */
+    protected function listen(Database $dbForPlatform, callable $getProjectDB): never
+    {
         while (true) {
             try {
                 go(fn () => $this->enqueueResources($dbForPlatform, $getProjectDB));
-                $this->scheduleTelemetryCount->record(count($this->schedules), ['resourceType' => static::getSupportedResource()]);
+                $this->scheduleTelemetryCount?->record(count($this->schedules), ['resourceType' => static::getSupportedResource()]);
                 sleep(static::ENQUEUE_TIMER);
             } catch (\Throwable $th) {
                 Console::error('Failed to enqueue resources: ' . $th->getMessage());
             }
-
         }
     }
 

--- a/src/Appwrite/Worker/Config.php
+++ b/src/Appwrite/Worker/Config.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Appwrite\Worker;
+
+use Appwrite\Event\Event;
+use Utopia\System\System;
+
+final class Config
+{
+    /**
+     * Worker Action names that a combined worker consumes.
+     *
+     * @var list<string>
+     */
+    public const array NAMES = [
+        'webhooks',
+        'deletes',
+        'databases',
+        'builds',
+        'jobs',
+        'screenshots',
+        'certificates',
+        'functions',
+        'mails',
+        'notifications',
+        'messaging',
+        'migrations',
+    ];
+
+    /**
+     * Per-queue coroutine caps. Databases must stay at 1 to avoid deadlocks.
+     * Omit → 1, never 8.
+     *
+     * @var array<string, int>
+     */
+    public const array MAX_COROUTINES = [
+        'databases' => 1,
+        'mails' => 1,
+        'messaging' => 1,
+        'migrations' => 1,
+        'notifications' => 1,
+        'webhooks' => 8,
+        'deletes' => 8,
+        'builds' => 8,
+        'jobs' => 8,
+        'screenshots' => 8,
+        'certificates' => 8,
+        'functions' => 8,
+    ];
+
+    public static function queueName(string $workerName): string
+    {
+        return match ($workerName) {
+            'databases' => System::getEnv('_APP_QUEUE_NAME', 'database_db_main'),
+            'webhooks' => System::getEnv('_APP_WEBHOOK_QUEUE_NAME', Event::WEBHOOK_QUEUE_NAME),
+            'deletes' => System::getEnv('_APP_DELETE_QUEUE_NAME', Event::DELETE_QUEUE_NAME),
+            'builds' => System::getEnv('_APP_BUILDS_QUEUE_NAME', Event::BUILDS_QUEUE_NAME),
+            'jobs' => System::getEnv('_APP_JOBS_QUEUE_NAME', Event::JOBS_QUEUE_NAME),
+            'screenshots' => System::getEnv('_APP_SCREENSHOTS_QUEUE_NAME', Event::SCREENSHOTS_QUEUE_NAME),
+            'certificates' => System::getEnv('_APP_CERTIFICATES_QUEUE_NAME', Event::CERTIFICATES_QUEUE_NAME),
+            'functions' => System::getEnv('_APP_FUNCTIONS_QUEUE_NAME', Event::FUNCTIONS_QUEUE_NAME),
+            'mails' => System::getEnv('_APP_MAILS_QUEUE_NAME', Event::MAILS_QUEUE_NAME),
+            'notifications' => System::getEnv('_APP_NOTIFICATIONS_QUEUE_NAME', Event::NOTIFICATIONS_QUEUE_NAME),
+            'messaging' => System::getEnv('_APP_MESSAGING_QUEUE_NAME', Event::MESSAGING_QUEUE_NAME),
+            'migrations' => System::getEnv('_APP_MIGRATIONS_QUEUE_NAME', Event::MIGRATIONS_QUEUE_NAME),
+            default => System::getEnv('_APP_QUEUE_NAME', 'v1-' . $workerName),
+        };
+    }
+
+    public static function maxCoroutines(string $workerName, bool $allowEnvOverride = false): int
+    {
+        // Concurrent database-worker coroutines can deadlock on ordered writes
+        // / adapter locks. This is a correctness constraint, not a tuning knob.
+        if ($workerName === 'databases') {
+            return 1;
+        }
+
+        $default = self::MAX_COROUTINES[$workerName] ?? 1;
+
+        if ($allowEnvOverride) {
+            $env = System::getEnv('_APP_WORKER_MAX_COROUTINES');
+            if ($env !== false && $env !== null && $env !== '') {
+                return max(1, (int) $env);
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    public static function totalMaxCoroutines(array $names): int
+    {
+        $sum = 0;
+        foreach ($names as $name) {
+            $sum += self::maxCoroutines($name);
+        }
+
+        return max(1, $sum);
+    }
+
+    /**
+     * @param list<string> $names
+     * @return array<string, array{queue: string, maxCoroutines: int}>
+     */
+    public static function jobs(array $names, bool $allowEnvOverride = false): array
+    {
+        $jobs = [];
+        foreach ($names as $name) {
+            $jobs[$name] = [
+                'queue' => self::queueName($name),
+                'maxCoroutines' => self::maxCoroutines($name, $allowEnvOverride && \count($names) === 1),
+            ];
+        }
+
+        return $jobs;
+    }
+}

--- a/src/Utopia/Platform/Platform.php
+++ b/src/Utopia/Platform/Platform.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Utopia\Platform;
+
+/**
+ * In-tree override of utopia-php/platform until workerNames / per-job
+ * maxCoroutines land in utopia-php/monorepo `packages/platform`. Composer
+ * PSR-4 maps `Utopia\Platform\` here so this class wins over vendor.
+ *
+ * init(TYPE_WORKER, ['workerName' => 'functions']) stays the single-queue path.
+ * Combined workers pass workerNames: ['all'] (or a list) and workerJobs keyed
+ * by action name with that queue's maxCoroutines (default 1).
+ */
+
+use Exception;
+use Utopia\CLI\Adapters\Generic;
+use Utopia\CLI\CLI;
+use Utopia\Http\Http;
+use Utopia\Http\Route;
+use Utopia\Queue\Adapter\Swoole;
+use Utopia\Queue\Server;
+
+abstract class Platform
+{
+    /**
+     * Modules
+     *
+     * @var array<Module>
+     */
+    protected array $modules = [];
+
+    protected CLI $cli;
+
+    protected Server $worker;
+
+    public function __construct(protected Module $core)
+    {
+        $this->modules[] = $this->core;
+    }
+
+    /**
+     * Initialize Application
+     */
+    public function init(string $type, array $params = []): void
+    {
+        foreach ($this->modules as $module) {
+            $services = $module->getServicesByType($type);
+            switch ($type) {
+                case Service::TYPE_HTTP:
+                    $this->initHttp($services);
+                    break;
+                case Service::TYPE_TASK:
+                    $adapter = $params['adapter'] ?? new Generic();
+                    $this->cli ??= new CLI($adapter);
+                    $this->initTasks($services);
+                    break;
+                case Service::TYPE_GRAPHQL:
+                    $this->initGraphQL();
+                    break;
+                case Service::TYPE_WORKER:
+                    $workerName = $params['workerName'] ?? null;
+
+                    if (! isset($this->worker)) {
+                        $consumer = $params['consumer'] ?? null;
+                        $workersNum = $params['workersNum'] ?? 0;
+                        $workerName = $params['workerName'] ?? null;
+                        $queueName = $params['queueName'] ?? 'v1-' . $workerName;
+                        $adapter = new Swoole($consumer, $workersNum, $queueName);
+                        $this->worker ??= new Server($adapter);
+                    }
+                    $this->initWorker($services, $workerName, $params);
+                    break;
+                default:
+                    throw new Exception('Please provide which type of initialization you want to carry out.');
+            }
+        }
+    }
+
+    /**
+     * Init HTTP service
+     */
+    protected function initHttp(array $services): void
+    {
+        foreach ($services as $service) {
+            foreach ($service->getActions() as $action) {
+                /** @var Action $action */
+                switch ($action->getType()) {
+                    case Action::TYPE_INIT:
+                        $hook = Http::init();
+                        break;
+                    case Action::TYPE_ERROR:
+                        $hook = Http::error();
+                        break;
+                    case Action::TYPE_OPTIONS:
+                        $hook = Http::options();
+                        break;
+                    case Action::TYPE_SHUTDOWN:
+                        $hook = Http::shutdown();
+                        break;
+                    case Action::TYPE_DEFAULT:
+                    default:
+                        $hook = Http::routes($action->getHttpMethods(), $action->getHttpPath());
+                        break;
+                }
+
+                $hook
+                    ->groups($action->getGroups())
+                    ->desc($action->getDesc() ?? '');
+
+                if ($hook instanceof Route) {
+                    foreach ($action->getHttpAliases() as $alias) {
+                        $hook->alias($alias);
+                    }
+                }
+
+                foreach ($action->getOptions() as $key => $option) {
+                    switch ($option['type']) {
+                        case 'param':
+                            $key = substr((string) $key, stripos((string) $key, ':') + 1);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
+                            break;
+                        case 'injection':
+                            $hook->inject($option['name']);
+                            break;
+                    }
+                }
+
+                foreach ($action->getLabels() as $key => $label) {
+                    $hook->label($key, $label);
+                }
+
+                $hook->action($action->getCallback());
+            }
+        }
+    }
+
+    /**
+     * Init CLI Services
+     */
+    protected function initTasks(array $services): void
+    {
+        $cli = $this->cli;
+        foreach ($services as $service) {
+            foreach ($service->getActions() as $key => $action) {
+                switch ($action->getType()) {
+                    case Action::TYPE_INIT:
+                        $hook = $cli->init();
+                        break;
+                    case Action::TYPE_ERROR:
+                        $hook = $cli->error();
+                        break;
+                    case Action::TYPE_SHUTDOWN:
+                        $hook = $cli->shutdown();
+                        break;
+                    case Action::TYPE_DEFAULT:
+                    default:
+                        $hook = $cli->task($key);
+                        break;
+                }
+                $hook
+                    ->groups($action->getGroups())
+                    ->desc($action->getDesc() ?? '');
+
+                foreach ($action->getOptions() as $key => $option) {
+                    switch ($option['type']) {
+                        case 'param':
+                            $key = substr((string) $key, stripos((string) $key, ':') + 1);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
+                            break;
+                        case 'injection':
+                            $hook->inject($option['name']);
+                            break;
+                    }
+                }
+
+                foreach ($action->getLabels() as $key => $label) {
+                    $hook->label($key, $label);
+                }
+
+                $hook->action($action->getCallback());
+            }
+        }
+    }
+
+    /**
+     * Init worker Services
+     *
+     * @param array<int|string, Service> $services
+     * @param array<string, mixed> $params
+     */
+    protected function initWorker(array $services, ?string $workerName, array $params = []): void
+    {
+        $worker = $this->worker;
+        $names = $params['workerNames'] ?? [];
+        if ($names === [] && $workerName !== null && $workerName !== '') {
+            $names = [$workerName];
+        }
+        $names = array_map(static fn ($name): string => strtolower((string) $name), $names);
+        $all = $names === [] || in_array('all', $names, true);
+        /** @var array<string, array{queue?: ?string, maxCoroutines?: int}> $jobs */
+        $jobs = $params['workerJobs'] ?? [];
+
+        foreach ($services as $service) {
+            foreach ($service->getActions() as $key => $action) {
+                if ($action->getType() == Action::TYPE_DEFAULT) {
+                    $name = strtolower((string) $key);
+                    if (!$all && !in_array($name, $names, true)) {
+                        continue;
+                    }
+                }
+                switch ($action->getType()) {
+                    case Action::TYPE_INIT:
+                        $hook = $worker->init();
+                        break;
+                    case Action::TYPE_ERROR:
+                        $hook = $worker->error();
+                        break;
+                    case Action::TYPE_SHUTDOWN:
+                        $hook = $worker->shutdown();
+                        break;
+                    case Action::TYPE_WORKER_START:
+                        $hook = $worker->workerStart();
+                        break;
+                    case Action::TYPE_WORKER_STOP:
+                        $hook = $worker->workerStop();
+                        break;
+                    case Action::TYPE_DEFAULT:
+                    default:
+                        $name = strtolower((string) $key);
+                        $config = $jobs[$name] ?? [];
+                        $hook = $worker->job(
+                            $config['queue'] ?? null,
+                            max(1, (int) ($config['maxCoroutines'] ?? 1)),
+                        );
+                        break;
+                }
+                $hook
+                    ->groups($action->getGroups())
+                    ->desc($action->getDesc() ?? '');
+
+                foreach ($action->getOptions() as $key => $option) {
+                    switch ($option['type']) {
+                        case 'param':
+                            $key = substr((string) $key, stripos((string) $key, ':') + 1);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
+                            break;
+                        case 'injection':
+                            $hook->inject($option['name']);
+                            break;
+                    }
+                }
+
+                foreach ($action->getLabels() as $key => $label) {
+                    $hook->label($key, $label);
+                }
+
+                $hook->action($action->getCallback());
+            }
+        }
+    }
+
+    /**
+     * Initialize GraphQL Services
+     */
+    protected function initGraphQL(): void {}
+
+    /**
+     * Add module
+     */
+    public function addModule(Module $module): self
+    {
+        $this->modules[] = $module;
+
+        return $this;
+    }
+
+    /**
+     * Add Service
+     */
+    public function addService(string $key, Service $service): self
+    {
+        $this->core->addService($key, $service);
+
+        return $this;
+    }
+
+    /**
+     * Remove Service
+     */
+    public function removeService(string $key): self
+    {
+        $this->core->removeService($key);
+
+        return $this;
+    }
+
+    /**
+     * Get Service
+     */
+    public function getService(string $key): ?Service
+    {
+        return $this->core->getService($key);
+    }
+
+    /**
+     * Get Services
+     */
+    public function getServices(): array
+    {
+        return $this->core->getServices();
+    }
+
+    /**
+     * Get the value of cli
+     */
+    public function getCli(): CLI
+    {
+        return $this->cli;
+    }
+
+    /**
+     * Set the value of cli
+     */
+    public function setCli(CLI $cli): self
+    {
+        $this->cli = $cli;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of worker
+     */
+    public function getWorker(): Server
+    {
+        return $this->worker;
+    }
+
+    /**
+     * Set the value of worker
+     */
+    public function setWorker(Server $worker): self
+    {
+        $this->worker = $worker;
+
+        return $this;
+    }
+}

--- a/src/Utopia/Queue/Adapter.php
+++ b/src/Utopia/Queue/Adapter.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Utopia\Queue;
+
+use Utopia\DI\Container;
+
+abstract class Adapter
+{
+    protected const int RECEIVE_TIMEOUT = 2;
+
+    /**
+     * Pause before asking again after the broker failed to answer, so an
+     * unreachable broker is retried at a steady rate rather than in a tight loop.
+     */
+    protected const int RECEIVE_BACKOFF = 1;
+
+    public Queue $queue;
+    protected ?Container $context = null;
+    protected bool $stopped = false;
+
+    public function __construct(
+        public Consumer $consumer,
+        public int $workerNum,
+        string $queue,
+        public string $namespace = 'utopia-queue',
+        protected Container $resources = new Container(),
+    ) {
+        $this->queue = new Queue($queue, $namespace);
+    }
+
+    /**
+     * Starts the Server.
+     */
+    abstract public function start(): self;
+
+    /**
+     * Stops the Server.
+     */
+    abstract public function stop(): self;
+
+    /** @phpstan-impure stop() flips this from a signal handler mid-consume(). */
+    protected function isStopped(): bool
+    {
+        return $this->stopped;
+    }
+
+    /**
+     * @param callable(Message): void $messageCallback
+     * @param callable(Message): void $successCallback
+     * @param callable(?Message, \Throwable): void $errorCallback Receives null when
+     *        the failure was in obtaining a message rather than handling one.
+     */
+    public function consume(callable $messageCallback, callable $successCallback, callable $errorCallback): void
+    {
+        $this->consumeQueue(
+            $this->queue,
+            1,
+            $messageCallback,
+            $successCallback,
+            $errorCallback,
+        );
+    }
+
+    /**
+     * Consume one queue. $maxCoroutines is accepted for adapter parity; the
+     * sequential fallback processes one message at a time (effective cap 1).
+     *
+     * @param callable(Message): void $messageCallback
+     * @param callable(Message): void $successCallback
+     * @param callable(?Message, \Throwable): void $errorCallback
+     */
+    public function consumeQueue(
+        Queue $queue,
+        int $maxCoroutines,
+        callable $messageCallback,
+        callable $successCallback,
+        callable $errorCallback,
+        ?Consumer $consumer = null,
+    ): void {
+        $this->stopped = false;
+        unset($maxCoroutines);
+
+        while (!$this->isStopped()) {
+            $message = $this->nextMessage($errorCallback, $queue, $consumer);
+
+            if (!$message instanceof Message) {
+                continue;
+            }
+
+            $this->context = new Container($this->resources());
+            $this->process($message, $messageCallback, $successCallback, $errorCallback, $queue, $consumer);
+        }
+    }
+
+    /**
+     * Consume many queues. Sequential adapters run them one after another
+     * (not concurrent); Swoole overrides this with independent loops.
+     *
+     * @param array<int, array{queue: Queue, maxCoroutines: int, consumer?: Consumer}> $queues
+     * @param callable(Message): void $messageCallback
+     * @param callable(Message): void $successCallback
+     * @param callable(?Message, \Throwable): void $errorCallback
+     */
+    public function consumeMany(
+        array $queues,
+        callable $messageCallback,
+        callable $successCallback,
+        callable $errorCallback,
+    ): void {
+        foreach ($queues as $spec) {
+            $this->consumeQueue(
+                $spec['queue'],
+                $spec['maxCoroutines'],
+                $messageCallback,
+                $successCallback,
+                $errorCallback,
+                $spec['consumer'] ?? null,
+            );
+        }
+    }
+
+    /**
+     * Never throws: a broker that cannot be reached is reported to
+     * $errorCallback and retried after RECEIVE_BACKOFF. Losing the worker to a
+     * transient outage is worse than waiting for the broker to come back.
+     *
+     * $errorCallback takes a nullable message for exactly this case — the
+     * failure is in obtaining one, so there is none to report alongside it.
+     *
+     * @param callable(?Message, \Throwable): void $errorCallback
+     */
+    protected function nextMessage(callable $errorCallback, ?Queue $queue = null, ?Consumer $consumer = null): ?Message
+    {
+        $queue ??= $this->queue;
+        $consumer ??= $this->consumer;
+
+        try {
+            return $consumer->receive($queue, static::RECEIVE_TIMEOUT);
+        } catch (\Throwable $error) {
+            // A reporting hook that throws must not cost the worker either.
+            try {
+                $errorCallback(null, $error);
+            } catch (\Throwable $reportFailure) {
+                $this->reportUnreported($error, $reportFailure);
+            }
+
+            sleep(static::RECEIVE_BACKOFF);
+
+            return null;
+        }
+    }
+
+    /**
+     * Never throws: a failed handler is rejected and reported to $errorCallback;
+     * a failing reject or callback is swallowed rather than left to escape (and
+     * be lost on a coroutine).
+     */
+    protected function process(
+        Message $message,
+        callable $messageCallback,
+        callable $successCallback,
+        callable $errorCallback,
+        ?Queue $queue = null,
+        ?Consumer $consumer = null,
+    ): void {
+        $queue ??= $this->queue;
+        $consumer ??= $this->consumer;
+
+        try {
+            $messageCallback($message);
+            $consumer->commit($queue, $message);
+            $successCallback($message);
+        } catch (\Throwable $error) {
+            try {
+                $consumer->reject($queue, $message);
+            } catch (\Throwable) {
+            }
+            try {
+                $errorCallback($message, $error);
+            } catch (\Throwable $reportFailure) {
+                $this->reportUnreported($error, $reportFailure, $message);
+            }
+        }
+    }
+
+    /**
+     * Last-resort trace for a failure whose reporting hook also failed.
+     *
+     * A hook typically needs resources of its own — a database handle to
+     * resolve the message's project, say — so the very outages that fail a
+     * message also fail the report of it, and the message is then rejected
+     * with nothing written anywhere. Production lost whole batches this way,
+     * visible only as messages appearing on the failed list. Stderr is the one
+     * sink that needs nothing to be working.
+     */
+    protected function reportUnreported(\Throwable $error, \Throwable $reportFailure, ?Message $message = null): void
+    {
+        try {
+            fwrite($this->trace(), \sprintf(
+                "[queue] %s failed and its error report failed too: %s (%s:%d) | report: %s\n",
+                $message instanceof Message ? "message {$message->getPid()}" : 'receive',
+                $error->getMessage(),
+                $error->getFile(),
+                $error->getLine(),
+                $reportFailure->getMessage(),
+            ));
+        } catch (\Throwable) {
+        }
+    }
+
+    /**
+     * Where {@see self::reportUnreported()} writes. Overridable so a caller can
+     * route the trace somewhere it will be retained, and so it can be asserted.
+     *
+     * @return resource
+     */
+    protected function trace(): mixed
+    {
+        return \defined('STDERR') ? STDERR : fopen('php://stderr', 'w');
+    }
+
+    public function resources(): Container
+    {
+        return $this->resources;
+    }
+
+    public function context(): Container
+    {
+        return $this->context ??= new Container($this->resources());
+    }
+
+    /**
+     * Is called when a Worker starts.
+     */
+    abstract public function workerStart(callable $callback): self;
+
+    /**
+     * Is called when a Worker stops.
+     */
+    abstract public function workerStop(callable $callback): self;
+}

--- a/src/Utopia/Queue/Adapter.php
+++ b/src/Utopia/Queue/Adapter.php
@@ -2,6 +2,11 @@
 
 namespace Utopia\Queue;
 
+/**
+ * In-tree override of utopia-php/queue Adapter until consumeQueue /
+ * consumeMany land in utopia-php/monorepo `packages/queue`.
+ */
+
 use Utopia\DI\Container;
 
 abstract class Adapter

--- a/src/Utopia/Queue/Adapter/Swoole.php
+++ b/src/Utopia/Queue/Adapter/Swoole.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Utopia\Queue\Adapter;
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+use Swoole\Coroutine\WaitGroup;
+use Swoole\Process;
+use Utopia\DI\Container;
+use Utopia\Queue\Adapter;
+use Utopia\Queue\Consumer;
+use Utopia\Queue\Queue;
+
+class Swoole extends Adapter
+{
+    protected const string CONTEXT_KEY = '__utopia__';
+
+    /** @var Process[] */
+    protected array $workers = [];
+
+    /** @var callable[] */
+    protected array $onWorkerStart = [];
+
+    /** @var callable[] */
+    protected array $onWorkerStop = [];
+
+    protected int $maxCoroutines;
+
+    /** @var Consumer[] */
+    protected array $queueConsumers = [];
+
+    public function __construct(
+        Consumer $consumer,
+        int $workerNum,
+        string $queue,
+        string $namespace = 'utopia-queue',
+        int $maxCoroutines = 1,
+        Container $resources = new Container(),
+    ) {
+        parent::__construct($consumer, $workerNum, $queue, $namespace, $resources);
+        $this->maxCoroutines = max(1, $maxCoroutines);
+    }
+
+    public function start(): self
+    {
+        for ($i = 0; $i < $this->workerNum; $i++) {
+            $this->spawnWorker($i);
+        }
+
+        Coroutine::set(['hook_flags' => SWOOLE_HOOK_ALL]);
+
+        Coroutine\run(function (): void {
+            Process::signal(SIGTERM, fn(): \Utopia\Queue\Adapter\Swoole => $this->stop());
+            Process::signal(SIGINT, fn(): \Utopia\Queue\Adapter\Swoole => $this->stop());
+            Process::signal(SIGCHLD, fn() => $this->reap());
+
+            while (\count($this->workers) > 0) {
+                Coroutine::sleep(1);
+            }
+        });
+
+        return $this;
+    }
+
+    protected function spawnWorker(int $workerId): void
+    {
+        $process = new Process(function () use ($workerId): void {
+            Coroutine::set(['hook_flags' => SWOOLE_HOOK_ALL]);
+
+            Coroutine\run(function () use ($workerId): void {
+                Process::signal(SIGTERM, function (): void {
+                    $this->stopped = true;
+                    $this->consumer->close();
+                    foreach ($this->queueConsumers as $consumer) {
+                        try {
+                            $consumer->close();
+                        } catch (\Throwable) {
+                        }
+                    }
+                });
+
+                foreach ($this->onWorkerStart as $callback) {
+                    $callback((string) $workerId);
+                }
+
+                foreach ($this->onWorkerStop as $callback) {
+                    $callback((string) $workerId);
+                }
+            });
+        }, false, 0, false);
+
+        $pid = $process->start();
+        $this->workers[$pid] = $process;
+    }
+
+    #[\Override]
+    public function consume(callable $messageCallback, callable $successCallback, callable $errorCallback): void
+    {
+        $this->consumeQueue(
+            $this->queue,
+            $this->maxCoroutines,
+            $messageCallback,
+            $successCallback,
+            $errorCallback,
+        );
+    }
+
+    /**
+     * Receive on one loop, process each message on its own coroutine. The
+     * channel caps concurrency at $maxCoroutines: push() blocks the loop while
+     * the pool is full.
+     *
+     * A slot is reserved before the receive, never after: a message popped with
+     * no capacity to run it would sit captive in this loop — out of the broker,
+     * unprocessed, invisible to every idle sibling consumer — for as long as the
+     * in-flight handlers hold the pool. Blocking without a message leaves it in
+     * the broker for whichever consumer frees up first.
+     */
+    #[\Override]
+    public function consumeQueue(
+        Queue $queue,
+        int $maxCoroutines,
+        callable $messageCallback,
+        callable $successCallback,
+        callable $errorCallback,
+        ?Consumer $consumer = null,
+    ): void {
+        $this->stopped = false;
+        $consumer ??= $this->consumer;
+        $this->queueConsumers[] = $consumer;
+        $slots = new Channel(max(1, $maxCoroutines));
+        $waitGroup = new WaitGroup();
+
+        while (!$this->isStopped()) {
+            $slots->push(true);
+
+            $message = $this->nextMessage($errorCallback, $queue, $consumer);
+
+            if (!$message instanceof \Utopia\Queue\Message) {
+                $slots->pop();
+                continue;
+            }
+
+            $waitGroup->add();
+
+            Coroutine::create(function () use ($message, $messageCallback, $successCallback, $errorCallback, $slots, $waitGroup, $queue, $consumer): void {
+                try {
+                    $this->process($message, $messageCallback, $successCallback, $errorCallback, $queue, $consumer);
+                } catch (\Throwable $error) {
+                    error_log('Uncaught error while processing queue message: ' . $error->getMessage());
+                } finally {
+                    $waitGroup->done();
+                    $slots->pop();
+                }
+            });
+        }
+
+        $waitGroup->wait();
+    }
+
+    /**
+     * Independent consume loop per queue so each cap is isolated (a databases
+     * loop at maxCoroutines=1 cannot share a pool with functions=8).
+     *
+     * @param array<int, array{queue: Queue, maxCoroutines: int, consumer?: Consumer}> $queues
+     */
+    #[\Override]
+    public function consumeMany(
+        array $queues,
+        callable $messageCallback,
+        callable $successCallback,
+        callable $errorCallback,
+    ): void {
+        $this->stopped = false;
+        $waitGroup = new WaitGroup();
+
+        foreach ($queues as $spec) {
+            $waitGroup->add();
+            Coroutine::create(function () use ($spec, $messageCallback, $successCallback, $errorCallback, $waitGroup): void {
+                try {
+                    $this->consumeQueue(
+                        $spec['queue'],
+                        $spec['maxCoroutines'],
+                        $messageCallback,
+                        $successCallback,
+                        $errorCallback,
+                        $spec['consumer'] ?? null,
+                    );
+                } finally {
+                    $waitGroup->done();
+                }
+            });
+        }
+
+        $waitGroup->wait();
+    }
+
+    #[\Override]
+    public function context(): Container
+    {
+        // Each message runs in its own coroutine, so the container is created
+        // lazily per coroutine and stays isolated across concurrent handlers.
+        if (Coroutine::getCid() !== -1) {
+            return Coroutine::getContext()[self::CONTEXT_KEY] ??= new Container($this->resources());
+        }
+
+        return $this->resources();
+    }
+
+    protected function reap(): void
+    {
+        while (($ret = Process::wait(false)) !== false) {
+            unset($this->workers[$ret['pid']]);
+        }
+    }
+
+    public function stop(): self
+    {
+        $this->stopped = true;
+
+        foreach ($this->queueConsumers as $consumer) {
+            try {
+                $consumer->close();
+            } catch (\Throwable) {
+            }
+        }
+
+        foreach (array_keys($this->workers) as $pid) {
+            Process::kill($pid, SIGTERM);
+        }
+
+        return $this;
+    }
+
+    public function workerStart(callable $callback): self
+    {
+        $this->onWorkerStart[] = $callback;
+        return $this;
+    }
+
+    public function workerStop(callable $callback): self
+    {
+        $this->onWorkerStop[] = $callback;
+        return $this;
+    }
+}

--- a/src/Utopia/Queue/Adapter/Swoole.php
+++ b/src/Utopia/Queue/Adapter/Swoole.php
@@ -2,6 +2,11 @@
 
 namespace Utopia\Queue\Adapter;
 
+/**
+ * In-tree override of utopia-php/queue Swoole adapter until per-queue
+ * consume loops land in utopia-php/monorepo `packages/queue`.
+ */
+
 use Swoole\Coroutine;
 use Swoole\Coroutine\Channel;
 use Swoole\Coroutine\WaitGroup;

--- a/src/Utopia/Queue/Server.php
+++ b/src/Utopia/Queue/Server.php
@@ -1,0 +1,566 @@
+<?php
+
+namespace Utopia\Queue;
+
+use Exception;
+use Throwable;
+use Utopia\DI\Container;
+use Utopia\Servers\Hook;
+use Utopia\Telemetry\Adapter as Telemetry;
+use Utopia\Telemetry\Adapter\None as NoTelemetry;
+use Utopia\Telemetry\Histogram;
+use Utopia\Telemetry\ObservableGauge;
+use Utopia\Validator;
+
+class Server
+{
+    /**
+     * Job
+     */
+    protected Job $job;
+
+    /**
+     * Named jobs keyed by queue name.
+     *
+     * @var array<string, Job>
+     */
+    protected array $jobs = [];
+
+    /**
+     * Per-queue coroutine caps. Defaults to 1 (safe).
+     *
+     * @var array<string, int>
+     */
+    protected array $jobCoroutines = [];
+
+    /**
+     * @var (callable(string): Consumer)|null
+     */
+    protected $consumerFactory = null;
+
+    /**
+     * Hooks that will run when error occur
+     *
+     * @var array<Hook>
+     */
+    protected array $errorHooks = [];
+
+    /**
+     * Hooks that will run before running job
+     *
+     * @var array<Hook>
+     */
+    protected array $initHooks = [];
+
+    /**
+     * Hooks that will run after running job
+     *
+     * @var array<Hook>
+     */
+    protected array $shutdownHooks = [];
+
+    /**
+     * Hooks that will run when worker starts
+     *
+     * @var array<Hook>
+     */
+    protected array $workerStartHooks = [];
+
+    /**
+     * Hooks that will run when worker stops
+     *
+     * @var array<Hook>
+     */
+    protected array $workerStopHooks = [];
+
+    private Histogram $jobWaitTime;
+    private Histogram $processDuration;
+    private ObservableGauge $queueDepth;
+
+    /**
+     * Creates an instance of a Queue server.
+     */
+    public function __construct(protected Adapter $adapter)
+    {
+        $this->job = new Job();
+        $this->setTelemetry(new NoTelemetry());
+    }
+
+    public function job(?string $queue = null, int $maxCoroutines = 1): Job
+    {
+        $job = new Job();
+        $queue ??= $this->adapter->queue->name;
+        $this->job = $job;
+        $this->jobs[$queue] = $job;
+        $this->jobCoroutines[$queue] = max(1, $maxCoroutines);
+
+        return $job;
+    }
+
+    /**
+     * Factory for a dedicated receive consumer per queue. Required when more
+     * than one queue is consumed so blocking BRPOP calls do not share a Redis
+     * connection across coroutines.
+     *
+     * @param callable(string): Consumer $factory
+     */
+    public function setConsumerFactory(callable $factory): self
+    {
+        $this->consumerFactory = $factory(...);
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, Job>
+     */
+    public function getJobs(): array
+    {
+        return $this->jobs;
+    }
+
+    public function getJobCoroutines(string $queue): int
+    {
+        return $this->jobCoroutines[$queue] ?? 1;
+    }
+
+    protected function jobFor(Message $message): Job
+    {
+        return $this->jobs[$message->getQueue()] ?? $this->job;
+    }
+
+    /**
+     * Static resources container.
+     *
+     * Shortcut for the underlying adapter's {@see Adapter::resources()}. Use
+     * `$server->resources()->set(...)` to register app-wide services that are
+     * shared across every message for the lifetime of the server.
+     */
+    public function resources(): Container
+    {
+        return $this->adapter->resources();
+    }
+
+    /**
+     * Per-message context container.
+     *
+     * Shortcut for the underlying adapter's {@see Adapter::context()}. Use
+     * `$server->context()->set(...)` to register message-scoped resources and
+     * `$server->context()->get(...)` to read them. Lookups fall through to the
+     * static resources container, so app-wide services remain accessible.
+     */
+    public function context(): Container
+    {
+        return $this->adapter->context();
+    }
+
+    public function setTelemetry(Telemetry $telemetry): void
+    {
+        $this->jobWaitTime = $telemetry->createHistogram(
+            'messaging.process.wait.duration',
+            's',
+            null,
+            [
+                'ExplicitBucketBoundaries' => [
+                    0.005,
+                    0.01,
+                    0.025,
+                    0.05,
+                    0.075,
+                    0.1,
+                    0.25,
+                    0.5,
+                    0.75,
+                    1,
+                    2.5,
+                    5,
+                    7.5,
+                    10,
+                ],
+            ],
+        );
+
+        // https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/#metric-messagingprocessduration
+        $this->processDuration = $telemetry->createHistogram(
+            'messaging.process.duration',
+            's',
+            null,
+            [
+                'ExplicitBucketBoundaries' => [
+                    0.005,
+                    0.01,
+                    0.025,
+                    0.05,
+                    0.075,
+                    0.1,
+                    0.25,
+                    0.5,
+                    0.75,
+                    1,
+                    2.5,
+                    5,
+                    7.5,
+                    10,
+                ],
+            ],
+        );
+
+        $this->queueDepth = $telemetry->createObservableGauge(
+            'messaging.queue.depth',
+            '{message}',
+            'Number of pending messages in the queue.',
+        );
+
+        $this->queueDepth->observe(function (callable $observe): void {
+            if (!$this->adapter->consumer instanceof Publisher) {
+                return;
+            }
+
+            $queues = $this->jobs !== []
+                ? array_keys($this->jobs)
+                : [$this->adapter->queue->name];
+
+            foreach ($queues as $queueName) {
+                $queue = new Queue($queueName, $this->adapter->queue->namespace);
+
+                try {
+                    $size = $this->adapter->consumer->getQueueSize($queue);
+                } catch (Throwable) {
+                    continue;
+                }
+
+                $observe($size, [
+                    'messaging.destination.name' => $queue->name,
+                    'messaging.destination.namespace' => $queue->namespace,
+                ]);
+            }
+        });
+    }
+
+    /**
+     * Shutdown Hooks
+     */
+    public function shutdown(): Hook
+    {
+        $hook = new Hook();
+        $hook->groups(['*']);
+        $this->shutdownHooks[] = $hook;
+        return $hook;
+    }
+
+    /**
+     * Stops the Queue server.
+     */
+    public function stop(): self
+    {
+        try {
+            $this->adapter->stop();
+        } catch (Throwable $error) {
+            $this->resources()->set('error', fn(): \Throwable => $error);
+            foreach ($this->errorHooks as $hook) {
+                $hook->getAction()(...$this->getArguments($this->resources(), $hook));
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Init Hooks
+     */
+    public function init(): Hook
+    {
+        $hook = new Hook();
+        $hook->groups(['*']);
+        $this->initHooks[] = $hook;
+        return $hook;
+    }
+
+    /**
+     * Starts the Queue Server
+     */
+    public function start(): self
+    {
+        try {
+            $this->adapter->workerStart(function (string $workerId): void {
+                $this->resources()->set('workerId', fn(): string => $workerId);
+
+                foreach ($this->workerStartHooks as $hook) {
+                    $hook->getAction()(...$this->getArguments($this->resources(), $hook));
+                }
+
+                $messageCallback = function (Message $message) {
+                    $receivedAtTimestamp = microtime(true);
+                    $job = $this->jobFor($message);
+                    try {
+                        // The enqueue timestamp comes from the publisher's
+                        // clock and this from the consumer's, so on an idle
+                        // queue a few milliseconds of skew between the two
+                        // hosts yields a negative duration. Recording it
+                        // decrements a cumulative histogram sum, which every
+                        // Prometheus reader takes for a counter reset and
+                        // re-attributes the process's whole lifetime sum to
+                        // one interval — one -20ms sample paged a two-hour
+                        // queue wait on a queue that was empty throughout.
+                        $waitDuration = max(
+                            0.0,
+                            microtime(true) - $message->getTimestamp(),
+                        );
+                        $this->jobWaitTime->record($waitDuration);
+
+                        $this->context()->set('message', fn(): \Utopia\Queue\Message => $message);
+
+                        if ($job->getHook()) {
+                            foreach ($this->initHooks as $hook) {
+                                if (\in_array('*', $hook->getGroups())) {
+                                    $arguments = $this->getArguments(
+                                        $this->context(),
+                                        $hook,
+                                        $message->getPayload(),
+                                    );
+                                    $hook->getAction()(...$arguments);
+                                }
+                            }
+                        }
+
+                        foreach ($job->getGroups() as $group) {
+                            foreach ($this->initHooks as $hook) {
+                                if (\in_array($group, $hook->getGroups())) {
+                                    $arguments = $this->getArguments(
+                                        $this->context(),
+                                        $hook,
+                                        $message->getPayload(),
+                                    );
+                                    $hook->getAction()(...$arguments);
+                                }
+                            }
+                        }
+
+                        return \call_user_func_array(
+                            $job->getAction(),
+                            $this->getArguments(
+                                $this->context(),
+                                $job,
+                                $message->getPayload(),
+                            ),
+                        );
+                    } finally {
+                        $this->processDuration->record(microtime(true) - $receivedAtTimestamp);
+                    }
+                };
+
+                $successCallback = function (Message $message): void {
+                    $job = $this->jobFor($message);
+                    $this->context()->set('message', fn(): \Utopia\Queue\Message => $message);
+
+                    if ($job->getHook()) {
+                        foreach ($this->shutdownHooks as $hook) {
+                            if (\in_array('*', $hook->getGroups())) {
+                                $arguments = $this->getArguments(
+                                    $this->context(),
+                                    $hook,
+                                    $message->getPayload(),
+                                );
+                                $hook->getAction()(...$arguments);
+                            }
+                        }
+                    }
+
+                    foreach ($job->getGroups() as $group) {
+                        foreach ($this->shutdownHooks as $hook) {
+                            if (\in_array($group, $hook->getGroups())) {
+                                $arguments = $this->getArguments(
+                                    $this->context(),
+                                    $hook,
+                                    $message->getPayload(),
+                                );
+                                $hook->getAction()(...$arguments);
+                            }
+                        }
+                    }
+                };
+
+                $errorCallback = function (?Message $message, Throwable $th): void {
+                    $this->context()->set('error', fn(): \Throwable => $th);
+                    if ($message instanceof \Utopia\Queue\Message) {
+                        $this->context()->set('message', fn(): \Utopia\Queue\Message => $message);
+                    }
+
+                    foreach ($this->errorHooks as $hook) {
+                        $hook->getAction()(...$this->getArguments($this->context(), $hook));
+                    }
+                };
+
+                if (\count($this->jobs) > 1) {
+                    $queues = [];
+                    foreach ($this->jobs as $queueName => $job) {
+                        $queues[] = [
+                            'queue' => new Queue($queueName, $this->adapter->queue->namespace),
+                            'maxCoroutines' => $this->jobCoroutines[$queueName] ?? 1,
+                            'consumer' => \is_callable($this->consumerFactory)
+                                ? ($this->consumerFactory)($queueName)
+                                : $this->adapter->consumer,
+                        ];
+                    }
+                    $this->adapter->consumeMany($queues, $messageCallback, $successCallback, $errorCallback);
+                } else {
+                    $this->adapter->consume($messageCallback, $successCallback, $errorCallback);
+                }
+            });
+
+            $this->adapter->workerStop(function (string $workerId): void {
+                $this->resources()->set('workerId', fn(): string => $workerId);
+
+                try {
+                    // Call user-defined workerStop hooks
+                    foreach ($this->workerStopHooks as $hook) {
+                        try {
+                            $hook->getAction()(...$this->getArguments($this->resources(), $hook));
+                        } catch (Throwable) {
+                        }
+                    }
+                } finally {
+                    // Always close consumer connection, even if hooks throw
+                    $this->adapter->consumer->close();
+                }
+            });
+
+            $this->adapter->start();
+        } catch (Throwable $error) {
+            $this->resources()->set('error', fn(): \Throwable => $error);
+            foreach ($this->errorHooks as $hook) {
+                $hook->getAction()(...$this->getArguments($this->resources(), $hook));
+            }
+
+            throw $error;
+        }
+        return $this;
+    }
+
+    /**
+     * Is called when a Worker starts.
+     */
+    public function workerStart(): Hook
+    {
+        $hook = new Hook();
+        $hook->groups(['*']);
+        $this->workerStartHooks[] = $hook;
+        return $hook;
+    }
+
+    /**
+     * Returns Worker starts hooks.
+     */
+    public function getWorkerStart(): array
+    {
+        return $this->workerStartHooks;
+    }
+
+    /**
+     * Is called when a Worker stops.
+     */
+    public function workerStop(): Hook
+    {
+        $hook = new Hook();
+        $hook->groups(['*']);
+        $this->workerStopHooks[] = $hook;
+        return $hook;
+    }
+
+    /**
+     * Returns Worker stops hooks.
+     */
+    public function getWorkerStop(): array
+    {
+        return $this->workerStopHooks;
+    }
+
+    /**
+     * Get Arguments
+     */
+    protected function getArguments(Container $context, Hook $hook, array $payload = []): array
+    {
+        $arguments = [];
+        foreach ($hook->getParams() as $key => $param) {
+            $payloadKey = $key;
+            if (!\array_key_exists($key, $payload) && !empty($param['aliases'])) {
+                foreach ($param['aliases'] as $alias) {
+                    if (\array_key_exists($alias, $payload)) {
+                        $payloadKey = $alias;
+                        break;
+                    }
+                }
+            }
+
+            // Get value from route or request object
+            $value = $payload[$payloadKey] ?? $param['default'];
+            $value
+                = $value === '' || $value === null ? $param['default'] : $value;
+
+            $this->validate($key, $param, $value, $context);
+            $hook->setParamValue($key, $value);
+            $arguments[$param['order']] = $value;
+        }
+
+        foreach ($hook->getInjections() as $injection) {
+            $arguments[$injection['order']] = $context->get(
+                $injection['name'],
+            );
+        }
+
+        // call_user_func_array passes integer keys in iteration order, not key
+        // order, so sort the two-pass (params, then injections) array by key.
+        ksort($arguments);
+
+        return $arguments;
+    }
+
+    /**
+     * Validate Param
+     *
+     * Creates an validator instance and validate given value with given rules.
+     *
+     *
+     * @throws Exception
+     *
+     */
+    protected function validate(string $key, array $param, mixed $value, Container $context): void
+    {
+        if ('' !== $value && $value !== null) {
+            $validator = $param['validator']; // checking whether the class exists
+
+            if (\is_callable($validator)) {
+                $validatorKey = '_validator:' . $key;
+                $context->set($validatorKey, $validator, $param['injections']);
+                $validator = $context->get($validatorKey);
+            }
+
+            if (!$validator instanceof Validator) {
+                // is the validator object an instance of the Validator class
+                throw new Exception(
+                    'Validator object is not an instance of the Validator class',
+                    500,
+                );
+            }
+
+            if (!$validator->isValid($value)) {
+                throw new Exception(
+                    'Invalid ' . $key . ': ' . $validator->getDescription(),
+                    400,
+                );
+            }
+        } elseif (!$param['optional']) {
+            throw new Exception("Param $key is not optional.", 400);
+        }
+    }
+
+    /**
+     * Register hook. Will be executed when error occurs.
+     */
+    public function error(): Hook
+    {
+        $hook = new Hook();
+        $hook->groups(['*']);
+        $this->errorHooks[] = $hook;
+        return $hook;
+    }
+}

--- a/src/Utopia/Queue/Server.php
+++ b/src/Utopia/Queue/Server.php
@@ -2,6 +2,15 @@
 
 namespace Utopia\Queue;
 
+/**
+ * In-tree override of utopia-php/queue until this API lands in
+ * utopia-php/monorepo `packages/queue`. Composer PSR-4 maps
+ * `Utopia\Queue\` here so these classes win over vendor.
+ *
+ * Adds named jobs, an independent consume loop per queue, and a required
+ * per-job maxCoroutines (default 1 — never a shared cap).
+ */
+
 use Exception;
 use Throwable;
 use Utopia\DI\Container;

--- a/tests/unit/Docker/Compose/GeneratorTest.php
+++ b/tests/unit/Docker/Compose/GeneratorTest.php
@@ -64,9 +64,30 @@ final class GeneratorTest extends TestCase
     {
         $compose = $this->render();
 
-        $this->assertArrayHasKey('appwrite-worker-screenshots', $compose['services']);
+        $this->assertArrayHasKey('appwrite-worker', $compose['services']);
+        $this->assertArrayHasKey('appwrite-task-scheduler', $compose['services']);
         $this->assertArrayHasKey('appwrite-task-interval', $compose['services']);
         $this->assertArrayHasKey('appwrite-embedding', $compose['services']);
+        $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-worker']);
+        $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-task-scheduler']);
+        $this->assertArrayNotHasKey('appwrite-worker-screenshots', $compose['services']);
+        $this->assertArrayNotHasKey('appwrite-worker-functions', $compose['services']);
+        $this->assertArrayNotHasKey('appwrite-task-scheduler-functions', $compose['services']);
+    }
+
+    public function testSelectsSeparateBackground(): void
+    {
+        $compose = $this->render([
+            'background' => 'separate',
+        ]);
+
+        $this->assertArrayNotHasKey('appwrite-worker', $compose['services']);
+        $this->assertArrayNotHasKey('appwrite-task-scheduler', $compose['services']);
+        $this->assertArrayHasKey('appwrite-worker-screenshots', $compose['services']);
+        $this->assertArrayHasKey('appwrite-worker-functions', $compose['services']);
+        $this->assertArrayHasKey('appwrite-task-scheduler-functions', $compose['services']);
+        $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-worker-functions']);
+        $this->assertArrayNotHasKey('profiles', $compose['services']['appwrite-task-scheduler-functions']);
     }
 
     public function testKeepsMongoInitFiles(): void

--- a/tests/unit/Platform/Tasks/ScheduleTest.php
+++ b/tests/unit/Platform/Tasks/ScheduleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform\Tasks;
+
+use Appwrite\Platform\Services\Tasks;
+use Appwrite\Platform\Tasks\Schedule;
+use Appwrite\Platform\Tasks\ScheduleExecutions;
+use Appwrite\Platform\Tasks\ScheduleFunctions;
+use Appwrite\Platform\Tasks\ScheduleMessages;
+use PHPUnit\Framework\TestCase;
+
+final class ScheduleTest extends TestCase
+{
+    public function testCombinedScheduleIsRegisteredAlongsideSeparateTasks(): void
+    {
+        $service = new Tasks();
+
+        $this->assertInstanceOf(Schedule::class, $service->getAction('schedule'));
+        $this->assertInstanceOf(ScheduleFunctions::class, $service->getAction('schedule-functions'));
+        $this->assertInstanceOf(ScheduleExecutions::class, $service->getAction('schedule-executions'));
+        $this->assertInstanceOf(ScheduleMessages::class, $service->getAction('schedule-messages'));
+    }
+}

--- a/tests/unit/Platform/Workers/RegistrationTest.php
+++ b/tests/unit/Platform/Workers/RegistrationTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Platform\Workers;
 
+use Appwrite\Platform\Modules\Databases\Services\Workers as DatabasesWorkers;
+use Appwrite\Platform\Modules\Functions\Services\Workers as FunctionsWorkers;
 use Appwrite\Platform\Services\Workers;
 use Appwrite\Platform\Workers\Mails;
 use Appwrite\Platform\Workers\Notifications;
+use Appwrite\Worker\Config as WorkerConfig;
 use PHPUnit\Framework\TestCase;
 
 final class RegistrationTest extends TestCase
@@ -25,6 +28,27 @@ final class RegistrationTest extends TestCase
 
         $this->assertIsString($contents);
         $this->assertStringNotContainsString("mails' ? 'notifications'", $contents);
-        $this->assertStringContainsString('\'workerName\' => strtolower($workerName)', $contents);
+        $this->assertStringContainsString("'workerNames'", $contents);
+        $this->assertStringContainsString('WorkerConfig', $contents);
+    }
+
+    public function testRegisteredWorkerNamesMatchConfigWithoutDuplicates(): void
+    {
+        $names = [];
+        foreach ([new Workers(), new DatabasesWorkers(), new FunctionsWorkers()] as $service) {
+            foreach ($service->getActions() as $key => $action) {
+                $name = \strtolower((string) $key);
+                $this->assertArrayNotHasKey($name, $names, "Duplicate worker action '{$name}'");
+                $names[$name] = true;
+            }
+        }
+
+        $registered = \array_keys($names);
+        \sort($registered);
+        $expected = WorkerConfig::NAMES;
+        \sort($expected);
+
+        $this->assertSame($expected, $registered);
+        $this->assertSame(1, WorkerConfig::maxCoroutines('databases'));
     }
 }

--- a/tests/unit/Queue/FakeAdapter.php
+++ b/tests/unit/Queue/FakeAdapter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Queue;
+
+use Utopia\Queue\Adapter;
+use Utopia\Queue\Consumer;
+use Utopia\Queue\Message;
+use Utopia\Queue\Queue;
+
+final class FakeConsumer implements Consumer
+{
+    public function receive(Queue $queue, int $timeout): ?Message
+    {
+        return null;
+    }
+
+    public function commit(Queue $queue, Message $message): void
+    {
+    }
+
+    public function reject(Queue $queue, Message $message): void
+    {
+    }
+
+    public function close(): void
+    {
+    }
+}
+
+final class RecordingAdapter extends Adapter
+{
+    /**
+     * @var list<array{queue: string, maxCoroutines: int}>
+     */
+    public array $consumed = [];
+
+    public function __construct(string $queue = 'v1-functions')
+    {
+        parent::__construct(new FakeConsumer(), 1, $queue);
+    }
+
+    public function start(): self
+    {
+        return $this;
+    }
+
+    public function stop(): self
+    {
+        return $this;
+    }
+
+    public function workerStart(callable $callback): self
+    {
+        return $this;
+    }
+
+    public function workerStop(callable $callback): self
+    {
+        return $this;
+    }
+
+    public function consumeQueue(
+        Queue $queue,
+        int $maxCoroutines,
+        callable $messageCallback,
+        callable $successCallback,
+        callable $errorCallback,
+        ?Consumer $consumer = null,
+    ): void {
+        $this->consumed[] = [
+            'queue' => $queue->name,
+            'maxCoroutines' => $maxCoroutines,
+        ];
+    }
+}

--- a/tests/unit/Queue/ServerJobsTest.php
+++ b/tests/unit/Queue/ServerJobsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Queue;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Queue\Job;
+use Utopia\Queue\Queue;
+use Utopia\Queue\Server;
+
+final class ServerJobsTest extends TestCase
+{
+    public function testJobRegistersIndependentCoroutineCaps(): void
+    {
+        $server = new Server(new RecordingAdapter());
+
+        $functions = $server->job('v1-functions', 8);
+        $databases = $server->job('database_db_main', 1);
+
+        $this->assertInstanceOf(Job::class, $functions);
+        $this->assertInstanceOf(Job::class, $databases);
+        $this->assertNotSame($functions, $databases);
+        $this->assertSame(8, $server->getJobCoroutines('v1-functions'));
+        $this->assertSame(1, $server->getJobCoroutines('database_db_main'));
+        $this->assertCount(2, $server->getJobs());
+    }
+
+    public function testOmittedCoroutineCapDefaultsToOne(): void
+    {
+        $server = new Server(new RecordingAdapter('v1-mails'));
+
+        $server->job('v1-mails');
+
+        $this->assertSame(1, $server->getJobCoroutines('v1-mails'));
+    }
+
+    public function testConsumeManyKeepsPerQueueCaps(): void
+    {
+        $adapter = new RecordingAdapter();
+
+        $adapter->consumeMany(
+            [
+                [
+                    'queue' => new Queue('database_db_main'),
+                    'maxCoroutines' => 1,
+                ],
+                [
+                    'queue' => new Queue('v1-functions'),
+                    'maxCoroutines' => 8,
+                ],
+            ],
+            static fn () => null,
+            static fn () => null,
+            static fn () => null,
+        );
+
+        $this->assertSame(
+            [
+                ['queue' => 'database_db_main', 'maxCoroutines' => 1],
+                ['queue' => 'v1-functions', 'maxCoroutines' => 8],
+            ],
+            $adapter->consumed,
+        );
+    }
+}

--- a/tests/unit/Utopia/Platform/InitWorkerTest.php
+++ b/tests/unit/Utopia/Platform/InitWorkerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Platform;
+
+use PHPUnit\Framework\TestCase;
+use Tests\Unit\Queue\RecordingAdapter;
+use Utopia\Platform\Action;
+use Utopia\Platform\Module;
+use Utopia\Platform\Platform;
+use Utopia\Platform\Service;
+use Utopia\Queue\Server;
+
+final class InitWorkerTest extends TestCase
+{
+    public function testCombinedWorkersKeepIndependentCoroutineCaps(): void
+    {
+        $platform = $this->platform();
+        $server = new Server(new RecordingAdapter());
+        $platform->setWorker($server);
+
+        $platform->init(Service::TYPE_WORKER, [
+            'workerName' => 'all',
+            'workerNames' => ['all'],
+            'workerJobs' => [
+                'databases' => ['queue' => 'database_db_main', 'maxCoroutines' => 1],
+                'functions' => ['queue' => 'v1-functions', 'maxCoroutines' => 8],
+            ],
+        ]);
+
+        $this->assertCount(2, $server->getJobs());
+        $this->assertSame(1, $server->getJobCoroutines('database_db_main'));
+        $this->assertSame(8, $server->getJobCoroutines('v1-functions'));
+    }
+
+    public function testSingleWorkerNamePathStillRegistersOneJob(): void
+    {
+        $platform = $this->platform();
+        $server = new Server(new RecordingAdapter('v1-functions'));
+        $platform->setWorker($server);
+
+        $platform->init(Service::TYPE_WORKER, [
+            'workerName' => 'functions',
+            'workerJobs' => [
+                'functions' => ['queue' => 'v1-functions', 'maxCoroutines' => 8],
+            ],
+        ]);
+
+        $this->assertCount(1, $server->getJobs());
+        $this->assertSame(8, $server->getJobCoroutines('v1-functions'));
+        $this->assertSame(1, $server->getJobCoroutines('database_db_main'));
+    }
+
+    private function platform(): Platform
+    {
+        $service = new class () extends Service {
+            public function __construct()
+            {
+                $this->type = Service::TYPE_WORKER;
+                $this->addAction('databases', new class () extends Action {
+                    public function __construct()
+                    {
+                        $this->callback(static fn () => null);
+                    }
+                });
+                $this->addAction('functions', new class () extends Action {
+                    public function __construct()
+                    {
+                        $this->callback(static fn () => null);
+                    }
+                });
+            }
+        };
+
+        $module = new class ($service) extends Module {
+            public function __construct(Service $service)
+            {
+                $this->addService('workers', $service);
+            }
+        };
+
+        return new class ($module) extends Platform {};
+    }
+}

--- a/tests/unit/Worker/ConfigTest.php
+++ b/tests/unit/Worker/ConfigTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Worker;
+
+use Appwrite\Event\Event;
+use Appwrite\Worker\Config;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    public function testDatabasesCoroutineCapIsOne(): void
+    {
+        $this->assertSame(1, Config::maxCoroutines('databases'));
+    }
+
+    public function testDatabasesCapIgnoresEnvOverride(): void
+    {
+        $previous = \getenv('_APP_WORKER_MAX_COROUTINES');
+        \putenv('_APP_WORKER_MAX_COROUTINES=8');
+
+        try {
+            $this->assertSame(1, Config::maxCoroutines('databases', allowEnvOverride: true));
+        } finally {
+            \putenv($previous === false ? '_APP_WORKER_MAX_COROUTINES' : '_APP_WORKER_MAX_COROUTINES=' . $previous);
+        }
+    }
+
+    public function testUnknownWorkerDefaultsToOne(): void
+    {
+        $this->assertSame(1, Config::maxCoroutines('unknown-worker'));
+    }
+
+    public function testFunctionsKeepEightCoroutines(): void
+    {
+        $this->assertSame(8, Config::maxCoroutines('functions'));
+    }
+
+    public function testCombinedTotalIsSumOfPerQueueCaps(): void
+    {
+        $this->assertSame(61, Config::totalMaxCoroutines(Config::NAMES));
+    }
+
+    public function testQueueNamesMatchPublishers(): void
+    {
+        $this->assertSame(Event::FUNCTIONS_QUEUE_NAME, Config::queueName('functions'));
+        $this->assertSame(Event::MAILS_QUEUE_NAME, Config::queueName('mails'));
+        $this->assertSame(Event::DELETE_QUEUE_NAME, Config::queueName('deletes'));
+        $this->assertSame('database_db_main', Config::queueName('databases'));
+    }
+
+    public function testJobsAttachPerQueueCaps(): void
+    {
+        $jobs = Config::jobs(['databases', 'functions']);
+
+        $this->assertSame(1, $jobs['databases']['maxCoroutines']);
+        $this->assertSame(8, $jobs['functions']['maxCoroutines']);
+        $this->assertSame('database_db_main', $jobs['databases']['queue']);
+        $this->assertSame(Event::FUNCTIONS_QUEUE_NAME, $jobs['functions']['queue']);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Combined worker and scheduler containers are now the default Docker Compose topology so `docker compose up` and a fresh install run a smaller stack (one worker + one scheduler instead of 12 workers + 3 schedulers).

**Combined (default):** `appwrite-worker` consumes all 12 queues in one process; `appwrite-task-scheduler` runs functions, executions, and messages each in a coroutine.

**Separate (opt-in):** today’s per-queue containers remain for scale-out:

```bash
docker compose -f docker-compose.yml -f docker-compose.separate.yml --profile separate up -d
```

Installer: `--background=combined|separate` (default combined). Upgrades keep the detected topology unless `--background` is explicit.

Per-queue `maxCoroutines` are required and independent. Databases stays at **1** (deadlock correctness) even if `_APP_WORKER_MAX_COROUTINES` is set. Combined `_APP_WORKER_MAX_COROUTINES=61` is pool sizing only (sum of caps), not a shared cap. Each queue has its own consume loop (no multi-key BRPOP).

### Utopia libraries (why they are in this repo)

The new APIs belong in **utopia-php/queue** and **utopia-php/platform**. Development for those packages happens in [utopia-php/monorepo](https://github.com/utopia-php/monorepo) (`packages/queue`, `packages/platform`); the split GitHub repos are read-only mirrors.

This PR vendors the library changes as Composer PSR-4 overrides (same pattern as `src/Utopia/Bus`) so Appwrite can ship before those packages release:

| Library | In-tree override | API |
|---------|------------------|-----|
| `utopia-php/queue` | `src/Utopia/Queue/{Server,Adapter,Adapter/Swoole}.php` | Named jobs, independent consume loop per queue, per-job `maxCoroutines` (default **1**) |
| `utopia-php/platform` | `src/Utopia/Platform/Platform.php` | `initWorker` accepts `workerNames` + `workerJobs`; single-name `workerName` path unchanged |

`Appwrite.php` does **not** fork Platform. `app/worker.php` passes `workerNames` / `workerJobs` from `Appwrite\Worker\Config`.

Follow-up: copy these files into the monorepo packages, drop the PSR-4 maps, and bump `composer.json`. A push to `utopia-php/monorepo` from this agent was denied (403).

Maintenance and interval stay separate. Worker Action business logic and queue names are unchanged.

## Test Plan

- Unit: `tests/unit/Worker/ConfigTest.php` (databases=1, publisher-aligned queue names, combined sum=61)
- Unit: `tests/unit/Queue/ServerJobsTest.php` (independent per-queue caps; omit → 1; consumeMany does not share a cap)
- Unit: `tests/unit/Utopia/Platform/InitWorkerTest.php` (combined vs single-name `initWorker`)
- Unit: `tests/unit/Platform/Workers/RegistrationTest.php` (12 unique worker names match the config table)
- Unit: `tests/unit/Docker/Compose/GeneratorTest.php` (default omits the 15 separate services and strips profiles; `background=separate` is the inverse)
- Unit: `tests/unit/Platform/Tasks/ScheduleTest.php` (combined `schedule` registered beside the three existing tasks)
- E2E: run against the combined default stack (`docker compose up`). Do not start combined and separate together (double consume).

```bash
docker compose exec appwrite test tests/unit/Worker/ConfigTest.php
docker compose exec appwrite test tests/unit/Queue/ServerJobsTest.php
docker compose exec appwrite test tests/unit/Utopia/Platform/InitWorkerTest.php
docker compose exec appwrite test tests/unit/Platform/Workers/RegistrationTest.php
docker compose exec appwrite test tests/unit/Docker/Compose/GeneratorTest.php
docker compose exec appwrite test tests/unit/Platform/Tasks/ScheduleTest.php
```

## Related PRs and Issues

- Combined worker/scheduler containers plan
- Follow-up: utopia-php/monorepo `packages/queue` + `packages/platform`

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a27182e1-aa7e-4195-abe4-bfdcfb7a6d5d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a27182e1-aa7e-4195-abe4-bfdcfb7a6d5d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

