### PR TITLE
Guard missing deployment in VCS preview lookup

### DIFF
--- a/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
+++ b/src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
@@ -181,7 +181,7 @@ trait Deployment
 
                     $commentStatus = $existingDeployment->getAttribute('status', 'waiting');
 
-                    if ($resource->getCollection() === 'sites') {
+                    if ($resource->getCollection() === 'sites' && !$existingDeployment->isEmpty()) {
                         $previewRule = $authorization->skip(fn () => $dbForPlatform->findOne('rules', [
                             Query::equal('projectInternalId', [$project->getSequence()]),
                             Query::equal('type', ['deployment']), // Not redirect


### PR DESCRIPTION
## What does this PR do?

Skips the site preview-rule lookup when no existing deployment was found for a pull-request build.

```text
before: empty deployment -> query rules with an invalid internal ID
 after: empty deployment -> keep the preview URL empty
```

## Test Plan

```text
composer lint src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
composer analyze src/Appwrite/Platform/Modules/VCS/Http/GitHub/Deployment.php
```

## Related PRs and Issues

- [CLOUD-3KJD](https://appwrite.sentry.io/issues/CLOUD-3KJD)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
