### PR TITLE
Fix migration execution realtime assertion

### DIFF
--- a/tests/e2e/Services/Migrations/MigrationsBase.php
+++ b/tests/e2e/Services/Migrations/MigrationsBase.php
@@ -2381,7 +2381,8 @@ trait MigrationsBase
                     $payload = $message['data']['payload'] ?? null;
                     $this->assertIsArray($payload, 'Execution update has no payload: ' . json_encode($message, JSON_PRETTY_PRINT));
                     $this->assertSame($executionId, $payload['$id'] ?? null, 'Realtime returned a different execution: ' . json_encode($payload, JSON_PRETTY_PRINT));
-                    $this->assertSame($functionId, $payload['functionId'] ?? null, 'Execution ran a different function: ' . json_encode($payload, JSON_PRETTY_PRINT));
+                    $this->assertSame($functionId, $payload['resourceId'] ?? null, 'Execution ran a different function: ' . json_encode($payload, JSON_PRETTY_PRINT));
+                    $this->assertSame('functions', $payload['resourceType'] ?? null, 'Execution ran with a different resource type: ' . json_encode($payload, JSON_PRETTY_PRINT));
 
                     if (($payload['status'] ?? null) === 'failed') {
                         $this->fail('Execution failed: ' . json_encode($payload['errors'] ?? $payload, JSON_PRETTY_PRINT));


### PR DESCRIPTION
## What does this PR do?

Updates the migration function realtime assertion to match the generic execution resource identity introduced in #13209.

```text
before: functionId
 after: resourceId + resourceType
```

This fixes the PostgreSQL Migrations CI failure where the payload contained the expected function under `resourceId`, but the test still read the removed `functionId` field.

## Test Plan

```text
composer lint tests/e2e/Services/Migrations/MigrationsBase.php
php -l tests/e2e/Services/Migrations/MigrationsBase.php
git diff --check
```

The focused migration test was attempted locally, but stopped earlier because the migrated deployment remained in `waiting`; it did not reach the changed realtime assertion. The linked CI failure payload confirms `resourceId` and `resourceType` are present.

## Related PRs and Issues

- Follow-up to #13209
- Fixes the failure in https://github.com/appwrite/appwrite/actions/runs/32110299204/job/95628397146

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
