### PR TITLE
Return avatar not found for undecodable remote images

### DIFF
--- a/src/Appwrite/Platform/Modules/Avatars/Http/Image/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Image/Get.php
@@ -101,7 +101,7 @@ class Get extends Action
 
         try {
             $image = new Image($res->getBody());
-        } catch (\Throwable) {
+        } catch (\ImagickException) {
             throw new Exception(Exception::AVATAR_IMAGE_NOT_FOUND);
         }
 

--- a/src/Appwrite/Platform/Modules/Avatars/Http/Image/Get.php
+++ b/src/Appwrite/Platform/Modules/Avatars/Http/Image/Get.php
@@ -101,8 +101,8 @@ class Get extends Action
 
         try {
             $image = new Image($res->getBody());
-        } catch (\Throwable $exception) {
-            throw new Exception(Exception::GENERAL_SERVER_ERROR, 'Unable to parse image');
+        } catch (\Throwable) {
+            throw new Exception(Exception::AVATAR_IMAGE_NOT_FOUND);
         }
 
         $image->crop((int) $width, (int) $height);

--- a/tests/e2e/Client.php
+++ b/tests/e2e/Client.php
@@ -99,13 +99,15 @@ class Client
      *
      * @param string $method
      * @param string $path
-     * @param array $params
      * @param array $headers
+     * @param mixed $params
      * @param bool $decode
+     * @param bool $followRedirects
+     * @param int $timeout
      * @return array
      * @throws Exception
      */
-    public function call(string $method, string $path = '', array $headers = [], mixed $params = [], bool $decode = true, bool $followRedirects = true): array
+    public function call(string $method, string $path = '', array $headers = [], mixed $params = [], bool $decode = true, bool $followRedirects = true, int $timeout = 120): array
     {
         $headers            = array_merge($this->headers, $headers);
         $ch                 = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
@@ -145,7 +147,7 @@ class Client
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36');
         curl_setopt($ch, CURLOPT_HTTPHEADER, $formattedHeaders);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         curl_setopt($ch, CURLOPT_COOKIEFILE, ''); // enable in-memory RFC 6265 cookie engine
         curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
             $len = strlen($header);

--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -261,7 +261,7 @@ trait AvatarsBase
                 'x-appwrite-project' => $this->getProject()['$id'],
             ], [
                 'url' => 'https://appwrite.io/robots.txt',
-            ]);
+            ], timeout: 5);
 
             $this->assertEquals(404, $response['headers']['status-code']);
             $this->assertEquals(Exception::AVATAR_IMAGE_NOT_FOUND, $response['body']['type']);

--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -256,14 +256,16 @@ trait AvatarsBase
 
         $this->assertEquals(404, $response['headers']['status-code']);
 
-        $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
-            'x-appwrite-project' => $this->getProject()['$id'],
-        ], [
-            'url' => 'https://appwrite.io/robots.txt',
-        ]);
+        $this->assertEventually(function () {
+            $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], [
+                'url' => 'https://appwrite.io/robots.txt',
+            ]);
 
-        $this->assertEquals(404, $response['headers']['status-code']);
-        $this->assertEquals(Exception::AVATAR_IMAGE_NOT_FOUND, $response['body']['type']);
+            $this->assertEquals(404, $response['headers']['status-code']);
+            $this->assertEquals(Exception::AVATAR_IMAGE_NOT_FOUND, $response['body']['type']);
+        }, 30_000, 2_000);
 
         $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
             'x-appwrite-project' => $this->getProject()['$id'],

--- a/tests/e2e/Services/Avatars/AvatarsBase.php
+++ b/tests/e2e/Services/Avatars/AvatarsBase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\E2E\Services\Avatars;
 
+use Appwrite\Extend\Exception;
 use Tests\E2E\Client;
 
 trait AvatarsBase
@@ -254,6 +255,15 @@ trait AvatarsBase
         ]);
 
         $this->assertEquals(404, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ], [
+            'url' => 'https://appwrite.io/robots.txt',
+        ]);
+
+        $this->assertEquals(404, $response['headers']['status-code']);
+        $this->assertEquals(Exception::AVATAR_IMAGE_NOT_FOUND, $response['body']['type']);
 
         $response = $this->client->call(Client::METHOD_GET, '/avatars/image', [
             'x-appwrite-project' => $this->getProject()['$id'],


### PR DESCRIPTION
## What does this PR do?

Maps an undecodable 200 response from a remote avatar URL to `avatar_image_not_found` instead of `general_server_error`.

```text
remote body is not an image: 500 general_server_error -> 404 avatar_image_not_found
```

Adds E2E coverage using a text response from `appwrite.io`.

## Test Plan

```text
composer lint src/Appwrite/Platform/Modules/Avatars/Http/Image/Get.php
composer lint tests/e2e/Services/Avatars/AvatarsBase.php
composer analyze src/Appwrite/Platform/Modules/Avatars/Http/Image/Get.php
```

The E2E test was not run locally because the `appwrite` container is not running.

## Related PRs and Issues

- [CLOUD-38HN](https://appwrite.sentry.io/issues/CLOUD-38HN)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
