### PR TITLE
Remove singular x-appwrite method metadata

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5287,16 +5287,16 @@
     "packages-dev": [
         {
             "name": "appwrite/sdk-generator",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-generator.git",
-                "reference": "b02a0c070acd096978bd6bd05eb8d799e1cf9a2f"
+                "reference": "463353d15cd246be710d30e78b42c9dfc2fa3224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/b02a0c070acd096978bd6bd05eb8d799e1cf9a2f",
-                "reference": "b02a0c070acd096978bd6bd05eb8d799e1cf9a2f",
+                "url": "https://api.github.com/repos/appwrite/sdk-generator/zipball/463353d15cd246be710d30e78b42c9dfc2fa3224",
+                "reference": "463353d15cd246be710d30e78b42c9dfc2fa3224",
                 "shasum": ""
             },
             "require": {
@@ -5333,9 +5333,9 @@
             "description": "SDK generator for Appwrite APIs across multiple programming languages and platforms",
             "support": {
                 "issues": "https://github.com/appwrite/sdk-generator/issues",
-                "source": "https://github.com/appwrite/sdk-generator/tree/4.0.1"
+                "source": "https://github.com/appwrite/sdk-generator/tree/4.0.2"
             },
-            "time": "2026-08-15T17:04:18+00:00"
+            "time": "2026-08-17T05:02:47+00:00"
         },
         {
             "name": "brianium/paratest",

--- a/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
+++ b/src/Appwrite/SDK/Specification/Format/OpenAPI3.php
@@ -144,7 +144,6 @@ class OpenAPI3 extends Format
                 'responses' => [],
                 'deprecated' => $sdk->isDeprecated(),
                 'x-appwrite' => [ // Appwrite related metadata
-                    'method' => $methodName,
                     'group' => $sdk->getGroup(),
                     'cookies' => $route->getLabel('sdk.cookies', false),
                     'type' => $sdk->getType()->value ?? '',
@@ -811,7 +810,6 @@ class OpenAPI3 extends Format
                 if (\count($methods) > 1 && $index > 0) {
                     $suffix = \ucfirst(\strtolower($method));
                     $methodTemp['operationId'] .= $suffix;
-                    $methodTemp['x-appwrite']['method'] .= $suffix;
                 }
                 $body = [
                     'content' => [

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -273,8 +273,8 @@ final class FormatTest extends TestCase
 
         $this->assertSame('testGetOrUpdateTest', $get['operationId']);
         $this->assertSame('testGetOrUpdateTestPost', $post['operationId']);
-        $this->assertSame('getOrUpdateTest', $get['x-appwrite']['method']);
-        $this->assertSame('getOrUpdateTestPost', $post['x-appwrite']['method']);
+        $this->assertArrayNotHasKey('method', $get['x-appwrite']);
+        $this->assertArrayNotHasKey('method', $post['x-appwrite']);
         $this->assertSame('path', $get['parameters'][0]['in']);
         $this->assertSame('query', $get['parameters'][1]['in']);
         $this->assertArrayNotHasKey('requestBody', $get);

--- a/tests/unit/SDK/Specification/FormatTest.php
+++ b/tests/unit/SDK/Specification/FormatTest.php
@@ -273,8 +273,6 @@ final class FormatTest extends TestCase
 
         $this->assertSame('testGetOrUpdateTest', $get['operationId']);
         $this->assertSame('testGetOrUpdateTestPost', $post['operationId']);
-        $this->assertArrayNotHasKey('method', $get['x-appwrite']);
-        $this->assertArrayNotHasKey('method', $post['x-appwrite']);
         $this->assertSame('path', $get['parameters'][0]['in']);
         $this->assertSame('query', $get['parameters'][1]['in']);
         $this->assertArrayNotHasKey('requestBody', $get);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Stops emitting singular `x-appwrite.method` from OpenAPI operations. SDK method names now come from the service-qualified `operationId`; plural `x-appwrite.methods` aliases remain unchanged.

```text
before: operationId: accountCreate, x-appwrite.method: create
after:  operationId: accountCreate
```

Uses `appwrite/sdk-generator` 4.0.2, released by appwrite/sdk-generator#1804.

## Test Plan

- `vendor/bin/phpunit tests/unit/SDK/Specification/FormatTest.php` — 20 tests, 103 assertions
- `composer update appwrite/sdk-generator --with-dependencies --minimal-changes` — updated the lock file to 4.0.2
- `composer lint src/Appwrite/SDK/Specification/Format/OpenAPI3.php tests/unit/SDK/Specification/FormatTest.php`
- `composer refactor:check`
- Generated current 1.9.x client, server, and console specs; canonical diffs contained only removal of 149, 554, and 610 singular fields respectively
- Generated every SDK target through `php app/cli.php sdks --platform=* --sdk=* --version=1.9.x --git=no --mode=examples` using appwrite/sdk-generator 4.0.2

## Related PRs and Issues

- appwrite/sdk-generator#1804
- appwrite/sdk-generator#1790

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?


