### PR TITLE
refactor(functions): expose project access hook

### DIFF
--- a/src/Appwrite/Platform/Workers/Functions.php
+++ b/src/Appwrite/Platform/Workers/Functions.php
@@ -344,7 +344,7 @@ class Functions extends Action
         }
     }
 
-    private function updateProjectAccess(Document $project, Database $dbForPlatform): void
+    protected function updateProjectAccess(Document $project, Database $dbForPlatform): void
     {
         if (!$project->isEmpty() && $project->getId() !== 'console') {
             $accessedAt = $project->getAttribute('accessedAt', 0);

--- a/tests/unit/Platform/Workers/FunctionsTest.php
+++ b/tests/unit/Platform/Workers/FunctionsTest.php
@@ -88,6 +88,7 @@ final class FunctionsTest extends TestCase
         $this->assertSame('/path', $message->path);
         $this->assertSame(['x-test' => 'value'], $message->headers);
         $this->assertSame('PATCH', $message->method);
+        $this->assertSame(1, $worker->projectAccessUpdates);
     }
 
     #[DataProvider('inactiveScheduleProvider')]
@@ -184,8 +185,15 @@ final class FunctionsTest extends TestCase
 
 final class TestFunctions extends Functions
 {
+    public int $projectAccessUpdates = 0;
+
     public function schedule(Database $dbForPlatform, Document $project, Document $execution, string $functionId, callable $enqueue): bool
     {
         return $this->enqueueScheduledExecution($dbForPlatform, $project, $execution, $functionId, $enqueue);
+    }
+
+    protected function updateProjectAccess(Document $project, Database $dbForPlatform): void
+    {
+        $this->projectAccessUpdates++;
     }
 }


### PR DESCRIPTION
## What does this PR do?

Makes the functions worker project-access update hook protected so editions can extend scheduled-execution access tracking.

Cloud updates both project and team access as best-effort billing metadata. Scheduled execution hydration moved from the scheduler to the functions worker in appwrite/appwrite#13265, so the extension point must move with it.

The default server behavior does not change.

## Test Plan

- composer lint
- composer check -- --no-progress
- composer refactor:check
- composer format src/Appwrite/Platform/Workers/Functions.php tests/unit/Platform/Workers/FunctionsTest.php
- vendor/bin/phpunit tests/unit/Platform/Workers/FunctionsTest.php

All commands pass locally.

## Related PRs and Issues

- appwrite/appwrite#13265
- appwrite-labs/cloud#5364

## Checklist

- [x] Have you read the Contributing Guidelines on issues?
- [x] This PR does not change API metadata.
