### PR TITLE
fix(tests): sign in before creating a JWT in the session-delete test

### DIFF
--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1776,11 +1776,25 @@ final class AccountCustomClientTest extends Scope
     {
         $data = $this->setupAccountWithVerifiedEmail();
 
+        // testDeleteAccountSessions deletes every session on the shared cached
+        // account, so sign in again rather than reusing $data['session'].
+        $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', array_merge([
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+        ]), [
+            'email' => $data['email'],
+            'password' => $data['password'],
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $session = $response['cookies']['a_session_' . $this->getProject()['$id']];
+
         $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
             'x-appwrite-project' => $this->getProject()['$id'],
-            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $data['session'],
+            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $session,
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);


### PR DESCRIPTION
## What

`AccountCustomClientTest::testDeleteAccountSessionsWithJWT` fails on its **first** assertion, before it reaches the JWT behaviour it exists to cover:

```
1) Tests\E2E\Services\Account\AccountCustomClientTest::testDeleteAccountSessionsWithJWT
Failed asserting that 401 matches expected 201.
tests/e2e/Services/Account/AccountCustomClientTest.php:1786
```

Line 1786 is the `POST /account/jwt` assertion, so the session cookie the test presents is being rejected.

## Why

`setupAccountWithVerifiedEmail()` memoises its result in a `static` keyed by project id, and every test in the class shares that one account.

`testDeleteAccountSessions()` is declared immediately above the new test. It takes the cached session and calls `DELETE /account/sessions`, which revokes **every** session on that account:

```php
$data = $this->setupAccountWithVerifiedEmail();
$session = $data['session'];
// DELETE /account/sessions  -> 204
```

`testDeleteAccountSessionsWithJWT()` then calls `setupAccountWithVerifiedEmail()` again, gets the same cached array back, and presents the already-revoked `$data['session']` — so `POST /account/jwt` correctly answers 401.

The two tests declared between them, `testDeleteAccountSession` and `testDeleteAccountSessionCurrent`, are careful about this: each mints its own extra session to delete and asserts the cached one still works (`GET /account` -> 200). `testDeleteAccountSessions` is the only test that revokes the shared session, and nothing after it may reuse that secret.

This was latent until now. `testCreateAccountRecovery`, the next test in the file, only reads `$data['email']`, so it never noticed. The new test is the first consumer of `$data['session']` after the revocation.

## Why CI here is green either way

**This PR's green CI does not demonstrate the fix, and I do not want it read that way.**

This job runs the suite through ParaTest in `--functional` mode:

```yaml
{ name: 'Account', runner: runner4, functional: true, processes: null },
```
```bash
if [ "${{ matrix.service.functional }}" = "true" ]; then FUNCTIONAL_FLAG="--functional"; fi
appwrite vendor/bin/paratest --processes "$PARATEST_PROCESSES" $FUNCTIONAL_FLAG "$SERVICE_PATH" ...
```

`--functional` distributes individual **test methods** across worker processes. `testDeleteAccountSessions` and `testDeleteAccountSessionsWithJWT` therefore need not share a process, and a `static` cache is per-process — so the revoked session usually is not the one the JWT test sees. The defect is structurally invisible to this pipeline.

It is visible to any consumer that runs the same file serially in one process. That is where it was found: a downstream repo vendors this suite and runs `phpunit` over `tests/e2e/Services/Account` as a single process, and has failed on it at line 1786 in **every** run since the commit that added the test.

So the ordering hazard above is real regardless of what this pipeline reports; `--functional` is hiding it rather than disproving it.

## Approach, and what I rejected

Invalidating the cache in `testDeleteAccountSessions` does **not** work. The setup helpers chain:

```
setupAccountWithVerifiedEmail  -> self::$verifiedData
  setupAccountWithVerification -> self::$verificationData
    setupAccountWithUpdatedPrefs -> self::$updatedPrefsData
```

Clearing only `$verifiedData` produces a miss on the outer entry, which then re-reads the still-populated inner entry and hands back the *same revoked session*. Clearing the whole chain would force a fresh account plus a verification-email round trip in the middle of the class — slower and more fragile than the problem it solves.

Instead the test signs in again for a live session, which is exactly the idiom `testDeleteAccountSession` already uses a few tests above:

```php
$response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', ..., [
    'email' => $data['email'],
    'password' => $data['password'],
]);
```

`$data` carries the current credentials (`setupAccountWithUpdatedPassword`/`setupAccountWithUpdatedEmail` merge the updated values into the cached array), so this signs into the same account. It also makes the test independent of both the order the class runs in and whether it is sharded across processes.

## Verification

- **Red observed**, on the identical vendored file, serially, at line 1786 with `401 != 201`, reproducing on every run since the test landed.
- **Cause established by reading the ordering**, not inferred from the failure text.
- **Green after the fix on this pipeline** — stated for completeness, but as explained above it carries no signal here. The meaningful green is the serial consumer, which I will confirm once this is released and picked up.

**Not verified:** I have not run this suite serially on my own machine. It needs the full stack plus a mail catcher, and the only stack available to me was built from an unrelated branch, so a green there would not have meant anything.

**Worth watching:** this fix lets the test reach its second assertion (`DELETE /account/sessions` with `x-appwrite-jwt` -> 204) in the serial case for the first time. If that assertion then fails, it is a genuine product finding about JWT-authenticated session deletion rather than a problem with this change.

## Possibly worth a separate look

`--functional` masking an order-dependent defect is not specific to this test. Any test in a `--functional` service that depends on state a sibling test mutates is currently unobservable in this pipeline. That is a broader call than this PR should make, so I have not touched the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
