### PR TITLE
fix(tests): give the bulk session deletes their own account

### DIFF
--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1744,7 +1744,9 @@ final class AccountCustomClientTest extends Scope
 
     public function testDeleteAccountSessions(): void
     {
-        $data = $this->setupAccountWithVerifiedEmail();
+        // Deleting every session invalidates the account setupAccountWithVerifiedEmail()
+        // caches, so this owns one rather than emptying the one its siblings share.
+        $data = $this->createFreshAccountWithSession();
         $session = $data['session'];
 
         /**
@@ -1774,7 +1776,7 @@ final class AccountCustomClientTest extends Scope
 
     public function testDeleteAccountSessionsWithJWT(): void
     {
-        $data = $this->setupAccountWithVerifiedEmail();
+        $data = $this->createFreshAccountWithSession();
 
         $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
             'origin' => 'http://localhost',


### PR DESCRIPTION
`testDeleteAccountSessionsWithJWT` fails on its first assertion, before it reaches the JWT-authorized delete it exists to cover:

```
1) Tests\E2E\Services\Account\AccountCustomClientTest::testDeleteAccountSessionsWithJWT
Failed asserting that 401 matches expected 201.
tests/e2e/Services/Account/AccountCustomClientTest.php:1786
```

## Cause

`setupAccountWithVerifiedEmail()` caches one account per project in a static and returns the same account -- and the same session -- to all seven of its callers. `testDeleteAccountSessions` takes that shared session and issues `DELETE /account/sessions`, which destroys every session on the account, and nothing invalidates the cache. `testDeleteAccountSessionsWithJWT` runs next, reads the same cache, and posts the now-dead session to `/account/jwt`, which answers 401.

`setupAccountWithVerification()` is not an escape hatch: it caches too, and the verified helper is built on it, so both hand back the same session.

## Why CI mostly hid it

The static is per process. Under `paratest --processes N` the two tests usually land on different workers, each building its own account, so the collision is a matter of sharding. It surfaced on `8c3bea5`, the commit that added the test, and passed on main before and after. A single-process `phpunit` run puts every method in one process in file order, where the failure is deterministic -- appwrite-labs/cloud runs the CE suite that way and has failed it on every run since picking up the test.

## Fix

Both tests that delete every session now build their own account with `createFreshAccountWithSession()`. Neither borrows state a sibling destroys, and the shared cache stays valid for the callers that only need the account's email. The remaining session tests (`testDeleteAccountSession`, `testDeleteAccountSessionCurrent`) create an extra session and delete only that one, so they were never part of this and are untouched.

## Verification

Run against a local stack with single-process `phpunit`, the shape that fails deterministically:

- Before, on `origin/main`: `Tests: 2, Assertions: 17, Failures: 1` -- reproduced at line 1786
- After: `OK (2 tests, 18 assertions)`
- Whole class after: `Tests: 62, Assertions: 913, Skipped: 1`, no failures

`composer lint` passes on the file.