### PR TITLE
fix(schedules): anchor cron selection on a persisted enqueue window

### DIFF
--- a/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
+++ b/src/Appwrite/Platform/Tasks/ScheduleFunctions.php
@@ -5,11 +5,14 @@ namespace Appwrite\Platform\Tasks;
 use Appwrite\Event\Message\Func as FunctionMessage;
 use Appwrite\Event\Publisher\Func as FunctionPublisher;
 use Cron\CronExpression;
+use Utopia\Cache\Cache;
 use Utopia\Console;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
+use Utopia\Queue\Broker\Pool as BrokerPool;
 use Utopia\Span\Span;
 use Utopia\System\System;
+use Utopia\Telemetry\Adapter as Telemetry;
 
 /**
  * ScheduleFunctions
@@ -21,6 +24,22 @@ class ScheduleFunctions extends ScheduleBase
 {
     public const UPDATE_TIMER = 10; // seconds
     public const ENQUEUE_TIMER = 60; // seconds
+
+    /**
+     * How far back, in seconds, the persisted enqueue window is trusted.
+     * Bounds the catch-up burst after downtime: an every-minute schedule
+     * replays at most this window's worth of missed occurrences.
+     */
+    public const ENQUEUE_LOOKBACK = self::ENQUEUE_TIMER * 5;
+
+    protected ?Cache $cache = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->inject('cache');
+    }
 
     public static function getName(): string
     {
@@ -37,6 +56,13 @@ class ScheduleFunctions extends ScheduleBase
         return RESOURCE_TYPE_FUNCTIONS;
     }
 
+    public function action(BrokerPool $publisher, BrokerPool $publisherMigrations, BrokerPool $publisherFunctions, BrokerPool $publisherMessaging, callable $getIsResourceBlocked, Database $dbForPlatform, callable $getProjectDB, Telemetry $telemetry, ?Cache $cache = null): never
+    {
+        $this->cache = $cache;
+
+        parent::action($publisher, $publisherMigrations, $publisherFunctions, $publisherMessaging, $getIsResourceBlocked, $dbForPlatform, $getProjectDB, $telemetry);
+    }
+
     /**
      * Spread window, in seconds, for a given schedule. The default applies
      * _APP_FUNCTIONS_SCHEDULE_SPREAD to every schedule; override to scope
@@ -47,59 +73,70 @@ class ScheduleFunctions extends ScheduleBase
         return (int) System::getEnv('_APP_FUNCTIONS_SCHEDULE_SPREAD', '0');
     }
 
+    /**
+     * Cron occurrences of $schedule inside ($windowStart, $timeFrame),
+     * oldest first. Anchoring on the window instead of "now" keeps the
+     * selection stable no matter how long the caller's loop has already
+     * been running: an occurrence on a minute boundary the loop crosses
+     * mid-pass stays selectable, and one that fell between two ticks is
+     * still returned by the tick whose window covers it.
+     *
+     * @return array<\DateTime>
+     */
+    public static function occurrencesWithin(string $schedule, \DateTime $windowStart, string $timeFrame): array
+    {
+        $occurrences = [];
+
+        try {
+            $cron = new CronExpression($schedule);
+            $next = $cron->getNextRunDate($windowStart);
+
+            while (DateTime::format($next) < $timeFrame) {
+                $occurrences[] = $next;
+                $next = $cron->getNextRunDate($next);
+            }
+        } catch (\InvalidArgumentException | \RuntimeException) {
+            // invalid or impossible cron expressions have no occurrences
+        }
+
+        return $occurrences;
+    }
+
     protected function enqueueResources(Database $dbForPlatform, callable $getProjectDB): void
     {
         $timerStart = \microtime(true);
-        $time = DateTime::now();
+        $tickStart = new \DateTime();
+        $time = DateTime::format($tickStart);
 
         $spread = (int) System::getEnv('_APP_FUNCTIONS_SCHEDULE_SPREAD', '0');
 
-        // TODO: Track the last enqueue timestamp to subtract ENQUEUE_TIMER drift from
-        // the time frame. Previously this used $this->lastEnqueueUpdate as a property
-        // but enabling the assignment broke scheduling, so the diff stays 0.
-        $enqueueDiff = 0;
-        $timeFrame = DateTime::addSeconds(new \DateTime(), static::ENQUEUE_TIMER - $enqueueDiff);
+        // The window opens where the previous tick's window closed (persisted
+        // in cache), so occurrences missed between ticks — a process restart,
+        // or wall time passing them while the previous pass was still running
+        // — are enqueued late instead of never. A window end older than
+        // ENQUEUE_LOOKBACK is discarded to cap the catch-up burst after a
+        // long outage.
+        $windowStart = $this->loadWindowEnd() ?? $tickStart;
+        $timeFrame = DateTime::addSeconds(clone $tickStart, static::ENQUEUE_TIMER);
 
-        Console::log("Enqueue tick: started at: $time (with diff $enqueueDiff, spread {$spread}s)");
+        Console::log("Enqueue tick: started at: $time (window start " . DateTime::format($windowStart) . ", spread {$spread}s)");
 
         $total = 0;
 
         $delayedExecutions = []; // Group executions with same delay to share one coroutine
 
         foreach ($this->schedules as $key => $schedule) {
-            try {
-                $cron = new CronExpression($schedule['schedule']);
-                $nextDate = $cron->getNextRunDate();
-            } catch (\InvalidArgumentException) {
-                // ignore invalid cron expressions
-                continue;
-            } catch (\RuntimeException) {
-                // ignore impossible cron expressions
-                continue;
+            foreach (self::occurrencesWithin($schedule['schedule'], $windowStart, $timeFrame) as $nextDate) {
+                $total++;
+
+                $offset = self::spreadOffset($schedule['resourceId'], $this->spreadWindow($schedule, $dbForPlatform));
+                // Recovered past-due occurrences enqueue immediately.
+                $delay = \max(0, $nextDate->getTimestamp() - \time() + $offset);
+
+                // nextDate carries the offset so enqueue-delay telemetry measures
+                // lateness against the intended (spread) enqueue time.
+                $delayedExecutions[$delay][] = ['key' => $key, 'nextDate' => $nextDate->modify("+{$offset} seconds")];
             }
-
-            $next = DateTime::format($nextDate);
-
-            $currentTick = $next < $timeFrame;
-
-            if (!$currentTick) {
-                continue;
-            }
-
-            $total++;
-
-            $promiseStart = \time(); // in seconds
-            $executionStart = $nextDate->getTimestamp(); // in seconds
-            $offset = self::spreadOffset($schedule['resourceId'], $this->spreadWindow($schedule, $dbForPlatform));
-            $delay = $executionStart - $promiseStart + $offset; // Time to wait from now until execution needs to be queued
-
-            if (!isset($delayedExecutions[$delay])) {
-                $delayedExecutions[$delay] = [];
-            }
-
-            // nextDate carries the offset so enqueue-delay telemetry measures
-            // lateness against the intended (spread) enqueue time.
-            $delayedExecutions[$delay][] = ['key' => $key, 'nextDate' => $nextDate->modify("+{$offset} seconds")];
         }
 
         foreach ($delayedExecutions as $delay => $schedules) {
@@ -144,8 +181,30 @@ class ScheduleFunctions extends ScheduleBase
             });
         }
 
+        $this->saveWindowEnd($timeFrame);
+
         $timerEnd = \microtime(true);
 
         Console::log("Enqueue tick: {$total} executions were enqueued in " . ($timerEnd - $timerStart) . " seconds");
+    }
+
+    private function loadWindowEnd(): ?\DateTime
+    {
+        try {
+            $value = $this->cache?->load(static::getName() . '-enqueue-window-end', self::ENQUEUE_LOOKBACK);
+
+            return \is_string($value) ? new \DateTime($value) : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function saveWindowEnd(string $windowEnd): void
+    {
+        try {
+            $this->cache?->save(static::getName() . '-enqueue-window-end', $windowEnd);
+        } catch (\Throwable $th) {
+            Console::error('Failed to persist enqueue window end: ' . $th->getMessage());
+        }
     }
 }

--- a/tests/unit/Platform/Tasks/ScheduleFunctionsTest.php
+++ b/tests/unit/Platform/Tasks/ScheduleFunctionsTest.php
@@ -13,6 +13,46 @@ use Utopia\Database\Database;
 
 final class ScheduleFunctionsTest extends TestCase
 {
+    public function testOccurrenceOnMinuteBoundarySurvivesWindowAnchor(): void
+    {
+        // A tick that starts milliseconds before a minute boundary crosses it
+        // while the schedule loop is still running. Selection anchored on the
+        // window start must still return the boundary occurrence — a lookup
+        // anchored on the evaluation-time "now" would already be past it.
+        $windowStart = new \DateTime('2026-08-17 15:59:59.941');
+        $timeFrame = '2026-08-17 16:00:59.941';
+
+        $occurrences = ScheduleFunctions::occurrencesWithin('*/15 * * * *', $windowStart, $timeFrame);
+
+        $this->assertSame(
+            ['2026-08-17 16:00:00'],
+            \array_map(fn ($occurrence) => $occurrence->format('Y-m-d H:i:s'), $occurrences)
+        );
+    }
+
+    public function testMissedOccurrencesAreBackfilled(): void
+    {
+        // The window start comes from the previous pass (persisted watermark),
+        // so a restart gap yields every missed occurrence, oldest first.
+        $windowStart = new \DateTime('2026-08-18 03:00:59.500');
+        $timeFrame = '2026-08-18 03:31:00.500';
+
+        $occurrences = ScheduleFunctions::occurrencesWithin('*/15 * * * *', $windowStart, $timeFrame);
+
+        $this->assertSame(
+            ['2026-08-18 03:15:00', '2026-08-18 03:30:00'],
+            \array_map(fn ($occurrence) => $occurrence->format('Y-m-d H:i:s'), $occurrences)
+        );
+    }
+
+    public function testEmptyWindowAndInvalidCronYieldNothing(): void
+    {
+        $windowStart = new \DateTime('2026-08-18 03:01:00.000');
+
+        $this->assertSame([], ScheduleFunctions::occurrencesWithin('*/15 * * * *', $windowStart, '2026-08-18 03:10:00.000'));
+        $this->assertSame([], ScheduleFunctions::occurrencesWithin('not a cron', $windowStart, '2026-08-18 04:00:00.000'));
+    }
+
     public function testSpreadWindowDefaultsToEnv(): void
     {
         $task = new class () extends ScheduleFunctions {


### PR DESCRIPTION
## Problem

`ScheduleFunctions::enqueueResources()` fixes its 60s `$timeFrame` once at tick start, but evaluates every schedule's `getNextRunDate()` against an implicit, **moving** "now" as the loop runs. Two failure modes follow, both silent (no error, no execution record, no retry):

1. **Minute-boundary phase race.** If a tick starts milliseconds before a minute boundary, the boundary slips into the past while the loop is still iterating. `getNextRunDate()` then returns the *following* occurrence (outside the 60s frame) and the boundary run is dropped. Swoole's `sleep(60)` keeps the tick phase nearly constant (~1-2ms drift per minute), so one bad phase drops the entire minute-aligned cohort on **every tick** until the phase drifts across the boundary. Observed in production (Appwrite Cloud, sfo3, 2026-08-17): ~90% of scheduled executions lost for 45 minutes straight, per-tick selection decaying 64 → 10 → 1 as the phase crept toward the boundary, then instant recovery the moment it crossed.
2. **Restart gap.** The scheduler holds no watermark, so every occurrence that falls between process stop and the end of the initial `collectSchedules()` load is unrecoverable — the next tick's `getNextRunDate()` only looks forward from now.

This is the long-standing "scheduled functions skip runs" report (e.g. Discord thread 1252401241414303876). The in-code TODO about `$enqueueDiff`/`lastEnqueueUpdate` was reaching for this; a previous `<` → `<=` attempt (9be447aacf, reverted in 04173600ae) couldn't fix it because the boundary loss isn't a comparison problem.

## Fix

Selection is anchored on an explicit half-open window instead of "now":

- `occurrencesWithin($schedule, $windowStart, $timeFrame)` enumerates cron occurrences from a fixed base, so an occurrence stays selectable no matter how long the loop has been running.
- The window **opens where the previous tick's window closed**. The window end is persisted in cache (Redis) under `schedule-functions-enqueue-window-end`, so windows tile the timeline across ticks *and* across process restarts.
- Past-due occurrences (recovered after a gap) enqueue immediately — `$delay` is clamped at 0.
- A persisted window end older than `ENQUEUE_LOOKBACK` (5 ticks) is discarded, capping the catch-up burst after a long outage: an every-minute schedule replays at most 5 missed runs.
- Cache wiring is scoped to `ScheduleFunctions` (own `__construct`/`action` with an optional trailing `?Cache` param), leaving the `ScheduleBase` contract untouched for downstream subclasses. With no cache available, behaviour degrades to exactly the window of the current tick.

## Tests

- `testOccurrenceOnMinuteBoundarySurvivesWindowAnchor` — verified red against the previous now-based lookup, green with the anchored one.
- `testMissedOccurrencesAreBackfilled` — a restart-sized gap yields every missed occurrence, oldest first.
- `testEmptyWindowAndInvalidCronYieldNothing`.

No E2E covers the scheduler tick path (it spans task ↔ Redis ↔ worker); the phase race itself is only reachable with a controlled clock, which is why the selection logic was extracted into a pure, directly-tested method.

## Known limits (unchanged from before)

- Occurrences already selected and sleeping in coroutines when the process dies are lost (≤1 tick + spread worth); the watermark is advanced at selection time to avoid double-firing on the far more common paths.
- Two schedulers running concurrently during a rollout can still double-enqueue, exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)