### PR TITLE
Preserve invalid legacy query values for endpoint validation

### DIFF
--- a/src/Appwrite/Utopia/Request/Filters/V20.php
+++ b/src/Appwrite/Utopia/Request/Filters/V20.php
@@ -48,21 +48,22 @@ class V20 extends Filter
             $content['queries'] = [];
         }
 
-        // Handle case where queries is an array but empty
-        if (\is_array($content['queries'])) {
-            $content['queries'] = \array_filter($content['queries'], function ($q) {
-                if (\is_object($q) && empty((array)$q)) {
-                    return false;
-                }
-                if (\is_string($q) && \trim($q) === '') {
-                    return false;
-                }
-                if (empty($q)) {
-                    return false;
-                }
-                return true;
-            });
+        if (!\is_array($content['queries'])) {
+            return $content;
         }
+
+        $content['queries'] = \array_filter($content['queries'], function ($q) {
+            if (\is_object($q) && empty((array)$q)) {
+                return false;
+            }
+            if (\is_string($q) && \trim($q) === '') {
+                return false;
+            }
+            if (empty($q)) {
+                return false;
+            }
+            return true;
+        });
 
         try {
             $parsed = Query::parseQueries($content['queries']);

--- a/tests/e2e/Services/Databases/LegacyCustomServerTest.php
+++ b/tests/e2e/Services/Databases/LegacyCustomServerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\E2E\Services\Databases;
 
+use Appwrite\Extend\Exception;
+use Tests\E2E\Client;
 use Tests\E2E\Scopes\ApiLegacy;
 use Tests\E2E\Scopes\ProjectCustom;
 use Tests\E2E\Scopes\Scope;
@@ -15,4 +17,20 @@ final class LegacyCustomServerTest extends Scope
     use ProjectCustom;
     use SideServer;
     use ApiLegacy;
+
+    public function testListDocumentsRejectsInvalidLegacyQueryType(): void
+    {
+        $response = $this->client->call(
+            Client::METHOD_GET,
+            $this->getRecordUrl('database', 'collection') . '?queries=invalid',
+            array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+                'x-appwrite-response-format' => '1.7.4',
+            ], $this->getHeaders())
+        );
+
+        $this->assertSame(400, $response['headers']['status-code']);
+        $this->assertSame(Exception::GENERAL_ARGUMENT_INVALID, $response['body']['type']);
+    }
 }

--- a/tests/unit/Utopia/Request/Filters/V20Test.php
+++ b/tests/unit/Utopia/Request/Filters/V20Test.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Utopia\Request\Filters;
+
+use Appwrite\Utopia\Request\Filter;
+use Appwrite\Utopia\Request\Filters\V20;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class V20Test extends TestCase
+{
+    protected Filter $filter;
+
+    protected function setUp(): void
+    {
+        $this->filter = new V20();
+    }
+
+    public static function invalidQueriesProvider(): \Iterator
+    {
+        yield 'string' => ['invalid'];
+        yield 'integer' => [1];
+        yield 'object' => [new \stdClass()];
+    }
+
+    #[DataProvider('invalidQueriesProvider')]
+    public function testPreservesInvalidQueriesForEndpointValidation(mixed $queries): void
+    {
+        $content = ['queries' => $queries];
+
+        $this->assertSame($content, $this->filter->parse($content, 'databases.listDocuments'));
+        $this->assertSame($content, $this->filter->parse($content, 'databases.getDocument'));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Preserves non-array `queries` values in the 1.7 compatibility filter so the endpoint validator can return a controlled argument error.

```text
before: string queries -> Query::parseQueries() type error
 after: string queries -> endpoint validation -> 400
```

Adds unit coverage for string, integer, and object values.

## Test Plan

```text
composer lint src/Appwrite/Utopia/Request/Filters/V20.php
composer lint tests/unit/Utopia/Request/Filters/V20Test.php
composer analyze src/Appwrite/Utopia/Request/Filters/V20.php
vendor/bin/phpunit --configuration phpunit.xml tests/unit/Utopia/Request/Filters/V20Test.php
```

All three unit-test cases pass.

## Related PRs and Issues

- [CLOUD-3M6M](https://appwrite.sentry.io/issues/CLOUD-3M6M)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
