### PR TITLE
fix(queries): catch invalid deployment and identity searches

### DIFF
--- a/src/Appwrite/Platform/Modules/Functions/Http/Deployments/XList.php
+++ b/src/Appwrite/Platform/Modules/Functions/Http/Deployments/XList.php
@@ -124,6 +124,8 @@ class XList extends Base
             $total = $includeTotal ? $dbForProject->count('deployments', $filterQueries, APP_LIMIT_COUNT) : 0;
         } catch (OrderException $e) {
             throw new Exception(Exception::DATABASE_QUERY_ORDER_NULL, "The order attribute '{$e->getAttribute()}' had a null value. Cursor pagination requires all documents order attribute values are non-null.");
+        } catch (QueryException $e) {
+            throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
         $response->addFilter(new ListSelection($selectQueries, 'deployments'));

--- a/src/Appwrite/Platform/Modules/Sites/Http/Deployments/XList.php
+++ b/src/Appwrite/Platform/Modules/Sites/Http/Deployments/XList.php
@@ -124,6 +124,8 @@ class XList extends Base
             $total = $includeTotal ? $dbForProject->count('deployments', $filterQueries, APP_LIMIT_COUNT) : 0;
         } catch (OrderException $e) {
             throw new Exception(Exception::DATABASE_QUERY_ORDER_NULL, "The order attribute '{$e->getAttribute()}' had a null value. Cursor pagination requires all documents order attribute values are non-null.");
+        } catch (QueryException $e) {
+            throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
 
         $response->addFilter(new ListSelection($selectQueries, 'deployments'));

--- a/src/Appwrite/Platform/Modules/Users/Http/Users/Identities/XList.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/Identities/XList.php
@@ -90,6 +90,8 @@ class XList extends Action
             $total = $includeTotal ? $dbForProject->count('identities', $queries, APP_LIMIT_COUNT) : 0;
         } catch (OrderException $e) {
             throw new Exception(Exception::DATABASE_QUERY_ORDER_NULL, "The order attribute '{$e->getAttribute()}' had a null value. Cursor pagination requires all documents order attribute values are non-null.");
+        } catch (QueryException $e) {
+            throw new Exception(Exception::GENERAL_QUERY_INVALID, $e->getMessage());
         }
         $response->dynamic(new Document([
             'identities' => $identities,

--- a/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
+++ b/tests/e2e/Services/Functions/FunctionsCustomServerTest.php
@@ -1648,6 +1648,16 @@ final class FunctionsCustomServerTest extends Scope
         $this->assertArrayHasKey('sourceSize', $deployments['body']['deployments'][0]);
         $this->assertArrayHasKey('buildSize', $deployments['body']['deployments'][0]);
 
+        /**
+         * Test for FAILURE
+         */
+        $deployments = $this->listDeployments($functionId, [
+            'search' => 'deployment',
+        ]);
+
+        $this->assertEquals(400, $deployments['headers']['status-code']);
+        $this->assertSame('general_query_invalid', $deployments['body']['type']);
+
         $deployments = $this->listDeployments($functionId, [
             'queries' => [
                 Query::limit(1)->toString(),

--- a/tests/e2e/Services/Sites/SitesCustomServerTest.php
+++ b/tests/e2e/Services/Sites/SitesCustomServerTest.php
@@ -1995,6 +1995,16 @@ final class SitesCustomServerTest extends Scope
         $this->assertArrayHasKey('sourceSize', $deployments['body']['deployments'][0]);
         $this->assertArrayHasKey('buildSize', $deployments['body']['deployments'][0]);
 
+        /**
+         * Test for FAILURE
+         */
+        $deployments = $this->listDeployments($siteId, [
+            'search' => 'deployment',
+        ]);
+
+        $this->assertEquals(400, $deployments['headers']['status-code']);
+        $this->assertSame('general_query_invalid', $deployments['body']['type']);
+
         $deployments = $this->listDeployments($siteId, [
             'queries' => [
                 Query::limit(1)->toString(),

--- a/tests/e2e/Services/Users/UsersBase.php
+++ b/tests/e2e/Services/Users/UsersBase.php
@@ -858,6 +858,19 @@ trait UsersBase
         $this->assertNotEmpty($response['body']['phone']);
     }
 
+    public function testListIdentitiesInvalidSearch(): void
+    {
+        $response = $this->client->call(Client::METHOD_GET, '/users/identities', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], $this->getHeaders()), [
+            'search' => 'identity',
+        ]);
+
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertSame('general_query_invalid', $response['body']['type']);
+    }
+
     public function testListUsers(): void
     {
         $data = $this->setupUser();


### PR DESCRIPTION
## What does this PR do?

Deployment and identity list endpoints add a search query for collections without a `search` attribute. Database validation rejects the query, and the uncaught exception currently returns a 500.

This translates those database query errors into the established invalid-query response and adds coverage for function deployments, site deployments, and identities.

```text
before: search=... -> 500
 after: search=... -> 400 general_query_invalid
```

## Test Plan

```text
composer lint <changed files>
composer analyze <changed files>
```

E2E coverage was added but not run locally because the `appwrite` container is not running.

## Related PRs and Issues

- Fixes [CLOUD-3CPN](https://appwrite.sentry.io/issues/7129079493/)
- Follow-up to #13208

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
