### PR TITLE
Fix GraphQL mutations over GET

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1281,6 +1281,11 @@ return [
         'description' => 'Too many queries.',
         'code' => 400,
     ],
+    Exception::GRAPHQL_METHOD_UNSUPPORTED => [
+        'name' => Exception::GRAPHQL_METHOD_UNSUPPORTED,
+        'description' => 'GET requests only support GraphQL query operations.',
+        'code' => 405,
+    ],
 
     /** Migrations */
     Exception::MIGRATION_NOT_FOUND => [

--- a/app/controllers/api/graphql.php
+++ b/app/controllers/api/graphql.php
@@ -12,8 +12,12 @@ use Appwrite\Utopia\Database\Documents\User;
 use Appwrite\Utopia\Request;
 use Appwrite\Utopia\Response;
 use GraphQL\Error\DebugFlag;
+use GraphQL\Error\SyntaxError;
 use GraphQL\GraphQL;
+use GraphQL\Language\Parser;
+use GraphQL\Language\Source;
 use GraphQL\Type\Schema as GQLSchema;
+use GraphQL\Utils\AST;
 use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
@@ -86,7 +90,15 @@ Http::get('/v1/graphql')
             $query['variables'] = \json_decode($variables, true);
         }
 
-        $output = execute($schema, $promiseAdapter, $query);
+        try {
+            $output = execute($schema, $promiseAdapter, $query, readOnly: true);
+        } catch (Exception $exception) {
+            if ($exception->getType() === Exception::GRAPHQL_METHOD_UNSUPPORTED) {
+                $response->addHeader('Allow', 'POST');
+            }
+
+            throw $exception;
+        }
 
         $response
             ->setStatusCode(Response::STATUS_CODE_OK)
@@ -201,13 +213,15 @@ Http::post('/v1/graphql')
  * @param GQLSchema $schema
  * @param Adapter $promiseAdapter
  * @param array $query
+ * @param bool $readOnly
  * @return array
  * @throws Exception
  */
 function execute(
     GQLSchema $schema,
     Adapter $promiseAdapter,
-    array $query
+    array $query,
+    bool $readOnly = false
 ): array {
     $maxBatchSize = System::getEnv('_APP_GRAPHQL_MAX_BATCH_SIZE', 10);
     $maxComplexity = System::getEnv('_APP_GRAPHQL_MAX_COMPLEXITY', 250);
@@ -245,10 +259,27 @@ function execute(
 
     $promises = [];
     foreach ($query as $indexed) {
+        $source = $indexed['query'];
+
+        if ($readOnly) {
+            try {
+                $document = Parser::parse(new Source($source, 'GraphQL'));
+                $operation = AST::getOperationAST($document, $indexed['operationName'] ?? null);
+
+                if ($operation !== null && $operation->operation !== 'query') {
+                    throw new Exception(Exception::GRAPHQL_METHOD_UNSUPPORTED);
+                }
+
+                $source = $document;
+            } catch (SyntaxError) {
+                // Let the executor preserve the existing GraphQL error response.
+            }
+        }
+
         $promises[] = GraphQL::promiseToExecute(
             $promiseAdapter,
             $schema,
-            $indexed['query'],
+            $source,
             variableValues: $indexed['variables'] ?? null,
             operationName: $indexed['operationName'] ?? null,
             validationRules: $validations

--- a/src/Appwrite/Extend/Exception.php
+++ b/src/Appwrite/Extend/Exception.php
@@ -355,6 +355,7 @@ class Exception extends \Exception
     /** GraphqQL */
     public const string GRAPHQL_NO_QUERY = 'graphql_no_query';
     public const string GRAPHQL_TOO_MANY_QUERIES = 'graphql_too_many_queries';
+    public const string GRAPHQL_METHOD_UNSUPPORTED = 'graphql_method_unsupported';
 
     /** Migrations */
     public const string MIGRATION_NOT_FOUND = 'migration_not_found';

--- a/tests/e2e/Services/GraphQL/AccountTest.php
+++ b/tests/e2e/Services/GraphQL/AccountTest.php
@@ -220,6 +220,86 @@ final class AccountTest extends Scope
         return $jwt;
     }
 
+    public function testRejectMutationsOverGet(): void
+    {
+        $projectId = $this->getProject()['$id'];
+        $headers = \array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+        ], $this->getHeaders());
+        unset($headers['origin']);
+
+        $accountDocument = '
+            query getAccount {
+                accountGet {
+                    name
+                }
+            }
+            mutation updateAccountName($name: String!) {
+                accountUpdateName(name: $name) {
+                    name
+                }
+            }
+        ';
+
+        $accountBefore = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $accountDocument,
+            'operationName' => 'getAccount',
+        ]);
+        $this->assertEquals(200, $accountBefore['headers']['status-code']);
+        $this->assertArrayNotHasKey('errors', $accountBefore['body']);
+
+        $accountMutation = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $accountDocument,
+            'operationName' => 'updateAccountName',
+            'variables' => \json_encode(['name' => 'Changed over GET']),
+        ]);
+        $this->assertGetMutationRejected($accountMutation);
+
+        $ambiguousOperation = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $accountDocument,
+            'variables' => \json_encode(['name' => 'Changed over GET']),
+        ]);
+        $this->assertEquals(200, $ambiguousOperation['headers']['status-code']);
+        $this->assertArrayHasKey('errors', $ambiguousOperation['body']);
+
+        $accountAfter = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $accountDocument,
+            'operationName' => 'getAccount',
+        ]);
+        $this->assertEquals(
+            $accountBefore['body']['data']['accountGet']['name'],
+            $accountAfter['body']['data']['accountGet']['name']
+        );
+
+        $sessionMutation = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $this->getQuery(self::DELETE_ACCOUNT_SESSION),
+            'variables' => \json_encode(['sessionId' => 'current']),
+        ]);
+        $this->assertGetMutationRejected($sessionMutation);
+
+        $session = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $this->getQuery(self::GET_ACCOUNT_SESSION),
+            'variables' => \json_encode(['sessionId' => 'current']),
+        ]);
+        $this->assertEquals(200, $session['headers']['status-code']);
+        $this->assertEquals(
+            $this->getUser()['sessionId'],
+            $session['body']['data']['accountGetSession']['_id']
+        );
+
+        $jwtMutation = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => $this->getQuery(self::CREATE_ACCOUNT_JWT),
+        ]);
+        $this->assertGetMutationRejected($jwtMutation);
+
+        $syntaxError = $this->client->call(Client::METHOD_GET, '/graphql', $headers, [
+            'query' => 'mutation {',
+        ]);
+        $this->assertEquals(200, $syntaxError['headers']['status-code']);
+        $this->assertArrayHasKey('errors', $syntaxError['body']);
+    }
+
     public function testGetAccount(): array
     {
         $projectId = $this->getProject()['$id'];
@@ -500,5 +580,13 @@ final class AccountTest extends Scope
         $this->getUser();
 
         return $account;
+    }
+
+    private function assertGetMutationRejected(array $response): void
+    {
+        $this->assertEquals(405, $response['headers']['status-code']);
+        $this->assertEquals('POST', $response['headers']['allow']);
+        $this->assertEquals('graphql_method_unsupported', $response['body']['type']);
+        $this->assertEquals('GET requests only support GraphQL query operations.', $response['body']['message']);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Rejects selected non-query GraphQL operations sent through `GET /v1/graphql` before resolver execution. Operation selection uses the parsed AST and `operationName`, while valid GET queries and POST mutations remain unchanged.

```text
GET mutation -> 405 Method Not Allowed
Allow: POST
```

Adds regression coverage for account updates, session deletion, JWT creation, ambiguous documents, syntax errors, and side-effect prevention.

## Test Plan

```text
composer check app/controllers/api/graphql.php src/Appwrite/Extend/Exception.php app/config/errors.php tests/e2e/Services/GraphQL/AccountTest.php
docker compose exec appwrite test tests/e2e/Services/GraphQL --filter=testRejectMutationsOverGet
docker compose exec appwrite test tests/e2e/Services/GraphQL/LocalizationTest.php --filter=testGetLocale
docker compose exec appwrite test tests/e2e/Services/GraphQL/BatchTest.php --filter='test(ArrayBatchedMutations|ArrayBatchedMixedOperations)'
```

## Related PRs and Issues

- [CLO-4744](https://linear.app/appwrite/issue/CLO-4744/csrf-via-graphql-get-mutations-in-v1graphql)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
