### PR TITLE
Map transaction relationship failures to client errors

### DIFF
--- a/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
+++ b/src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
@@ -25,6 +25,7 @@ use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Exception\Query as QueryException;
+use Utopia\Database\Exception\Relationship as RelationshipException;
 use Utopia\Database\Exception\Structure as StructureException;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Query;
@@ -319,6 +320,11 @@ class Update extends Action
                     'status' => 'failed',
                 ])));
                 throw new Exception(Exception::TRANSACTION_CONFLICT, previous: $e);
+            } catch (RelationshipException $e) {
+                $authorization->skip(fn () => $dbForProject->updateDocument('transactions', $transactionId, new Document([
+                    'status' => 'failed',
+                ])));
+                throw new Exception(Exception::RELATIONSHIP_VALUE_INVALID, $e->getMessage());
             } catch (StructureException $e) {
                 $authorization->skip(fn () => $dbForProject->updateDocument('transactions', $transactionId, new Document([
                     'status' => 'failed',

--- a/tests/e2e/Services/Databases/Transactions/TransactionsBase.php
+++ b/tests/e2e/Services/Databases/Transactions/TransactionsBase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\E2E\Services\Databases\Transactions;
 
+use Appwrite\Extend\Exception;
 use Tests\E2E\Client;
 use Tests\E2E\Scopes\SchemaPolling;
 use Utopia\Database\Helpers\ID;
@@ -490,6 +491,84 @@ trait TransactionsBase
         ]);
 
         $this->assertEquals(400, $response['headers']['status-code']);
+    }
+
+    public function testCommitInvalidRelationship(): void
+    {
+        if (!$this->getSupportForRelationships()) {
+            $this->markTestSkipped('Relationships are not supported');
+        }
+
+        $headers = [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ];
+
+        $database = $this->client->call(Client::METHOD_POST, $this->getDatabaseUrl(), $headers, [
+            'databaseId' => ID::unique(),
+            'name' => 'TransactionRelationshipTestDB',
+        ]);
+        $this->assertEquals(201, $database['headers']['status-code']);
+        $databaseId = $database['body']['$id'];
+
+        $collections = [];
+        foreach (['parents', 'children'] as $name) {
+            $collection = $this->client->call(Client::METHOD_POST, $this->getContainerUrl($databaseId), $headers, [
+                $this->getContainerIdParam() => ID::unique(),
+                'name' => $name,
+                'permissions' => [
+                    Permission::create(Role::any()),
+                    Permission::read(Role::any()),
+                ],
+            ]);
+            $this->assertEquals(201, $collection['headers']['status-code']);
+            $collections[$name] = $collection['body']['$id'];
+        }
+
+        $relationship = $this->client->call(
+            Client::METHOD_POST,
+            $this->getSchemaUrl($databaseId, $collections['parents']) . '/relationship',
+            $headers,
+            [
+                $this->getRelatedIdParam() => $collections['children'],
+                'type' => 'oneToOne',
+                'twoWay' => false,
+                'key' => 'child',
+            ]
+        );
+        $this->assertEquals(202, $relationship['headers']['status-code']);
+        $this->waitForAllAttributes($databaseId, $collections['parents']);
+
+        $transaction = $this->client->call(Client::METHOD_POST, $this->getTransactionUrl(), $headers);
+        $this->assertEquals(201, $transaction['headers']['status-code']);
+        $transactionId = $transaction['body']['$id'];
+
+        $operation = $this->client->call(
+            Client::METHOD_POST,
+            $this->getTransactionUrl($transactionId) . '/operations',
+            $headers,
+            [
+                'operations' => [[
+                    'databaseId' => $databaseId,
+                    $this->getContainerIdParam() => $collections['parents'],
+                    'action' => 'create',
+                    $this->getRecordIdParam() => ID::unique(),
+                    'data' => ['child' => 123],
+                ]],
+            ]
+        );
+        $this->assertEquals(201, $operation['headers']['status-code']);
+
+        $commit = $this->client->call(Client::METHOD_PATCH, $this->getTransactionUrl($transactionId), $headers, [
+            'commit' => true,
+        ]);
+        $this->assertEquals(400, $commit['headers']['status-code']);
+        $this->assertEquals(Exception::RELATIONSHIP_VALUE_INVALID, $commit['body']['type']);
+
+        $failed = $this->client->call(Client::METHOD_GET, $this->getTransactionUrl($transactionId), $headers);
+        $this->assertEquals(200, $failed['headers']['status-code']);
+        $this->assertEquals('failed', $failed['body']['status']);
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Catches relationship failures during transaction commit, marks the transaction as failed, and returns `relationship_value_invalid` instead of an unexpected 500.

```text
invalid staged relationship -> failed transaction + controlled 400
```

Adds E2E coverage for committing a staged create operation with an invalid relationship value.

## Test Plan

```text
composer lint src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
composer lint tests/e2e/Services/Databases/Transactions/TransactionsBase.php
composer analyze src/Appwrite/Platform/Modules/Databases/Http/Databases/Transactions/Update.php
```

The E2E test was not run locally because the `appwrite` container is not running.

## Related PRs and Issues

- [CLOUD-39T0](https://appwrite.sentry.io/issues/CLOUD-39T0)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
