### PR TITLE
Bind project management authorization to path target

### DIFF
--- a/app/controllers/shared/api.php
+++ b/app/controllers/shared/api.php
@@ -53,6 +53,7 @@ Http::init()
     ->inject('dbForProject')
     ->inject('auditContext')
     ->inject('project')
+    ->inject('projectIdFromPath')
     ->inject('user')
     ->inject('session')
     ->inject('servers')
@@ -63,7 +64,7 @@ Http::init()
     ->inject('lock')
     ->inject('impersonatorUser')
     ->inject('targetUser')
-    ->action(function (Route $route, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, Lock $lock, Document $impersonatorUser, User $targetUser) {
+    ->action(function (Route $route, Request $request, Database $dbForPlatform, Database $dbForProject, AuditContext $auditContext, Document $project, string $projectIdFromPath, User $user, ?Document $session, array $servers, string $mode, Document $team, ?Key $apiKey, Authorization $authorization, Lock $lock, Document $impersonatorUser, User $targetUser) {
 
         /**
          * Handle user authentication and session validation.
@@ -109,6 +110,17 @@ Http::init()
          *     - Validate factor completion
          *     - Throw exception if factors incomplete
          */
+
+        // Bind project management authorization to the project in the path.
+        if ($projectIdFromPath !== '') {
+            $headerProjectId = $request->getHeaderLine('x-appwrite-project', '');
+
+            foreach ([$headerProjectId, $project->getId()] as $contextProjectId) {
+                if ($contextProjectId !== '' && $contextProjectId !== 'console' && $contextProjectId !== $projectIdFromPath) {
+                    throw new Exception(Exception::USER_UNAUTHORIZED);
+                }
+            }
+        }
 
         // Step 1: Check if project is empty
         if ($project->isEmpty()) {
@@ -293,8 +305,7 @@ Http::init()
 
             $projectId = $project->getId();
             if ($projectId === 'console' && str_starts_with($route->getPath(), '/v1/projects/:projectId')) {
-                $uri = $request->getURI();
-                $projectId = explode('/', $uri)[3];
+                $projectId = $projectIdFromPath;
             }
 
             // Base scopes for admin users to allow listing teams and projects.

--- a/app/init/resources/request.php
+++ b/app/init/resources/request.php
@@ -582,7 +582,22 @@ return function (Container $context): void {
         return $user;
     }, ['mode', 'project', 'console', 'request', 'response', 'dbForProject', 'dbForPlatform', 'store', 'proofForToken', 'authorization']);
 
-    $context->set('project', function ($dbForPlatform, $request, $console, $authorization, Http $utopia) {
+    $context->set('projectIdFromPath', function (Request $request, Http $utopia): string {
+        $match = $utopia->match($request);
+        if (empty($match)) {
+            return '';
+        }
+
+        $path = (string) \parse_url($request->getURI(), PHP_URL_PATH);
+        $segments = \array_values(\array_filter(\explode('/', $path), fn (string $segment) => $segment !== ''));
+        if (($segments[0] ?? '') !== 'v1' || ($segments[1] ?? '') !== 'projects') {
+            return '';
+        }
+
+        return $match->params['projectId'] ?? '';
+    }, ['request', 'utopia']);
+
+    $context->set('project', function ($dbForPlatform, $request, $console, $authorization, Http $utopia, string $projectIdFromPath) {
         /** @var Appwrite\Utopia\Request $request */
         /** @var Utopia\Database\Database $dbForPlatform */
         /** @var Utopia\Database\Document $console */
@@ -594,7 +609,7 @@ return function (Container $context): void {
         // For non-GET requests getParam() reads the body, so a project passed
         // as a query parameter (e.g. presigned artifact URLs) is only visible
         // via getQuery().
-        if (empty($projectId)) {
+        if ($projectId === '') {
             $projectId = (string) $request->getQuery('project', '');
         }
 
@@ -604,22 +619,22 @@ return function (Container $context): void {
         $deprecatedProjectPathPrefix = '/v1/projects/';
         $route = $utopia->match($request)?->route;
         if (!empty($route)) {
-            $isDeprecatedAlias = \str_starts_with($request->getURI(), $deprecatedProjectPathPrefix) &&
+            $isDeprecatedAlias = $projectIdFromPath !== '' &&
                 !\str_starts_with($route->getPath(), $deprecatedProjectPathPrefix);
 
             if ($isDeprecatedAlias) {
-                $projectId = \explode('/', $request->getURI(), 5)[3] ?? '';
+                $projectId = $projectIdFromPath;
             }
         }
 
-        if (empty($projectId) || $projectId === 'console') {
+        if ($projectId === '' || $projectId === 'console') {
             return $console;
         }
 
         $project = $authorization->skip(fn () => $dbForPlatform->getDocument('projects', $projectId));
 
         return $project;
-    }, ['dbForPlatform', 'request', 'console', 'authorization', 'utopia']);
+    }, ['dbForPlatform', 'request', 'console', 'authorization', 'utopia', 'projectIdFromPath']);
 
     $context->set('session', function (User $user, Store $store, Token $proofForToken) {
         if ($user->isEmpty()) {
@@ -891,7 +906,7 @@ return function (Container $context): void {
         $mode = $request->getParam('mode', $request->getHeaderLine('x-appwrite-mode', APP_MODE_DEFAULT));
 
         $projectId = $request->getParam('project', $request->getHeaderLine('x-appwrite-project', ''));
-        if (!empty($projectId) && $project->getId() !== $projectId) {
+        if ($projectId !== '' && $project->getId() !== $projectId) {
             $mode = APP_MODE_ADMIN;
         }
 
@@ -962,7 +977,7 @@ return function (Container $context): void {
         return $key;
     }, ['request', 'project', 'servers', 'dbForPlatform', 'authorization']);
 
-    $context->set('team', function (Document $project, Database $dbForPlatform, Http $utopia, Request $request, Authorization $authorization) {
+    $context->set('team', function (Document $project, Database $dbForPlatform, Http $utopia, Request $request, Authorization $authorization, string $projectIdFromPath) {
         $teamInternalId = '';
         if ($project->getId() !== 'console') {
             $teamInternalId = $project->getAttribute('teamInternalId', '');
@@ -971,9 +986,7 @@ return function (Container $context): void {
             $path = ! empty($route) ? $route->getPath() : $request->getURI();
             $orgHeader = $request->getHeaderLine('x-appwrite-organization', '');
             if (str_starts_with($path, '/v1/projects/:projectId')) {
-                $uri = $request->getURI();
-                $pid = explode('/', $uri)[3];
-                $p = $authorization->skip(fn () => $dbForPlatform->getDocument('projects', $pid));
+                $p = $authorization->skip(fn () => $dbForPlatform->getDocument('projects', $projectIdFromPath));
                 $teamInternalId = $p->getAttribute('teamInternalId', '');
             } elseif ($path === '/v1/projects') {
                 $teamId = $request->getParam('teamId', '');
@@ -1003,7 +1016,7 @@ return function (Container $context): void {
         });
 
         return $team;
-    }, ['project', 'dbForPlatform', 'utopia', 'request', 'authorization']);
+    }, ['project', 'dbForPlatform', 'utopia', 'request', 'authorization', 'projectIdFromPath']);
 
     $context->set('previewHostname', function (Request $request, ?Key $apiKey) {
         $allowed = false;

--- a/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
+++ b/tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
@@ -338,6 +338,65 @@ final class ProjectsConsoleClientTest extends Scope
         $this->assertNotEmpty($response['body']['$id']);
         $this->assertEquals('Team 1 Project', $response['body']['name']);
         $this->assertEquals($team2, $response['body']['teamId']);
+
+        $victimProjectId = ID::unique();
+        $response = $this->client->call(Client::METHOD_POST, '/projects', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-response-format' => '1.9.4',
+        ], $this->getHeaders()), [
+            'projectId' => $victimProjectId,
+            'name' => 'Victim Project',
+            'teamId' => $team1,
+            'region' => System::getEnv('_APP_REGION', 'default'),
+        ]);
+
+        $this->assertEquals(201, $response['headers']['status-code']);
+
+        $response = $this->client->call(Client::METHOD_PATCH, '/projects/' . $victimProjectId . '/team', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-mode' => 'admin',
+            'x-appwrite-response-format' => '1.9.4',
+        ], $this->getHeaders()), [
+            'teamId' => $team2,
+        ]);
+
+        $this->assertEquals(401, $response['headers']['status-code']);
+        $this->assertEquals(Exception::USER_UNAUTHORIZED, $response['body']['type']);
+
+        $response = $this->client->call(Client::METHOD_PATCH, '//projects/anything/team', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-mode' => 'admin',
+            'x-appwrite-response-format' => '1.9.4',
+        ], $this->getHeaders()), [
+            'teamId' => $team2,
+        ]);
+
+        $this->assertEquals(401, $response['headers']['status-code']);
+        $this->assertEquals(Exception::USER_UNAUTHORIZED, $response['body']['type']);
+
+        $response = $this->client->call(Client::METHOD_PATCH, '/projects/0/team', array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $projectId,
+            'x-appwrite-mode' => 'admin',
+            'x-appwrite-response-format' => '1.9.4',
+        ], $this->getHeaders()), [
+            'teamId' => $team2,
+        ]);
+
+        $this->assertEquals(401, $response['headers']['status-code']);
+        $this->assertEquals(Exception::USER_UNAUTHORIZED, $response['body']['type']);
+
+        $response = $this->client->call(Client::METHOD_GET, '/projects/' . $victimProjectId, array_merge([
+            'content-type' => 'application/json',
+            'x-appwrite-project' => $this->getProject()['$id'],
+            'x-appwrite-response-format' => '1.9.4',
+        ], $this->getHeaders()));
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals($team1, $response['body']['teamId']);
     }
 
     #[Group('projectsCRUD')]


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Binds `/v1/projects/:projectId/*` authorization to the router-resolved path target and rejects conflicting concrete project contexts.

```text
x-appwrite-project: project-A
PATCH /v1/projects/project-B/team

project             = project-A
projectIdFromPath   = project-B
result              = 401 user_unauthorized
```

`console` remains a valid management context:

```text
x-appwrite-project: console
PATCH /v1/projects/project-B/team

project             = console       # session/auth context
projectIdFromPath   = project-B     # operation target
result              = authorize roles against project-B
```

The values remain separate because `project` controls more than authorization:

```text
project
├── mode + session cookie
├── user database
├── dbForProject
├── API key decoding
└── CORS, events, audits, and storage
```

Replacing it with the path target would change existing request behavior:

```text
before: project=console   → a_session_console + platform DB
unsafe: project=project-B → a_session_project-B + project-B tenant DB
```

The target ID also needs to survive a missing project document:

```text
PATCH /v1/projects/missing/team

project->getId()        = ""
projectIdFromPath       = "missing"
```

The resource uses Utopia's matched route parameter instead of manually trusting URI indexes:

```php
$match = $utopia->match($request);
return $match->params['projectId'] ?? '';
```

## Test Plan

```text
composer lint app/controllers/shared/api.php app/init/resources/request.php tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
composer analyze app/controllers/shared/api.php app/init/resources/request.php tests/e2e/Services/Projects/ProjectsConsoleClientTest.php
docker compose exec appwrite test tests/e2e/Services/Projects --filter='/test(TransferProjectTeam|UpdateProject)$/'
```

E2E result: 2 tests, 36 assertions.

## Related PRs and Issues

- [CLO-4741](https://linear.app/appwrite/issue/CLO-4741/cross-project-authorization-bypass-in-v1projectsprojectid-management)

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
