### PR TITLE
test(account): do not mint a JWT from a deleted cached session

### DIFF
--- a/tests/e2e/Services/Account/AccountCustomClientTest.php
+++ b/tests/e2e/Services/Account/AccountCustomClientTest.php
@@ -1770,17 +1770,53 @@ final class AccountCustomClientTest extends Scope
 
         $this->assertEquals(401, $response['headers']['status-code']);
 
+        $projectId = $this->getProject()['$id'];
+        unset(
+            self::$accountData[$projectId],
+            self::$sessionData[$projectId],
+            self::$updatedNameData[$projectId],
+            self::$updatedPasswordData[$projectId],
+            self::$updatedEmailData[$projectId],
+            self::$updatedPrefsData[$projectId],
+            self::$verificationData[$projectId],
+            self::$verifiedData[$projectId],
+        );
     }
 
     public function testDeleteAccountSessionsWithJWT(): void
     {
-        $data = $this->setupAccountWithVerifiedEmail();
+        $email = uniqid() . 'user@localhost.test';
+        $password = 'password';
+        $projectId = $this->getProject()['$id'];
+
+        $response = $this->client->call(Client::METHOD_POST, '/account', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], [
+            'userId' => ID::unique(),
+            'email' => $email,
+            'password' => $password,
+            'name' => 'JWT session delete',
+        ]);
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/account/sessions/email', [
+            'origin' => 'http://localhost',
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], [
+            'email' => $email,
+            'password' => $password,
+        ]);
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $session = $response['cookies']['a_session_' . $projectId];
 
         $response = $this->client->call(Client::METHOD_POST, '/account/jwt', [
             'origin' => 'http://localhost',
             'content-type' => 'application/json',
-            'x-appwrite-project' => $this->getProject()['$id'],
-            'cookie' => 'a_session_' . $this->getProject()['$id'] . '=' . $data['session'],
+            'x-appwrite-project' => $projectId,
+            'cookie' => 'a_session_' . $projectId . '=' . $session,
         ]);
 
         $this->assertEquals(201, $response['headers']['status-code']);


### PR DESCRIPTION
## What

`testDeleteAccountSessionsWithJWT` was added after `testDeleteAccountSessions`, which deletes every session on the per-project cached fixture. The new test reused that cookie and `POST /account/jwt` returned 401 in every dedicated Account run (26–34ms, 3/3 on cloud#5313 and current main).

Mint a fresh account/session for the JWT case, and drop the cached fixture after the bulk session delete so later helpers cannot reuse a dead cookie.

## Test Plan

- [x] Account dedicated was red on the cached cookie (401 vs 201 at the JWT create)
- [ ] CE Account E2E / cloud CE Account (dedicated) after the bump