### PR TITLE
chore(sdks): move the cli target to sdk-generator 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "appwrite/sdk-generator": "^3.0",
+        "appwrite/sdk-generator": "^4.0",
         "brianium/paratest": "7.*",
         "phpunit/phpunit": "12.*",
         "swoole/ide-helper": "6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0f6adf44ebc98b165308699ca7c41fb",
+    "content-hash": "c7acee2d0fe6b2299e47df05257a7225",
     "packages": [
         {
             "name": "adhocore/jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ca087676c3a1fdd1786d6e683050e81",
+    "content-hash": "d0f6adf44ebc98b165308699ca7c41fb",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -5287,16 +5287,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "31c03de12bd01bff37795f8bbbae836d6f622fae"
+                "reference": "b02a0c070acd096978bd6bd05eb8d799e1cf9a2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/31c03de12bd01bff37795f8bbbae836d6f622fae",
-                "reference": "31c03de12bd01bff37795f8bbbae836d6f622fae",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/b02a0c070acd096978bd6bd05eb8d799e1cf9a2f",
+                "reference": "b02a0c070acd096978bd6bd05eb8d799e1cf9a2f",
                 "shasum": ""
             },
             "require": {
@@ -5333,9 +5333,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/3.0.0"
+                "source": "https://github.com/appwrite/sdk-generator/tree/4.0.1"
             },
-            "time": "2026-08-14T08:18:40+00:00"
+            "time": "2026-08-15T17:04:18+00:00"
         },
         {
             "name": "brianium/paratest",

--- a/src/Appwrite/Platform/Tasks/SDKs.php
+++ b/src/Appwrite/Platform/Tasks/SDKs.php
@@ -5,13 +5,13 @@ namespace Appwrite\Platform\Tasks;
 use Appwrite\SDK\Language\Android;
 use Appwrite\SDK\Language\Apple;
 use Appwrite\SDK\Language\ClaudePlugin;
+use Appwrite\SDK\Language\CLI;
 use Appwrite\SDK\Language\CodexPlugin;
 use Appwrite\SDK\Language\CursorPlugin;
 use Appwrite\SDK\Language\Dart;
 use Appwrite\SDK\Language\DotNet;
 use Appwrite\SDK\Language\Flutter;
 use Appwrite\SDK\Language\Go;
-use Appwrite\SDK\Language\GoCLI;
 use Appwrite\SDK\Language\GraphQL;
 use Appwrite\SDK\Language\Kotlin;
 use Appwrite\SDK\Language\Node;
@@ -358,7 +358,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                         }
                         break;
                     case 'cli':
-                        $config = new GoCLI();
+                        $config = new CLI();
                         $config->setNPMPackage('appwrite-cli');
                         $config->setExecutableName('appwrite');
                         $config->setLogo("


### PR DESCRIPTION
Updates `appwrite/sdk-generator` to `^4.0` and points the `cli` target at the `CLI` language class.

## Why

`sdk-generator` 4.0.0 made `cli` generate Go directly: `templates/go-cli` moved into `templates/cli` and the transitional `GoCLI` class was removed. `SDKs.php` still constructs `new GoCLI()`, so the repository cannot move past `3.0.0` without this rename.

Staying on `3.0.0` also blocks CLI releases. The generator pins `sdk-for-go/v6 v6.5.0` there, while the console spec has moved ahead of it — `sites create` and `sites update` now take `scopes`, and the generated command resolves it to a setter the pinned SDK does not have:

```
internal/cmd/services/sites.go:236:39: service.WithCreateScopes undefined (type *sites.Sites has no field or method WithCreateScopes)
internal/cmd/services/sites.go:470:39: service.WithUpdateScopes undefined
```

A new *parameter* on an existing method has no escape hatch — `excludeRules` covers services, methods and definitions only, and excluding `sites.create`/`sites.update` would delete two shipping commands. 4.0.1 pins `sdk-for-go/v7 v7.1.0`, which has both setters.

## Changes

- `composer.json` / `composer.lock`: `appwrite/sdk-generator` `^3.0` → `^4.0` (resolves to 4.0.1). No other package moves.
- `src/Appwrite/Platform/Tasks/SDKs.php`: `GoCLI` → `CLI`, import reordered by Pint.

## Verification

`php app/cli.php sdks --platform=console --sdk=cli --version=1.9.x --git=no --ai=no` generates cleanly, and the generated `go.mod` now reads `github.com/appwrite/sdk-for-go/v7 v7.1.0`. `composer lint` passes. No other `GoCLI` or `go-cli` reference remains in the repository.