### PR TITLE
fix(users): send full user object in updatePrefs event payload

### DIFF
--- a/app/controllers/api/account.php
+++ b/app/controllers/api/account.php
@@ -3682,7 +3682,12 @@ Http::patch('/v1/account/prefs')
 
         $user = $dbForProject->updateDocument('users', $user->getId(), $user);
 
-        $queueForEvents->setParam('userId', $user->getId());
+        // Fix: include the full user object in the event payload so that
+        // users.[userId].update.prefs listeners receive a consistent payload
+        // matching all other users.[userId].update.* events (issue #7234).
+        $queueForEvents
+            ->setParam('userId', $user->getId())
+            ->setPayload($response->output($user, Response::MODEL_ACCOUNT));
 
         $response->dynamic($user, Response::MODEL_ACCOUNT);
     });

--- a/src/Appwrite/Platform/Modules/Users/Http/Users/Prefs/Update.php
+++ b/src/Appwrite/Platform/Modules/Users/Http/Users/Prefs/Update.php
@@ -66,6 +66,9 @@ class Update extends Action
 
         $queueForEvents
             ->setParam('userId', $user->getId())
+            // Emit the full user object in the event payload so that
+            // users.[userId].update.prefs listeners receive a consistent payload
+            // matching all other users.[userId].update.* events (issue #7234).
             ->setPayload($response->output($user, Response::MODEL_USER));
 
         $response->dynamic(new Document($prefs), Response::MODEL_PREFERENCES);


### PR DESCRIPTION
When PATCH /v1/account/prefs or PATCH /v1/users/:userId/prefs is called, the users.[userId].update.prefs event was firing with an inconsistent payload compared to all other users.[userId].update.* events:

- Other update endpoints (email, name, password, status, etc.) emit the full user object via setPayload().
- updatePrefs on the account route had no setPayload() call at all, resulting in an empty/missing payload for listeners.
- updatePrefs on the users admin route already had setPayload() but lacked an explanatory comment.

Changes:
- app/controllers/api/account.php: added ->setPayload(\->output( \, Response::MODEL_ACCOUNT)) to the queueForEvents chain in the PATCH /v1/account/prefs handler.
- src/Appwrite/Platform/Modules/Users/Http/Users/Prefs/Update.php: added a doc comment explaining why the full user object is emitted.

Fixes #7234

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The problem: When you update user preferences (PATCH /v1/account/prefs), Appwrite fires a users.[userId].update.prefs event that can trigger a Function. But the event payload was empty — your Function received no data about the user. Every other user update event (name, email, password, status) correctly sends the full user object in the payload.

The fix: One line — add ->setPayload($response->output($user, Response::MODEL_ACCOUNT)) to the account prefs handler so it behaves the same as all other user update events.

Impact: Functions subscribed to users.*.update.prefs now receive the full user object, consistent with every other users.*.update.* event.

## Test Plan

1. Manual verification via Appwrite Console
Start a local Appwrite instance (docker compose up -d)
Create a project and deploy a Function subscribed to the users.*.update.prefs event
Have the Function log context.req.bodyRaw or the full request body
Call PATCH /v1/account/prefs with any prefs payload (e.g. {"theme": "dark"})
Check the Function execution logs
Before this fix: body is empty or missing
After this fix: body contains the full user object with all fields ($id, email, name, prefs, etc.)

2. Compare with another update event
Repeat step 4 but call PATCH /v1/account/name instead — the payload structure should now be identical between both events.

3. Admin route (/v1/users/:userId/prefs)
Using an API key, call PATCH /v1/users/{userId}/prefs
Verify the Function receives the same full user object as the account route above
4. Existing E2E tests
docker compose exec appwrite test tests/e2e/Services/Account
docker compose exec appwrite test tests/e2e/Services/Users
Both suites should pass without modification since the HTTP response (MODEL_ACCOUNT / MODEL_PREFERENCES) is unchanged — only the internal event payload is affected.

## Related PRs and Issues

- (Related PR or issue)

## Checklist

- [yes ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [yes ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
