### PR TITLE
test(sites): expect computeScopes grants in ephemeral key scopes

### DIFF
--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -11,6 +11,7 @@ use Tests\E2E\Client;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
 use Tests\E2E\Scopes\SideServer;
+use Utopia\Config\Config;
 use Utopia\Console;
 use Utopia\Database\Document;
 use Utopia\Database\Helpers\ID;
@@ -857,8 +858,13 @@ final class SitesCustomServerTest extends Scope
         $jwt = new JWT(System::getEnv('_APP_OPENSSL_KEY_V1'), 'HS256', 900, 0);
         $payload = $jwt->decode(\substr($key, \strlen($prefix)));
 
+        // Editions force extra grants onto every site key through computeScopes
+        // (empty here, cloud adds proxy.invalidations.write), so a key must carry
+        // the user-granted scopes plus those grants and nothing else.
+        $granted = Config::getParam('computeScopes', [])['sites'] ?? [];
+
         $this->assertEquals($this->getProject()['$id'], $payload['projectId']);
-        $this->assertEquals($scopes, $payload['scopes']);
+        $this->assertEquals(\array_values(\array_unique(\array_merge($scopes, $granted))), $payload['scopes']);
     }
 
     public function testListSites(): void


### PR DESCRIPTION
## What does this PR do?

Follow-up to #13219. `assertEphemeralKey()` in `SitesCustomServerTest` asserts the ephemeral key's scopes are **exactly** the user-granted list, but `Deployments::scopes()` intentionally merges the per-edition `computeScopes` grants into every site key.

The config ships empty in this repo, so the expectation is unchanged here. But editions that force grants run this suite from vendor and fail on the exact-equality assertion — cloud adds `proxy.invalidations.write` to site keys (appwrite-labs/cloud#5308) and `testScopes` fails with:

```
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
 Array (
     0 => 'users.read'
+    1 => 'proxy.invalidations.write'
 )
```

The fix computes the expected list the same way the server resolves it — user-granted scopes plus the `sites` entry of `computeScopes`, and still nothing else — so the assertion keeps proving no scope leaks in every edition.

## Test plan

- Pint and PHPStan clean on the changed file
- In this repo the merged-in grants are `[]`, so the assertion is byte-for-byte what it was — existing CI coverage of `testScopes` is unchanged
- On cloud, this is exactly the assertion shape that turns the failing `Tests / CE / E2E / Sites` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)