### PR TITLE
Skip bulk session events without a current cookie session

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -692,6 +692,8 @@ Http::delete('/v1/account/sessions')
             $queueForEvents
                 ->setParam('userId', $user->getId())
                 ->setParam('sessionId', $currentSession->getId());
+        } else {
+            $queueForEvents->reset();
         }
 
         $response->noContent();

--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1772,6 +1772,30 @@ final class AccountCustomClientTest extends Scope
 
     }
 
+    public function testDeleteAccountSessionsWithJWT(): void
+    {
+        $data = $this->setupAccountWithVerifiedEmail();
+
+        $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $data['session'],
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $jwt = $response['body']['jwt'];
+
+        $response = $this->client->call(Client::METHOD_DELETE, '/account/sessions', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-jwt' => $jwt,
+        ]);
+
+        $this->assertEquals(204, $response['headers']['status-code']);
+    }
+
     public function testCreateAccountRecovery(): void
     {
         $data = $this->setupAccountWithVerifiedEmail();


### PR DESCRIPTION
## What does this PR do?

Resets the event queue when bulk session deletion is authorized without a current cookie session, such as through JWT authentication. This prevents event generation with missing `userId` and `sessionId` parameters.

```text
current cookie session: emit the session deletion event
no current session:     clear the incomplete event
```

Adds E2E coverage for deleting all sessions through a JWT without a cookie.

## Test Plan

```text
composer lint app/controllers/api/account.php
composer lint tests/e2e/Services/Account/AccountCustomClientTest.php
composer analyze app/controllers/api/account.php
```

The E2E test was not run locally because the `appwrite` container is not running.

## Related PRs and Issues

- [CLOUD-3K6G](https://appwrite.sentry.io/issues/CLOUD-3K6G)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
