### PR TITLE
Let the installer configure public API HTTPS

### DIFF
--- a/app/config/variables.php
+++ b/app/config/variables.php
@@ -54,7 +54,7 @@ return [
             ],
             [
                 'name' => '_APP_OPTIONS_FORCE_HTTPS',
-                'description' => 'Allows you to force HTTPS connection to your API. This feature redirects any HTTP call to HTTPS and adds the \'Strict-Transport-Security\' header to all HTTP responses. By default, set to \'enabled\'. To disable, set to \'disabled\'. This feature will work only when your ports are set to default 80 and 443, and you have set up wildcard certificates with DNS challenge.',
+                'description' => 'Controls whether Appwrite generates HTTPS API URLs and enforces HTTPS for incoming API requests. Set to \'enabled\' whenever the public API is served over HTTPS, including when TLS is terminated by a reverse proxy. When enabled, HTTP GET requests are redirected to HTTPS and other HTTP requests are rejected. The default value is \'disabled\' to support local and plain HTTP installations.',
                 'introduction' => '',
                 'default' => 'disabled',
                 'required' => false,

--- a/app/views/install/installer.phtml
+++ b/app/views/install/installer.phtml
@@ -7,6 +7,7 @@ $defaultHttpsPort ??= '443';
 $defaultAppDomain = $vars['_APP_DOMAIN']['default'] ?? 'localhost';
 $defaultAppDomain = ($defaultAppDomain === 'traefik') ? 'localhost' : $defaultAppDomain;
 $defaultEmailCertificates ??= '';
+$defaultForceHttps ??= ($vars['_APP_OPTIONS_FORCE_HTTPS']['default'] ?? 'disabled') === 'enabled';
 $defaultDatabase = $vars['_APP_DB_ADAPTER']['default'] ?? 'postgresql';
 $enabledDatabases ??= ['postgresql', 'mariadb', 'mongodb'];
 $isLocalInstall ??= false;
@@ -61,6 +62,7 @@ $installerVersion = @filemtime(__DIR__ . '/installer/js/installer.js') ?: time()
     data-default-https-port="<?php echo htmlspecialchars((string) $defaultHttpsPort, ENT_QUOTES, 'UTF-8'); ?>"
     data-default-app-domain="<?php echo htmlspecialchars((string) $defaultAppDomain, ENT_QUOTES, 'UTF-8'); ?>"
     data-default-email-certificates="<?php echo htmlspecialchars((string) $defaultEmailCertificates, ENT_QUOTES, 'UTF-8'); ?>"
+    data-default-force-https="<?php echo $defaultForceHttps ? 'true' : 'false'; ?>"
     data-default-secret-key=""
     data-default-assistant-openai-key=""
     data-default-database="<?php echo htmlspecialchars((string) $defaultDatabase, ENT_QUOTES, 'UTF-8'); ?>"

--- a/app/views/install/installer/css/styles.css
+++ b/app/views/install/installer/css/styles.css
@@ -1813,7 +1813,7 @@ body {
     }
 }
 
-.migration-option {
+.toggle-option {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -1827,21 +1827,21 @@ body {
     transition: outline-color 0.15s ease-in-out;
 }
 
-.migration-option:hover {
+.toggle-option:hover {
     outline-color: var(--border-neutral-stronger);
 }
 
-.migration-option-content {
+.toggle-option-content {
     display: flex;
     flex-direction: column;
     gap: 2px;
 }
 
-.migration-switch {
+.toggle-switch {
     flex-shrink: 0;
 }
 
-.migration-switch-track {
+.toggle-switch-track {
     position: relative;
     display: block;
     width: 32px;
@@ -1851,7 +1851,7 @@ body {
     transition: background 0.15s ease-in-out;
 }
 
-.migration-switch-thumb {
+.toggle-switch-thumb {
     position: absolute;
     top: 2px;
     left: 2px;
@@ -1862,15 +1862,15 @@ body {
     transition: transform 0.15s ease-in-out;
 }
 
-#run-migration:checked ~ .migration-switch-track {
+.toggle-switch input:checked ~ .toggle-switch-track {
     background: var(--bgcolor-neutral-invert-weak);
 }
 
-#run-migration:checked ~ .migration-switch-track .migration-switch-thumb {
+.toggle-switch input:checked ~ .toggle-switch-track .toggle-switch-thumb {
     transform: translateX(12px);
 }
 
-#run-migration:focus-visible ~ .migration-switch-track {
+.toggle-switch input:focus-visible ~ .toggle-switch-track {
     box-shadow: 0 0 0 var(--border-width-l) var(--border-focus);
 }
 

--- a/app/views/install/installer/js/modules/progress.js
+++ b/app/views/install/installer/js/modules/progress.js
@@ -370,6 +370,7 @@
             database: formState?.database || 'postgresql',
             appDomain: normalizedDomain,
             emailCertificates: normalizedEmail,
+            forceHttps: formState?.forceHttps === true,
             opensslKey: (formState?.opensslKey || '').trim(),
             assistantOpenAIKey: normalizedAssistantKey,
             accountEmail: normalizedAccountEmail,

--- a/app/views/install/installer/js/modules/state.js
+++ b/app/views/install/installer/js/modules/state.js
@@ -16,6 +16,7 @@
         httpPort: null,
         httpsPort: null,
         emailCertificates: null,
+        forceHttps: null,
         opensslKey: null,
         assistantOpenAIKey: null,
         accountEmail: null,
@@ -44,6 +45,7 @@
         setStateIfEmpty('httpPort', data.defaultHttpPort);
         setStateIfEmpty('httpsPort', data.defaultHttpsPort);
         setStateIfEmpty('emailCertificates', data.defaultEmailCertificates);
+        setStateIfEmpty('forceHttps', data.defaultForceHttps === 'true');
         setStateIfEmpty('opensslKey', data.defaultSecretKey);
         setStateIfEmpty('assistantOpenAIKey', data.defaultAssistantOpenaiKey);
         if (data.lockedDatabase) {
@@ -135,6 +137,7 @@
         setStateIfEmpty('httpPort', payload.httpPort);
         setStateIfEmpty('httpsPort', payload.httpsPort);
         setStateIfEmpty('emailCertificates', payload.emailCertificates);
+        setStateIfEmpty('forceHttps', payload.forceHttps);
         setStateIfEmpty('accountEmail', payload.accountEmail);
     };
 

--- a/app/views/install/installer/js/modules/ui.js
+++ b/app/views/install/installer/js/modules/ui.js
@@ -256,6 +256,14 @@
             badge.classList.add(hasKey ? 'badge-success' : 'badge-warning');
         }
 
+        const httpsBadge = root.querySelector('[data-review-https-badge]');
+        if (httpsBadge) {
+            const forceHttps = formState?.forceHttps === true;
+            httpsBadge.textContent = forceHttps ? 'HTTPS' : 'HTTP';
+            httpsBadge.classList.remove('badge-success', 'badge-neutral');
+            httpsBadge.classList.add(forceHttps ? 'badge-success' : 'badge-neutral');
+        }
+
         const assistantBadge = root.querySelector('[data-review-assistant-badge]');
         if (assistantBadge) {
             const hasAssistantKey = Boolean((formState?.assistantOpenAIKey || '').trim());

--- a/app/views/install/installer/js/steps.js
+++ b/app/views/install/installer/js/steps.js
@@ -62,6 +62,16 @@
         update();
     };
 
+    const bindCheckboxToState = (input, key) => {
+        if (!input) return;
+        const update = () => {
+            formState[key] = input.checked;
+            dispatchStateChange?.(key);
+        };
+        input.addEventListener('change', update);
+        update();
+    };
+
     const lockDatabaseSelection = (root, lockedDatabase) => {
         if (lockedDatabase) {
             const radios = root.querySelectorAll('input[name="database"]');
@@ -109,6 +119,7 @@
         State.setStateIfEmpty?.('httpPort', root.querySelector('#http-port')?.value);
         State.setStateIfEmpty?.('httpsPort', root.querySelector('#https-port')?.value);
         State.setStateIfEmpty?.('emailCertificates', root.querySelector('#ssl-email')?.value);
+        State.setStateIfEmpty?.('forceHttps', root.querySelector('#force-https')?.checked);
         State.setStateIfEmpty?.('assistantOpenAIKey', root.querySelector('#assistant-openai-key')?.value);
     };
 
@@ -124,6 +135,11 @@
 
         const sslEmail = root.querySelector('#ssl-email');
         if (sslEmail && formState.emailCertificates) sslEmail.value = formState.emailCertificates;
+
+        const forceHttps = root.querySelector('#force-https');
+        if (forceHttps && typeof formState.forceHttps === 'boolean') {
+            forceHttps.checked = formState.forceHttps;
+        }
 
         const assistantKey = root.querySelector('#assistant-openai-key');
         if (assistantKey && formState.assistantOpenAIKey) {
@@ -166,12 +182,14 @@
         const httpPort = root.querySelector('#http-port');
         const httpsPort = root.querySelector('#https-port');
         const sslEmail = root.querySelector('#ssl-email');
+        const forceHttps = root.querySelector('#force-https');
         const assistantKey = root.querySelector('#assistant-openai-key');
 
         bindInputToState(hostname, 'appDomain');
         bindInputToState(httpPort, 'httpPort');
         bindInputToState(httpsPort, 'httpsPort');
         bindInputToState(sslEmail, 'emailCertificates');
+        bindCheckboxToState(forceHttps, 'forceHttps');
         bindInputToState(assistantKey, 'assistantOpenAIKey');
 
         bindErrorClear?.(hostname);

--- a/app/views/install/installer/templates/steps/step-1.phtml
+++ b/app/views/install/installer/templates/steps/step-1.phtml
@@ -5,6 +5,7 @@ $defaultAppDomain ??= 'localhost';
 $defaultHttpPort ??= '80';
 $defaultHttpsPort ??= '443';
 $defaultEmailCertificates ??= '';
+$defaultForceHttps ??= false;
 $defaultAssistantOpenAIKey ??= '';
 $defaultDatabase ??= 'postgresql';
 $enabledDatabases ??= ['postgresql', 'mariadb', 'mongodb'];
@@ -43,6 +44,19 @@ $assistantOpenAIKeyValue = htmlspecialchars((string) $defaultAssistantOpenAIKey,
                     value="<?php echo $hostnameValue; ?>"
                 >
             </div>
+
+            <label class="toggle-option" for="force-https">
+                <span class="toggle-option-content">
+                    <span class="typography-text-m-500 text-neutral-primary">Use HTTPS</span>
+                    <span id="force-https-description" class="typography-text-xs-400 text-neutral-tertiary">Turn this on when your Appwrite domain is served over HTTPS, including through a reverse proxy.</span>
+                </span>
+                <span class="toggle-switch">
+                    <input type="checkbox" id="force-https" name="forceHttps" class="sr-only" aria-describedby="force-https-description" <?php echo $defaultForceHttps ? 'checked' : ''; ?>>
+                    <span class="toggle-switch-track" aria-hidden="true">
+                        <span class="toggle-switch-thumb"></span>
+                    </span>
+                </span>
+            </label>
 
             <div class="input-group stack-xs">
                 <label class="label-text typography-text-m-500 text-neutral-secondary">Database</label>

--- a/app/views/install/installer/templates/steps/step-4.phtml
+++ b/app/views/install/installer/templates/steps/step-4.phtml
@@ -5,6 +5,7 @@ $defaultAppDomain = $defaultAppDomain ?? 'localhost';
 $defaultHttpPort = $defaultHttpPort ?? '80';
 $defaultHttpsPort = $defaultHttpsPort ?? '443';
 $defaultEmailCertificates = $defaultEmailCertificates ?? '';
+$defaultForceHttps = $defaultForceHttps ?? false;
 $defaultSecretKey = $defaultSecretKey ?? '';
 $defaultDatabase = $defaultDatabase ?? 'postgresql';
 $selectedDatabase = $lockedDatabase ?: $defaultDatabase;
@@ -39,6 +40,10 @@ $badgeClass = $defaultSecretKey !== '' ? 'badge-success' : 'badge-warning';
                             <?php echo htmlspecialchars((string) $defaultDatabaseLabel, ENT_QUOTES, 'UTF-8'); ?>
                         </div>
                         <div class="review-label typography-text-xs-400 text-neutral-tertiary">Database</div>
+                    </div>
+                    <div class="review-row">
+                        <span class="badge <?php echo $defaultForceHttps ? 'badge-success' : 'badge-neutral'; ?> typography-text-xs-400" data-review-https-badge><?php echo $defaultForceHttps ? 'HTTPS' : 'HTTP'; ?></span>
+                        <div class="review-label typography-text-xs-400 text-neutral-tertiary">Public API protocol</div>
                     </div>
                     <div class="review-row">
                         <div class="typography-text-m-500 text-neutral-primary" data-review-value="httpPort">

--- a/app/views/install/installer/templates/steps/step-6.phtml
+++ b/app/views/install/installer/templates/steps/step-6.phtml
@@ -11,15 +11,15 @@ $isUpgrade = $isUpgrade ?? false;
         </div>
 
         <div class="stack-xl">
-            <label class="migration-option" for="run-migration">
-                <span class="migration-option-content">
+            <label class="toggle-option" for="run-migration">
+                <span class="toggle-option-content">
                     <span class="typography-text-m-500 text-neutral-primary">Run migration automatically</span>
                     <span class="typography-text-xs-400 text-neutral-tertiary">Recommended when upgrading to a new version</span>
                 </span>
-                <span class="migration-switch">
+                <span class="toggle-switch">
                     <input type="checkbox" id="run-migration" name="migrate" class="sr-only" checked>
-                    <span class="migration-switch-track" aria-hidden="true">
-                        <span class="migration-switch-thumb"></span>
+                    <span class="toggle-switch-track" aria-hidden="true">
+                        <span class="toggle-switch-thumb"></span>
                     </span>
                 </span>
             </label>

--- a/src/Appwrite/Platform/Installer/Http/Installer/Install.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/Install.php
@@ -35,6 +35,7 @@ class Install extends Action
             ->param('appDomain', '', new AppDomain(), 'Application domain (hostname, IP, or bracket IPv6 with optional port)')
             ->param('httpPort', 80, new Range(1, 65535), 'HTTP port')
             ->param('httpsPort', 443, new Range(1, 65535), 'HTTPS port')
+            ->param('forceHttps', false, new \Utopia\Validator\Boolean(true), 'Generate HTTPS API URLs and enforce HTTPS', true)
             ->param('emailCertificates', '', new Email(allowEmpty: true), 'Email for SSL certificates', true)
             ->param('opensslKey', '', new Text(64, 0), 'Secret API key', true)
             ->param('assistantOpenAIKey', '', new Text(256, 0), 'OpenAI API key for assistant', true)
@@ -64,6 +65,7 @@ class Install extends Action
         string $appDomain,
         int $httpPort,
         int $httpsPort,
+        bool $forceHttps,
         string $emailCertificates,
         string $opensslKey,
         string $assistantOpenAIKey,
@@ -224,6 +226,7 @@ class Install extends Action
                 '_APP_OPENSSL_KEY_V1' => $opensslKey,
                 '_APP_DOMAIN' => $appDomain ?: 'localhost',
                 '_APP_DOMAIN_TARGET' => $appDomain ?: 'localhost',
+                '_APP_OPTIONS_FORCE_HTTPS' => $forceHttps ? 'enabled' : 'disabled',
                 '_APP_EMAIL_CERTIFICATES' => $emailCertificates,
                 '_APP_DB_ADAPTER' => $lockedDatabase ?? ($database ?: 'postgresql'),
                 '_APP_ASSISTANT_OPENAI_API_KEY' => $assistantOpenAIKey,
@@ -238,19 +241,33 @@ class Install extends Action
                     'database' => $database,
                     'appDomain' => $appDomain,
                     'emailCertificates' => $emailCertificates,
+                    'forceHttps' => $forceHttps,
                 ];
                 foreach ($inputValues as $field => $inputValue) {
-                    if (isset($stored[$field]) && $inputValue !== '') {
-                        $storedValue = (string) $stored[$field];
-                        if (in_array($field, ['httpPort', 'httpsPort'], true)) {
-                            $storedValue = trim($storedValue);
-                            $inputValue = trim($inputValue);
-                        }
-                        if ($storedValue !== $inputValue) {
+                    if (!isset($stored[$field])) {
+                        continue;
+                    }
+                    if ($field === 'forceHttps') {
+                        if ((bool) $stored[$field] !== $inputValue) {
                             $state->updateGlobalLock($installId, Server::STATUS_ERROR);
                             $this->sendBadRequest($response, $swooleResponse, $wantsStream, 'Installation payload mismatch');
                             return;
                         }
+                        continue;
+                    }
+                    if ($inputValue === '') {
+                        continue;
+                    }
+                    $inputValue = (string) $inputValue;
+                    $storedValue = (string) $stored[$field];
+                    if (in_array($field, ['httpPort', 'httpsPort'], true)) {
+                        $storedValue = trim($storedValue);
+                        $inputValue = trim($inputValue);
+                    }
+                    if ($storedValue !== $inputValue) {
+                        $state->updateGlobalLock($installId, Server::STATUS_ERROR);
+                        $this->sendBadRequest($response, $swooleResponse, $wantsStream, 'Installation payload mismatch');
+                        return;
                     }
                 }
 
@@ -282,6 +299,8 @@ class Install extends Action
                 $payloadInput['_APP_DOMAIN_TARGET'] = $stored['appDomain'] ?? $payloadInput['_APP_DOMAIN_TARGET'];
                 $payloadInput['_APP_EMAIL_CERTIFICATES'] = $stored['emailCertificates'] ?? $payloadInput['_APP_EMAIL_CERTIFICATES'];
                 $payloadInput['_APP_DB_ADAPTER'] = $lockedDatabase ?? ($stored['database'] ?? $payloadInput['_APP_DB_ADAPTER']);
+                $forceHttps = (bool) ($stored['forceHttps'] ?? $forceHttps);
+                $payloadInput['_APP_OPTIONS_FORCE_HTTPS'] = $forceHttps ? 'enabled' : 'disabled';
                 $httpPort = (int) ($stored['httpPort'] ?? $httpPort ?: $config->getDefaultHttpPort());
                 $httpsPort = (int) ($stored['httpsPort'] ?? $httpsPort ?: $config->getDefaultHttpsPort());
             }
@@ -297,6 +316,7 @@ class Install extends Action
                     'database' => $lockedDatabase ?? ($database ?: 'postgresql'),
                     'appDomain' => $appDomain ?: 'localhost',
                     'emailCertificates' => $emailCertificates,
+                    'forceHttps' => $forceHttps,
                     'opensslKeyHash' => $state->hashSensitiveValue($opensslKey),
                     'assistantOpenAIKeyHash' => $state->hashSensitiveValue($assistantOpenAIKey),
                 ],

--- a/src/Appwrite/Platform/Installer/Http/Installer/View.php
+++ b/src/Appwrite/Platform/Installer/Http/Installer/View.php
@@ -48,6 +48,7 @@ class View extends Action
         $isLocalInstall = $config->isLocal();
 
         $defaultEmailCertificates = $vars['_APP_EMAIL_CERTIFICATES']['default'] ?? '';
+        $defaultForceHttps = ($vars['_APP_OPTIONS_FORCE_HTTPS']['default'] ?? 'disabled') === 'enabled';
         if ($isLocalInstall && empty($defaultEmailCertificates)) {
             $defaultEmailCertificates = 'walterobrien@example.com';
         }

--- a/tests/unit/Platform/Modules/Installer/Http/Installer/ViewTest.php
+++ b/tests/unit/Platform/Modules/Installer/Http/Installer/ViewTest.php
@@ -23,6 +23,26 @@ final class ViewTest extends TestCase
         $this->assertLessThan($mongo, $maria);
     }
 
+    public function testHttpsDefaultsToDisabled(): void
+    {
+        $html = $this->render();
+
+        $this->assertStringContainsString('data-default-force-https="false"', $html);
+        $this->assertDoesNotMatchRegularExpression('/id="force-https"[^>]*checked/', $html);
+    }
+
+    public function testHttpsUsesExistingInstallerSetting(): void
+    {
+        $html = $this->render([
+            'vars' => [
+                '_APP_OPTIONS_FORCE_HTTPS' => ['default' => 'enabled'],
+            ],
+        ]);
+
+        $this->assertStringContainsString('data-default-force-https="true"', $html);
+        $this->assertMatchesRegularExpression('/id="force-https"[^>]*checked/', $html);
+    }
+
     public function testUpgradeWithoutDetectedDatabaseRemainsSelectable(): void
     {
         $html = $this->render([

--- a/tests/unit/Platform/Modules/Installer/ModuleTest.php
+++ b/tests/unit/Platform/Modules/Installer/ModuleTest.php
@@ -134,7 +134,7 @@ final class ModuleTest extends TestCase
         $this->assertSame('/install', $action->getHttpPath());
         $this->assertSame(Action::TYPE_DEFAULT, $action->getType());
         $this->assertActionParams($action, [
-            'appDomain', 'httpPort', 'httpsPort', 'emailCertificates', 'opensslKey',
+            'appDomain', 'httpPort', 'httpsPort', 'forceHttps', 'emailCertificates', 'opensslKey',
             'assistantOpenAIKey', 'accountEmail', 'accountPassword', 'database',
             'installId', 'retryStep', 'migrate',
         ]);


### PR DESCRIPTION
## What does this PR do?

Adds an explicit **Use HTTPS** option to the web installer. The selection is shown during review, submitted with the install payload, and written to `_APP_OPTIONS_FORCE_HTTPS`.

```text
fresh localhost/plain HTTP install -> disabled
public API over HTTPS             -> enabled by the operator
upgrade                            -> preserves the existing value
```

This also clarifies that the variable controls generated API URLs and must be enabled when TLS terminates at a reverse proxy.

### Why HTTPS remains opt-in

Appwrite also supports localhost, raw IP addresses, private networks, custom ports, and deployments that intentionally expose only plain HTTP. Those installations do not have a TLS endpoint. Enabling this option by default would generate unreachable `https://` API URLs and could cause connection or redirect failures. The installer therefore keeps it disabled until the operator confirms that the public API is served over HTTPS, either directly or through a TLS-terminating reverse proxy.

## Screenshots

| HTTP default | HTTPS selected |
| --- | --- |
| ![HTTP is disabled by default in the installer](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/01-http-default-d5713411.png) | ![HTTPS enabled for a public domain](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/02-https-selected-27861386.png) |

| Review summary | Mobile layout |
| --- | --- |
| ![HTTPS in the installation review summary](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/03-review-https-0119dc0f.png) | ![HTTPS option on a mobile viewport](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/04-https-selected-mobile-12466ce4.png) |

## Test Plan

```text
composer lint app/config/variables.php src/Appwrite/Platform/Installer/Http/Installer/Install.php src/Appwrite/Platform/Installer/Http/Installer/View.php tests/unit/Platform/Modules/Installer/Http/Installer/ViewTest.php
vendor/bin/phpunit tests/unit/Platform/Modules/Installer
vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G src/Appwrite/Platform/Installer/Http/Installer/Install.php src/Appwrite/Platform/Installer/Http/Installer/View.php tests/unit/Platform/Modules/Installer/Http/Installer/ViewTest.php
node --check <changed installer JavaScript files>
```

All passed. Installer PHPUnit coverage: 195 tests, 560 assertions, with 10 existing deprecations.

Playwright was run against the rendered installer at desktop and mobile viewports. It verified the disabled default, keyboard toggle behavior, review summary, no mobile overflow, and the final `forceHttps: true` install payload. 2 tests passed. A full Docker installation was not run because the local Docker daemon was unavailable.

## Related PRs and Issues

- https://github.com/Dokploy/templates/pull/1087
- https://appwrite.io/threads/1538184240431370403

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? (Not applicable; this updates the self-hosted installer and environment variable documentation.)


