### PR TITLE
Rust Users via Traefik: full E2E parity (52/52)

### DIFF
--- a/3.x.x/.dockerignore
+++ b/3.x.x/.dockerignore
@@ -1,0 +1,11 @@
+target
+**/target
+.git
+**/.git
+benchmarks
+**/benches
+**/*.md
+!crates/*/README.md
+!apps/server/README.md
+Dockerfile
+.dockerignore

--- a/3.x.x/AGENTS.md
+++ b/3.x.x/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent instructions (Appwrite 3.x Rust)
+
+Port Appwrite services to Rust under this workspace. Match PHP **product behavior** and **high-level architecture**. Do **not** replicate PHP runtime or language-specific APIs.
+
+## Keep
+
+- Module / Platform / Action layout (REST verbs only on HTTP)
+- Utopia DI, hooks, events, response models, Document DB API
+- Adapter selection via `_APP_DB_*` and shared cache keys with PHP where both run
+- Traefik split routing (`/v1/users*` → Rust, everything else → PHP) until more services move
+
+## Drop / avoid
+
+- PHP-specific surfaces: PDO, `PDOStatement`, PHP DSNs as a public API, reflection patterns copied for their own sake
+- Re-implementing C extensions or PHP stdlib when Rust crates already cover the need
+- Catch-all “utils” crates that blur Utopia domain boundaries
+
+## Database
+
+Call engine adapters (`Postgres::connect`, `Mysql::connect_db`, `MariaDb::connect_db`, `Sqlite::open`, `Mongo::connect`). Prefer the high-level `Database` / `Document` / `Query` API from `appwrite-platform` (`dbForProject`, `dbForPlatform`).
+
+[`SqlClient`](crates/utopia-database/src/sql_client.rs) is the Rust connection layer **behind** those adapters (using `postgres` / `mysql` / `rusqlite`). It is not a PDO port and should stay out of product code.
+
+## Quality
+
+From `3.x.x/`:
+
+```bash
+cargo fmt-check
+cargo lint
+cargo test -p appwrite-platform
+cargo build -p appwrite-server --release
+```
+
+Users E2E via Traefik: compose up, point Scope at `http://appwrite.test/v1`, run `tests/e2e/Services/Users`.

--- a/3.x.x/Cargo.lock
+++ b/3.x.x/Cargo.lock
@@ -5997,6 +5997,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
+ "tokio",
  "utopia-cache",
  "utopia-console",
  "utopia-pools",

--- a/3.x.x/Cargo.lock
+++ b/3.x.x/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "utopia-cache",
  "utopia-database",
  "utopia-di",
+ "utopia-emails",
  "utopia-http",
  "utopia-platform",
  "utopia-servers",

--- a/3.x.x/README.md
+++ b/3.x.x/README.md
@@ -40,6 +40,24 @@ Naming makes ownership obvious: `cargo test -p utopia-http` vs `cargo test -p ap
 
 Shared env with PHP: `_APP_DB_HOST`, `_APP_DB_PORT`, `_APP_DB_USER`, `_APP_DB_PASS`, `_APP_DB_SCHEMA`, `_APP_OPENSSL_KEY_V1`.
 
+## Architecture (keep / drop)
+
+Follow Appwrite's **high-level** shape from PHP, not PHP's runtime:
+
+**Keep (domain architecture):**
+
+- Platform composition, Modules, HTTP Actions (`create` / `get` / `list` / `update` / `delete`)
+- Utopia DI, hooks, events, response models
+- Document / Query / `Database` adapter API (`dbForPlatform`, `dbForProject`)
+- Shared env vars and Traefik split routing with PHP
+
+**Drop (PHP-specific tooling):**
+
+- PDO, `PDOStatement`, PHP DSNs, reflection-heavy patterns, and other PHP runtime APIs
+- Replicating PHP extension surfaces when a Rust crate already does the job (`postgres`, `mysql`, `rusqlite`, Tokio, Hyper, …)
+
+Prefer idiomatic Rust under the Utopia/Appwrite public APIs. Engine connections live behind `Postgres::connect` / `Mysql::connect_db` / `Sqlite::open` ([`SqlClient`](crates/utopia-database/src/sql_client.rs) is an internal adapter helper, not a PDO port).
+
 ## Build and test
 
 From this directory (`3.x.x/`):

--- a/3.x.x/apps/server/src/main.rs
+++ b/3.x.x/apps/server/src/main.rs
@@ -31,7 +31,6 @@ fn main() -> Result<()> {
 }
 
 async fn async_main(state: Arc<AppwriteState>, adapter: &str) -> Result<()> {
-
     // PHP has no equivalent -- this seeds an in-memory dev project with a
     // `standard` key scoped to `users.read`/`users.write` so `apps/server`
     // (or a test) can exercise `/v1/users*` without a real platform

--- a/3.x.x/apps/server/src/main.rs
+++ b/3.x.x/apps/server/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     // Connect before entering the Tokio runtime. The sync `postgres` client
     // (and other sync engines) call `Handle::block_on` internally; doing that
     // under `#[tokio::main]` panics with nested-runtime errors. Request-path
-    // PDO calls still use `block_in_place` inside utopia-database.
+    // sync SQL client calls still use `block_in_place` inside utopia-database.
     let (state, adapter) = AppwriteState::connect_from_env();
     println!("appwrite-server: dbForPlatform/dbForProject adapter = {adapter}");
     let state = Arc::new(state);

--- a/3.x.x/apps/server/src/main.rs
+++ b/3.x.x/apps/server/src/main.rs
@@ -14,15 +14,23 @@ use appwrite_platform::AppwriteState;
 use serde_json::json;
 use utopia_http::prelude::*;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Mirrors PHP's `_APP_DB_ADAPTER`-driven adapter choice
-    // (`postgresql` / `mysql` / `mariadb` / `mongodb`), falling back to the
-    // in-memory `dbForPlatform`/`dbForProject` stand-in when the adapter is
-    // `memory`/unset, the matching Cargo feature is missing, or connect fails.
+fn main() -> Result<()> {
+    // Connect before entering the Tokio runtime. The sync `postgres` client
+    // (and other sync engines) call `Handle::block_on` internally; doing that
+    // under `#[tokio::main]` panics with nested-runtime errors. Request-path
+    // PDO calls still use `block_in_place` inside utopia-database.
     let (state, adapter) = AppwriteState::connect_from_env();
     println!("appwrite-server: dbForPlatform/dbForProject adapter = {adapter}");
     let state = Arc::new(state);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(async_main(state, adapter))
+}
+
+async fn async_main(state: Arc<AppwriteState>, adapter: &str) -> Result<()> {
 
     // PHP has no equivalent -- this seeds an in-memory dev project with a
     // `standard` key scoped to `users.read`/`users.write` so `apps/server`

--- a/3.x.x/crates/appwrite-platform/Cargo.toml
+++ b/3.x.x/crates/appwrite-platform/Cargo.toml
@@ -26,7 +26,7 @@ utopia-http = { workspace = true }
 utopia-di = { workspace = true }
 utopia-validators = { workspace = true }
 utopia-database = { workspace = true, features = ["postgres", "mysql", "mongo"] }
-utopia-cache = { workspace = true }
+utopia-cache = { workspace = true, features = ["redis"] }
 utopia-auth = { workspace = true }
 utopia-emails = { workspace = true }
 utopia-servers = { workspace = true }

--- a/3.x.x/crates/appwrite-platform/Cargo.toml
+++ b/3.x.x/crates/appwrite-platform/Cargo.toml
@@ -28,6 +28,7 @@ utopia-validators = { workspace = true }
 utopia-database = { workspace = true, features = ["postgres", "mysql", "mongo"] }
 utopia-cache = { workspace = true }
 utopia-auth = { workspace = true }
+utopia-emails = { workspace = true }
 utopia-servers = { workspace = true }
 appwrite-exception = { workspace = true }
 appwrite-hooks = { workspace = true }

--- a/3.x.x/crates/appwrite-platform/README.md
+++ b/3.x.x/crates/appwrite-platform/README.md
@@ -50,3 +50,6 @@ assert_eq!(
   `appwrite-event`, not the Redis-backed `Utopia\Queue\Publisher` PHP uses.
   Swapping in a real publisher is an `apps/server` wiring change, not a
   change to this crate's composition surface.
+- Live SQL uses Rust engine crates via Utopia adapters (`Postgres`, `Mysql`,
+  `MariaDb`). Product code should not construct a low-level SQL client or
+  mirror PHP PDO; see `3.x.x/AGENTS.md` and `3.x.x/README.md`.

--- a/3.x.x/crates/appwrite-platform/src/db.rs
+++ b/3.x.x/crates/appwrite-platform/src/db.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use utopia_cache::adapter::Memory as CacheMemory;
+use utopia_cache::adapter::{Memory as CacheMemory, Redis as CacheRedis};
 use utopia_cache::Cache;
 #[cfg(feature = "mongo")]
 use utopia_database::adapter::mongo::Mongo;
@@ -222,6 +222,19 @@ impl ProjectDb {
         with_db!(self, db => db.create(database))
     }
 
+    /// PHP `$dbForProject->purgeCachedDocument($collection, $id)`.
+    ///
+    /// Writing a child document (a session, a target) leaves the parent user
+    /// document cached with the old relationship, so the handlers that mutate
+    /// one purge the other, exactly where the PHP handlers do.
+    pub fn purge_cached_document(
+        &mut self,
+        collection: &str,
+        id: &str,
+    ) -> utopia_database::Result<bool> {
+        with_db!(self, db => db.purge_cached_document(collection, Some(id)))
+    }
+
     pub fn create_collection(
         &mut self,
         id: &str,
@@ -325,16 +338,58 @@ pub fn new_memory_project_database(project_id: &str) -> Database<Memory> {
 
 fn configure_live_database<A: utopia_database::adapter::Adapter>(
     mut db: Database<A>,
-    schema: &str,
+    config: &DatabaseConfig,
     namespace: &str,
 ) -> Result<Database<A>, DatabaseError> {
     db.disable_validation();
     db.get_authorization_mut().disable();
-    db.set_database(schema)
+    // PHP's pooled PDO adapter carries the DSN host, and that host is a
+    // segment of every cache key. Without it, Rust would read and purge a
+    // different key space than the PHP server sharing this Redis.
+    db.get_adapter_mut().set_hostname(config.host.as_str());
+    db.set_database(&config.schema)
         .map_err(|err| DatabaseError::database(format!("setDatabase failed: {err}")))?;
     db.set_namespace(namespace)
         .map_err(|err| DatabaseError::database(format!("setNamespace failed: {err}")))?;
     Ok(db)
+}
+
+/// The cache PHP and Rust share.
+///
+/// `Database` builds keys as `{cacheName}-cache-{hostname}:{namespace}:
+/// {tenant}:collection:{id}[:{documentId}]`, so pointing both servers at the
+/// same Redis makes a purge on one side invalidate the other's entry. Falls
+/// back to a private in-process cache when Redis is unreachable: correct for
+/// this process, but PHP will not see its purges.
+fn shared_cache() -> Cache {
+    let Some(host) = std::env::var("_APP_REDIS_HOST")
+        .ok()
+        .filter(|host| !host.is_empty())
+    else {
+        return Cache::new(CacheMemory::new());
+    };
+    let port = std::env::var("_APP_REDIS_PORT")
+        .ok()
+        .and_then(|port| port.parse::<u16>().ok())
+        .unwrap_or(6379);
+    let user = std::env::var("_APP_REDIS_USER").unwrap_or_default();
+    let pass = std::env::var("_APP_REDIS_PASS").unwrap_or_default();
+    let credentials = match (user.is_empty(), pass.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => format!(":{pass}@"),
+        _ => format!("{user}:{pass}@"),
+    };
+
+    match CacheRedis::connect_url(&format!("redis://{credentials}{host}:{port}/")) {
+        Ok(redis) => Cache::new(redis),
+        Err(err) => {
+            eprintln!(
+                "appwrite-platform: redis cache connect failed ({err}); falling back to an \
+                 in-process cache, which PHP cannot invalidate"
+            );
+            Cache::new(CacheMemory::new())
+        }
+    }
 }
 
 fn new_project_database_live(
@@ -351,7 +406,7 @@ pub fn new_platform_database(config: &DatabaseConfig) -> Result<ProjectDb, Datab
 }
 
 fn open_database(config: &DatabaseConfig, namespace: &str) -> Result<ProjectDb, DatabaseError> {
-    let cache = Cache::new(CacheMemory::new());
+    let cache = shared_cache();
     match config.kind {
         AdapterKind::Memory => Err(DatabaseError::database(
             "open_database called for memory adapter",
@@ -366,8 +421,7 @@ fn open_database(config: &DatabaseConfig, namespace: &str) -> Result<ProjectDb, 
                 &config.schema,
             )
             .map_err(|err| DatabaseError::database(format!("postgres connect failed: {err}")))?;
-            let db =
-                configure_live_database(Database::new(adapter, cache), &config.schema, namespace)?;
+            let db = configure_live_database(Database::new(adapter, cache), config, namespace)?;
             Ok(ProjectDb::Postgres(db))
         }
         #[cfg(not(feature = "postgres"))]
@@ -385,11 +439,8 @@ fn open_database(config: &DatabaseConfig, namespace: &str) -> Result<ProjectDb, 
                 false,
             )
             .map_err(|err| DatabaseError::database(format!("mysql connect failed: {err}")))?;
-            let db = configure_live_database(
-                Database::new(Mysql::new(pdo), cache),
-                &config.schema,
-                namespace,
-            )?;
+            let db =
+                configure_live_database(Database::new(Mysql::new(pdo), cache), config, namespace)?;
             Ok(ProjectDb::Mysql(db))
         }
         #[cfg(feature = "mysql")]
@@ -405,7 +456,7 @@ fn open_database(config: &DatabaseConfig, namespace: &str) -> Result<ProjectDb, 
             .map_err(|err| DatabaseError::database(format!("mariadb connect failed: {err}")))?;
             let db = configure_live_database(
                 Database::new(MariaDb::new(pdo), cache),
-                &config.schema,
+                config,
                 namespace,
             )?;
             Ok(ProjectDb::MariaDb(db))
@@ -419,8 +470,7 @@ fn open_database(config: &DatabaseConfig, namespace: &str) -> Result<ProjectDb, 
             let uri = mongo_uri(config);
             let adapter = Mongo::connect(&uri)
                 .map_err(|err| DatabaseError::database(format!("mongodb connect failed: {err}")))?;
-            let db =
-                configure_live_database(Database::new(adapter, cache), &config.schema, namespace)?;
+            let db = configure_live_database(Database::new(adapter, cache), config, namespace)?;
             Ok(ProjectDb::Mongo(db))
         }
         #[cfg(not(feature = "mongo"))]

--- a/3.x.x/crates/appwrite-platform/src/db.rs
+++ b/3.x.x/crates/appwrite-platform/src/db.rs
@@ -17,8 +17,6 @@ use utopia_database::adapter::mysql::{MariaDb, Mysql};
 use utopia_database::adapter::postgres::Postgres;
 pub use utopia_database::adapter::Memory;
 use utopia_database::helpers::{Permission, Role};
-#[cfg(feature = "mysql")]
-use utopia_database::pdo::Pdo;
 use utopia_database::{Database, DatabaseError, Document, Query};
 
 use crate::state::{COLLECTIONS, PLATFORM_NAMESPACE};
@@ -343,7 +341,7 @@ fn configure_live_database<A: utopia_database::adapter::Adapter>(
 ) -> Result<Database<A>, DatabaseError> {
     db.disable_validation();
     db.get_authorization_mut().disable();
-    // PHP's pooled PDO adapter carries the DSN host, and that host is a
+    // PHP's pooled SQL adapter carries the DSN host, and that host is a
     // segment of every cache key. Without it, Rust would read and purge a
     // different key space than the PHP server sharing this Redis.
     db.get_adapter_mut().set_hostname(config.host.as_str());
@@ -430,35 +428,28 @@ fn open_database(config: &DatabaseConfig, namespace: &str) -> Result<ProjectDb, 
         )),
         #[cfg(feature = "mysql")]
         AdapterKind::Mysql => {
-            let pdo = Pdo::mysql(
+            let adapter = Mysql::connect_db(
                 &config.host,
                 config.port,
                 &config.user,
                 &config.pass,
                 Some(config.schema.as_str()),
-                false,
             )
             .map_err(|err| DatabaseError::database(format!("mysql connect failed: {err}")))?;
-            let db =
-                configure_live_database(Database::new(Mysql::new(pdo), cache), config, namespace)?;
+            let db = configure_live_database(Database::new(adapter, cache), config, namespace)?;
             Ok(ProjectDb::Mysql(db))
         }
         #[cfg(feature = "mysql")]
         AdapterKind::MariaDb => {
-            let pdo = Pdo::mysql(
+            let adapter = MariaDb::connect_db(
                 &config.host,
                 config.port,
                 &config.user,
                 &config.pass,
                 Some(config.schema.as_str()),
-                true,
             )
             .map_err(|err| DatabaseError::database(format!("mariadb connect failed: {err}")))?;
-            let db = configure_live_database(
-                Database::new(MariaDb::new(pdo), cache),
-                config,
-                namespace,
-            )?;
+            let db = configure_live_database(Database::new(adapter, cache), config, namespace)?;
             Ok(ProjectDb::MariaDb(db))
         }
         #[cfg(not(feature = "mysql"))]

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
@@ -188,7 +188,10 @@ pub fn resolve(
     project: &Value,
     project_db: &ProjectDatabase,
 ) -> Option<Session> {
-    let project_id = project.get("$id").and_then(Value::as_str).unwrap_or_default();
+    let project_id = project
+        .get("$id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     let mode = mode(ctx);
 
     let store = decode_store(ctx, project_id, &mode)?;
@@ -218,7 +221,10 @@ pub fn resolve(
         admin_scopes(db, &user, project)?
     } else {
         // A plain project session is PHP's `ROLE_USERS`.
-        MEMBER_SCOPES.iter().map(|scope| (*scope).to_string()).collect()
+        MEMBER_SCOPES
+            .iter()
+            .map(|scope| (*scope).to_string())
+            .collect()
     };
 
     // PHP grants `users.read` to an impersonator so the Console can look a
@@ -254,8 +260,15 @@ pub fn resolve(
 /// membership on the project's team grants. `None` where PHP throws
 /// `USER_UNAUTHORIZED`, which the caller turns into the same scope failure an
 /// anonymous request gets.
-fn admin_scopes(db: &mut ProjectDb, user: &utopia_database::Document, project: &Value) -> Option<Vec<String>> {
-    let project_id = project.get("$id").and_then(Value::as_str).unwrap_or_default();
+fn admin_scopes(
+    db: &mut ProjectDb,
+    user: &utopia_database::Document,
+    project: &Value,
+) -> Option<Vec<String>> {
+    let project_id = project
+        .get("$id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     let team_id = project
         .get("teamId")
         .and_then(Value::as_str)
@@ -422,7 +435,10 @@ mod tests {
 
     #[test]
     fn project_scoped_roles_apply_only_to_their_project() {
-        assert_eq!(applicable_role("project-proj1-admin", "proj1"), Some("admin"));
+        assert_eq!(
+            applicable_role("project-proj1-admin", "proj1"),
+            Some("admin")
+        );
         assert_eq!(applicable_role("project-proj1-admin", "proj2"), None);
         assert_eq!(applicable_role("project-proj1-admin", CONSOLE), None);
     }

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
@@ -1,0 +1,396 @@
+//! Console (session-cookie) authentication for the `api` group. Rust port of
+//! the session half of `app/init/resources/request.php`'s `user` resource plus
+//! the "Admin User Authentication" branch of `app/controllers/shared/api.php`.
+//!
+//! The Console sends `cookie: a_session_console=<store>` and
+//! `x-appwrite-mode: admin` with no API key. Resolving that into a scope list
+//! takes four steps, all mirrored below: decode the Store payload, load the
+//! console user from the platform database, verify the session secret against
+//! that user's sessions, and turn the user's confirmed membership on the
+//! project's team into the scopes `app/config/roles.php` grants those roles.
+//!
+//! Simplifications versus PHP (documented, not silently dropped): no
+//! `x-fallback-cookies` header (a workaround for clients that block
+//! third-party cookies), and no JWT or account-API-key branch. Neither is
+//! reachable from the Console flows this module serves.
+
+use std::sync::Arc;
+
+use appwrite_auth::Key;
+use serde_json::Value;
+use utopia_auth::{Proof, Store};
+use utopia_database::{AttrValue, Query};
+use utopia_http::ActionContext;
+
+use crate::state::{AppwriteState, ProjectDb};
+
+/// PHP `APP_MODE_ADMIN`.
+pub const MODE_ADMIN: &str = "admin";
+/// PHP's console project id.
+const CONSOLE: &str = "console";
+
+/// PHP `app/config/roles.php`'s `$member`.
+const MEMBER_SCOPES: &[&str] = &[
+    "global",
+    "public",
+    "home",
+    "console",
+    "graphql",
+    "sessions.write",
+    "account",
+    "teams.read",
+    "teams.write",
+    "presences.read",
+    "presences.write",
+    "documents.read",
+    "documents.write",
+    "rows.read",
+    "rows.write",
+    "embeddings.write",
+    "files.read",
+    "files.write",
+    "projects.read",
+    "locale.read",
+    "avatars.read",
+    "executions.read",
+    "executions.write",
+    "targets.read",
+    "targets.write",
+    "subscribers.write",
+    "subscribers.read",
+    "assistant.read",
+    "rules.read",
+];
+
+/// PHP `app/config/roles.php`'s `$admins`.
+const ADMIN_SCOPES: &[&str] = &[
+    "global",
+    "graphql",
+    "sessions.write",
+    "teams.read",
+    "teams.write",
+    "documents.read",
+    "documents.write",
+    "rows.read",
+    "rows.write",
+    "embeddings.write",
+    "files.read",
+    "files.write",
+    "buckets.read",
+    "buckets.write",
+    "users.read",
+    "users.write",
+    "presences.read",
+    "presences.write",
+    "databases.read",
+    "databases.write",
+    "collections.read",
+    "collections.write",
+    "tables.read",
+    "tables.write",
+    "platforms.read",
+    "platforms.write",
+    "mocks.read",
+    "mocks.write",
+    "project.policies.read",
+    "project.policies.write",
+    "project.oauth2.read",
+    "project.oauth2.write",
+    "templates.read",
+    "templates.write",
+    "projects.write",
+    "keys.read",
+    "keys.write",
+    "devKeys.read",
+    "devKeys.write",
+    "webhooks.read",
+    "webhooks.write",
+    "project.read",
+    "project.write",
+    "locale.read",
+    "avatars.read",
+    "health.read",
+    "functions.read",
+    "functions.write",
+    "sites.read",
+    "sites.write",
+    "log.read",
+    "log.write",
+    "executions.read",
+    "executions.write",
+    "rules.read",
+    "rules.write",
+    "migrations.read",
+    "migrations.write",
+    "vcs.read",
+    "vcs.write",
+    "targets.read",
+    "targets.write",
+    "providers.write",
+    "providers.read",
+    "messages.write",
+    "messages.read",
+    "topics.write",
+    "topics.read",
+    "subscribers.write",
+    "subscribers.read",
+    "tokens.read",
+    "tokens.write",
+    "schedules.read",
+    "schedules.write",
+    "stages.read",
+    "stages.write",
+    "insights.read",
+    "insights.write",
+    "reports.read",
+    "reports.write",
+];
+
+/// PHP `$roles[$role]['scopes']`.
+fn scopes_for_role(role: &str) -> Vec<&'static str> {
+    match role {
+        "admin" | "developer" => ADMIN_SCOPES.to_vec(),
+        "owner" => {
+            let mut scopes = MEMBER_SCOPES.to_vec();
+            scopes.extend_from_slice(ADMIN_SCOPES);
+            scopes
+        }
+        "users" => MEMBER_SCOPES.to_vec(),
+        _ => Vec::new(),
+    }
+}
+
+/// An authenticated Console user and the scopes their team membership grants.
+#[derive(Debug)]
+pub struct Session {
+    pub user: Value,
+    pub key: Key,
+}
+
+/// PHP `$request->getHeaderLine('x-appwrite-mode', APP_MODE_DEFAULT)`.
+#[must_use]
+pub fn mode(ctx: &ActionContext) -> String {
+    let header = ctx.request().header_line("x-appwrite-mode");
+    if header.is_empty() {
+        "default".to_string()
+    } else {
+        header
+    }
+}
+
+/// Resolve the Console session for this request, or `None` when the request
+/// carries no session, the session does not verify, or the user has no
+/// confirmed membership granting scopes on this project's team.
+#[must_use]
+pub fn resolve(state: &Arc<AppwriteState>, ctx: &ActionContext, project: &Value) -> Option<Session> {
+    let project_id = project.get("$id").and_then(Value::as_str).unwrap_or_default();
+    let mode = mode(ctx);
+
+    let store = decode_store(ctx, project_id, &mode)?;
+    let id = store.get_property("id")?.as_str()?.to_string();
+    let secret = store.get_property("secret")?.as_str()?.to_string();
+    if id.is_empty() || secret.is_empty() {
+        return None;
+    }
+
+    // PHP picks the platform database for admin mode and for the console
+    // project itself; every other request reads the project's own users.
+    let platform = state.platform_db()?;
+    let mut db = platform.lock().unwrap_or_else(|error| error.into_inner());
+    if mode != MODE_ADMIN && project_id != CONSOLE {
+        return None;
+    }
+
+    let user = db.get_document("users", &id, &[], false).ok()?;
+    if user.is_empty() {
+        return None;
+    }
+    if !session_verifies(&mut db, &user, &secret) {
+        return None;
+    }
+
+    let team_id = project.get("teamId").and_then(Value::as_str).unwrap_or_default();
+    let roles = confirmed_roles(&mut db, &user, team_id);
+    // PHP throws `USER_UNAUTHORIZED` here; returning `None` lets the caller
+    // fall through to the same scope check an anonymous request gets, which
+    // produces the identical 401 for every route that needs a scope.
+    if roles.is_empty() {
+        return None;
+    }
+
+    // PHP seeds `['teams.read', 'projects.read']` so an admin with only
+    // project-scoped roles can still list the teams and projects they see.
+    let mut scopes: Vec<String> = vec!["teams.read".into(), "projects.read".into()];
+    for role in &roles {
+        let Some(role) = applicable_role(role, project_id) else {
+            continue;
+        };
+        scopes.extend(scopes_for_role(role).into_iter().map(str::to_string));
+    }
+    scopes.sort_unstable();
+    scopes.dedup();
+
+    let user_json = crate::state::document_to_json(&user);
+    Some(Session {
+        key: Key {
+            project_id: project_id.to_string(),
+            scopes,
+            name: "Console".to_string(),
+            key_type: appwrite_auth::TYPE_STANDARD.to_string(),
+            expired: false,
+            role: "admin".to_string(),
+        },
+        user: user_json,
+    })
+}
+
+/// PHP's `project-<projectId>-<role>` handling: a team-wide role always
+/// applies, a project-scoped one only on its own project.
+fn applicable_role<'a>(role: &'a str, project_id: &str) -> Option<&'a str> {
+    let Some(scoped) = role.strip_prefix("project-") else {
+        return Some(role);
+    };
+    if project_id == CONSOLE || !scoped.starts_with(project_id) {
+        return None;
+    }
+    scoped.rsplit_once('-').map(|(_, role)| role)
+}
+
+/// PHP `$store->decode($request->getCookie(...))` with the
+/// `x-appwrite-session` header fallback SSR clients use.
+fn decode_store(ctx: &ActionContext, project_id: &str, mode: &str) -> Option<Store> {
+    let key = if mode == MODE_ADMIN {
+        format!("a_session_{CONSOLE}")
+    } else {
+        format!("a_session_{project_id}")
+    };
+
+    let mut store = Store::new();
+    let mut cookie = ctx.request().cookie(&key, "");
+    if cookie.is_empty() {
+        cookie = ctx.request().cookie(&format!("{key}_legacy"), "");
+    }
+    if !cookie.is_empty() {
+        store.decode(&cookie);
+    }
+    if store.get_property("secret").is_none() {
+        let header = ctx.request().header_line("x-appwrite-session");
+        if header.is_empty() {
+            return None;
+        }
+        store.decode(&header);
+    }
+    Some(store)
+}
+
+/// PHP `User::sessionVerify()`: the secret must hash to one of the user's
+/// unexpired sessions.
+fn session_verifies(db: &mut ProjectDb, user: &utopia_database::Document, secret: &str) -> bool {
+    let Some(sequence) = user.get_sequence() else {
+        return false;
+    };
+    let Ok(mut proof) = utopia_auth::Token::new(32) else {
+        return false;
+    };
+    proof.set_hasher(Arc::new(utopia_auth::Sha::new()));
+
+    let now = crate::modules::users::base::now_iso();
+    db.find(
+        "sessions",
+        &[
+            Query::equal("userInternalId", vec![AttrValue::from(sequence.as_str())]),
+            Query::limit(100),
+        ],
+        "read",
+    )
+    .unwrap_or_default()
+    .iter()
+    .any(|session| {
+        let stored = session.get_attribute("secret").as_str().unwrap_or_default();
+        let expire = session.get_attribute("expire").as_str().unwrap_or_default();
+        !stored.is_empty() && proof.verify(secret, stored) && expire >= now.as_str()
+    })
+}
+
+/// PHP's membership loop: the roles on the user's first confirmed membership
+/// for `team_id`.
+fn confirmed_roles(
+    db: &mut ProjectDb,
+    user: &utopia_database::Document,
+    team_id: &str,
+) -> Vec<String> {
+    if team_id.is_empty() {
+        return Vec::new();
+    }
+    let Some(sequence) = user.get_sequence() else {
+        return Vec::new();
+    };
+    db.find(
+        "memberships",
+        &[
+            Query::equal("userInternalId", vec![AttrValue::from(sequence.as_str())]),
+            Query::equal("teamId", vec![AttrValue::from(team_id)]),
+            Query::limit(100),
+        ],
+        "read",
+    )
+    .unwrap_or_default()
+    .iter()
+    .find(|membership| {
+        membership
+            .get_attribute("confirm")
+            .as_bool()
+            .unwrap_or(false)
+    })
+    .map(|membership| {
+        membership
+            .get_attribute("roles")
+            .to_json()
+            .as_array()
+            .map(|roles| {
+                roles
+                    .iter()
+                    .filter_map(|role| role.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_gets_both_member_and_admin_scopes() {
+        let scopes = scopes_for_role("owner");
+        assert!(scopes.contains(&"account"));
+        assert!(scopes.contains(&"users.write"));
+    }
+
+    #[test]
+    fn admin_and_developer_share_the_admin_scope_list() {
+        assert_eq!(scopes_for_role("admin"), scopes_for_role("developer"));
+        assert!(scopes_for_role("admin").contains(&"users.read"));
+        assert!(!scopes_for_role("admin").contains(&"account"));
+    }
+
+    #[test]
+    fn unknown_role_grants_nothing() {
+        assert!(scopes_for_role("editor").is_empty());
+    }
+
+    #[test]
+    fn team_wide_roles_apply_everywhere() {
+        assert_eq!(applicable_role("owner", "proj1"), Some("owner"));
+        assert_eq!(applicable_role("owner", CONSOLE), Some("owner"));
+    }
+
+    #[test]
+    fn project_scoped_roles_apply_only_to_their_project() {
+        assert_eq!(applicable_role("project-proj1-admin", "proj1"), Some("admin"));
+        assert_eq!(applicable_role("project-proj1-admin", "proj2"), None);
+        assert_eq!(applicable_role("project-proj1-admin", CONSOLE), None);
+    }
+}

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
@@ -223,12 +223,14 @@ pub fn resolve(
 
     // PHP grants `users.read` to an impersonator so the Console can look a
     // target user up before impersonation starts, and keeps it for the
-    // duration of the impersonation.
+    // duration of the impersonation. Both arms of PHP's condition
+    // (`impersonator` set, or an impersonation already resolved) require the
+    // capability, so a caller who merely sends the headers gains nothing.
     let impersonator = user
         .get_attribute("impersonator")
         .as_bool()
         .unwrap_or(false);
-    if (impersonator || impersonating(ctx)) && !scopes.iter().any(|scope| scope == "users.read") {
+    if impersonator && !scopes.iter().any(|scope| scope == "users.read") {
         scopes.push("users.read".to_string());
     }
     scopes.sort_unstable();
@@ -273,33 +275,6 @@ fn admin_scopes(db: &mut ProjectDb, user: &utopia_database::Document, project: &
         scopes.extend(scopes_for_role(role).into_iter().map(str::to_string));
     }
     Some(scopes)
-}
-
-/// Whether the request asks to impersonate someone, by header or by the
-/// query-param fallback the Console uses for direct file URLs.
-fn impersonating(ctx: &ActionContext) -> bool {
-    const HEADERS: [&str; 3] = [
-        "x-appwrite-impersonate-user-id",
-        "x-appwrite-impersonate-user-email",
-        "x-appwrite-impersonate-user-phone",
-    ];
-    const PARAMS: [&str; 6] = [
-        "impersonateuserid",
-        "impersonateUserId",
-        "impersonateemail",
-        "impersonateEmail",
-        "impersonatephone",
-        "impersonatePhone",
-    ];
-    HEADERS
-        .iter()
-        .any(|header| !ctx.request().header_line(header).is_empty())
-        || PARAMS.iter().any(|param| {
-            ctx.request()
-                .param_ref(param)
-                .and_then(Value::as_str)
-                .is_some_and(|value| !value.is_empty())
-        })
 }
 
 /// PHP's `project-<projectId>-<role>` handling: a team-wide role always

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/console.rs
@@ -22,7 +22,7 @@ use utopia_auth::{Proof, Store};
 use utopia_database::{AttrValue, Query};
 use utopia_http::ActionContext;
 
-use crate::state::{AppwriteState, ProjectDb};
+use crate::state::{AppwriteState, ProjectDatabase, ProjectDb};
 
 /// PHP `APP_MODE_ADMIN`.
 pub const MODE_ADMIN: &str = "admin";
@@ -178,11 +178,16 @@ pub fn mode(ctx: &ActionContext) -> String {
     }
 }
 
-/// Resolve the Console session for this request, or `None` when the request
-/// carries no session, the session does not verify, or the user has no
-/// confirmed membership granting scopes on this project's team.
+/// Resolve the session-authenticated user for this request, or `None` when
+/// the request carries no session, the session does not verify, or an admin
+/// request's user has no confirmed membership on the project's team.
 #[must_use]
-pub fn resolve(state: &Arc<AppwriteState>, ctx: &ActionContext, project: &Value) -> Option<Session> {
+pub fn resolve(
+    state: &Arc<AppwriteState>,
+    ctx: &ActionContext,
+    project: &Value,
+    project_db: &ProjectDatabase,
+) -> Option<Session> {
     let project_id = project.get("$id").and_then(Value::as_str).unwrap_or_default();
     let mode = mode(ctx);
 
@@ -193,27 +198,67 @@ pub fn resolve(state: &Arc<AppwriteState>, ctx: &ActionContext, project: &Value)
         return None;
     }
 
-    // PHP picks the platform database for admin mode and for the console
+    // PHP reads the platform database for admin mode and for the console
     // project itself; every other request reads the project's own users.
-    let platform = state.platform_db()?;
-    let mut db = platform.lock().unwrap_or_else(|error| error.into_inner());
-    if mode != MODE_ADMIN && project_id != CONSOLE {
-        return None;
-    }
+    let is_admin = mode == MODE_ADMIN || project_id == CONSOLE;
+    let platform = if is_admin { state.platform_db() } else { None };
+    let mut guard = match &platform {
+        Some(platform) => platform.lock().unwrap_or_else(|error| error.into_inner()),
+        None if is_admin => return None,
+        None => project_db.lock().unwrap_or_else(|error| error.into_inner()),
+    };
+    let db = &mut *guard;
 
     let user = db.get_document("users", &id, &[], false).ok()?;
-    if user.is_empty() {
-        return None;
-    }
-    if !session_verifies(&mut db, &user, &secret) {
+    if user.is_empty() || !session_verifies(db, &user, &secret) {
         return None;
     }
 
-    let team_id = project.get("teamId").and_then(Value::as_str).unwrap_or_default();
-    let roles = confirmed_roles(&mut db, &user, team_id);
-    // PHP throws `USER_UNAUTHORIZED` here; returning `None` lets the caller
-    // fall through to the same scope check an anonymous request gets, which
-    // produces the identical 401 for every route that needs a scope.
+    let mut scopes = if is_admin {
+        admin_scopes(db, &user, project)?
+    } else {
+        // A plain project session is PHP's `ROLE_USERS`.
+        MEMBER_SCOPES.iter().map(|scope| (*scope).to_string()).collect()
+    };
+
+    // PHP grants `users.read` to an impersonator so the Console can look a
+    // target user up before impersonation starts, and keeps it for the
+    // duration of the impersonation.
+    let impersonator = user
+        .get_attribute("impersonator")
+        .as_bool()
+        .unwrap_or(false);
+    if (impersonator || impersonating(ctx)) && !scopes.iter().any(|scope| scope == "users.read") {
+        scopes.push("users.read".to_string());
+    }
+    scopes.sort_unstable();
+    scopes.dedup();
+
+    let user_json = crate::state::document_to_json(&user);
+    Some(Session {
+        key: Key {
+            project_id: project_id.to_string(),
+            scopes,
+            name: "Session".to_string(),
+            key_type: appwrite_auth::TYPE_STANDARD.to_string(),
+            expired: false,
+            role: if is_admin { "admin" } else { "users" }.to_string(),
+        },
+        user: user_json,
+    })
+}
+
+/// PHP's "Admin User Authentication" branch: the scopes the user's confirmed
+/// membership on the project's team grants. `None` where PHP throws
+/// `USER_UNAUTHORIZED`, which the caller turns into the same scope failure an
+/// anonymous request gets.
+fn admin_scopes(db: &mut ProjectDb, user: &utopia_database::Document, project: &Value) -> Option<Vec<String>> {
+    let project_id = project.get("$id").and_then(Value::as_str).unwrap_or_default();
+    let team_id = project
+        .get("teamId")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let roles = confirmed_roles(db, user, team_id);
     if roles.is_empty() {
         return None;
     }
@@ -227,21 +272,34 @@ pub fn resolve(state: &Arc<AppwriteState>, ctx: &ActionContext, project: &Value)
         };
         scopes.extend(scopes_for_role(role).into_iter().map(str::to_string));
     }
-    scopes.sort_unstable();
-    scopes.dedup();
+    Some(scopes)
+}
 
-    let user_json = crate::state::document_to_json(&user);
-    Some(Session {
-        key: Key {
-            project_id: project_id.to_string(),
-            scopes,
-            name: "Console".to_string(),
-            key_type: appwrite_auth::TYPE_STANDARD.to_string(),
-            expired: false,
-            role: "admin".to_string(),
-        },
-        user: user_json,
-    })
+/// Whether the request asks to impersonate someone, by header or by the
+/// query-param fallback the Console uses for direct file URLs.
+fn impersonating(ctx: &ActionContext) -> bool {
+    const HEADERS: [&str; 3] = [
+        "x-appwrite-impersonate-user-id",
+        "x-appwrite-impersonate-user-email",
+        "x-appwrite-impersonate-user-phone",
+    ];
+    const PARAMS: [&str; 6] = [
+        "impersonateuserid",
+        "impersonateUserId",
+        "impersonateemail",
+        "impersonateEmail",
+        "impersonatephone",
+        "impersonatePhone",
+    ];
+    HEADERS
+        .iter()
+        .any(|header| !ctx.request().header_line(header).is_empty())
+        || PARAMS.iter().any(|param| {
+            ctx.request()
+                .param_ref(param)
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        })
 }
 
 /// PHP's `project-<projectId>-<role>` handling: a team-wide role always

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/init.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/init.rs
@@ -46,43 +46,6 @@ pub fn action() -> Action {
                 return send_error(&ctx, &Exception::new(Exception::PROJECT_NOT_FOUND));
             };
 
-            let key_secret = ctx.request().header_line("x-appwrite-key");
-            let mut console_user = None;
-            let key = if !key_secret.is_empty() {
-                Key::decode_standard(&project, &key_secret)
-            } else if let Some(session) = console::resolve(&state, &ctx, &project) {
-                console_user = Some(session.user);
-                session.key
-            } else {
-                Key::guest(project_id.clone())
-            };
-
-            if key.expired {
-                return send_error(&ctx, &Exception::new(Exception::PROJECT_KEY_EXPIRED));
-            }
-
-            // PHP grants `users.read` to an impersonator so the Console can
-            // look a target user up before impersonation starts.
-            let mut key = key;
-            if console_user
-                .as_ref()
-                .and_then(|user| user.get("impersonator"))
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-                && !key.scopes.iter().any(|scope| scope == "users.read")
-            {
-                key.scopes.push("users.read".to_string());
-            }
-
-            if let Some(required) = required_scope(&ctx) {
-                if !key_satisfies_scope(&key, &required) {
-                    return send_error(
-                        &ctx,
-                        &Exception::new(Exception::GENERAL_UNAUTHORIZED_SCOPE),
-                    );
-                }
-            }
-
             let sequence = state.project_sequence(&project);
             let db = match state
                 .databases
@@ -93,6 +56,27 @@ pub fn action() -> Action {
                     return send_error(&ctx, &Exception::new(Exception::GENERAL_SERVER_ERROR));
                 }
             };
+
+            let key_secret = ctx.request().header_line("x-appwrite-key");
+            let key = if key_secret.is_empty() {
+                console::resolve(&state, &ctx, &project, &db)
+                    .map_or_else(|| Key::guest(project_id.clone()), |session| session.key)
+            } else {
+                Key::decode_standard(&project, &key_secret)
+            };
+
+            if key.expired {
+                return send_error(&ctx, &Exception::new(Exception::PROJECT_KEY_EXPIRED));
+            }
+
+            if let Some(required) = required_scope(&ctx) {
+                if !key_satisfies_scope(&key, &required) {
+                    return send_error(
+                        &ctx,
+                        &Exception::new(Exception::GENERAL_UNAUTHORIZED_SCOPE),
+                    );
+                }
+            }
 
             ctx.container.set_cached("project", Resource::new(project));
             ctx.container.set_cached("apiKey", Resource::new(key));

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/init.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/init.rs
@@ -2,15 +2,13 @@
 //! of `app/controllers/shared/api.php`'s `Http::init()`.
 //!
 //! Simplifications versus PHP (documented, not silently dropped):
-//! - Only the `standard` API key type is supported (`Appwrite\Auth\Key`'s
-//!   `dynamic`/`jwt` cases -- session cookies, session headers, and JWTs --
-//!   are not wired into this hook yet; see `crates/appwrite-platform/README.md`
-//!   TODOs). Every `/v1/users*` route requires a `users.read`/`users.write`
-//!   scope, so an unauthenticated (guest) key always fails the scope check
-//!   below, which is the correct behavior for this module even without the
-//!   other key types.
-//! - No abuse/rate-limiting, mode (`X-Appwrite-Mode`) resolution, or usage
-//!   stats gate -- out of scope for the Users-API v1 milestone.
+//! - Only the `standard` API key type and the Console session cookie are
+//!   supported. JWT (`Appwrite\Auth\Key`'s `jwt` case) is not wired into this
+//!   hook; see `crates/appwrite-platform/README.md` TODOs. Every `/v1/users*`
+//!   route requires a `users.read`/`users.write` scope, so an unauthenticated
+//!   (guest) key always fails the scope check below.
+//! - No abuse/rate-limiting or usage stats gate -- out of scope for the
+//!   Users-API v1 milestone.
 
 use std::sync::Arc;
 
@@ -22,7 +20,7 @@ use utopia_platform::{Action, ActionType};
 
 use crate::state::AppwriteState;
 
-use super::send_error;
+use super::{console, send_error};
 
 #[must_use]
 pub fn action() -> Action {
@@ -49,14 +47,31 @@ pub fn action() -> Action {
             };
 
             let key_secret = ctx.request().header_line("x-appwrite-key");
-            let key = if key_secret.is_empty() {
-                Key::guest(project_id.clone())
-            } else {
+            let mut console_user = None;
+            let key = if !key_secret.is_empty() {
                 Key::decode_standard(&project, &key_secret)
+            } else if let Some(session) = console::resolve(&state, &ctx, &project) {
+                console_user = Some(session.user);
+                session.key
+            } else {
+                Key::guest(project_id.clone())
             };
 
             if key.expired {
                 return send_error(&ctx, &Exception::new(Exception::PROJECT_KEY_EXPIRED));
+            }
+
+            // PHP grants `users.read` to an impersonator so the Console can
+            // look a target user up before impersonation starts.
+            let mut key = key;
+            if console_user
+                .as_ref()
+                .and_then(|user| user.get("impersonator"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+                && !key.scopes.iter().any(|scope| scope == "users.read")
+            {
+                key.scopes.push("users.read".to_string());
             }
 
             if let Some(required) = required_scope(&ctx) {

--- a/3.x.x/crates/appwrite-platform/src/modules/core/hooks/mod.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/core/hooks/mod.rs
@@ -1,3 +1,4 @@
+pub mod console;
 pub mod error;
 pub mod init;
 pub mod shutdown;

--- a/3.x.x/crates/appwrite-platform/src/modules/users/base.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/base.rs
@@ -282,6 +282,13 @@ pub fn sequence_of(document: &utopia_database::Document) -> Value {
         .map_or(Value::Null, |sequence| json!(sequence))
 }
 
+/// [`sequence_of`] as a plain string, for building queries against the
+/// `userInternalId` column.
+#[must_use]
+pub fn sequence_str(document: &utopia_database::Document) -> String {
+    document.get_sequence().unwrap_or_default()
+}
+
 /// A `Boolean::new().loose(true)` param read back as a `bool`. `loose`
 /// accepts PHP's `http_build_query` encoding (`total=0` / `total=1`), so the
 /// stored param may still be the string form.

--- a/3.x.x/crates/appwrite-platform/src/modules/users/base.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/base.rs
@@ -4,8 +4,9 @@
 //! error/response plumbing every `http/*` handler in this module needs.
 //!
 //! Simplifications versus PHP (documented, not silently dropped):
-//! - `PersonalData`, disposable/canonical/free/corporate email policy, and
-//!   the cloud `$plan` gate are not implemented -- self-hosted Appwrite
+//! - `PersonalData` and the cloud `$plan` gate are not implemented, and the
+//!   disposable/canonical/free/corporate email *policies* are not enforced
+//!   (the metadata columns they read are populated). Self-hosted Appwrite
 //!   leaves all of these disabled unless the project is `console`, which
 //!   this milestone's dev-seeded project never is.
 //! - Duplicate target identifiers are not de-duplicated against an existing
@@ -246,8 +247,8 @@ pub fn user_not_found() -> Exception {
     Exception::new(Exception::USER_NOT_FOUND)
 }
 
-/// PHP `Utopia\Database\Helpers\Permission::{read,update,delete}` triple
-/// scoping a resource to its owning user, plus public read (`any()`).
+/// PHP `Base::createUser()`'s `users` document permissions: public read plus
+/// update/delete for the owning user.
 #[must_use]
 pub fn owner_permissions(user_id: &str) -> Vec<String> {
     vec![
@@ -255,6 +256,165 @@ pub fn owner_permissions(user_id: &str) -> Vec<String> {
         Permission::update(&Role::user(user_id.to_string(), String::new())),
         Permission::delete(&Role::user(user_id.to_string(), String::new())),
     ]
+}
+
+/// PHP's permission triple for user-owned sub-resources (`sessions`,
+/// `targets`): read/update/delete scoped to the owning user only, with no
+/// `any()` read.
+#[must_use]
+pub fn user_permissions(user_id: &str) -> Vec<String> {
+    vec![
+        Permission::read(&Role::user(user_id.to_string(), String::new())),
+        Permission::update(&Role::user(user_id.to_string(), String::new())),
+        Permission::delete(&Role::user(user_id.to_string(), String::new())),
+    ]
+}
+
+/// PHP `$user->getSequence()`, the `userInternalId` every user sub-resource
+/// (`sessions`, `tokens`, `targets`, `identities`, `memberships`) stores so
+/// PHP's `subQuery*` relationship filters can find it again. Always a string:
+/// the column is `VAR_STRING` in every one of those collections, and handing
+/// the driver a number instead fails to serialize.
+#[must_use]
+pub fn sequence_of(document: &utopia_database::Document) -> Value {
+    document
+        .get_sequence()
+        .map_or(Value::Null, |sequence| json!(sequence))
+}
+
+/// A `Boolean::new().loose(true)` param read back as a `bool`. `loose`
+/// accepts PHP's `http_build_query` encoding (`total=0` / `total=1`), so the
+/// stored param may still be the string form.
+#[must_use]
+pub fn param_bool(ctx: &ActionContext, key: &str, default: bool) -> bool {
+    match ctx.param_value(key) {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::String(value)) => !matches!(value.as_str(), "" | "0" | "false"),
+        Some(Value::Number(value)) => value.as_f64().is_some_and(|value| value != 0.0),
+        _ => default,
+    }
+}
+
+/// Rust port of the `userSearch` filter (`app/init/database/filters.php`):
+/// `implode(' ', array_filter([$id, $email, $name, $phone, ...'label:'.$label]))`.
+/// The field order and the `label:` prefix both matter -- this is the haystack
+/// `Query::search('search', ...)` matches against, and `array_filter` drops
+/// the empty entries so a user with no phone has no stray double space.
+///
+/// PHP registers this as a `Database` filter, which recomputes it on every
+/// write because `updateDocument` encodes the merged document. The Rust filter
+/// registry passes only the attribute value, not the owning document, so the
+/// handlers that change one of these fields call [`refreshed_search`] instead.
+#[must_use]
+pub fn user_search(
+    user_id: &str,
+    email: Option<&str>,
+    name: &str,
+    phone: Option<&str>,
+    labels: &[String],
+) -> String {
+    let mut parts = vec![
+        user_id.to_string(),
+        email.unwrap_or_default().to_string(),
+        name.to_string(),
+        phone.unwrap_or_default().to_string(),
+    ];
+    parts.extend(labels.iter().map(|label| format!("label:{label}")));
+    parts.retain(|part| !part.is_empty());
+    parts.join(" ")
+}
+
+/// Rebuild [`user_search`] from an already-loaded `users` document, applying
+/// `overrides` (the sparse update about to be written) on top of its current
+/// attributes first -- the same merged view PHP's filter sees.
+#[must_use]
+pub fn refreshed_search(user: &utopia_database::Document, overrides: &Value) -> String {
+    let current = document_to_json(user);
+    let pick = |key: &str| -> Option<String> {
+        overrides
+            .get(key)
+            .or_else(|| current.get(key))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    };
+    let labels = overrides
+        .get("labels")
+        .or_else(|| current.get("labels"))
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    user_search(
+        &user.get_id(),
+        pick("email").as_deref(),
+        pick("name").unwrap_or_default().as_str(),
+        pick("phone").as_deref(),
+        &labels,
+    )
+}
+
+/// [`update_user_fields`] plus the `search` rebuild every handler that
+/// changes `name`/`email`/`phone`/`labels` needs.
+pub fn update_user_fields_and_search(
+    db: &mut crate::state::ProjectDb,
+    user_id: &str,
+    mut fields: Value,
+) -> Result<Value, Exception> {
+    let user = require_document(db, "users", user_id, Exception::USER_NOT_FOUND)?;
+    let search = refreshed_search(&user, &fields);
+    if let Some(fields) = fields.as_object_mut() {
+        fields.insert("search".to_string(), json!(search));
+    }
+    update_user_fields(db, user_id, fields)
+}
+
+/// Rust port of `Base::createUser()`'s `$emailMetadata` block: the five
+/// `email*` columns derived from `Utopia\Emails\Email`, all `null` when the
+/// address is missing or unparseable (PHP's `catch (\Throwable)`).
+#[must_use]
+pub fn email_metadata(email: Option<&str>) -> Value {
+    let parsed = email
+        .filter(|value| !value.is_empty())
+        .and_then(|value| utopia_emails::Email::new(value).ok());
+    let Some(parsed) = parsed else {
+        return json!({
+            "emailCanonical": Value::Null,
+            "emailIsCanonical": Value::Null,
+            "emailIsCorporate": Value::Null,
+            "emailIsDisposable": Value::Null,
+            "emailIsFree": Value::Null,
+        });
+    };
+    let Ok(canonical) = parsed.get_canonical() else {
+        return json!({
+            "emailCanonical": Value::Null,
+            "emailIsCanonical": Value::Null,
+            "emailIsCorporate": Value::Null,
+            "emailIsDisposable": Value::Null,
+            "emailIsFree": Value::Null,
+        });
+    };
+    json!({
+        "emailCanonical": canonical,
+        "emailIsCanonical": parsed.get() == canonical,
+        "emailIsCorporate": parsed.is_corporate(),
+        "emailIsDisposable": parsed.is_disposable(),
+        "emailIsFree": parsed.is_free(),
+    })
+}
+
+/// Merge `extra`'s keys into `target` (both JSON objects).
+pub fn merge_into(target: &mut Value, extra: &Value) {
+    let (Some(target), Some(extra)) = (target.as_object_mut(), extra.as_object()) else {
+        return;
+    };
+    for (key, value) in extra {
+        target.insert(key.clone(), value.clone());
+    }
 }
 
 /// Parameters for [`create_user`], mirroring `Base::createUser()`'s
@@ -333,18 +493,14 @@ pub fn create_user(
     }
 
     let now = now_iso();
-    // PHP `'search' => implode(' ', [$userId, $email, $phone, $name])`, the
-    // fulltext-index field `Query::search('search', ...)` filters against
-    // (see `http::crud::list`). Not refreshed on email/phone/name updates
-    // (documented simplification: those handlers don't rewrite `search`).
-    let search = [
+    let search = user_search(
         resolved_id.as_str(),
-        email.as_deref().unwrap_or_default(),
-        phone.as_deref().unwrap_or_default(),
+        email.as_deref(),
         name.as_str(),
-    ]
-    .join(" ");
-    let doc_json = json!({
+        phone.as_deref(),
+        &[],
+    );
+    let mut doc_json = json!({
         "$id": resolved_id,
         "$permissions": owner_permissions(&resolved_id),
         "email": email,
@@ -359,12 +515,14 @@ pub fn create_user(
         "hash": hash_name,
         "hashOptions": hash_options,
         "registration": now.clone(),
+        "reset": false,
         "mfa": false,
         "name": name,
         "prefs": {},
         "accessedAt": now,
         "search": search,
     });
+    merge_into(&mut doc_json, &email_metadata(email.as_deref()));
 
     let document = document_from_json(doc_json);
     let created = db.create_document("users", document).map_err(db_error)?;
@@ -380,6 +538,30 @@ pub fn create_user(
     user_json["targets"] = Value::Array(targets);
 
     Ok(user_json)
+}
+
+/// PHP's `foreach ($sessions as $session) { $dbForProject->deleteDocument(
+/// 'sessions', $session->getId()); }` loop, shared by `Sessions\Bulk\Delete`
+/// and `Password\Update`'s `invalidateSessions` branch.
+pub fn delete_user_sessions(
+    db: &mut crate::state::ProjectDb,
+    user_id: &str,
+) -> Result<(), Exception> {
+    let sessions = db
+        .find(
+            "sessions",
+            &[
+                Query::equal("userId", vec![AttrValue::from(user_id)]),
+                Query::limit(1000),
+            ],
+            "read",
+        )
+        .map_err(db_error)?;
+    for session in sessions {
+        db.delete_document("sessions", &session.get_id())
+            .map_err(db_error)?;
+    }
+    Ok(())
 }
 
 /// PHP `Users\Get`/`Users\XList`'s `$user->setAttribute('targets', ...)`
@@ -419,8 +601,9 @@ pub fn create_target(
     let user_id = user.get_id();
     let target_json = json!({
         "$id": appwrite_database::resolve_id(appwrite_database::UNIQUE_SENTINEL),
-        "$permissions": owner_permissions(&user_id),
+        "$permissions": user_permissions(&user_id),
         "userId": user_id,
+        "userInternalId": sequence_of(user),
         "providerType": provider_type,
         "identifier": identifier,
         "expired": false,

--- a/3.x.x/crates/appwrite-platform/src/modules/users/base.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/base.rs
@@ -543,8 +543,19 @@ pub fn create_user(
         targets.push(create_target(db, &created, "sms", phone)?);
     }
     user_json["targets"] = Value::Array(targets);
+    purge_user(db, &created.get_id());
 
     Ok(user_json)
+}
+
+/// PHP `$dbForProject->purgeCachedDocument('users', $user->getId())`.
+///
+/// Writing a session, target or token leaves the user document's cached
+/// relationships stale, and that cache is shared with the PHP server, so the
+/// handlers that write one purge the other. Failures are ignored for the same
+/// reason PHP's is not checked: a cold cache is correct, just slower.
+pub fn purge_user(db: &mut crate::state::ProjectDb, user_id: &str) {
+    let _ = db.purge_cached_document("users", user_id);
 }
 
 /// PHP's `foreach ($sessions as $session) { $dbForProject->deleteDocument(
@@ -568,6 +579,7 @@ pub fn delete_user_sessions(
         db.delete_document("sessions", &session.get_id())
             .map_err(db_error)?;
     }
+    purge_user(db, user_id);
     Ok(())
 }
 

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/crud.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/crud.rs
@@ -7,9 +7,10 @@ use serde_json::{json, Value};
 use std::sync::Arc;
 use utopia_database::Query;
 use utopia_platform::{Action, HttpMethod};
-use utopia_validators::{ArrayList, Boolean, Nullable, Text};
+use utopia_validators::{Boolean, Nullable, Text};
 
 use crate::modules::users::base::{self, inject};
+use crate::modules::users::queries;
 use crate::modules::users::validators::Email;
 use crate::state::document_to_json;
 
@@ -144,10 +145,7 @@ pub fn get() -> Action {
     })
 }
 
-/// `GET /v1/users` (`listUsers`). Rust port of `Http/Users/XList.php`,
-/// simplified: no `queries` DSL / cursor pagination (documented gap; see
-/// module docs), just `search` (fulltext-ish substring match over id/name/
-/// email/phone) plus `total`.
+/// `GET /v1/users` (`listUsers`). Rust port of `Http/Users/XList.php`.
 #[must_use]
 pub fn list() -> Action {
     inject(
@@ -160,16 +158,18 @@ pub fn list() -> Action {
             .param(
                 "queries",
                 json!([]),
-                ArrayList::new(Text::new(4096)),
-                "Queries.",
+                queries::users(),
+                "Array of query strings generated using the Query class \
+                 provided by the SDK.",
                 true,
             )
             .param("search", json!(""), Text::new(256), "Search term.", true)
             .param(
                 "total",
                 json!(true),
-                Boolean::new(),
-                "Include total count.",
+                Boolean::new().loose(true),
+                "When set to false, the total count returned will be 0 and \
+                 will not be calculated.",
                 true,
             ),
         &["response", "dbForProject"],
@@ -179,18 +179,23 @@ pub fn list() -> Action {
             let db_handle = base::get_db(&ctx)?;
             let mut db = db_handle.lock().unwrap_or_else(|e| e.into_inner());
             let search = base::param_str(&ctx, "search").unwrap_or_default();
-            let include_total = ctx
-                .param_value("total")
-                .and_then(Value::as_bool)
-                .unwrap_or(true);
+            let include_total = base::param_bool(&ctx, "total", true);
 
-            let mut queries = vec![Query::limit(25)];
-            if !search.is_empty() {
-                queries.push(Query::search("search", search));
+            let mut parsed = queries::parse(&queries::raw_param(ctx.param_value("queries")))?;
+            queries::push_search(&mut parsed, queries::COLLECTION_USERS, &search)?;
+            queries::resolve_cursor(&mut db, &mut parsed, "users", |id| {
+                Exception::with_message(
+                    Exception::GENERAL_CURSOR_NOT_FOUND,
+                    format!("User '{id}' for the 'cursor' value not found."),
+                )
+            })?;
+            if !queries::has_method(&parsed, utopia_database::query::TYPE_LIMIT) {
+                parsed.push(Query::limit(25));
             }
-            let users = db.find("users", &queries, "read").map_err(base::db_error)?;
+
+            let users = db.find("users", &parsed, "read").map_err(base::db_error)?;
             let total = if include_total {
-                db.count("users", &[], None).map_err(base::db_error)?
+                db.count("users", &parsed, None).map_err(base::db_error)?
             } else {
                 0
             };

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/identities.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/identities.rs
@@ -1,8 +1,7 @@
 //! Identity endpoints. Rust port of
 //! `Http/Users/Identities/{XList,Delete}.php`.
 //!
-//! Simplifications versus PHP (documented, not silently dropped): no
-//! `queries` DSL / cursor pagination on list (see `crud::list`); the
+//! Simplifications versus PHP (documented, not silently dropped): the
 //! `identities` collection is never populated by this milestone (OAuth
 //! login lives in the not-yet-ported Account module), so `list`/`delete`
 //! only operate on whatever a caller (or a future Account port) writes
@@ -15,6 +14,7 @@ use utopia_platform::{Action, HttpMethod};
 use utopia_validators::{Boolean, Text};
 
 use crate::modules::users::base::{self, inject};
+use crate::modules::users::queries;
 use crate::state::document_to_json;
 
 /// `GET /v1/users/identities` (`listIdentities`).
@@ -27,6 +27,14 @@ pub fn list() -> Action {
             .desc("List identities")
             .groups(["api", "users"])
             .label("scope", "users.read")
+            .param(
+                "queries",
+                json!([]),
+                queries::identities(),
+                "Array of query strings generated using the Query class \
+                 provided by the SDK.",
+                true,
+            )
             .param(
                 "search",
                 json!(""),
@@ -48,20 +56,29 @@ pub fn list() -> Action {
             let db_handle = base::get_db(&ctx)?;
             let mut db = db_handle.lock().unwrap_or_else(|e| e.into_inner());
             let search = base::param_str(&ctx, "search").unwrap_or_default();
-            let include_total = ctx
-                .param_value("total")
-                .and_then(Value::as_bool)
-                .unwrap_or(true);
+            let include_total = base::param_bool(&ctx, "total", true);
 
-            let mut queries = vec![Query::limit(100)];
-            if !search.is_empty() {
-                queries.push(Query::search("search", search));
+            let mut parsed = queries::parse(&queries::raw_param(ctx.param_value("queries")))?;
+            // `identities` has no `search` attribute, so PHP's blanket
+            // `Query::search('search', ...)` append is exactly what makes a
+            // non-empty search term a 400 here.
+            queries::push_search(&mut parsed, queries::COLLECTION_IDENTITIES, &search)?;
+            queries::resolve_cursor(&mut db, &mut parsed, "identities", |id| {
+                Exception::with_message(
+                    Exception::GENERAL_CURSOR_NOT_FOUND,
+                    format!("User '{id}' for the 'cursor' value not found."),
+                )
+            })?;
+            if !queries::has_method(&parsed, utopia_database::query::TYPE_LIMIT) {
+                parsed.push(Query::limit(25));
             }
+
             let identities = db
-                .find("identities", &queries, "read")
+                .find("identities", &parsed, "read")
                 .map_err(base::db_error)?;
             let total = if include_total {
-                db.count("identities", &[], None).map_err(base::db_error)?
+                db.count("identities", &parsed, None)
+                    .map_err(base::db_error)?
             } else {
                 0
             };

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/memberships.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/memberships.rs
@@ -1,10 +1,9 @@
 //! Membership endpoints. Rust port of `Http/Users/Memberships/XList.php`.
 //!
-//! Simplifications versus PHP (documented, not silently dropped): no
-//! `queries` DSL / cursor pagination (see `crud::list`); the `memberships`
-//! and `teams` collections are never populated by this milestone (the
-//! Teams module is not yet ported), so `list` only enriches whatever a
-//! future Teams port writes into them.
+//! Simplifications versus PHP (documented, not silently dropped): the
+//! `memberships` and `teams` collections are only written by the Teams
+//! module, which is not yet ported, so `list` just enriches whatever that
+//! module (still served by PHP) writes into them.
 
 use appwrite_exception::Exception;
 use serde_json::{json, Value};
@@ -13,6 +12,7 @@ use utopia_platform::{Action, HttpMethod};
 use utopia_validators::{Boolean, Text};
 
 use crate::modules::users::base::{self, inject};
+use crate::modules::users::queries;
 use crate::state::document_to_json;
 
 /// `GET /v1/users/:userId/memberships` (`listUserMemberships`).
@@ -26,6 +26,14 @@ pub fn list() -> Action {
             .groups(["api", "users"])
             .label("scope", "users.read")
             .param("userId", json!(""), Text::new(36), "User ID.", false)
+            .param(
+                "queries",
+                json!([]),
+                queries::memberships(),
+                "Array of query strings generated using the Query class \
+                 provided by the SDK.",
+                true,
+            )
             .param(
                 "search",
                 json!(""),
@@ -50,23 +58,30 @@ pub fn list() -> Action {
             let user =
                 base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
             let search = base::param_str(&ctx, "search").unwrap_or_default();
-            let include_total = ctx
-                .param_value("total")
-                .and_then(Value::as_bool)
-                .unwrap_or(true);
+            let include_total = base::param_bool(&ctx, "total", true);
 
-            let mut queries = vec![
-                Query::equal("userId", vec![user_id.clone().into()]),
-                Query::limit(100),
-            ];
-            if !search.is_empty() {
-                queries.push(Query::search("search", search));
+            let mut parsed = queries::parse(&queries::raw_param(ctx.param_value("queries")))?;
+            queries::push_search(&mut parsed, queries::COLLECTION_MEMBERSHIPS, &search)?;
+            queries::resolve_cursor(&mut db, &mut parsed, "memberships", |id| {
+                Exception::with_message(
+                    Exception::GENERAL_CURSOR_NOT_FOUND,
+                    format!("Membership '{id}' for the 'cursor' value not found."),
+                )
+            })?;
+            if !queries::has_method(&parsed, utopia_database::query::TYPE_LIMIT) {
+                parsed.push(Query::limit(25));
             }
+            // PHP scopes the list to the route's user via the `memberships`
+            // relationship on the user document rather than a query, so the
+            // caller's queries never have to carry it.
+            parsed.insert(0, Query::equal("userId", vec![user_id.clone().into()]));
+
             let memberships = db
-                .find("memberships", &queries, "read")
+                .find("memberships", &parsed, "read")
                 .map_err(base::db_error)?;
             let total = if include_total {
-                memberships.len() as i64
+                db.count("memberships", &parsed, None)
+                    .map_err(base::db_error)?
             } else {
                 0
             };

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/mfa.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/mfa.rs
@@ -385,6 +385,7 @@ pub fn delete_authenticator() -> Action {
                 .ok_or_else(|| Exception::new(Exception::USER_AUTHENTICATOR_NOT_FOUND))?;
             db.delete_document("authenticators", &authenticator.get_id())
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
             Ok(())
         })();
         base::finish_no_content(&ctx, result)

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/properties.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/properties.rs
@@ -169,14 +169,14 @@ pub fn update_email() -> Action {
             let mut db = db_handle.lock().unwrap_or_else(|e| e.into_inner());
             let user_id = base::param_str(&ctx, "userId")?;
             let email = base::param_str(&ctx, "email")?.to_lowercase();
-            let user = base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
+            let user =
+                base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
 
             if !email.is_empty() {
                 // PHP checks unconditionally (not scoped to this user), so an
                 // update to an email already used by *any* target -- including
                 // this user's own current target -- fails the same way.
-                if base::find_one(&mut db, "identities", "providerEmail", email.as_str())?
-                    .is_some()
+                if base::find_one(&mut db, "identities", "providerEmail", email.as_str())?.is_some()
                 {
                     return Err(Exception::new(Exception::USER_EMAIL_ALREADY_EXISTS));
                 }
@@ -214,6 +214,7 @@ pub fn update_email() -> Action {
                 }
                 None => {}
             }
+            base::purge_user(&mut db, &user_id);
 
             let final_user =
                 base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
@@ -301,6 +302,7 @@ pub fn update_phone() -> Action {
                 }
                 None => {}
             }
+            base::purge_user(&mut db, &user_id);
 
             let final_user =
                 base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
@@ -373,6 +375,7 @@ pub fn update_password() -> Action {
             if auths_flag(&project, "invalidateSessions") {
                 base::delete_user_sessions(&mut db, &user_id)?;
             }
+            base::purge_user(&mut db, &user_id);
 
             Ok(updated)
         })();

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/properties.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/properties.rs
@@ -56,6 +56,21 @@ fn user_id_param(action: Action) -> Action {
     action.param("userId", json!(""), Text::new(36), "User ID.", false)
 }
 
+/// PHP `APP_LIMIT_ARRAY_LABELS_SIZE` (`app/init/constants.php`).
+const LIMIT_ARRAY_LABELS_SIZE: usize = 1000;
+
+/// PHP `new Text(36, allowList: [...Text::NUMBERS, ...Text::ALPHABET_UPPER,
+/// ...Text::ALPHABET_LOWER])`: labels are alphanumeric only, so `invalid-label`
+/// is rejected on the hyphen rather than stored.
+fn label_text() -> Text {
+    Text::new(36).with_allow_list(
+        ('0'..='9')
+            .chain('A'..='Z')
+            .chain('a'..='z')
+            .collect::<Vec<_>>(),
+    )
+}
+
 /// `PATCH /v1/users/:userId/status` (`updateUserStatus`).
 #[must_use]
 pub fn update_status() -> Action {
@@ -123,7 +138,7 @@ pub fn update_name() -> Action {
             let mut db = db_handle.lock().unwrap_or_else(|e| e.into_inner());
             let user_id = base::param_str(&ctx, "userId")?;
             let name = base::param_str(&ctx, "name")?;
-            base::update_user_fields(&mut db, &user_id, json!({ "name": name }))
+            base::update_user_fields_and_search(&mut db, &user_id, json!({ "name": name }))
         })();
         base::finish(&ctx, 200, appwrite_response::MODEL_USER, result)
     })
@@ -176,11 +191,12 @@ pub fn update_email() -> Action {
                 .unwrap_or_default()
                 .to_string();
 
-            base::update_user_fields(
-                &mut db,
-                &user_id,
-                json!({ "email": if email.is_empty() { Value::Null } else { json!(email) }, "emailVerification": false }),
-            )?;
+            let mut fields = json!({
+                "email": if email.is_empty() { Value::Null } else { json!(email) },
+                "emailVerification": false,
+            });
+            base::merge_into(&mut fields, &base::email_metadata(Some(email.as_str())));
+            base::update_user_fields_and_search(&mut db, &user_id, fields)?;
 
             match base::find_target_by_identifier(&mut db, &user_id, &old_email)? {
                 Some(old_target) if !email.is_empty() => {
@@ -263,7 +279,7 @@ pub fn update_phone() -> Action {
             } else {
                 json!(number)
             };
-            base::update_user_fields(
+            base::update_user_fields_and_search(
                 &mut db,
                 &user_id,
                 json!({ "phone": phone_value, "phoneVerification": false }),
@@ -321,41 +337,60 @@ pub fn update_password() -> Action {
             "New user password. Must be at least 8 chars.",
             false,
         ),
-        &["response", "dbForProject"],
+        &["response", "project", "dbForProject"],
     )
     .http_action(|ctx| async move {
         let result = (|| -> Result<Value, Exception> {
             let db_handle = base::get_db(&ctx)?;
+            let project = base::get_project(&ctx)?;
             let mut db = db_handle.lock().unwrap_or_else(|e| e.into_inner());
             let user_id = base::param_str(&ctx, "userId")?;
             let password = base::param_str(&ctx, "password")?;
             base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
 
-            if password.is_empty() {
-                return base::update_user_fields(
+            let updated = if password.is_empty() {
+                base::update_user_fields(
                     &mut db,
                     &user_id,
                     json!({ "password": "", "passwordUpdate": base::now_iso() }),
-                );
+                )?
+            } else {
+                let hasher = Password::create_hash(Password::ARGON2, HashMap::new())
+                    .map_err(base::hash_error)?;
+                let hashed = hasher.hash(&password).map_err(base::hash_error)?;
+                base::update_user_fields(
+                    &mut db,
+                    &user_id,
+                    json!({
+                        "password": hashed,
+                        "passwordUpdate": base::now_iso(),
+                        "hash": hasher.name(),
+                        "hashOptions": hasher.options(),
+                    }),
+                )?
+            };
+
+            if auths_flag(&project, "invalidateSessions") {
+                base::delete_user_sessions(&mut db, &user_id)?;
             }
 
-            let hasher = Password::create_hash(Password::ARGON2, HashMap::new())
-                .map_err(base::hash_error)?;
-            let hashed = hasher.hash(&password).map_err(base::hash_error)?;
-
-            base::update_user_fields(
-                &mut db,
-                &user_id,
-                json!({
-                    "password": hashed,
-                    "passwordUpdate": base::now_iso(),
-                    "hash": hasher.name(),
-                    "hashOptions": hasher.options(),
-                }),
-            )
+            Ok(updated)
         })();
         base::finish(&ctx, 200, appwrite_response::MODEL_USER, result)
     })
+}
+
+/// PHP `$project->getAttribute('auths', [])['<flag>'] ?? false`.
+fn auths_flag(project: &Value, flag: &str) -> bool {
+    project
+        .get("auths")
+        .and_then(|auths| auths.get(flag))
+        .is_some_and(|value| match value {
+            Value::Bool(value) => *value,
+            Value::Number(value) => value.as_f64().is_some_and(|value| value != 0.0),
+            Value::String(value) => !matches!(value.as_str(), "" | "0" | "false"),
+            _ => false,
+        })
 }
 
 /// `PUT /v1/users/:userId/labels` (`updateUserLabels`).
@@ -375,8 +410,10 @@ pub fn update_labels() -> Action {
         .param(
             "labels",
             json!([]),
-            utopia_validators::ArrayList::new(Text::new(36)),
-            "Array of user labels. Replaces the previous labels.",
+            utopia_validators::ArrayList::with_length(label_text(), LIMIT_ARRAY_LABELS_SIZE),
+            "Array of user labels. Replaces the previous labels. Maximum of \
+             1000 labels are allowed, each up to 36 alphanumeric characters \
+             long.",
             false,
         ),
         &["response", "dbForProject"],
@@ -397,7 +434,7 @@ pub fn update_labels() -> Action {
                     unique.push(label);
                 }
             }
-            base::update_user_fields(&mut db, &user_id, json!({ "labels": unique }))
+            base::update_user_fields_and_search(&mut db, &user_id, json!({ "labels": unique }))
         })();
         base::finish(&ctx, 200, appwrite_response::MODEL_USER, result)
     })

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/sessions.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/sessions.rs
@@ -91,6 +91,7 @@ pub fn create() -> Action {
             let created = db
                 .create_document("sessions", document_from_json(session_json))
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
 
             // PHP returns the Store-encoded `{id, secret}` pair, not the raw
             // token: `x-appwrite-session` / the session cookie carry that
@@ -200,6 +201,7 @@ pub fn delete() -> Action {
             }
             db.delete_document("sessions", &session_id)
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
             Ok(())
         })();
         base::finish_no_content(&ctx, result)
@@ -301,6 +303,7 @@ pub fn create_token() -> Action {
             let created = db
                 .create_document("tokens", document_from_json(token_json))
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
             let mut token_out = document_to_json(&created);
             token_out["secret"] = json!(secret);
             Ok(token_out)

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/sessions.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/sessions.rs
@@ -25,6 +25,8 @@ const SESSION_PROVIDER_SERVER: &str = "server";
 const TOKEN_EXPIRATION_LOGIN_LONG: i64 = 31_536_000;
 /// PHP `TOKEN_EXPIRATION_GENERIC`: 15 minutes, in seconds.
 const TOKEN_EXPIRATION_GENERIC: i64 = 900;
+/// PHP `TOKEN_TYPE_GENERIC` (`app/init/constants.php`).
+const TOKEN_TYPE_GENERIC: i64 = 8;
 
 fn expire_at(seconds: i64) -> String {
     let expire = chrono::Utc::now() + chrono::Duration::seconds(seconds);
@@ -75,8 +77,9 @@ pub fn create() -> Action {
 
             let session_json = json!({
                 "$id": appwrite_database::resolve_id(appwrite_database::UNIQUE_SENTINEL),
-                "$permissions": base::owner_permissions(&user_id),
+                "$permissions": base::user_permissions(&user_id),
                 "userId": user_id,
+                "userInternalId": base::sequence_of(&user),
                 "provider": SESSION_PROVIDER_SERVER,
                 "secret": hashed,
                 "userAgent": if user_agent.is_empty() { "UNKNOWN".to_string() } else { user_agent },
@@ -89,9 +92,17 @@ pub fn create() -> Action {
                 .create_document("sessions", document_from_json(session_json))
                 .map_err(base::db_error)?;
 
+            // PHP returns the Store-encoded `{id, secret}` pair, not the raw
+            // token: `x-appwrite-session` / the session cookie carry that
+            // encoding, and the DB keeps only the one-way hash.
+            let mut store = utopia_auth::Store::new();
+            store
+                .set_property("id", user_id.clone())
+                .set_property("secret", secret);
+            let encoded = store.encode().map_err(base::hash_error)?;
+
             let mut session_out = document_to_json(&created);
-            session_out["secret"] = json!(secret);
-            let _ = &user;
+            session_out["secret"] = json!(encoded);
             Ok(session_out)
         })();
         base::finish(&ctx, 201, appwrite_response::MODEL_SESSION, result)
@@ -216,21 +227,7 @@ pub fn delete_all() -> Action {
             let mut db = db_handle.lock().unwrap_or_else(|e| e.into_inner());
             let user_id = base::param_str(&ctx, "userId")?;
             base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
-
-            let sessions = db
-                .find(
-                    "sessions",
-                    &[
-                        Query::equal("userId", vec![user_id.clone().into()]),
-                        Query::limit(1000),
-                    ],
-                    "read",
-                )
-                .map_err(base::db_error)?;
-            for session in sessions {
-                let _ = db.delete_document("sessions", &session.get_id());
-            }
-            Ok(())
+            base::delete_user_sessions(&mut db, &user_id)
         })();
         base::finish_no_content(&ctx, result)
     })
@@ -280,7 +277,8 @@ pub fn create_token() -> Action {
                 .param_value("expire")
                 .and_then(Value::as_i64)
                 .unwrap_or(TOKEN_EXPIRATION_GENERIC);
-            base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
+            let user =
+                base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
 
             let mut proof = utopia_auth::Token::new(length).map_err(base::hash_error)?;
             proof.set_hasher(Arc::new(utopia_auth::Sha::new()));
@@ -292,9 +290,9 @@ pub fn create_token() -> Action {
 
             let token_json = json!({
                 "$id": appwrite_database::resolve_id(appwrite_database::UNIQUE_SENTINEL),
-                "$permissions": base::owner_permissions(&user_id),
                 "userId": user_id,
-                "type": "generic",
+                "userInternalId": base::sequence_of(&user),
+                "type": TOKEN_TYPE_GENERIC,
                 "secret": hashed,
                 "expire": expire,
                 "userAgent": if user_agent.is_empty() { "UNKNOWN".to_string() } else { user_agent },

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/sessions.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/sessions.rs
@@ -351,18 +351,22 @@ pub fn create_jwt() -> Action {
                 .param_value("duration")
                 .and_then(Value::as_i64)
                 .unwrap_or(900);
-            base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
+            let user =
+                base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
 
+            // PHP reads `$user->getAttribute('sessions')`, the relationship
+            // keyed on `userInternalId`, so match on the same column rather
+            // than `userId`.
             let sessions = db
                 .find(
                     "sessions",
                     &[
-                        Query::equal("userId", vec![user_id.clone().into()]),
+                        Query::equal("userInternalId", vec![base::sequence_str(&user).into()]),
                         Query::limit(1000),
                     ],
                     "read",
                 )
-                .unwrap_or_default();
+                .map_err(base::db_error)?;
             let session = if session_id == "recent" {
                 sessions.last().cloned()
             } else {

--- a/3.x.x/crates/appwrite-platform/src/modules/users/http/targets.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/http/targets.rs
@@ -100,7 +100,8 @@ pub fn create() -> Action {
                 _ => return Err(Exception::new(Exception::GENERAL_ARGUMENT_INVALID)),
             }
 
-            base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
+            let user =
+                base::require_document(&mut db, "users", &user_id, Exception::USER_NOT_FOUND)?;
 
             let resolved_id = appwrite_database::resolve_id(&target_id);
             let existing = db
@@ -116,6 +117,7 @@ pub fn create() -> Action {
                 "providerId": if provider_id.is_empty() { Value::Null } else { json!(provider_id) },
                 "providerType": provider_type,
                 "userId": user_id,
+                "userInternalId": base::sequence_of(&user),
                 "identifier": identifier,
                 "name": if name.is_empty() { Value::Null } else { json!(name) },
                 "expired": false,
@@ -123,6 +125,7 @@ pub fn create() -> Action {
             let created = db
                 .create_document("targets", document_from_json(target_json))
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
 
             Ok(document_to_json(&created))
         })();
@@ -317,6 +320,7 @@ pub fn update() -> Action {
                     document_from_json(Value::Object(fields)),
                 )
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
             Ok(document_to_json(&updated))
         })();
         base::finish(&ctx, 200, appwrite_response::MODEL_TARGET, result)
@@ -362,6 +366,7 @@ pub fn delete() -> Action {
 
             db.delete_document("targets", &target_id)
                 .map_err(base::db_error)?;
+            base::purge_user(&mut db, &user_id);
 
             let message = DeleteMessage::new(appwrite_event::DELETE_TYPE_TARGET)
                 .with_document(document_to_json(&target));

--- a/3.x.x/crates/appwrite-platform/src/modules/users/mod.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod base;
 pub mod http;
+pub mod queries;
 pub mod services;
 pub mod validators;
 

--- a/3.x.x/crates/appwrite-platform/src/modules/users/queries.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/queries.rs
@@ -280,7 +280,10 @@ pub fn raw_param(value: Option<&serde_json::Value>) -> Vec<String> {
         .map(|values| {
             values
                 .iter()
-                .filter_map(|value| value.as_str().map(str::to_string))
+                .map(|value| match value {
+                    serde_json::Value::String(query) => query.clone(),
+                    other => other.to_string(),
+                })
                 .collect()
         })
         .unwrap_or_default()

--- a/3.x.x/crates/appwrite-platform/src/modules/users/queries.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/queries.rs
@@ -19,7 +19,9 @@
 
 use appwrite_exception::Exception;
 use utopia_database::validator::queries::Queries;
-use utopia_database::validator::query::{Cursor, Filter, Limit, Offset, Order, QueryMethodValidator};
+use utopia_database::validator::query::{
+    Cursor, Filter, Limit, Offset, Order, QueryMethodValidator,
+};
 use utopia_database::{AttrValue, Document, Query};
 use utopia_validators::Validator;
 
@@ -128,9 +130,7 @@ const MEMBERSHIPS: &[Attribute] = &[
 ];
 
 /// PHP `Queries\Memberships::ALLOWED_ATTRIBUTES`.
-const MEMBERSHIPS_ALLOWED: &[&str] = &[
-    "userId", "teamId", "invited", "joined", "confirm", "roles",
-];
+const MEMBERSHIPS_ALLOWED: &[&str] = &["userId", "teamId", "invited", "joined", "confirm", "roles"];
 
 /// PHP `Queries\Base`'s `$internalAttributes`, appended to both the filterable
 /// and the full attribute set.
@@ -326,9 +326,7 @@ pub fn resolve_cursor(
 
     let document = db
         .get_document(collection, &id, &[], false)
-        .map_err(|err| {
-            Exception::with_message(Exception::GENERAL_SERVER_ERROR, err.to_string())
-        })?;
+        .map_err(|err| Exception::with_message(Exception::GENERAL_SERVER_ERROR, err.to_string()))?;
     if document.is_empty() {
         return Err(not_found(&id));
     }

--- a/3.x.x/crates/appwrite-platform/src/modules/users/queries.rs
+++ b/3.x.x/crates/appwrite-platform/src/modules/users/queries.rs
@@ -1,0 +1,410 @@
+//! `queries` param validators for the Users API. Rust port of
+//! `Appwrite\Utopia\Database\Validator\Queries\{Base, Users, Identities,
+//! Memberships}`.
+//!
+//! PHP builds these from `Config::getParam('collections')`, the same static
+//! definitions the project collections were provisioned from. There is no
+//! config loader in this crate, so the three collections the Users API
+//! filters over are transcribed below; they must stay in step with
+//! `app/config/collections/{projects,common}.php`.
+//!
+//! Two surfaces come out of this module and they are deliberately different:
+//! - [`users`] / [`identities`] / [`memberships`] validate the caller's
+//!   `queries` param, restricted to each collection's `ALLOWED_ATTRIBUTES`,
+//!   and are attached to the route so a rejection reads
+//!   `Invalid `queries` param: ...` (PHP's `GENERAL_ARGUMENT_INVALID`).
+//! - [`has_attribute`] answers whether the *whole* collection has a given
+//!   attribute, which is what PHP's `find()` checks when a handler appends a
+//!   `Query::search('search', ...)` of its own (PHP's `GENERAL_QUERY_INVALID`).
+
+use appwrite_exception::Exception;
+use utopia_database::validator::queries::Queries;
+use utopia_database::validator::query::{Cursor, Filter, Limit, Offset, Order, QueryMethodValidator};
+use utopia_database::{AttrValue, Document, Query};
+use utopia_validators::Validator;
+
+/// PHP `APP_DATABASE_QUERY_MAX_VALUES` (`app/init/constants.php`).
+const QUERY_MAX_VALUES: i64 = 500;
+/// PHP `Database::VAR_INTEGER`, the `idAttributeType` every Appwrite
+/// `Queries\Base` passes to `Filter`.
+const ID_ATTRIBUTE_TYPE: &str = utopia_database::constants::VAR_INTEGER;
+/// PHP `Utopia\Database\Validator\Query\Cursor`'s default `$maxLength`.
+const CURSOR_MAX_LENGTH: i64 = 255;
+
+/// One `('$id', type, array)` triple from a collection's `attributes` config.
+type Attribute = (&'static str, &'static str, bool);
+
+const STRING: &str = utopia_database::constants::VAR_STRING;
+const BOOLEAN: &str = utopia_database::constants::VAR_BOOLEAN;
+const DATETIME: &str = utopia_database::constants::VAR_DATETIME;
+
+/// `users` collection attributes (`app/config/collections/common.php`).
+const USERS: &[Attribute] = &[
+    ("keys", STRING, false),
+    ("name", STRING, false),
+    ("email", STRING, false),
+    ("phone", STRING, false),
+    ("status", BOOLEAN, false),
+    ("labels", STRING, true),
+    ("passwordHistory", STRING, true),
+    ("password", STRING, false),
+    ("hash", STRING, false),
+    ("hashOptions", STRING, false),
+    ("passwordUpdate", DATETIME, false),
+    ("prefs", STRING, false),
+    ("registration", DATETIME, false),
+    ("emailVerification", BOOLEAN, false),
+    ("phoneVerification", BOOLEAN, false),
+    ("reset", BOOLEAN, false),
+    ("mfa", BOOLEAN, false),
+    ("mfaRecoveryCodes", STRING, true),
+    ("authenticators", STRING, false),
+    ("sessions", STRING, false),
+    ("tokens", STRING, false),
+    ("challenges", STRING, false),
+    ("memberships", STRING, false),
+    ("targets", STRING, false),
+    ("search", STRING, false),
+    ("accessedAt", DATETIME, false),
+    ("emailCanonical", STRING, false),
+    ("emailIsFree", BOOLEAN, false),
+    ("emailIsDisposable", BOOLEAN, false),
+    ("emailIsCorporate", BOOLEAN, false),
+    ("emailIsCanonical", BOOLEAN, false),
+    ("impersonator", BOOLEAN, false),
+];
+
+/// PHP `Queries\Users::ALLOWED_ATTRIBUTES`.
+const USERS_ALLOWED: &[&str] = &[
+    "name",
+    "email",
+    "phone",
+    "status",
+    "passwordUpdate",
+    "registration",
+    "emailVerification",
+    "phoneVerification",
+    "labels",
+    "impersonator",
+    "accessedAt",
+];
+
+/// `identities` collection attributes.
+const IDENTITIES: &[Attribute] = &[
+    ("userInternalId", STRING, false),
+    ("userId", STRING, false),
+    ("provider", STRING, false),
+    ("providerUid", STRING, false),
+    ("providerEmail", STRING, false),
+    ("providerAccessToken", STRING, false),
+    ("providerAccessTokenExpiry", DATETIME, false),
+    ("providerRefreshToken", STRING, false),
+    ("secrets", STRING, false),
+    ("scopes", STRING, true),
+    ("expire", DATETIME, false),
+];
+
+/// PHP `Queries\Identities::ALLOWED_ATTRIBUTES`.
+const IDENTITIES_ALLOWED: &[&str] = &[
+    "userId",
+    "provider",
+    "providerUid",
+    "providerEmail",
+    "providerAccessTokenExpiry",
+];
+
+/// `memberships` collection attributes.
+const MEMBERSHIPS: &[Attribute] = &[
+    ("userInternalId", STRING, false),
+    ("userId", STRING, false),
+    ("teamInternalId", STRING, false),
+    ("teamId", STRING, false),
+    ("roles", STRING, true),
+    ("invited", DATETIME, false),
+    ("joined", DATETIME, false),
+    ("confirm", BOOLEAN, false),
+    ("secret", STRING, false),
+    ("search", STRING, false),
+];
+
+/// PHP `Queries\Memberships::ALLOWED_ATTRIBUTES`.
+const MEMBERSHIPS_ALLOWED: &[&str] = &[
+    "userId", "teamId", "invited", "joined", "confirm", "roles",
+];
+
+/// PHP `Queries\Base`'s `$internalAttributes`, appended to both the filterable
+/// and the full attribute set.
+const INTERNAL: &[Attribute] = &[
+    ("$id", STRING, false),
+    ("$createdAt", DATETIME, false),
+    ("$updatedAt", DATETIME, false),
+    ("$sequence", utopia_database::constants::VAR_INTEGER, false),
+];
+
+fn attribute_document((key, kind, array): Attribute) -> Document {
+    Document::from_pairs([
+        ("$id", AttrValue::from(key)),
+        ("key", AttrValue::from(key)),
+        ("type", AttrValue::from(kind)),
+        ("array", AttrValue::from(array)),
+    ])
+    .unwrap_or_default()
+}
+
+fn documents(attributes: &[Attribute], allowed: Option<&[&str]>) -> Vec<Document> {
+    attributes
+        .iter()
+        .filter(|(key, _, _)| allowed.is_none_or(|allowed| allowed.contains(key)))
+        .chain(INTERNAL.iter())
+        .copied()
+        .map(attribute_document)
+        .collect()
+}
+
+/// PHP `Queries\Base::__construct()`. `Select` is deliberately absent:
+/// `isSelectQueryAllowed()` is `false` for every Users-API list, so a `select`
+/// query has no validator to match and is rejected as an unknown method.
+fn base(attributes: &[Attribute], allowed: &[&str]) -> Queries {
+    let filterable = documents(attributes, Some(allowed));
+    let validators: Vec<Box<dyn QueryMethodValidator>> = vec![
+        Box::new(Limit::default()),
+        Box::new(Offset::default()),
+        Box::new(Cursor::new(CURSOR_MAX_LENGTH)),
+        Box::new(Filter::new(
+            &filterable,
+            ID_ATTRIBUTE_TYPE,
+            QUERY_MAX_VALUES,
+            min_allowed_date(),
+            max_allowed_date(),
+            true,
+            true,
+        )),
+        Box::new(Order::new(&filterable, true)),
+    ];
+    Queries::new(validators, 0)
+}
+
+/// PHP `Filter`'s `new \DateTime('0000-01-01')` default.
+fn min_allowed_date() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd_opt(1, 1, 1)
+        .unwrap_or_default()
+        .and_hms_opt(0, 0, 0)
+        .unwrap_or_default()
+}
+
+/// PHP `Filter`'s `new \DateTime('9999-12-31')` default.
+fn max_allowed_date() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd_opt(9999, 12, 31)
+        .unwrap_or_default()
+        .and_hms_opt(23, 59, 59)
+        .unwrap_or_default()
+}
+
+/// PHP `new Users()`.
+#[must_use]
+pub fn users() -> Queries {
+    base(USERS, USERS_ALLOWED)
+}
+
+/// PHP `new Identities()`.
+#[must_use]
+pub fn identities() -> Queries {
+    base(IDENTITIES, IDENTITIES_ALLOWED)
+}
+
+/// PHP `new Memberships()`.
+#[must_use]
+pub fn memberships() -> Queries {
+    base(MEMBERSHIPS, MEMBERSHIPS_ALLOWED)
+}
+
+/// Collection identifiers accepted by [`has_attribute`].
+pub const COLLECTION_USERS: &str = "users";
+pub const COLLECTION_IDENTITIES: &str = "identities";
+pub const COLLECTION_MEMBERSHIPS: &str = "memberships";
+
+/// Whether `collection` defines `attribute` at all (ignoring the
+/// filterable-attribute allow list). PHP gets this for free because
+/// `Database::find()` re-validates every query against the live collection
+/// schema; the Rust adapters do not, so handlers that append their own query
+/// (`search`) check here first.
+#[must_use]
+pub fn has_attribute(collection: &str, attribute: &str) -> bool {
+    let attributes = match collection {
+        COLLECTION_USERS => USERS,
+        COLLECTION_IDENTITIES => IDENTITIES,
+        COLLECTION_MEMBERSHIPS => MEMBERSHIPS,
+        _ => return false,
+    };
+    attributes.iter().any(|(key, _, _)| *key == attribute)
+        || INTERNAL.iter().any(|(key, _, _)| *key == attribute)
+}
+
+/// PHP's `Query::search('search', $search)` append, guarded by the schema
+/// check `Database::find()` would have done. Returns the same
+/// `GENERAL_QUERY_INVALID` / `Attribute not found in schema: ...` pair PHP
+/// surfaces for a collection with no `search` attribute (`identities`).
+pub fn push_search(
+    queries: &mut Vec<Query>,
+    collection: &str,
+    search: &str,
+) -> Result<(), Exception> {
+    if search.is_empty() {
+        return Ok(());
+    }
+    if !has_attribute(collection, "search") {
+        return Err(Exception::with_message(
+            Exception::GENERAL_QUERY_INVALID,
+            "Invalid query: Attribute not found in schema: search",
+        ));
+    }
+    queries.push(Query::search("search", search));
+    Ok(())
+}
+
+/// Parse the caller's already-validated `queries` param. The route's param
+/// validator has run by this point, so a parse failure here is only reachable
+/// for input the validator accepts but `parse` rejects; PHP maps that same
+/// case to `GENERAL_QUERY_INVALID`.
+pub fn parse(raw: &[String]) -> Result<Vec<Query>, Exception> {
+    Query::parse_queries(raw).map_err(|err| {
+        Exception::with_message(Exception::GENERAL_QUERY_INVALID, err.message().to_string())
+    })
+}
+
+/// The route param value (`queries`) as a list of raw query strings.
+#[must_use]
+pub fn raw_param(value: Option<&serde_json::Value>) -> Vec<String> {
+    value
+        .and_then(serde_json::Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether `queries` already carries a `limit`, so handlers only add PHP's
+/// default when the caller did not ask for one.
+#[must_use]
+pub fn has_method(queries: &[Query], method: &str) -> bool {
+    queries.iter().any(|query| query.get_method() == method)
+}
+
+/// PHP's cursor block: a `cursorAfter`/`cursorBefore` query arrives carrying
+/// only the document *id*, and the handler swaps in the loaded document
+/// before handing the query to `find()`. `not_found` builds the per-collection
+/// `GENERAL_CURSOR_NOT_FOUND` message.
+pub fn resolve_cursor(
+    db: &mut crate::state::ProjectDb,
+    queries: &mut [Query],
+    collection: &str,
+    not_found: impl Fn(&str) -> Exception,
+) -> Result<(), Exception> {
+    let Some(cursor) = queries.iter_mut().find(|query| {
+        matches!(
+            query.get_method(),
+            utopia_database::query::TYPE_CURSOR_AFTER | utopia_database::query::TYPE_CURSOR_BEFORE
+        )
+    }) else {
+        return Ok(());
+    };
+
+    let id = match cursor.get_value() {
+        AttrValue::Document(document) => document.get_id(),
+        AttrValue::String(id) => id.clone(),
+        other => other.to_json().as_str().unwrap_or_default().to_string(),
+    };
+    if id.is_empty() {
+        return Err(not_found(&id));
+    }
+
+    let document = db
+        .get_document(collection, &id, &[], false)
+        .map_err(|err| {
+            Exception::with_message(Exception::GENERAL_SERVER_ERROR, err.to_string())
+        })?;
+    if document.is_empty() {
+        return Err(not_found(&id));
+    }
+    cursor.set_value(AttrValue::Document(Box::new(document)));
+    Ok(())
+}
+
+/// A `Queries` validator's current message, used when a handler needs to
+/// re-report a validation failure it triggered itself.
+#[must_use]
+pub fn message(validator: &Queries) -> String {
+    validator.description()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_one(query: &str) -> Query {
+        Query::parse(query).expect("test query should parse")
+    }
+
+    #[test]
+    fn select_is_rejected_because_users_lists_disallow_it() {
+        let validator = users();
+        let select = parse_one(r#"{"method":"select","values":["name"]}"#);
+        assert!(!validator.is_valid_queries(&[select]));
+        assert_eq!(message(&validator), "Invalid query method: select");
+    }
+
+    #[test]
+    fn equal_on_an_allowed_attribute_passes() {
+        let validator = users();
+        let equal = parse_one(r#"{"method":"equal","attribute":"name","values":["bob"]}"#);
+        assert!(validator.is_valid_queries(&[equal]));
+    }
+
+    #[test]
+    fn equal_on_an_unlisted_attribute_is_rejected() {
+        let validator = users();
+        let equal = parse_one(r#"{"method":"equal","attribute":"password","values":["x"]}"#);
+        assert!(!validator.is_valid_queries(&[equal]));
+        assert_eq!(
+            message(&validator),
+            "Invalid query: Attribute not found in schema: password"
+        );
+    }
+
+    #[test]
+    fn equal_on_an_array_attribute_is_rejected() {
+        let validator = memberships();
+        let equal = parse_one(r#"{"method":"equal","attribute":"roles","values":["admin"]}"#);
+        assert!(!validator.is_valid_queries(&[equal]));
+        assert_eq!(
+            message(&validator),
+            "Invalid query: Cannot query equal on attribute \"roles\" because it is an array."
+        );
+    }
+
+    #[test]
+    fn contains_on_an_array_attribute_passes() {
+        let validator = memberships();
+        let contains = parse_one(r#"{"method":"contains","attribute":"roles","values":["admin"]}"#);
+        assert!(validator.is_valid_queries(&[contains]));
+    }
+
+    #[test]
+    fn identities_have_no_search_attribute() {
+        assert!(!has_attribute(COLLECTION_IDENTITIES, "search"));
+        assert!(has_attribute(COLLECTION_USERS, "search"));
+        assert!(has_attribute(COLLECTION_MEMBERSHIPS, "search"));
+    }
+
+    #[test]
+    fn push_search_reports_the_missing_schema_attribute() {
+        let mut queries = Vec::new();
+        let err = push_search(&mut queries, COLLECTION_IDENTITIES, "identity")
+            .expect_err("identities has no search attribute");
+        assert_eq!(err.type_(), Exception::GENERAL_QUERY_INVALID);
+        assert!(queries.is_empty());
+    }
+}

--- a/3.x.x/crates/appwrite-platform/src/state.rs
+++ b/3.x.x/crates/appwrite-platform/src/state.rs
@@ -256,6 +256,13 @@ impl AppwriteState {
         Some(project_json)
     }
 
+    /// PHP `inject('dbForPlatform')`. `None` in Memory mode, where there is
+    /// no separate platform database to consult.
+    #[must_use]
+    pub fn platform_db(&self) -> Option<&Mutex<ProjectDb>> {
+        self.platform.as_ref()
+    }
+
     #[must_use]
     pub fn project_sequence(&self, project: &Value) -> Option<String> {
         match project.get("$sequence")? {

--- a/3.x.x/crates/utopia-auth/src/proofs/token.rs
+++ b/3.x.x/crates/utopia-auth/src/proofs/token.rs
@@ -54,11 +54,16 @@ impl Token {
 
 impl Proof for Token {
     fn generate(&self) -> Result<String, AuthError> {
-        let bytes_length = (self.length / 2).max(1);
+        // PHP: `max(1, (int) ceil($this->length / 2))` then `substr($token, 0,
+        // $this->length)`. Rounding *up* matters for odd lengths: `length / 2`
+        // would leave the hex string one character short, and `substr` clamps
+        // where slicing would panic.
+        let bytes_length = self.length.div_ceil(2).max(1);
         let mut bytes = vec![0u8; bytes_length];
         rand::thread_rng().fill_bytes(&mut bytes);
-        let token = hex::encode(bytes);
-        Ok(token[..self.length].to_owned())
+        let mut token = hex::encode(bytes);
+        token.truncate(self.length);
+        Ok(token)
     }
 
     fn hash(&self, proof: &str) -> Result<String, AuthError> {

--- a/3.x.x/crates/utopia-auth/tests/proofs.rs
+++ b/3.x.x/crates/utopia-auth/tests/proofs.rs
@@ -10,6 +10,19 @@ fn token_generates_expected_length() {
 }
 
 #[test]
+fn token_generates_expected_length_for_odd_lengths() {
+    // PHP rounds the byte count up, so an odd length still yields that many
+    // hex characters instead of one short.
+    for length in [1, 3, 15, 127] {
+        let token = Token::new(length).expect("token should be created");
+        let proof = token.generate().expect("generate should succeed");
+
+        assert_eq!(proof.len(), length);
+        assert!(proof.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}
+
+#[test]
 fn token_default_length_is_256() {
     let token = Token::with_default_length().expect("token should be created");
     assert_eq!(token.length(), 256);

--- a/3.x.x/crates/utopia-database/Cargo.toml
+++ b/3.x.x/crates/utopia-database/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["database", "web-programming"]
 [features]
 default = ["sqlite"]
 mysql = ["dep:mysql"]
-postgres = ["dep:postgres", "dep:bytes"]
+postgres = ["dep:postgres", "dep:bytes", "dep:tokio"]
 sqlite = ["dep:rusqlite"]
 mongo = ["dep:mongodb"]
 redis = ["dep:redis"]
@@ -30,6 +30,7 @@ mysql = { workspace = true, optional = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 postgres = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["rt"] }
 rand = { workspace = true }
 redis = { workspace = true, optional = true }
 regex = { workspace = true }

--- a/3.x.x/crates/utopia-database/README.md
+++ b/3.x.x/crates/utopia-database/README.md
@@ -34,7 +34,7 @@ db.create(None).unwrap();
 | Adapter | PHP name | Feature | Notes |
 |---------|----------|---------|-------|
 | [`adapter::Memory`](src/adapter/memory.rs) | `Adapter\Memory` | default | In-process. Used by unit tests. |
-| [`adapter::Sql`](src/adapter/sql.rs) | `Adapter\SQL` | - | Shared quoting / type-map helpers + PDO wrapper. |
+| [`adapter::Sql`](src/adapter/sql.rs) | `Adapter\SQL` | - | Shared quoting / type-map helpers used by SQL engines. |
 | [`adapter::mysql::Mysql`](src/adapter/mysql.rs) | `Adapter\MySQL` | `mysql` | Compiles with the `mysql` crate. Live I/O env-gated. |
 | `adapter::mysql::MariaDb` | `Adapter\MariaDB` | `mysql` | Type alias of `Mysql`. |
 | [`adapter::postgres::Postgres`](src/adapter/postgres.rs) | `Adapter\Postgres` | `postgres` | |
@@ -55,7 +55,7 @@ db.create(None).unwrap();
 | [`Change`](src/change.rs) | `Change` | Old/new document pair. |
 | [`Connection`](src/connection.rs) | `Connection` | Lost-connection heuristics. |
 | [`Mirror`](src/mirror.rs) | `Mirror` | Dual-write. |
-| [`Pdo`](src/pdo.rs) / [`PdoStatement`](src/pdo.rs) | `PDO` / `PDOStatement` | |
+| [`SqlClient`](src/sql_client.rs) / [`SqlStatement`](src/sql_client.rs) | *(none - Rust)* | Engine connection behind SQL adapters. Not a PDO port; prefer `Postgres` / `Mysql` / `Sqlite`. |
 | [`Id`](src/helpers/id.rs) | `Helpers\ID` | `unique`, `custom`. |
 | [`Permission`](src/helpers/permission.rs) | `Helpers\Permission` | `read`/`create`/`update`/`delete`/`write`, `parse`, `aggregate`. |
 | [`Role`](src/helpers/role.rs) | `Helpers\Role` | `any`, `user`, `users`, `team`, `guests`, `label`, `member`. |
@@ -102,6 +102,7 @@ PHP `Utopia\Database\Validator\*` is under [`validator`](src/validator): `Key`, 
 - `AttrValue` replaces PHP `mixed`. Empty-document `get_id()` is `""` (PHP returns `""`; PHPUnit `assertEquals(null, '')` is loose).
 - `Id::unique()` returns `Result<String>`. `Role::user` / `users` take explicit status strings (PHP defaults to `''`).
 - `Database` is generic over the adapter (`Database<Memory>`). `Adapter` is not `dyn` because fluent setters return `&mut Self`.
+- SQL engines use Rust crates (`postgres`, `mysql`, `rusqlite`) behind [`SqlClient`](src/sql_client.rs). There is no PDO / DSN / `PDOStatement` public API - call `Postgres::connect`, `Mysql::connect_db`, or `Sqlite::open` instead.
 - SQL/Mongo adapters execute live queries. Default `cargo test -p utopia-database` runs Memory + SQLite. `cargo test -p utopia-database --features mysql,postgres,mongo` needs `docker compose -f docker-compose.test.yml up -d`.
 - Mongo remains on the family not-converting list; the adapter is still shipped and tested against a container.
 - Cache is [`utopia_cache::Cache`](../utopia-cache), not an in-crate stand-in.

--- a/3.x.x/crates/utopia-database/src/adapter/mongo.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/mongo.rs
@@ -95,10 +95,7 @@ impl Adapter for Mongo {
         _indexes: &[Document],
     ) -> Result<bool> {
         self.db()
-            .create_collection(
-                &format!("{}_{}", self.state.namespace, filter_key(name)),
-                None,
-            )
+            .create_collection(format!("{}_{}", self.state.namespace, filter_key(name)), None)
             .map_err(|e| DatabaseError::database(e.to_string()))?;
         Ok(true)
     }
@@ -194,7 +191,7 @@ impl Adapter for Mongo {
                 _ => {}
             }
         }
-        let mut find = self
+        let find = self
             .collection(&collection.get_id())
             .find(filter, None)
             .map_err(|e| DatabaseError::database(e.to_string()))?;
@@ -202,7 +199,7 @@ impl Adapter for Mongo {
         let skip = skip_n.unwrap_or(0).max(0) as usize;
         let take = limit_n.unwrap_or(i64::MAX).max(0) as usize;
         let mut i = 0usize;
-        while let Some(doc) = find.next() {
+        for doc in find {
             let doc = doc.map_err(|e| DatabaseError::database(e.to_string()))?;
             if i < skip {
                 i += 1;

--- a/3.x.x/crates/utopia-database/src/adapter/mysql.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/mysql.rs
@@ -1,30 +1,41 @@
-//! MySQL / MariaDB adapters (PHP `Adapter\MySQL`, `Adapter\MariaDB`).
+//! MySQL / MariaDB adapters.
 
 use super::sql::{quote_mysql, SqlAdapter};
 use crate::error::Result;
 use crate::impl_sql_engine;
-use crate::pdo::Pdo;
+use crate::sql_client::SqlClient;
 
-/// MySQL adapter (PHP `Utopia\Database\Adapter\MySQL`).
+/// MySQL adapter.
 #[derive(Debug)]
 pub struct Mysql {
     pub(crate) inner: SqlAdapter,
 }
 
 impl Mysql {
-    /// Connect using host/port credentials.
+    /// Connect using host/port credentials (no default database selected).
     pub fn connect(host: &str, port: u16, user: &str, pass: &str) -> Result<Self> {
-        let pdo = Pdo::mysql(host, port, user, pass, None, false)?;
+        Self::connect_db(host, port, user, pass, None)
+    }
+
+    /// Connect and optionally select a default database/schema.
+    pub fn connect_db(
+        host: &str,
+        port: u16,
+        user: &str,
+        pass: &str,
+        database: Option<&str>,
+    ) -> Result<Self> {
+        let client = SqlClient::mysql(host, port, user, pass, database, false)?;
         Ok(Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         })
     }
 
-    /// Wrap an existing PDO.
+    /// Wrap an existing [`SqlClient`].
     #[must_use]
-    pub fn new(pdo: Pdo) -> Self {
+    pub fn from_client(client: SqlClient) -> Self {
         Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         }
     }
 
@@ -37,26 +48,37 @@ impl Mysql {
 
 impl_sql_engine!(Mysql, "mysql");
 
-/// MariaDB adapter (PHP `Utopia\Database\Adapter\MariaDB`).
+/// MariaDB adapter.
 #[derive(Debug)]
 pub struct MariaDb {
     pub(crate) inner: SqlAdapter,
 }
 
 impl MariaDb {
-    /// Connect using host/port credentials.
+    /// Connect using host/port credentials (no default database selected).
     pub fn connect(host: &str, port: u16, user: &str, pass: &str) -> Result<Self> {
-        let pdo = Pdo::mysql(host, port, user, pass, None, true)?;
+        Self::connect_db(host, port, user, pass, None)
+    }
+
+    /// Connect and optionally select a default database/schema.
+    pub fn connect_db(
+        host: &str,
+        port: u16,
+        user: &str,
+        pass: &str,
+        database: Option<&str>,
+    ) -> Result<Self> {
+        let client = SqlClient::mysql(host, port, user, pass, database, true)?;
         Ok(Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         })
     }
 
-    /// Wrap an existing PDO.
+    /// Wrap an existing [`SqlClient`].
     #[must_use]
-    pub fn new(pdo: Pdo) -> Self {
+    pub fn from_client(client: SqlClient) -> Self {
         Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         }
     }
 

--- a/3.x.x/crates/utopia-database/src/adapter/postgres.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/postgres.rs
@@ -1,9 +1,9 @@
-//! Postgres adapter (PHP `Adapter\Postgres`).
+//! Postgres adapter.
 
 use super::sql::{quote_ansi, SqlAdapter};
 use crate::error::Result;
 use crate::impl_sql_engine;
-use crate::pdo::Pdo;
+use crate::sql_client::SqlClient;
 
 /// Postgres adapter.
 #[derive(Debug)]
@@ -14,17 +14,17 @@ pub struct Postgres {
 impl Postgres {
     /// Connect using host/port credentials.
     pub fn connect(host: &str, port: u16, user: &str, pass: &str, db: &str) -> Result<Self> {
-        let pdo = Pdo::postgres(host, port, user, pass, db)?;
+        let client = SqlClient::postgres(host, port, user, pass, db)?;
         Ok(Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         })
     }
 
-    /// Wrap an existing PDO.
+    /// Wrap an existing [`SqlClient`].
     #[must_use]
-    pub fn new(pdo: Pdo) -> Self {
+    pub fn from_client(client: SqlClient) -> Self {
         Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         }
     }
 

--- a/3.x.x/crates/utopia-database/src/adapter/sql.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/sql.rs
@@ -259,11 +259,16 @@ impl SqlAdapter {
                 let (low, high) = (values.first()?, values.get(1)?);
                 let low = bind(params, SqlParam::from_attr(low));
                 let high = bind(params, SqlParam::from_attr(high));
-                let not = if method == TYPE_NOT_BETWEEN { "NOT " } else { "" };
+                let not = if method == TYPE_NOT_BETWEEN {
+                    "NOT "
+                } else {
+                    ""
+                };
                 Some(format!("{column} {not}BETWEEN {low} AND {high}"))
             }
             TYPE_SEARCH | TYPE_NOT_SEARCH => {
-                let value = fulltext_value(query.get_value().as_str().unwrap_or_default(), self.dialect);
+                let value =
+                    fulltext_value(query.get_value().as_str().unwrap_or_default(), self.dialect);
                 if value.is_empty() {
                     return None;
                 }
@@ -368,7 +373,8 @@ impl SqlAdapter {
         params: &mut Vec<(String, SqlParam)>,
         next: &mut usize,
     ) -> Vec<String> {
-        let encode = |value: &AttrValue| serde_json::to_string(&value.to_json()).unwrap_or_default();
+        let encode =
+            |value: &AttrValue| serde_json::to_string(&value.to_json()).unwrap_or_default();
         let payloads: Vec<String> = if method == TYPE_CONTAINS_ALL {
             let all: Vec<serde_json::Value> =
                 query.get_values().iter().map(AttrValue::to_json).collect();
@@ -451,10 +457,8 @@ fn fulltext_value(value: &str, dialect: Dialect) -> String {
     let exact = value.len() > 1 && value.starts_with('"') && value.ends_with('"');
     match dialect {
         Dialect::Postgres => {
-            let cleaned = collapse_whitespace(&value.replace(
-                ['@', '+', '-', '*', '.', '\'', '"'],
-                " ",
-            ));
+            let cleaned =
+                collapse_whitespace(&value.replace(['@', '+', '-', '*', '.', '\'', '"'], " "));
             if cleaned.is_empty() {
                 return String::new();
             }
@@ -466,10 +470,9 @@ fn fulltext_value(value: &str, dialect: Dialect) -> String {
             format!("'{joined}'")
         }
         _ => {
-            let cleaned = collapse_whitespace(&value.replace(
-                ['@', '+', '-', '*', ')', '(', '<', '>', '~', '"'],
-                " ",
-            ));
+            let cleaned = collapse_whitespace(
+                &value.replace(['@', '+', '-', '*', ')', '(', '<', '>', '~', '"'], " "),
+            );
             if cleaned.is_empty() {
                 return String::new();
             }
@@ -1070,7 +1073,10 @@ impl Adapter for SqlAdapter {
                     .map(String::as_str)
                     .unwrap_or(ORDER_ASC)
                     .eq_ignore_ascii_case(ORDER_ASC);
-                (Self::internal_key(attribute).to_string(), ascending != backwards)
+                (
+                    Self::internal_key(attribute).to_string(),
+                    ascending != backwards,
+                )
             })
             .collect();
         if ordered.is_empty() {

--- a/3.x.x/crates/utopia-database/src/adapter/sql.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/sql.rs
@@ -325,6 +325,38 @@ impl SqlAdapter {
         }
     }
 
+    /// The lexicographic "after the cursor row" comparison over the effective
+    /// ordering: the first column that differs decides, and ties fall through
+    /// to the next one. `ordered` is already flipped for `cursorBefore`, so
+    /// the same expression serves both directions.
+    fn cursor_condition(
+        &self,
+        cursor: &Document,
+        ordered: &[(String, bool)],
+        params: &mut Vec<(String, SqlParam)>,
+        next: &mut usize,
+    ) -> Option<String> {
+        let mut condition = String::new();
+        for (column, ascending) in ordered.iter().rev() {
+            let value = cursor_value(cursor, column);
+            let quoted = self.q(column);
+            let strict = format!(":f{next}");
+            *next += 1;
+            params.push((strict.clone(), value.clone()));
+            let tie = format!(":f{next}");
+            *next += 1;
+            params.push((tie.clone(), value));
+
+            let operator = if *ascending { ">" } else { "<" };
+            condition = if condition.is_empty() {
+                format!("{quoted} {operator} {strict}")
+            } else {
+                format!("({quoted} {operator} {strict} OR ({quoted} = {tie} AND {condition}))")
+            };
+        }
+        (!condition.is_empty()).then_some(condition)
+    }
+
     /// The `contains`-family fragments for an array attribute: JSON
     /// containment rather than a substring match. `containsAll` tests the
     /// whole value list at once, the others test each value separately.
@@ -364,6 +396,23 @@ impl SqlAdapter {
             })
             .collect()
     }
+}
+
+/// The cursor document's value for an internal column, read back through the
+/// `$`-prefixed name it carries on a decoded document.
+fn cursor_value(cursor: &Document, column: &str) -> SqlParam {
+    let external = match column {
+        "_uid" => "$id",
+        "_id" => "$sequence",
+        "_createdAt" => "$createdAt",
+        "_updatedAt" => "$updatedAt",
+        other => other,
+    };
+    let value = cursor.get_attribute(external);
+    if value.is_null() && external != column {
+        return SqlParam::from_attr(cursor.get_attribute(column));
+    }
+    SqlParam::from_attr(value)
 }
 
 /// The `key`s of a collection's array attributes, which `contains` queries
@@ -993,8 +1042,8 @@ impl Adapter for SqlAdapter {
         offset: Option<i64>,
         order_attributes: &[String],
         order_types: &[String],
-        _cursor: Option<&Document>,
-        _cursor_direction: &str,
+        cursor: Option<&Document>,
+        cursor_direction: &str,
         _for_permission: &str,
     ) -> Result<Vec<Document>> {
         let name = filter_key(&collection.get_id());
@@ -1007,25 +1056,47 @@ impl Adapter for SqlAdapter {
                 where_sql.push(fragment);
             }
         }
+
+        // A `cursorBefore` page is the rows *preceding* the cursor, which SQL
+        // can only reach by walking the reversed order and flipping the page
+        // back afterwards.
+        let backwards = cursor_direction == CURSOR_BEFORE;
+        let mut ordered: Vec<(String, bool)> = order_attributes
+            .iter()
+            .enumerate()
+            .map(|(idx, attribute)| {
+                let ascending = order_types
+                    .get(idx)
+                    .map(String::as_str)
+                    .unwrap_or(ORDER_ASC)
+                    .eq_ignore_ascii_case(ORDER_ASC);
+                (Self::internal_key(attribute).to_string(), ascending != backwards)
+            })
+            .collect();
+        if ordered.is_empty() {
+            ordered.push(("_id".to_string(), !backwards));
+        }
+
+        if let Some(cursor) = cursor {
+            if let Some(fragment) = self.cursor_condition(cursor, &ordered, &mut params, &mut i) {
+                where_sql.push(fragment);
+            }
+        }
+
         let mut sql = format!("SELECT * FROM {}", self.table(&name));
         if !where_sql.is_empty() {
             sql.push_str(" WHERE ");
             sql.push_str(&where_sql.join(" AND "));
         }
-        if !order_attributes.is_empty() {
-            let mut orders = Vec::new();
-            for (idx, attr) in order_attributes.iter().enumerate() {
-                let dir = order_types
-                    .get(idx)
-                    .map(String::as_str)
-                    .unwrap_or(ORDER_ASC);
-                orders.push(format!("{} {dir}", self.q(Self::internal_key(attr))));
-            }
-            sql.push_str(" ORDER BY ");
-            sql.push_str(&orders.join(", "));
-        } else {
-            sql.push_str(&format!(" ORDER BY {}", self.q("_id")));
-        }
+        let orders: Vec<String> = ordered
+            .iter()
+            .map(|(column, ascending)| {
+                let direction = if *ascending { ORDER_ASC } else { ORDER_DESC };
+                format!("{} {direction}", self.q(column))
+            })
+            .collect();
+        sql.push_str(" ORDER BY ");
+        sql.push_str(&orders.join(", "));
         if let Some(limit) = limit {
             sql.push_str(&format!(" LIMIT {limit}"));
         }
@@ -1037,7 +1108,11 @@ impl Adapter for SqlAdapter {
             .map(|(k, v)| (k.as_str(), v.clone()))
             .collect();
         let rows = self.pdo.query(&sql, &refs)?;
-        Ok(rows.into_iter().map(row_to_document).collect())
+        let mut documents: Vec<Document> = rows.into_iter().map(row_to_document).collect();
+        if backwards {
+            documents.reverse();
+        }
+        Ok(documents)
     }
 
     fn count(&mut self, collection: &Document, queries: &[Query], max: Option<i64>) -> Result<i64> {

--- a/3.x.x/crates/utopia-database/src/adapter/sql.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/sql.rs
@@ -4,7 +4,7 @@ use crate::adapter::{filter_key, Adapter, AdapterState};
 use crate::constants::*;
 use crate::document::Document;
 use crate::error::{DatabaseError, Result};
-use crate::pdo::{Dialect, Pdo, SqlParam};
+use crate::sql_client::{Dialect, SqlClient, SqlParam};
 use crate::query::{
     Query, TYPE_BETWEEN, TYPE_CONTAINS, TYPE_CONTAINS_ALL, TYPE_CONTAINS_ANY, TYPE_ENDS_WITH,
     TYPE_EQUAL, TYPE_GREATER, TYPE_GREATER_EQUAL, TYPE_IS_NOT_NULL, TYPE_IS_NULL, TYPE_LESSER,
@@ -60,31 +60,31 @@ pub fn collection_attributes(collection: &Document) -> Vec<Document> {
     }
 }
 
-/// PHP `Utopia\Database\Adapter\SQL` - PDO-backed SQL adapter.
+/// Shared SQL adapter helpers used by MySQL, MariaDB, Postgres, and SQLite.
 #[derive(Debug)]
 pub struct Sql {
     state: AdapterState,
-    pdo: Option<Pdo>,
+    client: Option<SqlClient>,
     float_precision: i32,
 }
 
 impl Sql {
-    /// PHP `__construct($pdo)`.
+    /// Wrap a live [`SqlClient`].
     #[must_use]
-    pub fn new(pdo: Pdo) -> Self {
+    pub fn new(client: SqlClient) -> Self {
         Self {
             state: AdapterState::default(),
-            pdo: Some(pdo),
+            client: Some(client),
             float_precision: 17,
         }
     }
 
-    /// Construct without an open PDO (used by feature-gated stubs).
+    /// Construct without an open client (used by feature-gated stubs).
     #[must_use]
     pub fn disconnected() -> Self {
         Self {
             state: AdapterState::default(),
-            pdo: None,
+            client: None,
             float_precision: 17,
         }
     }
@@ -103,10 +103,10 @@ impl Sql {
         )
     }
 
-    /// The wrapped PDO, if any.
+    /// The wrapped SQL client, if any.
     #[must_use]
-    pub fn pdo(&self) -> Option<&Pdo> {
-        self.pdo.as_ref()
+    pub fn client(&self) -> Option<&SqlClient> {
+        self.client.as_ref()
     }
 }
 
@@ -129,18 +129,18 @@ pub type SqlResult<T> = Result<T>;
 #[derive(Debug)]
 pub struct SqlAdapter {
     state: AdapterState,
-    pdo: Pdo,
+    client: SqlClient,
     dialect: Dialect,
 }
 
 impl SqlAdapter {
-    /// Wrap an open PDO.
+    /// Wrap an open [`SqlClient`].
     #[must_use]
-    pub fn new(pdo: Pdo) -> Self {
-        let dialect = pdo.dialect();
+    pub fn new(client: SqlClient) -> Self {
+        let dialect = client.dialect();
         Self {
             state: AdapterState::default(),
-            pdo,
+            client,
             dialect,
         }
     }
@@ -188,8 +188,8 @@ impl SqlAdapter {
         }
     }
 
-    fn pdo_mut(&mut self) -> &mut Pdo {
-        &mut self.pdo
+    fn client_mut(&mut self) -> &mut SqlClient {
+        &mut self.client
     }
 
     /// PHP `getSQLCondition`: one query to one WHERE fragment, pushing its
@@ -498,15 +498,15 @@ impl Adapter for SqlAdapter {
     }
 
     fn ping(&mut self) -> bool {
-        self.pdo.ping().unwrap_or(false)
+        self.client.ping().unwrap_or(false)
     }
 
     fn start_transaction(&mut self) -> Result<bool> {
         if self.state.in_transaction == 0 {
-            self.pdo.exec("BEGIN", &[])?;
+            self.client.exec("BEGIN", &[])?;
         } else {
             let sql = format!("SAVEPOINT transaction{}", self.state.in_transaction);
-            self.pdo.exec(&sql, &[])?;
+            self.client.exec(&sql, &[])?;
         }
         self.state.in_transaction += 1;
         Ok(true)
@@ -517,13 +517,13 @@ impl Adapter for SqlAdapter {
             return Ok(false);
         }
         if self.state.in_transaction == 1 {
-            self.pdo.exec("COMMIT", &[])?;
+            self.client.exec("COMMIT", &[])?;
         } else {
             let sql = format!(
                 "RELEASE SAVEPOINT transaction{}",
                 self.state.in_transaction - 1
             );
-            self.pdo.exec(&sql, &[])?;
+            self.client.exec(&sql, &[])?;
         }
         self.state.in_transaction -= 1;
         Ok(true)
@@ -534,13 +534,13 @@ impl Adapter for SqlAdapter {
             return Ok(false);
         }
         if self.state.in_transaction == 1 {
-            self.pdo.exec("ROLLBACK", &[])?;
+            self.client.exec("ROLLBACK", &[])?;
         } else {
             let sql = format!(
                 "ROLLBACK TO SAVEPOINT transaction{}",
                 self.state.in_transaction - 1
             );
-            self.pdo.exec(&sql, &[])?;
+            self.client.exec(&sql, &[])?;
         }
         self.state.in_transaction -= 1;
         Ok(true)
@@ -555,10 +555,10 @@ impl Adapter for SqlAdapter {
                     return Ok(true);
                 }
                 let sql = format!("CREATE SCHEMA {}", self.q(&name));
-                self.pdo.exec(&sql, &[])?;
+                self.client.exec(&sql, &[])?;
                 for ext in ["postgis", "vector", "pg_trgm"] {
                     let _ = self
-                        .pdo
+                        .client
                         .exec(&format!("CREATE EXTENSION IF NOT EXISTS {ext}"), &[]);
                 }
                 Ok(true)
@@ -571,7 +571,7 @@ impl Adapter for SqlAdapter {
                     "CREATE DATABASE {} /*!40100 DEFAULT CHARACTER SET utf8mb4 */",
                     self.q(&name)
                 );
-                self.pdo.exec(&sql, &[])?;
+                self.client.exec(&sql, &[])?;
                 Ok(true)
             }
         }
@@ -583,7 +583,7 @@ impl Adapter for SqlAdapter {
             (Dialect::Sqlite, None) => Ok(true),
             (Dialect::Sqlite, Some(collection)) => {
                 let table = format!("{}_{}", self.state.namespace, filter_key(collection));
-                let rows = self.pdo.query(
+                let rows = self.client.query(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name = :table",
                     &[(":table", SqlParam::from_str(table.clone()))],
                 )?;
@@ -592,7 +592,7 @@ impl Adapter for SqlAdapter {
                     .any(|r| r.get("name").and_then(AttrValue::as_str) == Some(table.as_str())))
             }
             (Dialect::Postgres, None) => {
-                let rows = self.pdo.query(
+                let rows = self.client.query(
                     "SELECT schema_name FROM information_schema.schemata WHERE schema_name = :schema",
                     &[(":schema", SqlParam::from_str(database))],
                 )?;
@@ -600,7 +600,7 @@ impl Adapter for SqlAdapter {
             }
             (Dialect::Postgres, Some(collection)) => {
                 let table = format!("{}_{}", self.state.namespace, filter_key(collection));
-                let rows = self.pdo.query(
+                let rows = self.client.query(
                     "SELECT table_name FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table",
                     &[
                         (":schema", SqlParam::from_str(database)),
@@ -610,7 +610,7 @@ impl Adapter for SqlAdapter {
                 Ok(!rows.is_empty())
             }
             (_, None) => {
-                let rows = self.pdo.query(
+                let rows = self.client.query(
                     "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = :schema",
                     &[(":schema", SqlParam::from_str(database))],
                 )?;
@@ -618,7 +618,7 @@ impl Adapter for SqlAdapter {
             }
             (_, Some(collection)) => {
                 let table = format!("{}_{}", self.state.namespace, filter_key(collection));
-                let rows = self.pdo.query(
+                let rows = self.client.query(
                     "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table",
                     &[
                         (":schema", SqlParam::from_str(database)),
@@ -636,12 +636,12 @@ impl Adapter for SqlAdapter {
             Dialect::Sqlite => Ok(true),
             Dialect::Postgres => {
                 let sql = format!("DROP SCHEMA IF EXISTS {} CASCADE", self.q(&name));
-                self.pdo.exec(&sql, &[])?;
+                self.client.exec(&sql, &[])?;
                 Ok(true)
             }
             Dialect::Mysql | Dialect::Mariadb => {
                 let sql = format!("DROP DATABASE IF EXISTS {}", self.q(&name));
-                self.pdo.exec(&sql, &[])?;
+                self.client.exec(&sql, &[])?;
                 Ok(true)
             }
         }
@@ -758,8 +758,8 @@ impl Adapter for SqlAdapter {
                 ),
             ),
         };
-        self.pdo.exec(&collection_sql, &[])?;
-        self.pdo.exec(&perms_sql, &[])?;
+        self.client.exec(&collection_sql, &[])?;
+        self.client.exec(&perms_sql, &[])?;
         Ok(true)
     }
 
@@ -769,13 +769,13 @@ impl Adapter for SqlAdapter {
         let perms = self.table(&format!("{id}_perms"));
         match self.dialect {
             Dialect::Sqlite => {
-                self.pdo
+                self.client
                     .exec(&format!("DROP TABLE IF EXISTS {table}"), &[])?;
-                self.pdo
+                self.client
                     .exec(&format!("DROP TABLE IF EXISTS {perms}"), &[])?;
             }
             _ => {
-                self.pdo
+                self.client
                     .exec(&format!("DROP TABLE IF EXISTS {table}, {perms}"), &[])?;
             }
         }
@@ -798,7 +798,7 @@ impl Adapter for SqlAdapter {
             self.table(collection),
             self.q(&filter_key(id))
         );
-        self.pdo.exec(&sql, &[])?;
+        self.client.exec(&sql, &[])?;
         Ok(true)
     }
 
@@ -808,7 +808,7 @@ impl Adapter for SqlAdapter {
             self.table(collection),
             self.q(&filter_key(id))
         );
-        self.pdo.exec(&sql, &[])?;
+        self.client.exec(&sql, &[])?;
         Ok(true)
     }
 
@@ -819,7 +819,7 @@ impl Adapter for SqlAdapter {
             self.q(&filter_key(old)),
             self.q(&filter_key(new))
         );
-        self.pdo.exec(&sql, &[])?;
+        self.client.exec(&sql, &[])?;
         Ok(true)
     }
 
@@ -842,7 +842,7 @@ impl Adapter for SqlAdapter {
             self.q("_uid")
         );
         let rows = self
-            .pdo_mut()
+            .client_mut()
             .query(&sql, &[(":_uid", SqlParam::from_str(id))])?;
         Ok(rows
             .into_iter()
@@ -917,7 +917,7 @@ impl Adapter for SqlAdapter {
             .map(|(k, v)| (k.as_str(), v.clone()))
             .collect();
         if self.dialect == Dialect::Postgres {
-            let rows = self.pdo.query(&sql, &param_refs)?;
+            let rows = self.client.query(&sql, &param_refs)?;
             if let Some(id) = rows
                 .first()
                 .and_then(|r| r.get("_id"))
@@ -926,8 +926,8 @@ impl Adapter for SqlAdapter {
                 document.set_attribute("$sequence", AttrValue::from(id));
             }
         } else {
-            self.pdo.exec(&sql, &param_refs)?;
-            let id = self.pdo.last_insert_id().to_owned();
+            self.client.exec(&sql, &param_refs)?;
+            let id = self.client.last_insert_id().to_owned();
             if id.is_empty() || id == "0" {
                 return Err(DatabaseError::database(
                     "Error creating document empty \"$sequence\"",
@@ -961,7 +961,7 @@ impl Adapter for SqlAdapter {
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.clone()))
                 .collect();
-            let _ = self.pdo.exec(&sql, &refs);
+            let _ = self.client.exec(&sql, &refs);
         }
         Ok(document)
     }
@@ -1012,13 +1012,13 @@ impl Adapter for SqlAdapter {
             .iter()
             .map(|(k, v)| (k.as_str(), v.clone()))
             .collect();
-        self.pdo.exec(&sql, &refs)?;
+        self.client.exec(&sql, &refs)?;
         Ok(document)
     }
 
     fn delete_document(&mut self, collection: &str, id: &str) -> Result<bool> {
         let name = filter_key(collection);
-        self.pdo.exec(
+        self.client.exec(
             &format!(
                 "DELETE FROM {} WHERE {} = :_uid",
                 self.table(&name),
@@ -1026,7 +1026,7 @@ impl Adapter for SqlAdapter {
             ),
             &[(":_uid", SqlParam::from_str(id))],
         )?;
-        self.pdo.exec(
+        self.client.exec(
             &format!(
                 "DELETE FROM {} WHERE {} = :_uid",
                 self.table(&format!("{name}_perms")),
@@ -1113,7 +1113,7 @@ impl Adapter for SqlAdapter {
             .iter()
             .map(|(k, v)| (k.as_str(), v.clone()))
             .collect();
-        let rows = self.pdo.query(&sql, &refs)?;
+        let rows = self.client.query(&sql, &refs)?;
         let mut documents: Vec<Document> = rows.into_iter().map(row_to_document).collect();
         if backwards {
             documents.reverse();

--- a/3.x.x/crates/utopia-database/src/adapter/sql.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/sql.rs
@@ -6,8 +6,10 @@ use crate::document::Document;
 use crate::error::{DatabaseError, Result};
 use crate::pdo::{Dialect, Pdo, SqlParam};
 use crate::query::{
-    Query, TYPE_EQUAL, TYPE_GREATER, TYPE_GREATER_EQUAL, TYPE_IS_NOT_NULL, TYPE_IS_NULL,
-    TYPE_LESSER, TYPE_LESSER_EQUAL, TYPE_NOT_EQUAL,
+    Query, TYPE_BETWEEN, TYPE_CONTAINS, TYPE_CONTAINS_ALL, TYPE_CONTAINS_ANY, TYPE_ENDS_WITH,
+    TYPE_EQUAL, TYPE_GREATER, TYPE_GREATER_EQUAL, TYPE_IS_NOT_NULL, TYPE_IS_NULL, TYPE_LESSER,
+    TYPE_LESSER_EQUAL, TYPE_NOT_BETWEEN, TYPE_NOT_CONTAINS, TYPE_NOT_ENDS_WITH, TYPE_NOT_EQUAL,
+    TYPE_NOT_SEARCH, TYPE_NOT_STARTS_WITH, TYPE_OR, TYPE_SEARCH, TYPE_STARTS_WITH,
 };
 use crate::value::AttrValue;
 use indexmap::IndexMap;
@@ -189,6 +191,250 @@ impl SqlAdapter {
     fn pdo_mut(&mut self) -> &mut Pdo {
         &mut self.pdo
     }
+
+    /// PHP `getSQLCondition`: one query to one WHERE fragment, pushing its
+    /// binds onto `params`. `arrays` names the collection's array attributes,
+    /// which decide whether `contains` is a JSON containment test or a LIKE.
+    /// Returns `None` for a query that contributes no WHERE fragment (ordering
+    /// and paging are applied by the caller).
+    fn sql_condition(
+        &self,
+        query: &Query,
+        arrays: &[String],
+        params: &mut Vec<(String, SqlParam)>,
+        next: &mut usize,
+    ) -> Option<String> {
+        let method = query.get_method();
+        if query.is_nested() {
+            let joined = query
+                .get_values()
+                .iter()
+                .filter_map(AttrValue::as_query)
+                .filter_map(|inner| self.sql_condition(inner, arrays, params, next))
+                .collect::<Vec<_>>();
+            if joined.is_empty() {
+                return None;
+            }
+            let separator = if method == TYPE_OR { " OR " } else { " AND " };
+            return Some(format!("({})", joined.join(separator)));
+        }
+
+        let attribute = Self::internal_key(query.get_attribute());
+        let column = self.q(attribute);
+        let on_array = query.on_array() || arrays.iter().any(|key| key == attribute);
+        let mut bind = |params: &mut Vec<(String, SqlParam)>, value: SqlParam| -> String {
+            let key = format!(":f{next}");
+            *next += 1;
+            params.push((key.clone(), value));
+            key
+        };
+
+        match method {
+            TYPE_EQUAL | TYPE_NOT_EQUAL | TYPE_LESSER | TYPE_LESSER_EQUAL | TYPE_GREATER
+            | TYPE_GREATER_EQUAL => {
+                let op = match method {
+                    TYPE_EQUAL => "=",
+                    TYPE_NOT_EQUAL => "!=",
+                    TYPE_LESSER => "<",
+                    TYPE_LESSER_EQUAL => "<=",
+                    TYPE_GREATER => ">",
+                    _ => ">=",
+                };
+                if method == TYPE_EQUAL && query.get_values().len() > 1 {
+                    let keys: Vec<String> = query
+                        .get_values()
+                        .iter()
+                        .map(|value| bind(params, SqlParam::from_attr(value)))
+                        .collect();
+                    Some(format!("{column} IN ({})", keys.join(", ")))
+                } else {
+                    let key = bind(params, SqlParam::from_attr(query.get_value()));
+                    Some(format!("{column} {op} {key}"))
+                }
+            }
+            TYPE_IS_NULL => Some(format!("{column} IS NULL")),
+            TYPE_IS_NOT_NULL => Some(format!("{column} IS NOT NULL")),
+            TYPE_BETWEEN | TYPE_NOT_BETWEEN => {
+                let values = query.get_values();
+                let (low, high) = (values.first()?, values.get(1)?);
+                let low = bind(params, SqlParam::from_attr(low));
+                let high = bind(params, SqlParam::from_attr(high));
+                let not = if method == TYPE_NOT_BETWEEN { "NOT " } else { "" };
+                Some(format!("{column} {not}BETWEEN {low} AND {high}"))
+            }
+            TYPE_SEARCH | TYPE_NOT_SEARCH => {
+                let value = fulltext_value(query.get_value().as_str().unwrap_or_default(), self.dialect);
+                if value.is_empty() {
+                    return None;
+                }
+                let key = bind(params, SqlParam::from_str(&value));
+                let matches = match self.dialect {
+                    // Appwrite's Postgres adapter normalizes punctuation out of
+                    // the column before matching, so `label:x` and `a@b.com`
+                    // tokenize the same way they do in the query text.
+                    Dialect::Postgres => format!(
+                        "to_tsvector(regexp_replace({column}, '[^\\w]+',' ','g')) @@ websearch_to_tsquery({key})"
+                    ),
+                    Dialect::Mysql | Dialect::Mariadb => {
+                        format!("MATCH({column}) AGAINST ({key} IN BOOLEAN MODE)")
+                    }
+                    Dialect::Sqlite => format!("{column} LIKE {key}"),
+                };
+                Some(if method == TYPE_NOT_SEARCH {
+                    format!("NOT ({matches})")
+                } else {
+                    matches
+                })
+            }
+            TYPE_STARTS_WITH | TYPE_NOT_STARTS_WITH | TYPE_ENDS_WITH | TYPE_NOT_ENDS_WITH
+            | TYPE_CONTAINS | TYPE_NOT_CONTAINS | TYPE_CONTAINS_ANY | TYPE_CONTAINS_ALL => {
+                let negated = matches!(
+                    method,
+                    TYPE_NOT_STARTS_WITH | TYPE_NOT_ENDS_WITH | TYPE_NOT_CONTAINS
+                );
+                let fragments = if on_array {
+                    self.array_containment(method, &column, query, params, next)
+                } else {
+                    query
+                        .get_values()
+                        .iter()
+                        .map(|value| {
+                            let raw = value.as_str().unwrap_or_default();
+                            let escaped = escape_wildcards(raw);
+                            let pattern = match method {
+                                TYPE_STARTS_WITH | TYPE_NOT_STARTS_WITH => format!("{escaped}%"),
+                                TYPE_ENDS_WITH | TYPE_NOT_ENDS_WITH => format!("%{escaped}"),
+                                _ => format!("%{escaped}%"),
+                            };
+                            let key = bind(params, SqlParam::from_str(&pattern));
+                            format!("{column} LIKE {key}")
+                        })
+                        .collect()
+                };
+                if fragments.is_empty() {
+                    return None;
+                }
+                let joined = fragments.join(if negated { " AND " } else { " OR " });
+                Some(if negated {
+                    format!("NOT ({joined})")
+                } else {
+                    format!("({joined})")
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// The `contains`-family fragments for an array attribute: JSON
+    /// containment rather than a substring match. `containsAll` tests the
+    /// whole value list at once, the others test each value separately.
+    fn array_containment(
+        &self,
+        method: &str,
+        column: &str,
+        query: &Query,
+        params: &mut Vec<(String, SqlParam)>,
+        next: &mut usize,
+    ) -> Vec<String> {
+        let encode = |value: &AttrValue| serde_json::to_string(&value.to_json()).unwrap_or_default();
+        let payloads: Vec<String> = if method == TYPE_CONTAINS_ALL {
+            let all: Vec<serde_json::Value> =
+                query.get_values().iter().map(AttrValue::to_json).collect();
+            vec![serde_json::to_string(&all).unwrap_or_default()]
+        } else {
+            query
+                .get_values()
+                .iter()
+                .map(|value| serde_json::to_string(&vec![value.to_json()]).unwrap_or(encode(value)))
+                .collect()
+        };
+        payloads
+            .into_iter()
+            .map(|payload| {
+                let key = format!(":f{next}");
+                *next += 1;
+                params.push((key.clone(), SqlParam::from_str(&payload)));
+                match self.dialect {
+                    Dialect::Postgres => format!("{column} @> {key}::jsonb"),
+                    Dialect::Mysql | Dialect::Mariadb => {
+                        format!("JSON_CONTAINS({column}, {key})")
+                    }
+                    Dialect::Sqlite => format!("{column} LIKE '%' || {key} || '%'"),
+                }
+            })
+            .collect()
+    }
+}
+
+/// The `key`s of a collection's array attributes, which `contains` queries
+/// have to treat as JSON documents rather than strings.
+fn array_attributes(collection: &Document) -> Vec<String> {
+    collection_attributes(collection)
+        .iter()
+        .filter(|attribute| attribute.get_attribute("array").as_bool().unwrap_or(false))
+        .map(|attribute| {
+            let key = attribute.get_attribute("key");
+            let key = if key.is_null() {
+                attribute.get_attribute("$id")
+            } else {
+                key
+            };
+            key.as_str().unwrap_or_default().to_string()
+        })
+        .collect()
+}
+
+/// PHP `escapeWildcards`.
+fn escape_wildcards(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(ch, '%' | '_' | '[' | ']' | '^' | '\\') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+/// PHP `getFulltextValue`, which differs per engine: Postgres builds a
+/// `websearch_to_tsquery` string, MySQL/MariaDB a boolean-mode term.
+fn fulltext_value(value: &str, dialect: Dialect) -> String {
+    let exact = value.len() > 1 && value.starts_with('"') && value.ends_with('"');
+    match dialect {
+        Dialect::Postgres => {
+            let cleaned = collapse_whitespace(&value.replace(
+                ['@', '+', '-', '*', '.', '\'', '"'],
+                " ",
+            ));
+            if cleaned.is_empty() {
+                return String::new();
+            }
+            let joined = if exact {
+                cleaned
+            } else {
+                cleaned.split(' ').collect::<Vec<_>>().join(" or ")
+            };
+            format!("'{joined}'")
+        }
+        _ => {
+            let cleaned = collapse_whitespace(&value.replace(
+                ['@', '+', '-', '*', ')', '(', '<', '>', '~', '"'],
+                " ",
+            ));
+            if cleaned.is_empty() {
+                return String::new();
+            }
+            if exact {
+                format!("\"{cleaned}\"")
+            } else {
+                format!("{cleaned}*")
+            }
+        }
+    }
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 impl Adapter for SqlAdapter {
@@ -752,49 +998,13 @@ impl Adapter for SqlAdapter {
         _for_permission: &str,
     ) -> Result<Vec<Document>> {
         let name = filter_key(&collection.get_id());
+        let arrays = array_attributes(collection);
         let mut where_sql = Vec::new();
         let mut params: Vec<(String, SqlParam)> = Vec::new();
         let mut i = 0;
         for query in queries {
-            match query.get_method() {
-                TYPE_EQUAL | TYPE_NOT_EQUAL | TYPE_LESSER | TYPE_LESSER_EQUAL | TYPE_GREATER
-                | TYPE_GREATER_EQUAL => {
-                    let column = Self::internal_key(query.get_attribute());
-                    let op = match query.get_method() {
-                        TYPE_EQUAL => "=",
-                        TYPE_NOT_EQUAL => "!=",
-                        TYPE_LESSER => "<",
-                        TYPE_LESSER_EQUAL => "<=",
-                        TYPE_GREATER => ">",
-                        _ => ">=",
-                    };
-                    if query.get_method() == TYPE_EQUAL && query.get_values().len() > 1 {
-                        let mut keys = Vec::new();
-                        for value in query.get_values() {
-                            let key = format!(":f{i}");
-                            keys.push(key.clone());
-                            params.push((key, SqlParam::from_attr(value)));
-                            i += 1;
-                        }
-                        where_sql.push(format!("{} IN ({})", self.q(column), keys.join(", ")));
-                    } else {
-                        let key = format!(":f{i}");
-                        where_sql.push(format!("{} {op} {key}", self.q(column)));
-                        params.push((key, SqlParam::from_attr(query.get_value())));
-                        i += 1;
-                    }
-                }
-                TYPE_IS_NULL => where_sql.push(format!(
-                    "{} IS NULL",
-                    self.q(Self::internal_key(query.get_attribute()))
-                )),
-                TYPE_IS_NOT_NULL => {
-                    where_sql.push(format!(
-                        "{} IS NOT NULL",
-                        self.q(Self::internal_key(query.get_attribute()))
-                    ));
-                }
-                _ => {}
+            if let Some(fragment) = self.sql_condition(query, &arrays, &mut params, &mut i) {
+                where_sql.push(fragment);
             }
         }
         let mut sql = format!("SELECT * FROM {}", self.table(&name));

--- a/3.x.x/crates/utopia-database/src/adapter/sqlite.rs
+++ b/3.x.x/crates/utopia-database/src/adapter/sqlite.rs
@@ -3,7 +3,7 @@
 use super::sql::{quote_mysql, SqlAdapter};
 use crate::error::Result;
 use crate::impl_sql_engine;
-use crate::pdo::Pdo;
+use crate::sql_client::SqlClient;
 
 /// SQLite adapter.
 #[derive(Debug)]
@@ -19,17 +19,17 @@ impl Sqlite {
 
     /// Open a SQLite database at `path` (`:memory:` allowed).
     pub fn open(path: impl AsRef<str>) -> Result<Self> {
-        let pdo = Pdo::sqlite(path.as_ref())?;
+        let client = SqlClient::sqlite(path.as_ref())?;
         Ok(Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         })
     }
 
-    /// Wrap an existing PDO.
+    /// Wrap an existing [`SqlClient`].
     #[must_use]
-    pub fn from_pdo(pdo: Pdo) -> Self {
+    pub fn from_client(client: SqlClient) -> Self {
         Self {
-            inner: SqlAdapter::new(pdo),
+            inner: SqlAdapter::new(client),
         }
     }
 

--- a/3.x.x/crates/utopia-database/src/database.rs
+++ b/3.x.x/crates/utopia-database/src/database.rs
@@ -1463,6 +1463,15 @@ impl<A: Adapter> Database<A> {
         if collection_doc.is_empty() {
             return Err(DatabaseError::not_found("Collection not found"));
         }
+        let collection_id = collection_doc.get_id();
+        // PHP loads the stored document first and merges the caller's partial
+        // update over it, so callers can (and by Appwrite convention do) pass
+        // only the changed attributes and still get the whole document back.
+        let old = self
+            .skip_authorization(|db| db.silent(|db| db.get_document(&collection_id, id, &[], true)))?;
+        if old.is_empty() {
+            return Ok(Document::new());
+        }
         if collection_doc.get_id() != METADATA {
             let mut perms = collection_doc.get_update();
             let security = collection_doc
@@ -1470,6 +1479,7 @@ impl<A: Adapter> Database<A> {
                 .as_bool()
                 .unwrap_or(false);
             if security {
+                perms.extend(old.get_update());
                 perms.extend(document.get_update());
             }
             if !self
@@ -1482,11 +1492,21 @@ impl<A: Adapter> Database<A> {
                 ));
             }
         }
+        let created_at = document.get_attribute("$createdAt").clone();
+        document = merge_over(&old, document);
+        if !self.preserve_dates || matches!(created_at, AttrValue::Null) {
+            document.set_attribute("$createdAt", old.get_attribute("$createdAt").clone());
+        }
         if !self.preserve_dates {
             document.set_attribute("$updatedAt", AttrValue::from(DateTime::now()));
         }
         document.set_attribute("$id", AttrValue::from(id));
         document.set_attribute("$collection", AttrValue::from(collection_doc.get_id()));
+        // `$sequence` is immutable in PHP; carry the stored value forward so a
+        // partial update cannot drop or rewrite it.
+        if !matches!(old.get_attribute("$sequence"), AttrValue::Null) {
+            document.set_attribute("$sequence", old.get_attribute("$sequence").clone());
+        }
         document = self.encode(&collection_doc, document, false)?;
         document = self
             .adapter
@@ -2125,6 +2145,17 @@ impl<A: Adapter> Database<A> {
         });
         hex::encode(Md5::digest(payload.to_string().as_bytes()))
     }
+}
+
+/// PHP `\array_merge($old->getArrayCopy(), $document->getArrayCopy())`:
+/// `update`'s attributes win, `old`'s order is preserved for the keys they
+/// share, and keys only `old` has are carried through untouched.
+fn merge_over(old: &Document, update: Document) -> Document {
+    let mut merged: IndexMap<String, AttrValue> = old.get_array_copy(&[], &[]);
+    for (key, value) in update.iter() {
+        merged.insert(key.clone(), value.clone());
+    }
+    Document::from_map(merged).unwrap_or(update)
 }
 
 fn encode_json(value: &AttrValue) -> AttrValue {

--- a/3.x.x/crates/utopia-database/src/database.rs
+++ b/3.x.x/crates/utopia-database/src/database.rs
@@ -1467,8 +1467,9 @@ impl<A: Adapter> Database<A> {
         // PHP loads the stored document first and merges the caller's partial
         // update over it, so callers can (and by Appwrite convention do) pass
         // only the changed attributes and still get the whole document back.
-        let old = self
-            .skip_authorization(|db| db.silent(|db| db.get_document(&collection_id, id, &[], true)))?;
+        let old = self.skip_authorization(|db| {
+            db.silent(|db| db.get_document(&collection_id, id, &[], true))
+        })?;
         if old.is_empty() {
             return Ok(Document::new());
         }

--- a/3.x.x/crates/utopia-database/src/lib.rs
+++ b/3.x.x/crates/utopia-database/src/lib.rs
@@ -90,7 +90,7 @@ pub mod error;
 pub mod helpers;
 pub mod mirror;
 pub mod operator;
-pub mod pdo;
+pub mod sql_client;
 pub mod query;
 pub mod validator;
 pub mod value;
@@ -106,10 +106,7 @@ pub use error::{DatabaseError, Result};
 pub use helpers::{Id, Permission, Role};
 pub use mirror::{AllowAllFilter, Mirror, MirrorFilter};
 pub use operator::Operator;
-pub use pdo::{
-    Dialect, Pdo, PdoStatement, SqlParam, ATTR_TIMEOUT, PARAM_BOOL, PARAM_INT, PARAM_LOB,
-    PARAM_NULL, PARAM_STR,
-};
+pub use sql_client::{Dialect, SqlClient, SqlParam, SqlStatement};
 pub use query::{GroupedQueries, Query};
 pub use validator::authorization::{Authorization, Input};
 pub use value::AttrValue;
@@ -121,6 +118,6 @@ pub mod prelude {
     pub use crate::query::Query;
     pub use crate::{
         Adapter, AttrValue, Authorization, Change, Connection, Database, DatabaseError, DateTime,
-        Document, Operator, Pdo,
+        Document, Operator, SqlClient,
     };
 }

--- a/3.x.x/crates/utopia-database/src/pdo.rs
+++ b/3.x.x/crates/utopia-database/src/pdo.rs
@@ -602,13 +602,116 @@ impl postgres::types::ToSql for PgFlexible {
     postgres::types::to_sql_checked!();
 }
 
+/// A bound integer. `i64`'s own `ToSql` accepts `INT8` only, so binding one
+/// to a narrower column (`tokens.type` is `INT4`) fails with "error
+/// serializing parameter N". Widen/narrow against the column type the way the
+/// PHP driver's untyped bind does.
+#[cfg(feature = "postgres")]
+#[derive(Debug)]
+struct PgInt(i64);
+
+#[cfg(feature = "postgres")]
+impl postgres::types::ToSql for PgInt {
+    fn to_sql(
+        &self,
+        ty: &postgres::types::Type,
+        out: &mut bytes::BytesMut,
+    ) -> Result<postgres::types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        use postgres::types::{Json, Type};
+        match *ty {
+            Type::INT2 => i16::try_from(self.0)?.to_sql(ty, out),
+            Type::INT4 => i32::try_from(self.0)?.to_sql(ty, out),
+            Type::INT8 => self.0.to_sql(ty, out),
+            #[allow(clippy::cast_precision_loss)]
+            Type::FLOAT4 => (self.0 as f32).to_sql(ty, out),
+            #[allow(clippy::cast_precision_loss)]
+            Type::FLOAT8 => (self.0 as f64).to_sql(ty, out),
+            Type::BOOL => (self.0 != 0).to_sql(ty, out),
+            Type::JSON | Type::JSONB => Json(serde_json::json!(self.0)).to_sql(ty, out),
+            _ => self.0.to_string().to_sql(ty, out),
+        }
+    }
+
+    fn accepts(_ty: &postgres::types::Type) -> bool {
+        true
+    }
+
+    postgres::types::to_sql_checked!();
+}
+
+/// A bound float, widened/narrowed like [`PgInt`] (`f64` accepts `FLOAT8`
+/// only, so a `real` column would otherwise fail).
+#[cfg(feature = "postgres")]
+#[derive(Debug)]
+struct PgFloat(f64);
+
+#[cfg(feature = "postgres")]
+impl postgres::types::ToSql for PgFloat {
+    fn to_sql(
+        &self,
+        ty: &postgres::types::Type,
+        out: &mut bytes::BytesMut,
+    ) -> Result<postgres::types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        use postgres::types::{Json, Type};
+        #[allow(clippy::cast_possible_truncation)]
+        match *ty {
+            Type::FLOAT4 => (self.0 as f32).to_sql(ty, out),
+            Type::FLOAT8 => self.0.to_sql(ty, out),
+            Type::INT2 => (self.0 as i16).to_sql(ty, out),
+            Type::INT4 => (self.0 as i32).to_sql(ty, out),
+            Type::INT8 => (self.0 as i64).to_sql(ty, out),
+            Type::BOOL => (self.0 != 0.0).to_sql(ty, out),
+            Type::JSON | Type::JSONB => Json(serde_json::json!(self.0)).to_sql(ty, out),
+            _ => self.0.to_string().to_sql(ty, out),
+        }
+    }
+
+    fn accepts(_ty: &postgres::types::Type) -> bool {
+        true
+    }
+
+    postgres::types::to_sql_checked!();
+}
+
+/// A bound boolean, which Appwrite also stores in `INT`-typed columns
+/// (`Database::VAR_BOOLEAN` maps to `TINYINT` on MySQL) and in JSON.
+#[cfg(feature = "postgres")]
+#[derive(Debug)]
+struct PgBool(bool);
+
+#[cfg(feature = "postgres")]
+impl postgres::types::ToSql for PgBool {
+    fn to_sql(
+        &self,
+        ty: &postgres::types::Type,
+        out: &mut bytes::BytesMut,
+    ) -> Result<postgres::types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        use postgres::types::{Json, Type};
+        let as_int = i64::from(self.0);
+        match *ty {
+            Type::BOOL => self.0.to_sql(ty, out),
+            Type::INT2 => (as_int as i16).to_sql(ty, out),
+            Type::INT4 => (as_int as i32).to_sql(ty, out),
+            Type::INT8 => as_int.to_sql(ty, out),
+            Type::JSON | Type::JSONB => Json(serde_json::json!(self.0)).to_sql(ty, out),
+            _ => self.0.to_string().to_sql(ty, out),
+        }
+    }
+
+    fn accepts(_ty: &postgres::types::Type) -> bool {
+        true
+    }
+
+    postgres::types::to_sql_checked!();
+}
+
 #[cfg(feature = "postgres")]
 #[derive(Debug)]
 enum PgOwned {
     Null,
-    Bool(bool),
-    I64(i64),
-    F64(f64),
+    Bool(PgBool),
+    I64(PgInt),
+    F64(PgFloat),
     Text(PgFlexible),
 }
 
@@ -619,9 +722,9 @@ fn rewrite_postgres(sql: &str, params: &[(&str, SqlParam)]) -> (String, Vec<PgOw
         .into_iter()
         .map(|v| match v {
             SqlParam::Null => PgOwned::Null,
-            SqlParam::Bool(b) => PgOwned::Bool(b),
-            SqlParam::I64(i) => PgOwned::I64(i),
-            SqlParam::F64(f) => PgOwned::F64(f),
+            SqlParam::Bool(b) => PgOwned::Bool(PgBool(b)),
+            SqlParam::I64(i) => PgOwned::I64(PgInt(i)),
+            SqlParam::F64(f) => PgOwned::F64(PgFloat(f)),
             SqlParam::Text(s) => PgOwned::Text(PgFlexible(s)),
         })
         .collect();
@@ -672,6 +775,20 @@ fn postgres_cell(row: &postgres::Row, column: &postgres::Column) -> AttrValue {
     }
     if let Ok(v) = row.try_get::<_, Option<String>>(idx) {
         return v.map_or(AttrValue::Null, AttrValue::from);
+    }
+    // `datetime`-filtered attributes are real `TIMESTAMP` columns in Postgres
+    // (MySQL/MariaDB hand them back as strings). Render them in the same
+    // `Y-m-d H:i:s.v` shape the `datetime` filter's decode side expects, so
+    // `$createdAt`, `registration`, `accessedAt`, ... do not read back as null.
+    if let Ok(v) = row.try_get::<_, Option<chrono::NaiveDateTime>>(idx) {
+        return v.map_or(AttrValue::Null, |naive| {
+            AttrValue::from(crate::datetime::DateTime::format(naive))
+        });
+    }
+    if let Ok(v) = row.try_get::<_, Option<chrono::DateTime<chrono::Utc>>>(idx) {
+        return v.map_or(AttrValue::Null, |utc| {
+            AttrValue::from(crate::datetime::DateTime::format(utc.naive_utc()))
+        });
     }
     // `array`-typed attributes (`postgres_type`) store as JSON/JSONB, which
     // `postgres`'s `FromSql for String` does not accept -- only

--- a/3.x.x/crates/utopia-database/src/pdo.rs
+++ b/3.x.x/crates/utopia-database/src/pdo.rs
@@ -289,6 +289,18 @@ impl Pdo {
     }
 }
 
+/// The sync `postgres` crate drives tokio-postgres via `Handle::block_on`.
+/// Calling it from an async task panics with "Cannot start a runtime from
+/// within a runtime"; `block_in_place` is the supported escape hatch when a
+/// Tokio worker is already driving the thread (Hyper / `#[tokio::main]`).
+#[cfg(feature = "postgres")]
+fn postgres_blocking<T>(f: impl FnOnce() -> T) -> T {
+    match tokio::runtime::Handle::try_current() {
+        Ok(_) => tokio::task::block_in_place(f),
+        Err(_) => f(),
+    }
+}
+
 #[cfg(feature = "postgres")]
 impl Pdo {
     /// Connect to Postgres.
@@ -300,7 +312,7 @@ impl Pdo {
         db: &str,
     ) -> Result<Self, DatabaseError> {
         let url = format!("host={host} port={port} user={user} password={pass} dbname={db}");
-        let client = postgres::Client::connect(&url, postgres::NoTls)
+        let client = postgres_blocking(|| postgres::Client::connect(&url, postgres::NoTls))
             .map_err(|e| DatabaseError::database(format!("Postgres connect failed: {e}")))?;
         Ok(Self {
             dsn: format!("pgsql:host={host};port={port};dbname={db}"),
@@ -325,8 +337,7 @@ impl Pdo {
             .ok_or_else(|| DatabaseError::database("Postgres PDO is not connected"))?;
         let (sql, owned) = rewrite_postgres(sql, params);
         let refs = postgres_refs(&owned);
-        let n = client
-            .execute(&sql, refs.as_slice())
+        let n = postgres_blocking(|| client.execute(&sql, refs.as_slice()))
             .map_err(|e| map_postgres(&e))?;
         Ok(n)
     }
@@ -342,8 +353,7 @@ impl Pdo {
             .ok_or_else(|| DatabaseError::database("Postgres PDO is not connected"))?;
         let (sql, owned) = rewrite_postgres(sql, params);
         let refs = postgres_refs(&owned);
-        let rows = client
-            .query(&sql, refs.as_slice())
+        let rows = postgres_blocking(|| client.query(&sql, refs.as_slice()))
             .map_err(|e| map_postgres(&e))?;
         Ok(rows.iter().map(postgres_row_to_map).collect())
     }

--- a/3.x.x/crates/utopia-database/src/sql_client.rs
+++ b/3.x.x/crates/utopia-database/src/sql_client.rs
@@ -1,7 +1,12 @@
-//! PHP `Utopia\Database\PDO` / `PDOStatement` wrappers.
+//! Engine-specific SQL client used by the SQL adapters.
 //!
-//! Live connections are compiled behind `mysql`, `postgres`, and `sqlite`
-//! features. The type always exists so call sites compile.
+//! This is the Rust-native connection layer behind
+//! [`crate::adapter::postgres::Postgres`], [`crate::adapter::mysql::Mysql`],
+//! and [`crate::adapter::sqlite::Sqlite`]. Prefer those adapters (and the
+//! high-level [`crate::Database`] API) over talking to [`SqlClient`] directly.
+//!
+//! Live connections are compiled behind the `mysql`, `postgres`, and
+//! `sqlite` features.
 
 use std::collections::HashMap;
 
@@ -10,17 +15,7 @@ use crate::value::AttrValue;
 use indexmap::IndexMap;
 use serde_json::Number;
 
-/// PHP `PDO::PARAM_*` constants.
-pub const PARAM_NULL: i32 = 0;
-pub const PARAM_INT: i32 = 1;
-pub const PARAM_STR: i32 = 2;
-pub const PARAM_LOB: i32 = 3;
-pub const PARAM_BOOL: i32 = 5;
-
-/// Connection timeout attribute (PHP `PDO::ATTR_TIMEOUT`).
-pub const ATTR_TIMEOUT: i32 = 2;
-
-/// SQL dialect used by a live PDO.
+/// SQL dialect spoken by a live [`SqlClient`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Dialect {
     Mysql,
@@ -67,14 +62,14 @@ impl SqlParam {
     }
 }
 
-/// A prepared statement wrapper (PHP `Utopia\Database\PDOStatement`).
+/// A prepared statement helper used by SQL adapters.
 #[derive(Debug, Default)]
-pub struct PdoStatement {
+pub struct SqlStatement {
     query: String,
     params: HashMap<String, String>,
 }
 
-impl PdoStatement {
+impl SqlStatement {
     /// Create a statement for `query`.
     pub fn new(query: impl Into<String>) -> Self {
         Self {
@@ -83,9 +78,8 @@ impl PdoStatement {
         }
     }
 
-    /// Bind a named or positional parameter (PHP `bindValue`).
-    pub fn bind_value(&mut self, param: impl Into<String>, value: impl ToString, _type: i32) {
-        let _ = _type;
+    /// Bind a named or positional parameter.
+    pub fn bind_value(&mut self, param: impl Into<String>, value: impl ToString) {
         self.params.insert(param.into(), value.to_string());
     }
 
@@ -100,8 +94,7 @@ impl PdoStatement {
     }
 }
 
-/// A PDO-like connection (PHP `Utopia\Database\PDO`).
-pub struct Pdo {
+pub struct SqlClient {
     dsn: String,
     dialect: Dialect,
     last_insert_id: String,
@@ -113,16 +106,16 @@ pub struct Pdo {
     sqlite: Option<rusqlite::Connection>,
 }
 
-impl std::fmt::Debug for Pdo {
+impl std::fmt::Debug for SqlClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Pdo")
+        f.debug_struct("SqlClient")
             .field("dsn", &self.dsn)
             .field("dialect", &self.dialect)
             .finish_non_exhaustive()
     }
 }
 
-impl Pdo {
+impl SqlClient {
     /// Connect using a DSN string (PHP constructor). Live I/O requires features.
     pub fn new(dsn: impl Into<String>) -> Result<Self, DatabaseError> {
         let dsn = dsn.into();
@@ -151,8 +144,8 @@ impl Pdo {
     }
 
     /// Prepare a statement (PHP `prepare`).
-    pub fn prepare(&self, query: impl Into<String>) -> PdoStatement {
-        PdoStatement::new(query)
+    pub fn prepare(&self, query: impl Into<String>) -> SqlStatement {
+        SqlStatement::new(query)
     }
 
     /// Quote a string for interpolation (PHP `quote`).
@@ -180,7 +173,7 @@ impl Pdo {
         if self.sqlite.is_some() {
             return self.exec_sqlite(sql, params);
         }
-        Err(DatabaseError::database("PDO is not connected"))
+        Err(DatabaseError::database("SQL client is not connected"))
     }
 
     /// Query rows with named parameters.
@@ -202,7 +195,7 @@ impl Pdo {
         if self.sqlite.is_some() {
             return self.query_sqlite(sql, params);
         }
-        Err(DatabaseError::database("PDO is not connected"))
+        Err(DatabaseError::database("SQL client is not connected"))
     }
 
     /// `SELECT 1` ping.
@@ -212,7 +205,7 @@ impl Pdo {
 }
 
 #[cfg(feature = "mysql")]
-impl Pdo {
+impl SqlClient {
     /// Connect to MySQL / MariaDB.
     pub fn mysql(
         host: &str,
@@ -263,7 +256,7 @@ impl Pdo {
         let conn = self
             .mysql
             .as_mut()
-            .ok_or_else(|| DatabaseError::database("MySQL PDO is not connected"))?;
+            .ok_or_else(|| DatabaseError::database("MySQL SQL client is not connected"))?;
         let (sql, values) = rewrite_mysql(sql, params);
         conn.exec_drop(&sql, mysql::Params::Positional(values))
             .map_err(map_mysql)?;
@@ -280,7 +273,7 @@ impl Pdo {
         let conn = self
             .mysql
             .as_mut()
-            .ok_or_else(|| DatabaseError::database("MySQL PDO is not connected"))?;
+            .ok_or_else(|| DatabaseError::database("MySQL SQL client is not connected"))?;
         let (sql, values) = rewrite_mysql(sql, params);
         let result: Vec<mysql::Row> = conn
             .exec(&sql, mysql::Params::Positional(values))
@@ -302,8 +295,8 @@ fn postgres_blocking<T>(f: impl FnOnce() -> T) -> T {
 }
 
 #[cfg(feature = "postgres")]
-impl Pdo {
-    /// Connect to Postgres.
+impl SqlClient {
+    /// Connect to Postgres via the `postgres` crate.
     pub fn postgres(
         host: &str,
         port: u16,
@@ -334,7 +327,7 @@ impl Pdo {
         let client = self
             .postgres
             .as_mut()
-            .ok_or_else(|| DatabaseError::database("Postgres PDO is not connected"))?;
+            .ok_or_else(|| DatabaseError::database("Postgres SQL client is not connected"))?;
         let (sql, owned) = rewrite_postgres(sql, params);
         let refs = postgres_refs(&owned);
         let n = postgres_blocking(|| client.execute(&sql, refs.as_slice()))
@@ -350,7 +343,7 @@ impl Pdo {
         let client = self
             .postgres
             .as_mut()
-            .ok_or_else(|| DatabaseError::database("Postgres PDO is not connected"))?;
+            .ok_or_else(|| DatabaseError::database("Postgres SQL client is not connected"))?;
         let (sql, owned) = rewrite_postgres(sql, params);
         let refs = postgres_refs(&owned);
         let rows = postgres_blocking(|| client.query(&sql, refs.as_slice()))
@@ -365,8 +358,8 @@ impl Pdo {
 }
 
 #[cfg(feature = "sqlite")]
-impl Pdo {
-    /// Open SQLite at `path` (`:memory:` allowed).
+impl SqlClient {
+    /// Open SQLite at `path` (`:memory:` allowed) via `rusqlite`.
     pub fn sqlite(path: &str) -> Result<Self, DatabaseError> {
         let conn = rusqlite::Connection::open(path)
             .map_err(|e| DatabaseError::database(format!("SQLite open failed: {e}")))?;
@@ -392,7 +385,7 @@ impl Pdo {
         let conn = self
             .sqlite
             .as_mut()
-            .ok_or_else(|| DatabaseError::database("SQLite PDO is not connected"))?;
+            .ok_or_else(|| DatabaseError::database("SQLite SQL client is not connected"))?;
         let (sql, values) = rewrite_sqlite(sql, params);
         let n = conn
             .execute(&sql, rusqlite::params_from_iter(values.iter()))
@@ -409,7 +402,7 @@ impl Pdo {
         let conn = self
             .sqlite
             .as_mut()
-            .ok_or_else(|| DatabaseError::database("SQLite PDO is not connected"))?;
+            .ok_or_else(|| DatabaseError::database("SQLite SQL client is not connected"))?;
         let (sql, values) = rewrite_sqlite(sql, params);
         let mut stmt = conn.prepare(&sql).map_err(map_sqlite)?;
         let column_names: Vec<String> =

--- a/3.x.x/crates/utopia-database/src/validator/queries.rs
+++ b/3.x.x/crates/utopia-database/src/validator/queries.rs
@@ -156,7 +156,15 @@ impl Validator for Queries {
         };
         let mut queries = Vec::new();
         for item in arr {
-            match Query::parse(&item.to_string()) {
+            // A query arrives either already decoded (an object, as when the
+            // caller sent a JSON body) or as the JSON *string* an SDK's
+            // `Query::equal(...)->toString()` produces. Re-encoding the latter
+            // would hand `parse` a quoted string instead of the query.
+            let parsed = match item {
+                Value::String(query) => Query::parse(query),
+                other => Query::parse(&other.to_string()),
+            };
+            match parsed {
                 Ok(q) => queries.push(q),
                 Err(e) => {
                     self.set_message(format!("Invalid query: {}", e.message()));

--- a/3.x.x/crates/utopia-http/src/adapter/hyper.rs
+++ b/3.x.x/crates/utopia-http/src/adapter/hyper.rs
@@ -206,6 +206,7 @@ async fn hyper_to_utopia(req: HyperRequest<Incoming>) -> Result<Request> {
         request.set_raw_payload(raw);
     }
     request.parse_query_from_uri();
+    request.parse_cookies_from_header();
     request.parse_payload_from_raw();
     Ok(request)
 }

--- a/3.x.x/crates/utopia-http/src/adapter/hyper.rs
+++ b/3.x.x/crates/utopia-http/src/adapter/hyper.rs
@@ -206,6 +206,7 @@ async fn hyper_to_utopia(req: HyperRequest<Incoming>) -> Result<Request> {
         request.set_raw_payload(raw);
     }
     request.parse_query_from_uri();
+    request.parse_payload_from_raw();
     Ok(request)
 }
 

--- a/3.x.x/crates/utopia-http/src/request.rs
+++ b/3.x.x/crates/utopia-http/src/request.rs
@@ -184,6 +184,26 @@ impl Request {
         }
     }
 
+    /// Populate [`Self::cookies`] from the `Cookie` header, so
+    /// [`Self::cookie`] can answer without re-parsing per lookup.
+    pub fn parse_cookies_from_header(&mut self) {
+        if !self.cookies.is_empty() {
+            return;
+        }
+        let header = self.header_line("cookie");
+        for pair in header.split(';') {
+            let Some((name, value)) = pair.split_once('=') else {
+                continue;
+            };
+            let name = name.trim();
+            if name.is_empty() {
+                continue;
+            }
+            self.cookies
+                .insert(name.to_string(), urlencoding_decode(value.trim()));
+        }
+    }
+
     /// Populate [`Self::payload`] from [`Self::raw_payload`] using `Content-Type`.
     ///
     /// Mirrors Utopia PHP's request body → params merge for JSON objects and
@@ -336,6 +356,27 @@ mod payload_parse_tests {
         req.parse_payload_from_raw();
         assert_eq!(req.param_ref("userId"), Some(&json!("u1")));
         assert_eq!(req.param_ref("email"), Some(&json!("a@b.c")));
+    }
+
+    #[test]
+    fn parse_cookies_splits_the_cookie_header() {
+        let mut req = Request::new("GET", "/v1/users");
+        req.set_header("cookie", "a_session_console=abc; other=1; padded = 2 ");
+        req.parse_cookies_from_header();
+
+        assert_eq!(req.cookie("a_session_console", ""), "abc");
+        assert_eq!(req.cookie("other", ""), "1");
+        assert_eq!(req.cookie("padded", ""), "2");
+        assert_eq!(req.cookie("missing", "fallback"), "fallback");
+    }
+
+    #[test]
+    fn parse_cookies_decodes_percent_escapes() {
+        let mut req = Request::new("GET", "/v1/users");
+        req.set_header("cookie", "token=a%2Bb%3Dc");
+        req.parse_cookies_from_header();
+
+        assert_eq!(req.cookie("token", ""), "a+b=c");
     }
 
     #[test]

--- a/3.x.x/crates/utopia-http/src/request.rs
+++ b/3.x.x/crates/utopia-http/src/request.rs
@@ -180,19 +180,60 @@ impl Request {
         }
         self.query_parsed = true;
         if let Some(q) = self.uri.split_once('?').map(|(_, q)| q) {
-            let mut map = HashMap::new();
-            for pair in q.split('&') {
-                if pair.is_empty() {
-                    continue;
-                }
-                let mut it = pair.splitn(2, '=');
-                let k = urlencoding_decode(it.next().unwrap_or(""));
-                let v = urlencoding_decode(it.next().unwrap_or(""));
-                map.insert(k, Value::String(v));
-            }
-            self.query = map;
+            self.query = parse_urlencoded_map(q);
         }
     }
+
+    /// Populate [`Self::payload`] from [`Self::raw_payload`] using `Content-Type`.
+    ///
+    /// Mirrors Utopia PHP's request body → params merge for JSON objects and
+    /// `application/x-www-form-urlencoded` bodies. Nested JSON values are kept
+    /// as [`Value`]s (arrays/objects), not stringified.
+    pub fn parse_payload_from_raw(&mut self) {
+        if self.raw_payload.is_empty() || !self.payload.is_empty() {
+            return;
+        }
+        let content_type = self.header_line("content-type").to_ascii_lowercase();
+        let ctype = content_type
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim();
+        if ctype == "application/json" || ctype.ends_with("+json") {
+            if let Ok(Value::Object(map)) = serde_json::from_slice::<Value>(&self.raw_payload) {
+                self.payload = map.into_iter().collect();
+            }
+            return;
+        }
+        if ctype == "application/x-www-form-urlencoded"
+            || ctype.is_empty()
+                && self
+                    .raw_payload
+                    .iter()
+                    .all(|b| b.is_ascii() && !b.is_ascii_control() || *b == b'\r' || *b == b'\n')
+        {
+            if let Ok(s) = std::str::from_utf8(&self.raw_payload) {
+                // Only treat as urlencoded when it looks like key=value pairs.
+                if ctype == "application/x-www-form-urlencoded" || s.contains('=') {
+                    self.payload = parse_urlencoded_map(s);
+                }
+            }
+        }
+    }
+}
+
+fn parse_urlencoded_map(input: &str) -> HashMap<String, Value> {
+    let mut map = HashMap::new();
+    for pair in input.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let mut it = pair.splitn(2, '=');
+        let k = urlencoding_decode(it.next().unwrap_or(""));
+        let v = urlencoding_decode(it.next().unwrap_or(""));
+        map.insert(k, Value::String(v));
+    }
+    map
 }
 
 fn urlencoding_decode(s: &str) -> String {
@@ -224,4 +265,20 @@ fn urlencoding_decode(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod payload_parse_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_json_object_into_payload() {
+        let mut req = Request::new("POST", "/v1/users");
+        req.set_header("content-type", "application/json");
+        req.set_raw_payload(br#"{"userId":"u1","email":"a@b.c"}"#.to_vec());
+        req.parse_payload_from_raw();
+        assert_eq!(req.param_ref("userId"), Some(&json!("u1")));
+        assert_eq!(req.param_ref("email"), Some(&json!("a@b.c")));
+    }
 }

--- a/3.x.x/crates/utopia-http/src/request.rs
+++ b/3.x.x/crates/utopia-http/src/request.rs
@@ -214,11 +214,7 @@ impl Request {
             return;
         }
         let content_type = self.header_line("content-type").to_ascii_lowercase();
-        let ctype = content_type
-            .split(';')
-            .next()
-            .unwrap_or("")
-            .trim();
+        let ctype = content_type.split(';').next().unwrap_or("").trim();
         if ctype == "application/json" || ctype.ends_with("+json") {
             if let Ok(Value::Object(map)) = serde_json::from_slice::<Value>(&self.raw_payload) {
                 self.payload = map.into_iter().collect();

--- a/3.x.x/crates/utopia-http/src/request.rs
+++ b/3.x.x/crates/utopia-http/src/request.rs
@@ -231,40 +231,96 @@ fn parse_urlencoded_map(input: &str) -> HashMap<String, Value> {
         let mut it = pair.splitn(2, '=');
         let k = urlencoding_decode(it.next().unwrap_or(""));
         let v = urlencoding_decode(it.next().unwrap_or(""));
-        map.insert(k, Value::String(v));
+        match split_bracket_key(&k) {
+            Some((name, index)) => insert_indexed(&mut map, name, index, v),
+            None => {
+                map.insert(k, Value::String(v));
+            }
+        }
     }
     map
 }
 
+/// Split PHP's `name[index]` bracket syntax (as emitted by `http_build_query`)
+/// into its parts. `name[]` yields an empty index, meaning "append".
+fn split_bracket_key(key: &str) -> Option<(&str, &str)> {
+    let rest = key.strip_suffix(']')?;
+    let (name, index) = rest.split_once('[')?;
+    if name.is_empty() || index.contains('[') {
+        return None;
+    }
+    Some((name, index))
+}
+
+/// PHP `parse_str`'s bracket handling, limited to one level: a numeric or
+/// empty index builds an array (`queries[0]=..&queries[1]=..`), any other
+/// index builds an object (`filter[name]=..`).
+fn insert_indexed(map: &mut HashMap<String, Value>, name: &str, index: &str, value: String) {
+    if !index.is_empty() && index.parse::<usize>().is_err() {
+        let entry = map
+            .entry(name.to_string())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if !entry.is_object() {
+            *entry = Value::Object(serde_json::Map::new());
+        }
+        if let Some(object) = entry.as_object_mut() {
+            object.insert(index.to_string(), Value::String(value));
+        }
+        return;
+    }
+
+    let entry = map
+        .entry(name.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !entry.is_array() {
+        *entry = Value::Array(Vec::new());
+    }
+    let Some(array) = entry.as_array_mut() else {
+        return;
+    };
+    match index.parse::<usize>() {
+        Ok(at) => {
+            if array.len() <= at {
+                array.resize(at + 1, Value::Null);
+            }
+            array[at] = Value::String(value);
+        }
+        Err(_) => array.push(Value::String(value)),
+    }
+}
+
 fn urlencoding_decode(s: &str) -> String {
-    let mut out = String::new();
+    let mut out: Vec<u8> = Vec::with_capacity(s.len());
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
             b'+' => {
-                out.push(' ');
+                out.push(b' ');
                 i += 1;
             }
             b'%' if i + 2 < bytes.len() => {
                 if let Ok(v) = u8::from_str_radix(
-                    std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("00"),
+                    std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("zz"),
                     16,
                 ) {
-                    out.push(v as char);
+                    // Collect raw bytes rather than `char`s so a percent-encoded
+                    // multi-byte UTF-8 sequence round-trips instead of being
+                    // widened one byte at a time into Latin-1 code points.
+                    out.push(v);
                     i += 3;
                 } else {
-                    out.push('%');
+                    out.push(b'%');
                     i += 1;
                 }
             }
             c => {
-                out.push(c as char);
+                out.push(c);
                 i += 1;
             }
         }
     }
-    out
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 #[cfg(test)]
@@ -280,5 +336,34 @@ mod payload_parse_tests {
         req.parse_payload_from_raw();
         assert_eq!(req.param_ref("userId"), Some(&json!("u1")));
         assert_eq!(req.param_ref("email"), Some(&json!("a@b.c")));
+    }
+
+    #[test]
+    fn parse_query_collects_php_style_indexed_arrays() {
+        let mut req = Request::new("GET", "/v1/users?queries%5B0%5D=a&queries%5B1%5D=b&total=0");
+        req.parse_query_from_uri();
+        assert_eq!(req.param_ref("queries"), Some(&json!(["a", "b"])));
+        assert_eq!(req.param_ref("total"), Some(&json!("0")));
+    }
+
+    #[test]
+    fn parse_query_appends_empty_bracket_arrays() {
+        let mut req = Request::new("GET", "/v1/users?queries%5B%5D=a&queries%5B%5D=b");
+        req.parse_query_from_uri();
+        assert_eq!(req.param_ref("queries"), Some(&json!(["a", "b"])));
+    }
+
+    #[test]
+    fn parse_query_builds_objects_for_named_indexes() {
+        let mut req = Request::new("GET", "/v1/users?filter%5Bname%5D=bob");
+        req.parse_query_from_uri();
+        assert_eq!(req.param_ref("filter"), Some(&json!({ "name": "bob" })));
+    }
+
+    #[test]
+    fn parse_query_decodes_multibyte_utf8() {
+        let mut req = Request::new("GET", "/v1/users?search=caf%C3%A9");
+        req.parse_query_from_uri();
+        assert_eq!(req.param_ref("search"), Some(&json!("café")));
     }
 }

--- a/3.x.x/crates/utopia-validators/src/array_list.rs
+++ b/3.x.x/crates/utopia-validators/src/array_list.rs
@@ -26,34 +26,51 @@ impl ArrayList {
         }
     }
 
+    /// PHP's `$length` constructor argument: the *maximum* number of items,
+    /// not an exact count.
     pub fn length(mut self, length: usize) -> Self {
         self.length = Some(length);
         self
+    }
+
+    /// [`Self::new`] plus [`Self::length`], mirroring PHP's
+    /// `new ArrayList($validator, $length)`.
+    pub fn with_length(element: impl Validator + 'static, length: usize) -> Self {
+        Self::new(element).length(length)
     }
 }
 
 impl Validator for ArrayList {
     fn description(&self) -> String {
-        format!("Value must be an array of {}", self.element.description())
+        let mut message = String::from("Value must a valid array");
+        if let Some(length) = self.length.filter(|length| *length > 0) {
+            message.push_str(&format!(" no longer than {length} items"));
+        }
+        let element = self.element.description();
+        if !element.is_empty() && element != "0" {
+            message.push_str(&format!(" and {element}"));
+        }
+        message
     }
 
     fn is_array(&self) -> bool {
         true
     }
 
+    /// PHP `ArrayList::getType()` delegates to the element validator; the
+    /// `isArray()` flag above is what marks the param itself as a list.
     fn value_type(&self) -> ValueType {
-        ValueType::Array
+        self.element.value_type()
     }
 
     fn is_valid(&self, value: &Value) -> bool {
         let Some(arr) = value.as_array() else {
             return false;
         };
-        if let Some(len) = self.length {
-            if arr.len() != len {
-                return false;
-            }
+        if !arr.iter().all(|v| self.element.is_valid(v)) {
+            return false;
         }
-        arr.iter().all(|v| self.element.is_valid(v))
+        self.length
+            .is_none_or(|length| length == 0 || arr.len() <= length)
     }
 }

--- a/3.x.x/crates/utopia-validators/src/array_list.rs
+++ b/3.x.x/crates/utopia-validators/src/array_list.rs
@@ -1,6 +1,6 @@
 use crate::{Validator, ValueType};
 use serde_json::Value;
-use std::fmt;
+use std::fmt::{self, Write};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -44,11 +44,11 @@ impl Validator for ArrayList {
     fn description(&self) -> String {
         let mut message = String::from("Value must a valid array");
         if let Some(length) = self.length.filter(|length| *length > 0) {
-            message.push_str(&format!(" no longer than {length} items"));
+            let _ = write!(message, " no longer than {length} items");
         }
         let element = self.element.description();
         if !element.is_empty() && element != "0" {
-            message.push_str(&format!(" and {element}"));
+            let _ = write!(message, " and {element}");
         }
         message
     }

--- a/3.x.x/crates/utopia-validators/tests/validators.rs
+++ b/3.x.x/crates/utopia-validators/tests/validators.rs
@@ -87,6 +87,19 @@ fn nullable_json_array() {
     assert!(Json.is_valid(&json!("{\"a\":1}")));
     assert!(ArrayList::new(Integer::new()).is_valid(&json!([1, 2, 3])));
     assert!(!ArrayList::new(Integer::new()).is_valid(&json!([1, "x"])));
+
+    // PHP's `$length` is a maximum, not an exact count.
+    let capped = ArrayList::with_length(Integer::new(), 2);
+    assert!(capped.is_valid(&json!([])));
+    assert!(capped.is_valid(&json!([1, 2])));
+    assert!(!capped.is_valid(&json!([1, 2, 3])));
+    assert_eq!(
+        capped.description(),
+        format!(
+            "Value must a valid array no longer than 2 items and {}",
+            Integer::new().description()
+        )
+    );
 }
 
 #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,7 +340,7 @@ services:
       - traefik.http.routers.appwrite_rust_users_https.service=appwrite_rust_users
       - traefik.http.routers.appwrite_rust_users_https.tls=true
     depends_on:
-      ${_APP_DB_HOST:-postgresql}:
+      postgresql:
         condition: service_healthy
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,8 +340,10 @@ services:
       - traefik.http.routers.appwrite_rust_users_https.service=appwrite_rust_users
       - traefik.http.routers.appwrite_rust_users_https.tls=true
     depends_on:
-      - ${_APP_DB_HOST:-postgresql}
-      - redis
+      ${_APP_DB_HOST:-postgresql}:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       - APPWRITE_BIND=0.0.0.0:80
       - _APP_ENV


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Serves `/v1/users*` from the Rust `appwrite-server` binary behind Traefik while PHP continues to handle every other service. Users E2E against Traefik is green: **52 tests, 633 assertions**.

## Architecture direction

Rust follows Appwrite’s **high-level** shape (Platform, Modules, Actions, Document DB, DI, hooks) but does **not** mirror PHP runtime surfaces:

- `utopia-database` connection layer renamed `pdo` → `sql_client` (`SqlClient` / `SqlStatement`)
- Product wiring uses `Postgres::connect` / `Mysql::connect_db` / `MariaDb::connect_db` (Rust crates under the adapters)
- Documented in `3.x.x/AGENTS.md` and `3.x.x/README.md`: keep Utopia/Appwrite domain APIs; drop PDO-style public APIs

## Verification

- `cargo build -p appwrite-server --release`
- Traefik Users E2E (`Scope` temporarily `http://appwrite.test/v1`): OK (52/52)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54268da6-550e-4a39-aa83-1e480351bdfb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54268da6-550e-4a39-aa83-1e480351bdfb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

