### PR TITLE
Json object array transform

### DIFF
--- a/app/controllers/api/messaging.php
+++ b/app/controllers/api/messaging.php
@@ -54,6 +54,40 @@ use Utopia\Validator\WhiteList;
 
 use function Swoole\Coroutine\batch;
 
+/**
+ * Convert a request JSON object to the associative shape messages expect while
+ * retaining empty objects at any nested depth. Returns null untouched so the
+ * caller can distinguish "not provided" from an explicit empty object.
+ */
+function normalizeJsonObject(null|array|\stdClass $data): ?array
+{
+    if (\is_null($data)) {
+        return null;
+    }
+
+    $normalizeValue = function (mixed $value) use (&$normalizeValue): mixed {
+        if ($value instanceof \stdClass) {
+            $properties = (array) $value;
+
+            return $properties === []
+                ? $value
+                : \array_map($normalizeValue, $properties);
+        }
+
+        if (\is_array($value)) {
+            return \array_map($normalizeValue, $value);
+        }
+
+        return $value;
+    };
+
+    if ($data instanceof \stdClass) {
+        $data = (array) $data;
+    }
+
+    return \array_map($normalizeValue, $data);
+}
+
 Http::post('/v1/messaging/providers/mailgun')
     ->desc('Create Mailgun provider')
     ->groups(['api', 'messaging'])
@@ -987,12 +1021,12 @@ Http::post('/v1/messaging/providers/fcm')
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
-    ->action(function (string $providerId, string $name, array|string|null $serviceAccountJSON, ?bool $enabled, Event $queueForEvents, Database $dbForProject, Response $response) {
+    ->action(function (string $providerId, string $name, array|string|\stdClass|null $serviceAccountJSON, ?bool $enabled, Event $queueForEvents, Database $dbForProject, Response $response) {
         $providerId = $providerId == 'unique()' ? ID::unique() : $providerId;
 
         $serviceAccountJSON = \is_string($serviceAccountJSON)
             ? \json_decode($serviceAccountJSON, true)
-            : $serviceAccountJSON;
+            : normalizeJsonObject($serviceAccountJSON);
 
         $credentials = [];
 
@@ -2300,7 +2334,7 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
     ->inject('queueForEvents')
     ->inject('dbForProject')
     ->inject('response')
-    ->action(function (string $providerId, string $name, ?bool $enabled, array|string|null $serviceAccountJSON, Event $queueForEvents, Database $dbForProject, Response $response) {
+    ->action(function (string $providerId, string $name, ?bool $enabled, array|string|\stdClass|null $serviceAccountJSON, Event $queueForEvents, Database $dbForProject, Response $response) {
         $provider = $dbForProject->getDocument('providers', $providerId);
 
         if ($provider->isEmpty()) {
@@ -2319,7 +2353,7 @@ Http::patch('/v1/messaging/providers/fcm/:providerId')
         if (!\is_null($serviceAccountJSON)) {
             $serviceAccountJSON = \is_string($serviceAccountJSON)
                 ? \json_decode($serviceAccountJSON, true)
-                : $serviceAccountJSON;
+                : normalizeJsonObject($serviceAccountJSON);
 
             $provider->setAttribute('credentials', [
                 'serviceAccountJSON' => $serviceAccountJSON
@@ -3420,7 +3454,9 @@ Http::post('/v1/messaging/messages/push')
     ->inject('publisherForMessaging')
     ->inject('response')
     ->inject('platform')
-    ->action(function (string $messageId, string $title, string $body, ?array $topics, ?array $users, ?array $targets, ?array $data, string $action, string $image, string $icon, string $sound, string $color, string $tag, int $badge, bool $draft, ?string $scheduledAt, bool $contentAvailable, bool $critical, string $priority, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response, array $platform) {
+    ->action(function (string $messageId, string $title, string $body, ?array $topics, ?array $users, ?array $targets, null|array|\stdClass $data, string $action, string $image, string $icon, string $sound, string $color, string $tag, int $badge, bool $draft, ?string $scheduledAt, bool $contentAvailable, bool $critical, string $priority, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response, array $platform) {
+        $data = normalizeJsonObject($data);
+
         $messageId = $messageId == 'unique()'
             ? ID::unique()
             : $messageId;
@@ -4214,7 +4250,9 @@ Http::patch('/v1/messaging/messages/push/:messageId')
     ->inject('publisherForMessaging')
     ->inject('response')
     ->inject('platform')
-    ->action(function (string $messageId, ?array $topics, ?array $users, ?array $targets, ?string $title, ?string $body, ?array $data, ?string $action, ?string $image, ?string $icon, ?string $sound, ?string $color, ?string $tag, ?int $badge, ?bool $draft, ?string $scheduledAt, ?bool $contentAvailable, ?bool $critical, ?string $priority, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response, array $platform) {
+    ->action(function (string $messageId, ?array $topics, ?array $users, ?array $targets, ?string $title, ?string $body, null|array|\stdClass $data, ?string $action, ?string $image, ?string $icon, ?string $sound, ?string $color, ?string $tag, ?int $badge, ?bool $draft, ?string $scheduledAt, ?bool $contentAvailable, ?bool $critical, ?string $priority, Event $queueForEvents, Database $dbForProject, Database $dbForPlatform, Document $project, MessagingPublisher $publisherForMessaging, Response $response, array $platform) {
+        $data = normalizeJsonObject($data);
+
         $message = $dbForProject->getDocument('messages', $messageId);
 
         if ($message->isEmpty()) {

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Update.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Update.php
@@ -118,7 +118,7 @@ class Update extends PlatformAction
         ?string $userId,
         ?string $status,
         ?string $expiresAt,
-        ?array $metadata,
+        array|\stdClass|null $metadata,
         ?array $permissions,
         bool $purge,
         Response $response,
@@ -166,7 +166,7 @@ class Update extends PlatformAction
         }
 
         if ($metadata !== null) {
-            $updateData['metadata'] = $metadata;
+            $updateData['metadata'] = $presenceState->normalizeMetadata($metadata);
         }
 
         $updates = new Document($updateData);

--- a/src/Appwrite/Platform/Modules/Presences/HTTP/Upsert.php
+++ b/src/Appwrite/Platform/Modules/Presences/HTTP/Upsert.php
@@ -119,7 +119,7 @@ class Upsert extends PlatformAction
         ?string $status,
         ?array $permissions,
         ?string $expiresAt,
-        array $metadata,
+        array|\stdClass $metadata,
         Response $response,
         Request $request,
         Database $dbForProject,
@@ -158,16 +158,17 @@ class Upsert extends PlatformAction
         }
         $isGraphQL = $request->getHeaderLine('x-appwrite-source') === 'graphql';
 
+        $presenceState = new PresenceState();
+
         $presenceData = [
             'userInternalId' => $userInternalId,
             'userId' => $resolvedUserId,
             'status' => $status,
             'source' => $isGraphQL ? 'graphql' : 'rest',
             'expiresAt' => $expiresAt ?? DateTime::addSeconds(new \DateTime(), 15 * 60),
-            'metadata' => $metadata,
+            'metadata' => $presenceState->normalizeMetadata($metadata),
         ];
 
-        $presenceState = new PresenceState();
         $presenceDocument = new Document($presenceData);
         $ownerOverride = $permissions === null && ($isAPIKey || $isPrivilegedUser)
             ? $resolvedUserId

--- a/src/Appwrite/Presences/State.php
+++ b/src/Appwrite/Presences/State.php
@@ -74,6 +74,44 @@ class State
         return $document;
     }
 
+    /**
+     * Convert a request metadata object to the associative shape Document
+     * expects while retaining empty objects at any nested depth. `null` is
+     * returned untouched so callers can distinguish "not provided" from an
+     * explicit empty object.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function normalizeMetadata(array|\stdClass|null $metadata): ?array
+    {
+        if ($metadata === null) {
+            return null;
+        }
+
+        if ($metadata instanceof \stdClass) {
+            $metadata = (array) $metadata;
+        }
+
+        return \array_map($this->normalizeMetadataValue(...), $metadata);
+    }
+
+    private function normalizeMetadataValue(mixed $value): mixed
+    {
+        if ($value instanceof \stdClass) {
+            $properties = (array) $value;
+
+            return $properties === []
+                ? $value
+                : \array_map($this->normalizeMetadataValue(...), $properties);
+        }
+
+        if (\is_array($value)) {
+            return \array_map($this->normalizeMetadataValue(...), $value);
+        }
+
+        return $value;
+    }
+
     public function upsertForUser(
         Database $dbForProject,
         Document $presenceDocument,

--- a/tests/e2e/Services/Messaging/MessagingBase.php
+++ b/tests/e2e/Services/Messaging/MessagingBase.php
@@ -1787,6 +1787,45 @@ trait MessagingBase
         $this->assertEquals(200, $image['headers']['status-code']);
     }
 
+    public function testCreateDraftPushWithData(): void
+    {
+        // A nested `data` object is sent as a JSON object and must round-trip
+        // intact (the controller normalizes the decoded stdClass to an array).
+        $data = [
+            'route' => '/home',
+            'meta' => [
+                'count' => 2,
+                'flags' => ['a', 'b'],
+            ],
+        ];
+
+        $response = $this->client->call(Client::METHOD_POST, '/messaging/messages/push', [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ], [
+            'messageId' => ID::unique(),
+            'title' => 'New blog post',
+            'body' => 'Check out the new blog post',
+            'data' => $data,
+            'draft' => true,
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertEquals(MessageStatus::DRAFT, $response['body']['status']);
+        $this->assertEquals($data, $response['body']['data']['data']);
+
+        $messageId = $response['body']['$id'];
+        $message = $this->client->call(Client::METHOD_GET, '/messaging/messages/' . $messageId, [
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-key' => $this->getProject()['apiKey'],
+        ]);
+
+        $this->assertEquals(200, $message['headers']['status-code']);
+        $this->assertEquals($data, $message['body']['data']['data']);
+    }
+
     public function testScheduledMessage(): void
     {
         // Create user

--- a/tests/e2e/Services/Presences/PresenceBase.php
+++ b/tests/e2e/Services/Presences/PresenceBase.php
@@ -181,6 +181,55 @@ trait PresenceBase
         $this->assertArrayHasKey('expiresAt', $get['body']);
     }
 
+    public function testUpsertPresenceNestedMetadata(): void
+    {
+        $metadata = [
+            'device' => 'web',
+            'profile' => [
+                'os' => 'linux',
+                'versions' => ['stable' => 3, 'beta' => 4],
+            ],
+            'tags' => ['x', 'y'],
+        ];
+
+        if ($this->getSide() === 'client' || $this->getSide() === 'console') {
+            $headers = \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders());
+        } else {
+            $headers = \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getPresenceServerHeaders());
+        }
+
+        $payload = ['status' => 'online', 'metadata' => $metadata];
+        if ($this->getSide() === 'server') {
+            $payload['userId'] = $this->getUser()['$id'];
+        }
+
+        $upsert = $this->client->call(
+            Client::METHOD_PUT,
+            '/presences/' . ID::unique(),
+            $headers,
+            $payload
+        );
+
+        $this->assertEquals(200, $upsert['headers']['status-code']);
+        $this->assertNotEmpty($upsert['body']['$id']);
+        $this->assertEquals($metadata, $upsert['body']['metadata']);
+
+        $get = $this->client->call(
+            Client::METHOD_GET,
+            '/presences/' . $upsert['body']['$id'],
+            $headers
+        );
+
+        $this->assertEquals(200, $get['headers']['status-code']);
+        $this->assertEquals($metadata, $get['body']['metadata']);
+    }
+
     public function testListPresences(): void
     {
         if ($this->getSide() === 'client' || $this->getSide() === 'console') {
@@ -522,6 +571,54 @@ trait PresenceBase
         $this->assertEquals(200, $update['headers']['status-code']);
         $this->assertEquals('busy', $update['body']['status']);
         $this->assertEquals(['source' => 'update'], $update['body']['metadata']);
+    }
+
+    public function testUpdatePresenceNestedMetadata(): void
+    {
+        $metadata = [
+            'device' => 'web',
+            'profile' => [
+                'os' => 'linux',
+                'versions' => ['stable' => 3, 'beta' => 4],
+            ],
+            'tags' => ['x', 'y'],
+        ];
+
+        if ($this->getSide() === 'client' || $this->getSide() === 'console') {
+            $headers = \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getHeaders());
+
+            $upsert = $this->client->call(
+                Client::METHOD_PUT,
+                '/presences/' . ID::unique(),
+                $headers,
+                ['status' => 'online', 'metadata' => ['source' => 'setup']]
+            );
+            $this->assertEquals(200, $upsert['headers']['status-code']);
+            $presenceId = $upsert['body']['$id'];
+            $payload = ['metadata' => $metadata];
+        } else {
+            $headers = \array_merge([
+                'content-type' => 'application/json',
+                'x-appwrite-project' => $this->getProject()['$id'],
+            ], $this->getPresenceServerHeaders());
+
+            $presence = $this->setupPresence(['metadata' => ['source' => 'setup']]);
+            $presenceId = $presence['$id'];
+            $payload = ['metadata' => $metadata, 'userId' => $presence['userId']];
+        }
+
+        $update = $this->client->call(
+            Client::METHOD_PATCH,
+            '/presences/' . $presenceId,
+            $headers,
+            $payload
+        );
+
+        $this->assertEquals(200, $update['headers']['status-code']);
+        $this->assertEquals($metadata, $update['body']['metadata']);
     }
 
     public function testUpdatePresenceUserIdReassignsDefaultPermissions(): void


### PR DESCRIPTION
## What does this PR do?

Fixes a `TypeError` (HTTP 500) on endpoints that accept a JSON **object** parameter through `Utopia\Validator\JSON\ObjectValidator`.

### The issue

`ObjectValidator` deliberately decodes a JSON object to a `stdClass` rather than an associative array:

```php
// Decoding to objects rather than associative arrays keeps `{}` and `[]`
// distinguishable, which is impossible once both collapse to an empty array.
```

That distinction matters (an empty object `{}` must not silently become an empty list `[]`), but it means the validated value handed to the controller is now a `stdClass`. Several handlers still type-hint those params as `array` / `?array`, so PHP throws before the action body even runs:

```
Presences\HTTP\Upsert->action(..., Object(stdClass), ...)
messaging createPush closure(..., Object(stdClass), ...)
```

Affected params:
- **Presences** — `metadata` on `PUT /v1/presences/:presenceId` (upsert) and `PATCH /v1/presences/:presenceId` (update)
- **Messaging** — `data` on create/update push, and `serviceAccountJSON` on create/update FCM provider (these were `array|string|null`, which also excludes `stdClass`)

### The approach

Convert the `stdClass` to the associative array the `Document` layer expects **at the controller boundary**, recursively, while preserving nested empty objects as `stdClass` so the `{}` vs `[]` distinction the validator went out of its way to keep is not thrown away on the last step.

Alternatives considered and why they don't work:

- **Plain `json_decode($data, true)`** — can't be used at all: by the time the value reaches the handler the validator has *already* decoded it, so `$data` is a `stdClass`, not a JSON string. `json_decode()` expects a string and returns `null` for anything else, so this would silently drop the payload. There is no JSON string left to decode.
- **`json_decode(json_encode($x), true)`** (re-encode round-trip) — recursive, but collapses every `{}` → `[]`, destroying the exact distinction the validator preserves. That regressed distinction is the whole reason the validator emits `stdClass` in the first place.
- **Shallow `(array) $data` cast** — only converts the top level; nested objects would still reach `Document` as `stdClass` and fail one level down.

Placement follows the pattern already established by the Databases module (`Documents\Action::normalizeData`) — the transform lives next to its call sites rather than in a shared global base:
- **Presences**: a single `State::normalizeMetadata()` on `src/Appwrite/Presences/State.php`, since both upsert and update need it and `State` is the natural shared home for presence logic.
- **Messaging**: a file-local `normalizeJsonObject()` helper in the (procedural) controller, reused by all four paths; `null` is passed through untouched so update endpoints can still tell "not provided" from an explicit empty object.

## Test Plan

Added e2e coverage for the object round-trip (the previously-crashing path):

- `tests/e2e/Services/Presences` — `testUpsertPresenceNestedMetadata`, `testUpdatePresenceNestedMetadata` (run across client/console/server sides): send nested metadata objects and assert they round-trip on create/get and on update.
- `tests/e2e/Services/Messaging` — `testCreateDraftPushWithData`: create a draft push (no provider/DSN needed) with a nested `data` object and assert it round-trips on create and get.
- Existing FCM provider tests already send `serviceAccountJSON` as a nested map (→ object over the wire → `stdClass`), so that path has regression coverage that this fix restores.

```
docker compose exec appwrite test tests/e2e/Services/Presences --filter=NestedMetadata
docker compose exec appwrite test tests/e2e/Services/Messaging --filter=testCreateDraftPushWithData
```

_Note: the e2e client decodes responses with `assoc=true`, so the empty-object (`{}` vs `[]`) distinction is not observable at the HTTP boundary; the tests assert nested non-empty structure, which is the recursion the fix adds._

## Related PRs and Issues

- Follows the `normalizeData` pattern from `Modules/Databases/.../Documents/Action.php`

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
