### PR TITLE
Handle null record IDs in the shared create action

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
@@ -148,7 +148,7 @@ class Create extends Action
             ->callback($this->action(...));
     }
 
-    public function action(string $databaseId, string $documentId, string $collectionId, string|array|\stdClass $data, ?array $permissions, ?array $documents, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, User $user, Event $queueForEvents, Context $usage, Event $queueForRealtime, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, array $plan, Authorization $authorization, EventProcessor $eventProcessor): void
+    public function action(string $databaseId, ?string $documentId, string $collectionId, string|array|\stdClass $data, ?array $permissions, ?array $documents, ?string $transactionId, UtopiaResponse $response, Database $dbForProject, callable $getDatabasesDB, User $user, Event $queueForEvents, Context $usage, Event $queueForRealtime, FunctionPublisher $publisherForFunctions, Event $queueForWebhooks, array $plan, Authorization $authorization, EventProcessor $eventProcessor): void
     {
         $data = $this->normalizeData($data);
 

--- a/tests/e2e/Services/Databases/DatabasesBase.php
+++ b/tests/e2e/Services/Databases/DatabasesBase.php
@@ -2701,6 +2701,22 @@ trait DatabasesBase
             'x-appwrite-project' => $this->getProject()['$id'],
         ], $this->getHeaders());
 
+        $missingId = $this->client->call(
+            Client::METHOD_POST,
+            $this->getRecordUrl($databaseId, $data['moviesId']),
+            $headers,
+            [
+                $this->getRecordIdParam() => null,
+                'data' => ['title' => 'Missing ID'],
+            ]
+        );
+
+        $this->assertEquals(400, $missingId['headers']['status-code']);
+        $this->assertEquals(
+            $this->getRecordIdParam() === 'documentId' ? Exception::DOCUMENT_MISSING_DATA : Exception::ROW_MISSING_DATA,
+            $missingId['body']['type']
+        );
+
         $documentId = ID::unique();
         $invalid = $this->client->call(
             Client::METHOD_POST,


### PR DESCRIPTION
## What does this PR do?

Allows the shared document/row create action to receive an explicit null record ID. Existing missing-ID checks then return `document_missing_data` or `row_missing_data` instead of PHP raising a parameter `TypeError`.

```text
explicit null ID: TypeError -> controlled 400
```

Adds shared E2E coverage for both document and row routes.

## Test Plan

```text
composer lint src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
composer lint tests/e2e/Services/Databases/DatabasesBase.php
composer analyze src/Appwrite/Platform/Modules/Databases/Http/Databases/Collections/Documents/Create.php
```

The E2E test was not run locally because the `appwrite` container is not running.

## Related PRs and Issues

- [CLOUD-3NX2](https://appwrite.sentry.io/issues/CLOUD-3NX2)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
